### PR TITLE
Normals pass2

### DIFF
--- a/nodes/analyzer/normals.py
+++ b/nodes/analyzer/normals.py
@@ -28,8 +28,7 @@ from sverchok.data_structure import updateNode, match_long_repeat
 from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata, pydata_from_bmesh
 
 def calc_mesh_normals(vertices, edges, faces):
-    bm = bmesh_from_pydata(vertices, edges, faces)
-    bm.normal_update()
+    bm = bmesh_from_pydata(vertices, edges, faces, normal_update=True)
     vertex_normals = []
     face_normals = []
     for vertex in bm.verts:

--- a/nodes/analyzer/volume.py
+++ b/nodes/analyzer/volume.py
@@ -48,12 +48,8 @@ class SvVolumeNode(bpy.types.Node, SverchCustomTreeNode):
 
             out = []
             for verts_obj, faces_obj in zip(vertices, faces):
-                # this is for one object
-                bm = bmesh_from_pydata(verts_obj, [], faces_obj)
-                # geom_in = bm.verts[:] + bm.edges[:] + bm.faces[:]
-                bmesh.ops.recalc_face_normals(bm, faces=bm.faces[:])
+                bm = bmesh_from_pydata(verts_obj, [], faces_obj, normal_update=True)
                 out.append(bm.calc_volume())
-                bm.clear()
                 bm.free()
  
             vol_socket.sv_set(out)

--- a/nodes/modifier_change/holes_fill.py
+++ b/nodes/modifier_change/holes_fill.py
@@ -33,7 +33,8 @@ def fill_holes(vertices, edges, s):
     if len(edges[0]) != 2:
         return False
     
-    bm = bmesh_from_pydata(vertices, edges, [], normals='f')
+    bm = bmesh_from_pydata(vertices, edges, [], normal_update=True)
+
     bmesh.ops.holes_fill(bm, edges=bm.edges[:], sides=s)
     verts, edges, faces = pydata_from_bmesh(bm)
     return (verts, edges, faces)

--- a/nodes/modifier_change/holes_fill.py
+++ b/nodes/modifier_change/holes_fill.py
@@ -22,7 +22,7 @@ import bmesh
 
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode, repeat_last, dataCorrect
-from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata
+from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata, pydata_from_bmesh
 
 
 def fill_holes(vertices, edges, s):
@@ -33,21 +33,25 @@ def fill_holes(vertices, edges, s):
     if len(edges[0]) != 2:
         return False
     
-    bm = bmesh_from_pydata(vertices, edges, [])
-    res = bmesh.ops.holes_fill(bm, edges=bm.edges[:], sides=s)
-    bmesh.ops.recalc_face_normals(bm, faces=bm.faces[:])
-    edges = []
-    faces = []
-    bm.verts.index_update()
-    bm.edges.index_update()
-    bm.faces.index_update()
-    for edge in bm.edges[:]:
-        edges.append([v.index for v in edge.verts[:]])
-    verts = [vert.co[:] for vert in bm.verts[:]]
-    for face in bm.faces:
-        faces.append([v.index for v in face.verts[:]])
-    bm.clear()
-    bm.free()
+    bm = bmesh_from_pydata(vertices, edges, [], normals='f')
+    bmesh.ops.holes_fill(bm, edges=bm.edges[:], sides=s)
+
+    # bmesh.ops.recalc_face_normals(bm, faces=bm.faces[:])
+
+    # edges = []
+    # faces = []
+    # bm.verts.index_update()
+    # bm.edges.index_update()
+    # bm.faces.index_update()
+    # for edge in bm.edges[:]:
+    #     edges.append([v.index for v in edge.verts[:]])
+    # verts = [vert.co[:] for vert in bm.verts[:]]
+    # for face in bm.faces:
+    #     faces.append([v.index for v in face.verts[:]])
+    # bm.clear()
+    # bm.free()
+    verts, edges, faces = pydata_from_bmesh(bm)
+
     return (verts, edges, faces)
 
 

