### PR TITLE
Add UdpClientNode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ docs/_build
 docs/.make.bat.swp
 
 nodes/generator/meta_balls.py
+
+# IDE
+.idea

--- a/menu.py
+++ b/menu.py
@@ -231,6 +231,10 @@ def make_node_cats():
         ["ConverterNode",       "SocketConvert"],
     ]
 
+    node_cats['Network'] = [
+        ["UdpClientNode", "UDP Client"]
+    ]
+
     node_cats["Beta Nodes"] = [
         # for testing convenience, and while no documentation
         ['SvBevelNode',           "Bevel"],

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -208,6 +208,10 @@ nodes_dict = {
         'vertices_delete_doubles',
         'vertices_sort',
         'axis_input'
+    ],
+
+    'network': [
+        'udp_client'
     ]
 
 }

--- a/nodes/network/udp_client.py
+++ b/nodes/network/udp_client.py
@@ -1,0 +1,97 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import socket
+
+import bpy
+from bpy.props import IntProperty, FloatProperty, EnumProperty, StringProperty, BoolProperty
+from sverchok.node_tree import SverchCustomTreeNode, StringsSocket
+
+
+class UdpClientNode(bpy.types.Node, SverchCustomTreeNode):
+
+    bl_idname = 'UdpClientNode'
+    bl_label = 'UdpClient'
+
+    def send(self, context):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.setblocking(0)
+        sock.settimeout(self.timeout)
+        sock.sendto(bytes(self.send, 'UTF-8'), (self.ip, self.port))
+        try:
+            data, _ = sock.recvfrom(self.buffer_size)
+            self.receive = data.decode('UTF-8')
+        except socket.timeout:
+            print('Timeout')
+
+    send = StringProperty(name='send',
+                          description='Message to send',
+                          default='message',
+                          update=send)
+
+    receive = StringProperty(name='receive',
+                             description='Received message',
+                             default='')
+
+    ip = StringProperty(name='ip',
+                        description='IP address of server',
+                        default='127.0.0.1')
+
+    port = IntProperty(name='port',
+                       description='Port number to send message',
+                       default=9250)
+
+    buffer_size = IntProperty(name='buffer_size',
+                              description='Size of buffer',
+                              default=8192)
+
+    timeout = FloatProperty(name='timeout',
+                            description='Timeout (sec)',
+                            default=0.5)
+
+    active = BoolProperty(default=False, name='Active')
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'active', text='Active')
+        layout.prop(self, 'ip', text='IP')
+        layout.prop(self, 'port', text='Port')
+        layout.prop(self, 'buffer_size', text='Buffer')
+        layout.prop(self, 'timeout', text='Timeout')
+
+    def sv_init(self, context):
+        self.inputs.new('StringsSocket', 'send', 'send').prop_name = 'send'
+        self.outputs.new('StringsSocket', 'receive', 'receive')
+
+    def process(self):
+        if not self.active:
+            return
+
+        input_value = self.inputs[0].sv_get()
+        if self.send != input_value:
+            self.send = input_value
+
+        if self.outputs['receive'].is_linked:
+            self.outputs['receive'].sv_set(self.receive)
+
+
+def register():
+    bpy.utils.register_class(UdpClientNode)
+
+
+def unregister():
+    bpy.utils.unregister_class(UdpClientNode)


### PR DESCRIPTION
I have created UDP Client node to communicate with other programs as I mentioned #705. Please review it.

# Appearance
![image](https://cloud.githubusercontent.com/assets/1885971/9835270/71269ccc-5a1d-11e5-8f26-a6e616e4770b.png)

# Function
- Send UDP message given form inlet to server which has specified ip address and port number.
- If the node receive any message from server, received message will directly send to outlet (receive).

# Example
![image](https://cloud.githubusercontent.com/assets/1885971/9835275/caf1c63c-5a1d-11e5-84dc-2c9331d356c4.png)
- This is a short usage example of this node. UdpClient node receives current frame number from inlet and send it to the remote server. In this example, I built server as a simple echo server so server returns frame number to the node.
- I am currently planing to use this node to communicate with another program which is analyzing music sound date in real-time to show sound wave in sverchok like [this](https://twitter.com/taxpon/status/638680331684438016)