### PR TITLE
this one is for souix nation #NODAPL

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -45,7 +45,7 @@ bl_info = {
         "AgustinJB, Zeffii, Kosvor, "
         "Portnov, Elfnor"
     ),
-    "version": (0, 5, 7, 8),
+    "version": (0, 5, 7, 9),
     "blender": (2, 7, 9),
     "location": "Nodes > CustomNodesTree > Add user nodes",
     "description": "Parametric node-based geometry programming",

--- a/utils/snlite_utils.py
+++ b/utils/snlite_utils.py
@@ -19,6 +19,9 @@
 
 import bpy
 
+from sverchok.data_structure import match_long_repeat
+
+
 def get_valid_node(mat_name, node_name, bl_idname):
 
     materials = bpy.data.materials
@@ -57,3 +60,16 @@ def get_valid_evaluate_function(mat_name, node_name):
 
     return curve.evaluate
 
+
+def vectorize(all_data):
+
+    def listify(data):
+        print(data)
+        if isinstance(data, (int, float)):
+            data = [data]
+        return data
+
+    for idx, d in enumerate(all_data):
+        all_data[idx] = listify(d)
+
+    return match_long_repeat(all_data)


### PR DESCRIPTION
- add snlite helper `vectorize` (   `from sverchok.utils.snlite_utils import vectorize`  )
- add optional injection of a variable named `parameters` that is a list of all named inputs. meaning, if you had 3 inputs named `radius, control1, width` , then _parameters_ would be a wrapped list of those variables, effectively the same as `parameters = [radius, control1, width].

that can be written as this now.
```python
"""
in petals       s d=8    n=1 
in innerradius  s d=0.5  n=1 
in outerradius  s d=1.0  n=1
in petalwidth   s d=2.0  n=1
out points      v
out faces       s
"""

from add_curve_extra_objects.add_curve_aceous_galore import FlowerCurve
from sverchok.utils.snlite_utils import vectorize

params = vectorize(parameters)
points = [FlowerCurve(*param_set) for param_set in zip(*params)]
faces = [[list(range(len(n)))] for n in points]
```
the `parameters` variable is injected ( if the tickbox is enabled in the side bar for snlite )

  - ![image](https://cloud.githubusercontent.com/assets/619340/20759835/776bd0b6-b71e-11e6-85f6-77135c05426b.png)

and the `vectorize` function is part of the snlite helper library now.