### PR TITLE
add exception handling to remove_keymap

### DIFF
--- a/ui/nodeview_keymaps.py
+++ b/ui/nodeview_keymaps.py
@@ -48,8 +48,16 @@ def add_keymap():
 
 
 def remove_keymap():
+
     for km, kmi in nodeview_keymaps:
-        km.keymap_items.remove(kmi)
+        try:
+            km.keymap_items.remove(kmi)
+        except Exception as e:
+            err = repr(e)
+            if "cannot be removed from 'Node Editor'" in err:
+                print('keymaps for Node Editor already removed by another add-on, sverchok will skip this step in unregister')
+                break
+
     nodeview_keymaps.clear()
 
 

--- a/ui/nodeview_space_menu.py
+++ b/ui/nodeview_space_menu.py
@@ -215,11 +215,21 @@ def add_keymap():
         kmi = km.keymap_items.new('wm.call_menu', 'SPACE', 'PRESS', ctrl=True)
         kmi.properties.name = "NODEVIEW_MT_Dynamic_Menu"
         nodeview_keymaps.append((km, kmi))
-    
+
+
 def remove_keymap():
+
     for km, kmi in nodeview_keymaps:
-        km.keymap_items.remove(kmi)
+        try:
+            km.keymap_items.remove(kmi)
+        except Exception as e:
+            err = repr(e)
+            if "cannot be removed from 'Node Editor'" in err:
+                print('keymaps for Node Editor already removed by another add-on, sverchok will skip this step in unregister')
+                break
+
     nodeview_keymaps.clear()
+
 
 def register():
     for class_name in classes:


### PR DESCRIPTION
```python
def remove_keymap():

    for km, kmi in nodeview_keymaps:
        try:
            km.keymap_items.remove(kmi)
        except Exception as e:
            err = repr(e)
            if "cannot be removed from 'Node Editor'" in err:
                print('keymaps for Node Editor already removed by another add-on, sverchok will skip this step in unregister')
                break

    nodeview_keymaps.clear()
```
or the more crude " hair on fire " 
```python
def remove_keymap():

    for km, kmi in nodeview_keymaps:
        if kmi.name in km.keymap_items:
            km.keymap_items.remove(kmi)

    nodeview_keymaps.clear()
```