### PR TITLE
adds gist url tracking to local storage, for user convenience

### DIFF
--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -219,6 +219,9 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
         # iterate through references
         for obj in (data_objects.get(o.name) for o in self.object_names):
 
+            if not obj:
+                continue
+
             edgs = []
             vers = []
             vers_grouped = []

--- a/utils/sv_IO_panel_tools.py
+++ b/utils/sv_IO_panel_tools.py
@@ -855,6 +855,9 @@ class SvNodeTreeExportToGist(bpy.types.Operator):
             context.window_manager.clipboard = gist_url   # full destination url
             print(gist_url)
             self.report({'WARNING'}, "Copied gistURL to clipboad")
+
+            sv_gist_tools.write_or_append_datafiles(gist_url, gist_filename)
+
         except:
             self.report({'ERROR'}, "Error uploading the gist, check your internet connection!")
         finally:


### PR DESCRIPTION
- Each time your upload an anonymous gist this generates or updates a file in `\datafiles\sverchok` , called `MMMM_DD_gist_uploads.csv`.
- small fix in `ob3`
- small fix to `gist to layout`  code.