--- a/nodes/modifier_change/holes_fill.py
+++ b/nodes/modifier_change/holes_fill.py
@@ -35,23 +35,7 @@ def fill_holes(vertices, edges, s):
     
     bm = bmesh_from_pydata(vertices, edges, [], normals='f')
     bmesh.ops.holes_fill(bm, edges=bm.edges[:], sides=s)
-
-    # bmesh.ops.recalc_face_normals(bm, faces=bm.faces[:])
-
-    # edges = []
-    # faces = []
-    # bm.verts.index_update()
-    # bm.edges.index_update()
-    # bm.faces.index_update()
-    # for edge in bm.edges[:]:
-    #     edges.append([v.index for v in edge.verts[:]])
-    # verts = [vert.co[:] for vert in bm.verts[:]]
-    # for face in bm.faces:
-    #     faces.append([v.index for v in face.verts[:]])
-    # bm.clear()
-    # bm.free()
     verts, edges, faces = pydata_from_bmesh(bm)
-
     return (verts, edges, faces)
 
 

--- a/nodes/modifier_change/offset.py
+++ b/nodes/modifier_change/offset.py
@@ -47,7 +47,7 @@ class SvOffsetNode(bpy.types.Node, SverchCustomTreeNode):
         default=1, min=1, max=64,
         options={'ANIMATABLE'}, update=updateNode)
     radius = FloatProperty(
-        name='redius', description='radius of inset',
+        name='radius', description='radius of inset',
         default=0.04, min=0.0001,
         options={'ANIMATABLE'}, update=updateNode)
 

--- a/nodes/modifier_change/offset.py
+++ b/nodes/modifier_change/offset.py
@@ -51,16 +51,6 @@ class SvOffsetNode(bpy.types.Node, SverchCustomTreeNode):
         default=0.04, min=0.0001,
         options={'ANIMATABLE'}, update=updateNode)
 
-    mode_options = [(op, op, '', idx) for idx, op in enumerate(['fast', 'accurate'])]
-
-    selected_mode = bpy.props.EnumProperty(
-        items=mode_options,
-        description="offers which kind of recalc is desired",
-        default="fast", update=updateNode)
-
-    def draw_buttons(self, context, layout):
-        layout.prop(self, 'selected_mode', expand=True)
-
     def sv_init(self, context):
         self.inputs.new('VerticesSocket', 'Vers')
         self.inputs.new('StringsSocket', "Pols")
@@ -94,9 +84,7 @@ class SvOffsetNode(bpy.types.Node, SverchCustomTreeNode):
             fullList(radius, len(faces_obj))
             verlen = set(range(len(verts_obj)))
 
-            settings = {'normals': 'f' if self.selected_mode == 'accurate' else 'x'}
-            bm = bmesh_from_pydata(verts_obj, [], faces_obj, **settings)
-            
+            bm = bmesh_from_pydata(verts_obj, [], faces_obj, normal_update=True)
             result = self.Offset_pols(bm, offset, radius, nsides, verlen)
             outv.append(result[0])
             oute.append(result[1])
@@ -140,7 +128,7 @@ class SvOffsetNode(bpy.types.Node, SverchCustomTreeNode):
 
             f.select_set(0)
             list_del.append(f)
-            f.normal_update()
+            # f.normal_update()
 
             list_2 = [v.index for v in f.verts]
             dict_0 = {}
@@ -258,7 +246,6 @@ class SvOffsetNode(bpy.types.Node, SverchCustomTreeNode):
             else:
                 faces.append(indexes)
 
-        bme.clear()
         bme.free()
         return (verts, edges, faces, newpols)
 

--- a/nodes/modifier_change/offset.py
+++ b/nodes/modifier_change/offset.py
@@ -16,19 +16,20 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
-import bpy
-from bpy.props import BoolProperty, StringProperty, IntProperty, FloatProperty
+from math import tan, sin, cos, degrees, radians
 
+
+import bpy
 import bmesh
+from bpy.props import IntProperty, FloatProperty
+from mathutils import Matrix
+
 from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import (
-    changable_sockets, multi_socket,
-    fullList, dataCorrect, updateNode, Vector_generate
+    fullList, updateNode, Vector_generate
 )
 
