### PR TITLE
Implementation of `Calculate normals' node

### DIFF
--- a/docs/nodes/beta/beta.rst
+++ b/docs/nodes/beta/beta.rst
@@ -9,6 +9,7 @@ Beta
    bevel
    fibonacci
    exponential
+   calc_normals
    vector_polar_in
    vector_polar_out
    ngon

--- a/docs/nodes/beta/calc_normals.rst
+++ b/docs/nodes/beta/calc_normals.rst
@@ -1,0 +1,42 @@
+Calculate Normals
+=================
+
+*destination after Beta: Analyzers*
+
+Functionality
+-------------
+
+This node calculates normals for faces and edges of given mesh. Normals can be calculated even for meshes without faces, i.e. curves.
+
+Inputs
+------
+
+This node has the following inputs:
+
+- **Vertices**
+- **Edges**
+- **Polygons**
+
+Outputs
+-------
+
+This node has the following outputs:
+
+- **FaceNormals**. Normals of faces. This output will be empty if **Polygons** input is empty.
+- **VertexNormals**. Normals of vertices.
+
+Examples of usage
+-----------------
+
+Move each face of cube along its normal:
+
+.. image:: https://cloud.githubusercontent.com/assets/284644/5989203/f86367f2-a9a0-11e4-9292-d303838d561d.png
+
+Visualization of vertex normals for bezier curve:
+
+.. image:: https://cloud.githubusercontent.com/assets/284644/5989204/f8655fbc-a9a0-11e4-94d5-caf403d3a64a.png
+
+Normals can be also calculated for closed curves:
+
+.. image:: https://cloud.githubusercontent.com/assets/284644/5989202/f8632a44-a9a0-11e4-8745-19065eb13bcd.png
+

--- a/menu.py
+++ b/menu.py
@@ -228,6 +228,7 @@ def make_node_cats():
         ["SvScriptNodeMK2",     "Script 2"],
         ["VectorPolarInNode", "Vector polar input"],
         ["VectorPolarOutNode", "Vector polar output"],
+        ["GetNormalsNode", "Calculate normals"],
         ["SvGenFibonacci", "Fibonacci sequence"],
         ["SvGenExponential", "Exponential sequence"],
         ['SvNGonNode',    'NGon',     'RNDCURVE'],

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -1,6 +1,7 @@
 nodes_dict = {
     'analyzer': [
         'area',
+        'normals',
         'volume',
         'bbox',
         'distance_pp',

--- a/nodes/analyzer/normals.py
+++ b/nodes/analyzer/normals.py
@@ -1,0 +1,85 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import math
+
+from mathutils import Vector, Matrix
+
+import bpy
+from bpy.props import BoolProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode, match_long_repeat
+from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata, pydata_from_bmesh
+
+def calc_mesh_normals(vertices, edges, faces):
+    bm = bmesh_from_pydata(vertices, edges, faces)
+    bm.normal_update()
+    vertex_normals = []
+    face_normals = []
+    for vertex in bm.verts:
+        vertex_normals.append(tuple(vertex.normal))
+    for face in bm.faces:
+        face_normals.append(tuple(face.normal))
+    bm.free()
+    return vertex_normals, face_normals
+
+class GetNormalsNode(bpy.types.Node, SverchCustomTreeNode):
+    ''' Calculate normals of faces and vertices '''
+    bl_idname = 'GetNormalsNode'
+    bl_label = 'Calc Normals'
+    bl_icon = 'OUTLINER_OB_EMPTY'
+
+    def sv_init(self, context):
+        self.inputs.new('VerticesSocket', "Vertices")
+        self.inputs.new('StringsSocket', "Edges")
+        self.inputs.new('StringsSocket', "Polygons")
+
+        self.outputs.new('VerticesSocket', "FaceNormals")
+        self.outputs.new('VerticesSocket', "VertexNormals")
+
+    def process(self):
+
+        if not (self.outputs['VertexNormals'].is_linked or self.outputs['FaceNormals'].is_linked):
+            return
+
+        vertices_s = self.inputs['Vertices'].sv_get(default=[[]])
+        edges_s = self.inputs['Edges'].sv_get(default=[[]])
+        faces_s = self.inputs['Polygons'].sv_get(default=[[]])
+
+        result_vertex_normals = []
+        result_face_normals = []
+
+        meshes = match_long_repeat([vertices_s, edges_s, faces_s])
+        for vertices, edges, faces in zip(*meshes):
+            vertex_normals, face_normals = calc_mesh_normals(vertices, edges, faces)
+            result_vertex_normals.append(vertex_normals)
+            result_face_normals.append(face_normals)
+
+        if self.outputs['FaceNormals'].is_linked:
+            self.outputs['FaceNormals'].sv_set(result_face_normals)
+        if self.outputs['VertexNormals'].is_linked:
+            self.outputs['VertexNormals'].sv_set(result_vertex_normals)
+
+def register():
+    bpy.utils.register_class(GetNormalsNode)
+
+
+def unregister():
+    bpy.utils.unregister_class(GetNormalsNode)
+


### PR DESCRIPTION
Given a mesh, calculate normals for its faces and vertices.
Partly functionality of this node intersects with "Centers polygons" node, but: 1) "Centers polygons" cannot calculate normals of vertices, 2) "Centers polygons" cannot calculate normals for meshes without faces, i.e. for curves. On the other hand, "calculate normals" has nothing to do with matrices, as "centers polygons" does.
See also portnov#20.
Please review.