### PR TITLE
Add centering option to the plane node

### DIFF
--- a/nodes/generator/plane.py
+++ b/nodes/generator/plane.py
@@ -25,11 +25,17 @@ from sverchok.data_structure import updateNode, fullList, match_long_repeat
 from mathutils import Vector
 
 
-def make_plane(int_x, int_y, step_x, step_y, separate):
+def make_plane(int_x, int_y, step_x, step_y, separate, center):
     vertices = [(0.0, 0.0, 0.0)]
     vertices_S = []
     int_x = [int(int_x) if type(int_x) is not list else int(int_x[0])]
     int_y = [int(int_y) if type(int_y) is not list else int(int_y[0])]
+
+    # offset the starting point of the grid to center it
+    if center:
+        originX = -0.5*(int_x[0] - 1) * step_x[0]
+        originY = -0.5*(int_y[0] - 1) * step_y[0]
+        vertices = [(originX, originY, 0.0)]
 
     if type(step_x) is not list:
         step_x = [step_x]
@@ -103,6 +109,9 @@ class PlaneNode(bpy.types.Node, SverchCustomTreeNode):
     Separate = BoolProperty(name='Separate', description='Separate UV coords',
                             default=False,
                             update=updateNode)
+    Center = BoolProperty(name='Center', description='Center the grid',
+                          default=False,
+                          update=updateNode)
 
     def sv_init(self, context):
         self.inputs.new('StringsSocket', "Nº Vertices X").prop_name = 'int_X'
@@ -116,6 +125,7 @@ class PlaneNode(bpy.types.Node, SverchCustomTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "Separate", text="Separate")
+        layout.prop(self, "Center", text="Center")
 
     def process(self):
         inputs = self.inputs
@@ -130,7 +140,7 @@ class PlaneNode(bpy.types.Node, SverchCustomTreeNode):
         step_y = inputs["Step Y"].sv_get()
 
         params = match_long_repeat([int_x, int_y, step_x, step_y, [self.Separate]])
-        out = [a for a in (zip(*[make_plane(i_x, i_y, s_x, s_y, s) for i_x, i_y, s_x, s_y, s in zip(*params)]))]
+        out = [a for a in (zip(*[make_plane(i_x, i_y, s_x, s_y, s, self.Center) for i_x, i_y, s_x, s_y, s in zip(*params)]))]
 
         # outputs
         if outputs['Vertices'].is_linked:


### PR DESCRIPTION
Add option to the plane node to allow to generate the grid centered around origin.
The centering is OFF by default and it can be toggled on/off via the Center checkbox.

I’m not sure if the implementation is aligned with the contributing rules or the general design recommendations for the nodes, but I wanted to add a feature that I felt was missing in this node, namely the ability to center the grid around the origin. Using additional nodes to accomplish this simple  operation was in my opinion a bit too complicated and it would be easily achieved instead by simply providing a centering option. Other nodes like the Line node could adopt a similar feature.

![screen shot 2017-02-02 at 12 05 21 am](https://cloud.githubusercontent.com/assets/2083719/22537792/68a4ffbe-e8db-11e6-951f-8f1e37420687.png)