-from mathutils import Vector, Matrix
-from math import tan, sin, cos, degrees, radians
 
 
 class SvOffsetNode(bpy.types.Node, SverchCustomTreeNode):
@@ -50,8 +51,15 @@ class SvOffsetNode(bpy.types.Node, SverchCustomTreeNode):
         default=0.04, min=0.0001,
         options={'ANIMATABLE'}, update=updateNode)
 
+    mode_options = [(op, op, '', idx) for idx, op in enumerate(['fast', 'accurate'])]
+
+    selected_mode = bpy.props.EnumProperty(
+        items=mode_options,
+        description="offers which kind of recalc is desired",
+        default="fast", update=updateNode)
+
     def draw_buttons(self, context, layout):
-        pass
+        layout.prop(self, 'selected_mode', expand=True)
 
     def sv_init(self, context):
         self.inputs.new('VerticesSocket', 'Vers')
@@ -74,23 +82,25 @@ class SvOffsetNode(bpy.types.Node, SverchCustomTreeNode):
         offset = self.inputs['Offset'].sv_get()[0]
         nsides = self.inputs['N sides'].sv_get()[0][0]
         radius = self.inputs['Radius'].sv_get()[0]
-        #print(radius,nsides,offset)
+
         outv = []
         oute = []
         outo = []
         outn = []
+
+        # for each object
         for verts_obj, faces_obj in zip(vertices, faces):
-            # this is for one object
             fullList(offset, len(faces_obj))
             fullList(radius, len(faces_obj))
             verlen = set(range(len(verts_obj)))
-            bme = bmesh_from_pydata(verts_obj, [], faces_obj)
-            geom_in = bme.verts[:]+bme.edges[:]+bme.faces[:]
-            bmesh.ops.recalc_face_normals(bme, faces=bme.faces[:])
-            list_0 = [f.index for f in bme.faces]
-            # calculation itself
-            result = \
-                self.Offset_pols(bme, list_0, offset, radius, nsides, verlen)
+
+            if self.selected_mode == 'accurate':
+                bm = bmesh_from_pydata(verts_obj, [], faces_obj, normals='f')
+            else:
+                bm = bmesh_from_pydata(verts_obj, [], faces_obj)
+                bmesh.ops.recalc_face_normals(bm, faces=bm.faces[:])
+            
+            result = self.Offset_pols(bm, offset, radius, nsides, verlen)
             outv.append(result[0])
             oute.append(result[1])
             outo.append(result[2])
@@ -107,7 +117,8 @@ class SvOffsetNode(bpy.types.Node, SverchCustomTreeNode):
     #   in russian is called "Круговая порука", Various artists
     # #################
 
-    def a_rot(self, ang, rp, axis, q):
+    @staticmethod
+    def a_rot(ang, rp, axis, q):
         return (Matrix.Rotation(ang, 3, axis) * (q - rp)) + rp
 
     # #################
@@ -118,17 +129,22 @@ class SvOffsetNode(bpy.types.Node, SverchCustomTreeNode):
     # kp -      keep face, not delete it.
     # #################
 
-    def Offset_pols(self, bme, list_0, offset, radius, n_, verlen):
+    def Offset_pols(self, bme, offset, radius, n_, verlen):
 
         bm_verts = bme.verts
         bm_faces = bme.faces
         bm_edges = bme.edges
 
+        list_0 = bme.faces[:]
+
         list_del = []  # to delete old shape polygons
-        for q, fi in enumerate(list_0):
+        for q, f in enumerate(list_0):
             adj1 = radius[q]
             opp = offset[q]
-            f = bm_faces[fi]
+
+            #
+            # bm_faces.ensure_lookup_table()
+
             f.select_set(0)
             list_del.append(f)
             f.normal_update()
@@ -206,12 +222,7 @@ class SvOffsetNode(bpy.types.Node, SverchCustomTreeNode):
                     list_3.reverse()
                     list_2.extend(list_3)
 
-            # if kp == True: #not solved
             new_face = bm_faces.new(list_2)
