### PR TITLE
Update weights.py

### DIFF
--- a/nodes/analyzer/weights.py
+++ b/nodes/analyzer/weights.py
@@ -18,73 +18,79 @@
 
 import bpy
 import parser
-from bpy.props import StringProperty, FloatProperty, IntProperty, BoolProperty
+from bpy.props import StringProperty, BoolProperty, EnumProperty, FloatProperty
 from node_tree import SverchCustomTreeNode, StringsSocket
-from data_structure import (SvGetSocketAnyType, updateNode)
+from data_structure import (SvGetSocketAnyType, updateNode, match_short, match_long_cycle)
 
 class SvVertexGroupNode(bpy.types.Node, SverchCustomTreeNode):
     ''' Vertex Group '''
     bl_idname = 'SvVertexGroupNode'
     bl_label = 'weights'
     bl_icon = 'OUTLINER_OB_EMPTY'
-
-
-    allind = BoolProperty(name='All vertices', description='use all vertices of object', default=False, update=updateNode)
-    clear = BoolProperty(name='clear unused', description='clear weight of unindexed vertices', default=True, update=updateNode)
     
+    Itermodes = [
+    ("match_short",        "match_short",         "", 1),
+    ("match_long_cycle",   "match_long_cycle",    "", 2),
+    ]
     
+    Iteration = EnumProperty(name="iteration modes", description="Iteration modes",  default="match_short", items=Itermodes, update=updateNode)
     formula = StringProperty(name='formula', description='name of object to operate on', default='Cube', update=updateNode)
+    fade_speed = FloatProperty(name='fade', description='Speed of "clear unused" weights during animation',default=2,options={'ANIMATABLE'}, update=updateNode)
+    clear = BoolProperty(name='clear unused', description='clear weight of unindexed vertices', default=True, update=updateNode)
 
-    def draw_buttons(self, context, layout):
+    def draw_buttons(self, context,  layout):
         layout.prop(self, "formula", text="")
         row = layout.row(align=True)
-        row.prop(self, "allind", text="All vertices")
-        row.prop(self, "clear", text="clear unused")
-        
-
-    x_ = IntProperty(name='VertIND' , description='indixes of corresponding vertices', default=1, update=updateNode)
-    y_ = FloatProperty(name='Weights', description='weights for corresponding vertices', default=0.0, precision=3, update=updateNode)
-
-
+        row.prop(self,    "clear",   text="clear unused")
+        layout.prop(self, "Iteration", "Iteration modes")
+    
+    def draw_buttons_ext(self, context, layout):
+        row = layout.row(align=True)
+        row.prop(self, "fade_speed", text="Clearing speed")
+    
     def init(self, context):
-        self.inputs.new('StringsSocket', "VertIND").prop_name = 'x_'
-        self.inputs.new('StringsSocket', "Weights").prop_name = 'y_'
+        self.inputs.new('StringsSocket', "VertIND")
+        self.inputs.new('StringsSocket', "Weights")
 
     
     def update(self):
         
+        if not (self.formula in bpy.data.objects):
+            return
+        
+        vertex_weight = self.inputs['Weights'].links
+        if not (vertex_weight and (type(vertex_weight[0].from_socket) == StringsSocket)):
+            return
+
+        self.process()
+    
+    
+    def process(self):
+        
         obj= bpy.data.objects[self.formula]
-        if self.allind:
-            verts = [[i.index for i in obj.data.vertices]]
-        else:
-            
-            if 'VertIND' in self.inputs and self.inputs['VertIND'].links and \
-               type(self.inputs['VertIND'].links[0].from_socket) == StringsSocket:
-                verts = SvGetSocketAnyType(self, self.inputs['VertIND'])
-            else:
-                verts = [[self.x_]]
-            
-        if 'Weights' in self.inputs and self.inputs['Weights'].links and \
-           type(self.inputs['Weights'].links[0].from_socket) == StringsSocket:
-            if len(SvGetSocketAnyType(self, self.inputs['Weights'])[0])>1:
-                 wei = SvGetSocketAnyType(self, self.inputs['Weights'])
-            else:
-                 wei = [SvGetSocketAnyType(self, self.inputs['Weights'])[0]*len(verts[0])]
-        else:
-            wei = [[self.y_]*len(verts[0])]
-
-
         
+        if self.inputs['VertIND'].links:
+            verts = SvGetSocketAnyType(self, self.inputs['VertIND'])[0]
+        else:
+            verts = [i.index for i in obj.data.vertices]
+            
+        wei = SvGetSocketAnyType(self, self.inputs['Weights'])[0]
+        
+        if self.Iteration== 'match_short':
+            temp= match_short([ verts, wei ])
+            verts, wei= temp[0], temp[1]
+        if self.Iteration== 'match_long_cycle':
+            temp= match_long_cycle([ verts, wei ])
+            verts, wei= temp[0], temp[1]
+
         obj.data.update()
-        
-
         if obj.vertex_groups.active and obj.vertex_groups.active.name.find( 'Sv_VGroup' ) != -1:
     
             if self.clear:
-                obj.vertex_groups.active.add([i.index for i in obj.data.vertices], 0, "REPLACE")
+                obj.vertex_groups.active.add([i.index for i in obj.data.vertices], self.fade_speed, "SUBTRACT")
             g=0
-            while g!= len(wei[0]):
-                obj.vertex_groups.active.add([verts[0][g]], wei[0][g], "REPLACE")
+            while g!= len(wei):
+                obj.vertex_groups.active.add([verts[g]], wei[g], "REPLACE")
                 g=g+1
     
         else:


### PR DESCRIPTION
separated update and process. Instead of "use all" checkbox node now checks whether there is a connection to the VertIND socket. Ability to customize the slow decay of weight instead of an instantaneous disappearance when the user uses "clear unused" function.
