### PR TITLE
Fixed edge ordering in circle generator

### DIFF
--- a/nodes/generator/circle.py
+++ b/nodes/generator/circle.py
@@ -85,7 +85,7 @@ class SvCircleNode(bpy.types.Node, SverchCustomTreeNode):
             listEdg.append((0, Vertices))
             listEdg.append((Vertices-1, Vertices))
         else:
-            listEdg.append((0, Vertices-1))
+            listEdg.append((Vertices-1, 0))
         return listEdg
 
     def make_faces(self, Angle, Vertices):


### PR DESCRIPTION
In the circle generator the last edge was defined the opposite way.
This creates inconsistend normals when extruding.
The commit reverses the last edge so all edges point towards the "higher" vertex index (with zero being higher than the last vertex).