-
-            # if hasattr(bm_faces, "ensure_lookup_table"):
-            #     bm_faces.ensure_lookup_table()
-            # bm_faces[-1].select_set(1)
             new_face.select_set(1)
 
             n2_ = len(dict_0)
@@ -219,35 +230,21 @@ class SvOffsetNode(bpy.types.Node, SverchCustomTreeNode):
                 list_a = dict_0[o]
                 list_b = dict_0[(o + 1) % n2_]
                 bm_faces.new([list_a[0], list_b[0], list_b[-1], list_a[1]])
-                # bm_faces.index_update()
 
             # keeping triangulation of polygons commented
-            #if en0 == 'opt0':
             for k in dict_0:
                 if len(dict_0[k]) > 2:
                     bm_faces.new(dict_0[k])
-            #if en0 == 'opt1':
-            #    for k_ in dict_0:
-            #        q_ = dict_0[k_][0]
-            #        dict_0[k_].pop(0)
-            #        n3_ = len(dict_0[k_])
-            #        for kk in range(n3_ - 1):
-            #            bme.faces.new( [ dict_0[k_][kk], dict_0[k_][(kk + 1) % n3_], q_ ] )
-            #            bme.faces.index_update()
 
             # new indices for next iteration of loop
-            if hasattr(bm_verts, "ensure_lookup_table"):
-                bm_verts.ensure_lookup_table()
-                bm_faces.ensure_lookup_table()
+            bm_verts.ensure_lookup_table()
+            bm_faces.ensure_lookup_table()
 
-        # this is old
-        del_ = [bm_faces.remove(f) for f in list_del]
-        del del_
-        # i think, it deletes doubling faces
+        # remove old polygons
+        _ = [bm_faces.remove(f) for f in list_del]
 
         # remove doubles
         bmesh.ops.remove_doubles(bme, dist=0.0001)
-        # if radius 0 than cleaning loose
 
         # from Linus Yng solidify example
         edges = []

--- a/nodes/modifier_change/offset.py
+++ b/nodes/modifier_change/offset.py
@@ -94,11 +94,8 @@ class SvOffsetNode(bpy.types.Node, SverchCustomTreeNode):
             fullList(radius, len(faces_obj))
             verlen = set(range(len(verts_obj)))
 
-            if self.selected_mode == 'accurate':
-                bm = bmesh_from_pydata(verts_obj, [], faces_obj, normals='f')
-            else:
-                bm = bmesh_from_pydata(verts_obj, [], faces_obj)
-                bmesh.ops.recalc_face_normals(bm, faces=bm.faces[:])
+            settings = {'normals': 'f' if self.selected_mode == 'accurate' else 'x'}
+            bm = bmesh_from_pydata(verts_obj, [], faces_obj, **settings)
             
             result = self.Offset_pols(bm, offset, radius, nsides, verlen)
             outv.append(result[0])

--- a/nodes/modifier_change/offset.py
+++ b/nodes/modifier_change/offset.py
@@ -131,16 +131,12 @@ class SvOffsetNode(bpy.types.Node, SverchCustomTreeNode):
         bm_verts = bme.verts
         bm_faces = bme.faces
         bm_edges = bme.edges
-
         list_0 = bme.faces[:]
 
         list_del = []  # to delete old shape polygons
         for q, f in enumerate(list_0):
             adj1 = radius[q]
             opp = offset[q]
-
-            #
-            # bm_faces.ensure_lookup_table()
 
             f.select_set(0)
             list_del.append(f)

--- a/nodes/modifier_change/recalc_normals.py
+++ b/nodes/modifier_change/recalc_normals.py
@@ -68,8 +68,7 @@ class SvRecalcNormalsNode(bpy.types.Node, SverchCustomTreeNode):
 
         for vertices, edges, faces, mask in zip(*meshes):
 
-            bm = bmesh_from_pydata(vertices, edges, faces)
-            bm.normal_update()
+            bm = bmesh_from_pydata(vertices, edges, faces, normal_update=True)
             fullList(mask, len(faces))
 
             b_faces = []

