### PR TITLE
Fix a bug in Profile node: substraction parsing.

### DIFF
--- a/nodes/generator/profile.py
+++ b/nodes/generator/profile.py
@@ -393,7 +393,7 @@ class PathParser(object):
         # extract parens, but allow internal parens if needed.. internal parens
         # are not supported in literal_eval.
         side = component[1:-1]
-        pat = '([\(\)-+*\/])'
+        pat = '([\(\)\-+*\/])'
         chopped = re.split(pat, side)
 
         # - replace known variable chars with intended variable


### PR DESCRIPTION
Expressions like (b-c) were not parsed properly.
At line 397 of profile.py you got one element "b-c" instead of expected ["b", "c"].
Minus sign has special meaning inside [] brackets in regexps.