### PR TITLE
Add check for `self.plane` in `CSGNode.flip`

### DIFF
--- a/utils/csg_geom.py
+++ b/utils/csg_geom.py
@@ -276,7 +276,8 @@ class CSGNode(object):
         """
         for poly in self.polygons:
             poly.flip()
-        self.plane.flip()
+        if self.plane:
+            self.plane.flip()
         if self.front:
             self.front.invert()
         if self.back:


### PR DESCRIPTION
The `clone` method checks for the existence of `self.plane` before calling `self.plane.clone()`. This commit adds the same check to the `invert` method.