--- a/nodes/modifier_make/polygons_adaptative.py
+++ b/nodes/modifier_make/polygons_adaptative.py
@@ -81,20 +81,11 @@ class AdaptivePolsNode(bpy.types.Node, SverchCustomTreeNode):
             polsD = self.inputs['PolsD'].sv_get()  # donor many objects [:]
             versD_ = self.inputs['VersD'].sv_get()  # donor
             versD = Vector_generate(versD_)
-            ##### it is needed for normals of vertices
             polsR, polsD, versD = match_long_repeat([polsR, polsD, versD])
-            bm = bmesh_from_pydata(versR, [], polsR, normals='vf')
 
-            #bmesh.ops.recalc_face_normals(bm, faces=bm.faces[:])
+            bm = bmesh_from_pydata(versR, [], polsR, normal_update=True)
             bm.verts.ensure_lookup_table()
             new_ve = bm.verts
-
-            #new_me = bpy.data.meshes.new('recepient')
-            #new_me.from_pydata(versR, [], polsR)
-            #new_me.update(calc_edges=True)
-
-            #new_ve = new_me.vertices
-            #print (new_ve[0].normal, 'normal')
 
             vers_out = []
             pols_out = []
@@ -103,8 +94,6 @@ class AdaptivePolsNode(bpy.types.Node, SverchCustomTreeNode):
                 # part of donor to make limits
                 j = i
                 pD = polsD[i]
-                n_verts = len(vD)
-                n_faces = len(pD)
 
                 xx = [x[0] for x in vD]
                 x0 = (self.width_coef) / (max(xx)-min(xx))
@@ -116,10 +105,8 @@ class AdaptivePolsNode(bpy.types.Node, SverchCustomTreeNode):
                     z0 = 1 / zzz
                 else:
                     z0 = 0
-                #print (x0, y0, z0)
 
                 # part of recipient polygons to reciev donor
-
                 last = len(pR)-1
                 vs = [new_ve[v] for v in pR]  # new_ve  - temporery data
                 if z_coef:
@@ -137,15 +124,11 @@ class AdaptivePolsNode(bpy.types.Node, SverchCustomTreeNode):
                 pols_out.append(new_pols)
                 vers_out.append(new_vers)
                 i += 1
-            #bpy.data.meshes.remove(new_me)  # cleaning and washing
-            bm.free()
-            #print (Vector_degenerate(vers_out))
 
+            bm.free()
             output = Vector_degenerate(vers_out)
-            #print (output)
 
             self.outputs['Vertices'].sv_set(output)
-
             self.outputs['Poligons'].sv_set(pols_out)
 
 

--- a/nodes/modifier_make/solidify.py
+++ b/nodes/modifier_make/solidify.py
@@ -78,7 +78,7 @@ class SvSolidifyNode(bpy.types.Node, SverchCustomTreeNode):
 
     selected_mode = bpy.props.EnumProperty(
         items=mode_options,
-        description="offers which kind of recal is desired",
+        description="offers which kind of recalc is desired",
         default="fast", update=updateNode)
 
     def sv_init(self, context):

--- a/nodes/modifier_make/solidify.py
+++ b/nodes/modifier_make/solidify.py
@@ -26,7 +26,7 @@ from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata
 # by Linus Yng
 
 
-def solidify(vertices, faces, t, mode='accurate'):
+def solidify(vertices, faces, t):
 
     if not faces or not vertices:
         return False
@@ -36,12 +36,7 @@ def solidify(vertices, faces, t, mode='accurate'):
 
     verlen = set(range(len(vertices)))
 
-    if mode == 'accurate':
-        bm = bmesh_from_pydata(vertices, [], faces, normals='f')
-    else:
-        bm = bmesh_from_pydata(vertices, [], faces)
-        bmesh.ops.recalc_face_normals(bm, faces=bm.faces[:])
-
+    bm = bmesh_from_pydata(vertices, [], faces, normal_update=True)
     geom_in = bm.verts[:] + bm.edges[:] + bm.faces[:]
     bmesh.ops.solidify(bm, geom=geom_in, thickness=t[0])
 
@@ -74,13 +69,6 @@ class SvSolidifyNode(bpy.types.Node, SverchCustomTreeNode):
         name='Thickness', description='Shell thickness',
         default=0.1, update=updateNode)
 
