### PR TITLE
View draw fix

### DIFF
--- a/core/socket_data.py
+++ b/core/socket_data.py
@@ -51,7 +51,11 @@ def SvGetSocketInfo(socket):
     if socket.is_output:
         s_id = socket.socket_id
     elif socket.is_linked:
-        s_id = socket.other.socket_id
+        other = socket.other
+        if other:
+            s_id = socket.other.socket_id
+        else:
+            return ''
     else:
         return ''
     if ng in socket_data_cache:

--- a/core/socket_data.py
+++ b/core/socket_data.py
@@ -53,7 +53,7 @@ def SvGetSocketInfo(socket):
     elif socket.is_linked:
         other = socket.other
         if other:
-            s_id = socket.other.socket_id
+            s_id = other.socket_id
         else:
             return ''
     else:

--- a/nodes/viz/viewer_mk2.py
+++ b/nodes/viz/viewer_mk2.py
@@ -370,7 +370,7 @@ class ViewerNode2(bpy.types.Node, SverchCustomTreeNode):
         # an unrecoverable crash. It might even be an idea to have step in between
         # new connections and processing, it could auto rewire s->s v->v m->m.
         def check_origin(to_socket, socket_type):
-            origin_socket_bl_idname = inputs[to_socket].links[0].from_socket.bl_idname
+            origin_socket_bl_idname = inputs[to_socket].other.bl_idname
 
             if isinstance(socket_type, str):
                 return origin_socket_bl_idname == sock_dict.get(socket_type)


### PR DESCRIPTION
Should handle a case during reconnection where an linked socket don't have an socket at the other end of the link.
#1185 