### PR TITLE
Fix refactoring typo

### DIFF
--- a/nodes/transforms/scale.py
+++ b/nodes/transforms/scale.py
@@ -68,7 +68,7 @@ class SvScaleNode(bpy.types.Node, SverchCustomTreeNode):
 
     def process(self):
         # inputs
-        self.inputs['Vertices'].sv_get()
+        Vertices = self.inputs['Vertices'].sv_get()
         Center = self.inputs['Center'].sv_get(default=[[[0.0, 0.0, 0.0]]])
         Factor = self.inputs['Factor'].sv_get()
 


### PR DESCRIPTION
"Scale" node was not working. I guess it is a typo while refactoring.