-    mode_options = [(op, op, '', idx) for idx, op in enumerate(['fast', 'accurate'])]
-
-    selected_mode = bpy.props.EnumProperty(
-        items=mode_options,
-        description="offers which kind of recalc is desired",
-        default="fast", update=updateNode)
-
     def sv_init(self, context):
         self.inputs.new('StringsSocket', 'thickness').prop_name = 'thickness'
         self.inputs.new('VerticesSocket', 'vertices')
@@ -91,8 +79,6 @@ class SvSolidifyNode(bpy.types.Node, SverchCustomTreeNode):
         self.outputs.new('StringsSocket', 'polygons')
         self.outputs.new('StringsSocket', 'newpols')
 
-    def draw_buttons(self, context, layout):
-        layout.prop(self, 'selected_mode', expand=True)
 
     def process(self):
         if not any((s.is_linked for s in self.outputs)):
@@ -111,7 +97,7 @@ class SvSolidifyNode(bpy.types.Node, SverchCustomTreeNode):
         newpo_out = []
         fullList(thickness, len(verts))
         for v, p, t in zip(verts, polys, thickness):
-            res = solidify(v, p, t, mode=self.selected_mode)
+            res = solidify(v, p, t)
 
             if not res:
                 return

--- a/nodes/vector/normal.py
+++ b/nodes/vector/normal.py
@@ -40,26 +40,11 @@ class VectorNormalNode(bpy.types.Node, SverchCustomTreeNode):
 
         normalsFORout = []
         for i, obj in enumerate(vers):
-            """
-            mesh_temp = bpy.data.meshes.new('temp')
-            mesh_temp.from_pydata(obj, [], pols[i])
-            mesh_temp.update(calc_edges=True)
-            """
-            bm = bmesh_from_pydata(obj, [], pols[i])
-
-            bmesh.ops.recalc_face_normals(bm, faces=bm.faces[:])
-            bm.verts.ensure_lookup_table()
-            verts = bm.verts
-            tempobj = []
-
-            for idx in range(len(verts)):
-                tempobj.append(verts[idx].normal[:])
-
-            normalsFORout.append(tempobj)
+            bm = bmesh_from_pydata(obj, [], pols[i], normal_update=True)
+            normalsFORout.append([v.normal[:] for v in bm.verts])
             bm.free()
-
-        if self.outputs['Normals'].is_linked:
-            self.outputs['Normals'].sv_set(normalsFORout)
+        
+        self.outputs['Normals'].sv_set(normalsFORout)
 
 
 def register():

--- a/utils/sv_bmesh_utils.py
+++ b/utils/sv_bmesh_utils.py
@@ -89,7 +89,6 @@ def bmesh_from_pydata(verts=None, edges=None, faces=None, normals=""):
     if fast_face_normals:
         bmesh.ops.recalc_face_normals(bm, faces=bm.faces[:])
 
-    print('...\n', vertex_normals, face_normals, edge_normals, fast_face_normals)
     return bm
 
 

--- a/utils/sv_bmesh_utils.py
+++ b/utils/sv_bmesh_utils.py
@@ -94,8 +94,8 @@ def bmesh_from_pydata(verts=None, edges=None, faces=None, normals=""):
 
 def pydata_from_bmesh(bm):
     v = [v.co[:] for v in bm.verts]
-    e = [[i.index for i in e.verts] for e in bm.edges[:]]
-    p = [[i.index for i in p.verts] for p in bm.faces[:]]
+    e = [[i.index for i in e.verts] for e in bm.edges]
+    p = [[i.index for i in p.verts] for p in bm.faces]
     return v, e, p
 
 def with_bmesh(method):


### PR DESCRIPTION
- removed option fast/accurate for normal recal in solidfy, it is now correct + fast by default :)
- any node that was formerly doing recalc_normals now does a `bm.normal_update()` instead.
- removed the extra logic from `sv_bmesh_utils/  bmesh_from_pydata`
- removed the `[:]` from `sv_bmesh_utils/ pydata_from_bmesh` , not sure how that got there..?