### PR TITLE
CSGBoolean tweak to work arround  isinstance(args[0], Vector) returning false when passed a Vector instance

### DIFF
--- a/utils/csg_core.py
+++ b/utils/csg_core.py
@@ -80,7 +80,7 @@ class CSG(object):
             polyg = []
             for idx in face:
                 co = verts[idx]
-                polyg.append(Vertex(Vector(*co)))
+                polyg.append(Vertex(co))
             polygons.append(Polygon(polyg))
 
         return CSG.fromPolygons(polygons)


### PR DESCRIPTION
I'm not sure why but isinstance(args[0], Vector) appears to return false when initializing a Vector with a previously created Vector instance.  I wonder how feasible it would be to simplify Vector initialization to just always expect a list.

Regardless, this PR seems to get the current CSGBoolen implementation working.