### PR TITLE
Refactoring proposal: factor some input/output boilerplate code out from nodes to core code

### DIFF
--- a/data_structure.py
+++ b/data_structure.py
@@ -265,6 +265,10 @@ def sv_zip(*iterables):
         yield result
 
 def checking_links(process):
+    '''Decorator for process method of node.
+    This decorator does stanard checks for mandatory input and output links.
+    '''
+
     def real_process(node):
         # check_mandatory_links() node method should return True
         # if all mandatory inputs and outputs are linked.
@@ -287,6 +291,19 @@ def checking_links(process):
     return real_process
 
 def iterate_process(method, matcher, *inputs):
+    '''Shortcut function for usual iteration over set of input lists.
+    This is shortcut for boilerplate code like
+
+        res1 = []
+        res2 = []
+        params = match_long_repeat([input1,input2])
+        for i1, i2 in zip(*params):
+            r1,r2 = self.method(i1,i2)
+            res1.append(r1)
+            res2.append(r2)
+        return res1, res2
+    '''
+
     data = matcher(inputs)
     results = [list(method(*d)) for d in zip(*data)]
     return list(zip(*results))

--- a/data_structure.py
+++ b/data_structure.py
@@ -300,6 +300,7 @@ def checking_links(process):
 
 def iterate_process(method, matcher, *inputs, node=None):
     '''Shortcut function for usual iteration over set of input lists.
+
     This is shortcut for boilerplate code like
 
         res1 = []
@@ -320,6 +321,8 @@ def iterate_process(method, matcher, *inputs, node=None):
     return list(zip(*results))
 
 class Input(object):
+    '''Node input socket metainformation descriptor.'''
+
     def __init__(self, socktype, name, identifier=None, is_mandatory=True, default=sentinel, deepcopy=True):
         self.socktype = socktype
         self.name = name
@@ -338,6 +341,8 @@ class Input(object):
         return node.inputs[self.name].sv_get(default=self.default, deepcopy=self.deepcopy)
 
 class Output(object):
+    '''Node output socket metainformation descriptor.'''
+
     def __init__(self, socktype, name, is_mandatory=True):
         self.socktype = socktype
         self.name = name
@@ -354,6 +359,37 @@ class Output(object):
             node.outputs[self.name].sv_set(value)
 
 def match_inputs(matcher, inputs, outputs):
+    '''Decorator for inputs/outputs boilerplate.
+
+    Usage:
+
+    @match_inputs(match_long_repeat,
+                  inputs=[Input(...), Input(...)],
+                  outputs=[Output(...), Output(...)])
+    def process(self, i1, i2):
+        ...
+        return res1, res2
+
+    This is shortcut for code like
+
+    def process(self):
+        i1s = self.inputs['i1'].sv_get(..)
+        i2s = self.inputs['i2'].sv_get(..)
+        res1 = []
+        res2 = []
+
+        params = match_long_repeat([i1s, i2s])
+        for i1,i2 in zip(*params):
+            ...
+            res1.append(r1)
+            res2.append(r2)
+
+        if self.outputs['r1'].is_linked:
+            self.outputs['r1'].sv_set(res1)
+        if self.outputs['r2'].is_linked:
+            self.outputs['r2'].sv_set(res2)
+    '''
+
     def decorator(process):
         def real_process(node):
             inputs_data = [input_descriptor.get(node) for input_descriptor in inputs]
@@ -369,6 +405,13 @@ def match_inputs(matcher, inputs, outputs):
     return decorator
 
 def std_links_processing(matcher):
+    '''Shortcut decorator for "standard" inputs/outputs sockets processing routine.
+
+    This is shortcut for combination of @checking_links and @match_inputs.
+    Inputs and outputs descriptors are taken from node.input_descriptors and
+    node.output_descriptors correspondingly.
+    '''
+
     def decorator(process):
         def real_process(node):
             nonlocal process

--- a/node_tree.py
+++ b/node_tree.py
@@ -319,6 +319,10 @@ class SverchCustomTreeNode:
             self.color = color
 
     def create_sockets(self):
+        '''Create node input and output sockets from
+        their descriptions in self.input_descriptors and self.output_descriptors.
+        '''
+
         if hasattr(self, "input_descriptors"):
             for descriptor in self.input_descriptors:
                 descriptor.create(self)

--- a/node_tree.py
+++ b/node_tree.py
@@ -27,15 +27,13 @@ from bpy.types import NodeTree, NodeSocket, NodeSocketStandard
 from sverchok import data_structure
 from sverchok.data_structure import (SvGetSocketInfo, SvGetSocket,
                                      SvSetSocket, updateNode,
-                                     get_other_socket, SvNoDataError)
+                                     get_other_socket, SvNoDataError,
+                                     sentinel)
 
 from sverchok.core.update_system import (build_update_list, process_from_node,
                                          process_tree, get_update_lists,
                                          update_error_nodes)
 from sverchok.ui import color_def
-
-sentinel = object()
-
 
 def process_from_socket(self, context):
     self.node.process_node(context)
@@ -319,6 +317,17 @@ class SverchCustomTreeNode:
         if color:
             self.use_custom_color = True
             self.color = color
+
+    def create_sockets(self):
+        if hasattr(self, "input_descriptors"):
+            for descriptor in self.input_descriptors:
+                descriptor.create(self)
+        if hasattr(self, "output_descriptors"):
+            for descriptor in self.output_descriptors:
+                descriptor.create(self)
+
+    def sv_init(self, context):
+        self.create_sockets()
 
     def init(self, context):
         ng = self.id_data

--- a/nodes/modifier_change/triangulate.py
+++ b/nodes/modifier_change/triangulate.py
@@ -21,7 +21,7 @@ from bpy.props import IntProperty, EnumProperty, BoolProperty, FloatProperty
 import bmesh.ops
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import updateNode, match_long_repeat, fullList, checking_links, iterate_process
+from sverchok.data_structure import updateNode, match_long_repeat, fullList, checking_links, iterate_process, Input, Output, match_inputs, std_links_processing
 from sverchok.utils.sv_bmesh_utils import with_bmesh
 
 class SvTriangulateNode(bpy.types.Node, SverchCustomTreeNode):
@@ -54,27 +54,28 @@ class SvTriangulateNode(bpy.types.Node, SverchCustomTreeNode):
         default="0",
         update=updateNode)
 
-    mandatory_inputs = ['Vertices', 'Polygons']
-    mandatory_outputs = ['Vertices', 'Edges', 'Polygons', 'NewEdges', 'NewPolys']
+    input_descriptors = [
+         Input('VerticesSocket', 'Vertices', default=[[]]),
+         Input('StringsSocket',  'Edges',    default=[[]], is_mandatory=False),
+         Input('StringsSocket',  'Polygons', default=[[]]),
+         Input('StringsSocket',  'Mask',     default=[[True]], is_mandatory=False)
+        ]
 
-    def sv_init(self, context):
-        self.inputs.new('VerticesSocket', "Vertices", "Vertices")
-        self.inputs.new('StringsSocket', 'Edges', 'Edges')
-        self.inputs.new('StringsSocket', 'Polygons', 'Polygons')
-        self.inputs.new('StringsSocket', 'Mask')
-
-        self.outputs.new('VerticesSocket', 'Vertices')
-        self.outputs.new('StringsSocket', 'Edges')
-        self.outputs.new('StringsSocket', 'Polygons')
-        self.outputs.new('StringsSocket', 'NewEdges')
-        self.outputs.new('StringsSocket', 'NewPolys')
+    output_descriptors = [
+         Output('VerticesSocket', 'Vertices'),
+         Output('StringsSocket',  'Edges'),
+         Output('StringsSocket',  'Polygons'),
+         Output('StringsSocket',  'NewEdges'),
+         Output('StringsSocket',  'NewPolys')
+        ]
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "quad_mode")
         layout.prop(self, "ngon_mode")
 
+    @std_links_processing(match_long_repeat)
     @with_bmesh
-    def triangulate(self, bm, mask):
+    def process(self, bm, mask):
         fullList(mask, len(bm.faces))
 
         b_faces = []
@@ -90,32 +91,6 @@ class SvTriangulateNode(bpy.types.Node, SverchCustomTreeNode):
         b_new_faces = [[v.index for v in face.verts] for face in res['faces']]
 
         return bm, b_new_edges, b_new_faces
-
-    @checking_links
-    def process(self):
-
-        vertices_s = self.inputs['Vertices'].sv_get(default=[[]])
-        edges_s = self.inputs['Edges'].sv_get(default=[[]])
-        faces_s = self.inputs['Polygons'].sv_get(default=[[]])
-        mask_s = self.inputs['Mask'].sv_get(default=[[True]])
-
-        results = iterate_process(self.triangulate, match_long_repeat, vertices_s, edges_s, faces_s, mask_s)
-        result_vertices = results[0]
-        result_edges = results[1]
-        result_faces = results[2]
-        result_new_edges = results[3]
-        result_new_faces = results[4]
-
-        if self.outputs['Vertices'].is_linked:
-            self.outputs['Vertices'].sv_set(result_vertices)
-        if self.outputs['Edges'].is_linked:
-            self.outputs['Edges'].sv_set(result_edges)
-        if self.outputs['Polygons'].is_linked:
-            self.outputs['Polygons'].sv_set(result_faces)
-        if self.outputs['NewEdges'].is_linked:
-            self.outputs['NewEdges'].sv_set(result_new_edges)
-        if self.outputs['NewPolys'].is_linked:
-            self.outputs['NewPolys'].sv_set(result_new_faces)
 
 def register():
     bpy.utils.register_class(SvTriangulateNode)


### PR DESCRIPTION
I propose to simplify code of many nodes by removing duplicated boilerplate for standard inputs/outputs sockets processing routine.

Summary of changes:
* Decorator for checking if mandatory inputs/outputs are connected — checking_links.
* Classes for node input/output sockets metainformation.
* Such metainformation enables us to write default implementation of sv_init().
* Shortcut decorators for most "standard" (i beleive) routine of input/output data processing and matching of input lists — match_inputs and std_inputs_processing.
* Shortcut decorator for nodes which work by converting input lists to BMesh and then BMesh to lists again.

I also changed one pretty simple node to use changed API, for proof-of-concept and testing purposes. As you can see this change allows us to remove about 30 lines of boilerplate code from each node which uses "standard" inputs processing. Metainformation about input and output sockets can be also used later by upgrade system.
I tried to maintain backwards compatibility. All "old" nodes, which do not use new features, should work as they were.

Please review and test. Any suggestions are welcome.
