### PR TITLE
Update bmesh normals before recalculating.

### DIFF
--- a/nodes/modifier_change/recalc_normals.py
+++ b/nodes/modifier_change/recalc_normals.py
@@ -69,6 +69,7 @@ class SvRecalcNormalsNode(bpy.types.Node, SverchCustomTreeNode):
         for vertices, edges, faces, mask in zip(*meshes):
 
             bm = bmesh_from_pydata(vertices, edges, faces)
+            bm.normal_update()
             fullList(mask, len(faces))
 
             b_faces = []


### PR DESCRIPTION
This fixes normals if mesh was composed of several parts using Mesh Join
or similar nodes.