### PR TITLE
Texture viewer node

### DIFF
--- a/docs/nodes/viz/texture_viewer.rst
+++ b/docs/nodes/viz/texture_viewer.rst
@@ -1,0 +1,53 @@
+Texture Viewer
+==============
+
+Functionality
+-------------
+
+This node allows viewing a list of scalar values as a texture, very useful
+to display data from fractal, noise nodes and others. before outputting to a viewer_draw_mk2.
+
+Uses OpenGl calls to display the data.
+
+Inputs
+------
+
+float input
+
+Parameters
+----------
+
++-------------+-----------------------------------------------------------------------------------+
+| Feature     | info                                                                              |
++=============+===================================================================================+
+| Float input | float nested list                                                                 |
++-------------+-----------------------------------------------------------------------------------+
+| Show        | true or false (to display or not the texture)                                     |
++-------------+-----------------------------------------------------------------------------------+
+| Set texture | choose the size of the texture to display:                                        |
+| display     | (64x64px,128x128px, 256x256px, 512x512px, 1024x1024px)                            |
++-------------+-----------------------------------------------------------------------------------+
+
+Outputs
+-------
+
+Directly into node tree view in a blue bordered square.
+
+Properties panel
+----------------
+
+You can save the texture in /tmp folder. You can choose the format (jpeg, bmp, tiff, tgat, png).
+Save the texture clicking on the button SAVE.
+
+Examples
+--------
+Basic usage:
+
+https://cloud.githubusercontent.com/assets/1275858/23259574/0ba15b60-f9ce-11e6-9fd4-75ece759929b.png
+
+Links
+-----
+
+dev. thread: https://github.com/nortikin/sverchok/pull/1255
+texture viewer proposal: https://github.com/nortikin/sverchok/issues/1248
+Texture script by @ly29: https://github.com/Sverchok/Sverchok/issues/56

--- a/index.md
+++ b/index.md
@@ -180,6 +180,7 @@
     SvBmeshViewerNodeMK2
     IndexViewerNode
     Sv3DviewPropsNode
+    SvTextureViewerNode
 
 ## Text
     ViewerNodeTextMK2

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -252,8 +252,16 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     def copy(self, node):
         self.n_id = ''
 
-def save_bitmap(self):
-    pass
+    def save_bitmap(self,):
+       img = bpy.data.images.new(name="depthmap", width=64,height=64,alpha=False, float_buffer=True)
+       img.colorspace_settings.name = 'Linear'
+       # bake() #implemented in separate function
+       img.file_format = 'PNG'
+       # need to set to 16-bit here
+       img.filepath_raw = "/tmp/my_new_bake.png"
+       img.save()
+       print('saved!')
+
 
 def register():
     bpy.utils.register_class(SvTextureViewerNode)

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -59,13 +59,13 @@ def simple_screen(x, y, args):
         bgl.glTexEnvf(bgl.GL_TEXTURE_ENV, bgl.GL_TEXTURE_ENV_MODE, bgl.GL_REPLACE)
         bgl.glBindTexture(bgl.GL_TEXTURE_2D, texname)
 
-        #bgl.glColor4f(*color)
         bgl.glBegin(bgl.GL_QUADS)
 
-        for coord in [(x, y), (x, y+1), (x+1, y+1), (x+1, y)]:
-            bgl.glTexCoord2f(*coord)
-        for coord in [(x, y), (x+w, y), (w+x, y-h), (x, y-h)]:
-            bgl.glVertex2f(*coord)
+        #bgl.glNormal3f(0, 0, 1)
+        bgl.glTexCoord2d(0, 0); bgl.glVertex2f( x, y )
+        bgl.glTexCoord2d(1, 0); bgl.glVertex2f( x + 64 , y )
+        bgl.glTexCoord2d(1, 1); bgl.glVertex2f( x + 64, y + 64 )
+        bgl.glTexCoord2d(0, 1); bgl.glVertex2f( x, y + 64 )
 
         bgl.glEnd()
 
@@ -76,14 +76,14 @@ def simple_screen(x, y, args):
     def init_texture(width,height,texname,data):
 
         #bgl.glClearColor(0.0,0.0,0.0,0.0)
-        bgl.glShadeModel(bgl.GL_FLAT)
+        bgl.glShadeModel(bgl.GL_SMOOTH)
         bgl.glEnable(bgl.GL_DEPTH_TEST)
-        bgl.glEnable(bgl.GL_TEXTURE_2D)
+
         Buffer = bgl.Buffer(bgl.GL_FLOAT, [width,height], data)
         bgl.glPixelStorei(bgl.GL_UNPACK_ALIGNMENT,1)
 
         bgl.glGenTextures(1,Buffer)
-        #bgl.glEnable(bgl.GL_TEXTURE_2D)
+        bgl.glEnable(bgl.GL_TEXTURE_2D)
         #glBindTexture(target, texture): texture (unsigned int) – Specifies the name of a texture.
         bgl.glBindTexture(bgl.GL_TEXTURE_2D, texname)
 
@@ -93,10 +93,6 @@ def simple_screen(x, y, args):
         bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_T, bgl.GL_CLAMP)
         bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MAG_FILTER, bgl.GL_LINEAR)
         bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MIN_FILTER, bgl.GL_LINEAR)
-
-        #bgl.glEnable(bgl.GL_BLEND)
-        #bgl.glBlendFunc(bgl.GL_SRC_ALPHA, bgl.GL_ONE_MINUS_SRC_ALPHA)
-        #bgl.glShadeModel(bgl.GL_SMOOTH)
 
         bgl.glTexImage2D(
                bgl.GL_TEXTURE_2D, 0, bgl.GL_LUMINANCE, width, height, 0,
@@ -160,7 +156,8 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
             }
             nvBGL2.callback_enable(n_id, draw_data)
 
-
+    def free(self):
+        nvBGL2.callback_disable(node_id(self))
 
     # reset n_id on copy
     def copy(self, node):

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -120,13 +120,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         description="offers bitmap saving",
         default="PNG"
     )
-    '''
-    directory = StringProperty(
-        maxlen=1024,
-        subtype='FILE_PATH',
-        options={'HIDDEN', 'SKIP_SAVE'}
-    )
-    '''
+
     in_float = FloatProperty(
         min=0.0, max=1.0, default=0.0, name='Float Input',
         description='input for texture', update=updateNode
@@ -154,11 +148,10 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         c.prop(self, 'activate')
 
     def draw_buttons_ext(self, context, l):
-        l.label(text="save texture as bitmap image, choose a format:")
+        l.label(text="save texture as a bitmap image, choose a format:")
         l.separator()
         l.prop(self, "bitmap_save")
         l.separator()
-        l.row()
         l.operator("node.scriptlite_ui_callback", text="S A V E").fn_name="save_bitmap"
 
     def sv_init(self, context):

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -44,7 +44,7 @@ size_tex_dict = {
 
 bitmap_save_list=[
     ('PNG','png format', 'save texture in .png fromat','',0),
-    ('TGA','tga format','save texture in .tga fromat','',1),
+    ('TARGA','tga format','save texture in .tga fromat','',1),
     ('TIFF','tiff format','save texture in .tiff format','',2),
     ('BMP','bmp format','save texture in .tiff format','',3),
     ('JPEG','jpeg format','save texture in .jpeg format','',4)
@@ -235,8 +235,13 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         np_buff.shape = -1
         img.pixels[:] = np_buff
 
-        img.filepath_raw = "/tmp/" + image_name
-        img.save()
+        scene=bpy.context.scene
+        scene.render.image_settings.file_format= img_format
+
+        path = img.filepath_raw
+        path = "/tmp/" + image_name
+        img.save_render(path,scene)
+
         print('saved!')
 
 def register():

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -27,20 +27,6 @@ from sverchok.data_structure import updateNode, node_id
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.ui import nodeview_bgl_viewer_draw_mk2 as nvBGL2
 
-palette_dict = {
-    "default": (
-        (0.243299, 0.590403, 0.836084, 1.00),  # back_color
-        (0.390805, 0.754022, 1.000000, 1.00),  # grid_color
-        (1.000000, 0.330010, 0.107140, 1.00)   # line_color
-    ),
-    "scope": (
-        (0.274677, 0.366253, 0.386430, 1.00),  # back_color
-        (0.423268, 0.558340, 0.584078, 1.00),  # grid_color
-        (0.304762, 1.000000, 0.062827, 1.00)   # line_color
-    )
-
-}
-
 size_tex_list=[
     ('EXTRA_SMALL','extra_small 64x64px','extra small squared tex: 64px','',64),
     ('SMALL','small 128x128px','small squared tex: 128px','',128),
@@ -67,11 +53,11 @@ bitmap_save_list=[
 
 def simple_screen(x, y, args):
     #draw a simple scren display for the texture
-    back_color, grid_color, line_color = args[0]
+    border_color = (0.390805, 0.754022, 1.000000, 1.00)
 
-    texture = args[1]
-    size = args[2]
-    texname = args[3]
+    texture = args[0]
+    size = args[1]
+    texname = args[2]
     #print('size of tex inside simple screen: {0}'.format(size))
     texture = 1
     width = size
@@ -108,7 +94,7 @@ def simple_screen(x, y, args):
 
     draw_texture(x=x, y=y, w=width, h=height, texname=texname)
 
-    draw_borders(x=x, y=y, w=width, h=height, color=grid_color)
+    draw_borders(x=x, y=y, w=width, h=height, color=border_color)
 
 class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     '''Texture Viewer node'''
@@ -144,11 +130,6 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     in_float = FloatProperty(
         min=0.0, max=1.0, default=0.0, name='Float Input',
         description='input for texture', update=updateNode
-    )
-
-    theme_mode_options = [(m, m, '', idx) for idx, m in enumerate(["default", "scope"])]
-    selected_theme_mode = EnumProperty(
-        items=theme_mode_options, default="default", update=updateNode
     )
 
     def get_buffer(self):
@@ -204,7 +185,6 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
 
             size_tex = size_tex_dict.get(self.selected_mode)
 
-            palette = palette_dict.get(self.selected_theme_mode)[:]
             x, y = [int(j) for j in (self.location + Vector((self.width + 20, 0)))[:]]
 
             def init_texture(width,height,texname,texture):
@@ -242,7 +222,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
                 'mode': 'custom_function',
                 'custom_function': simple_screen,
                 'loc': (x, y),
-                'args': (palette, texture, size_tex, texname)
+                'args': (texture, size_tex, texname)
             }
 
             nvBGL2.callback_enable(n_id, draw_data)
@@ -266,8 +246,8 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         if image_name in bpy.data.images:
             img = bpy.data.images[image_name]
         else:
-            img = bpy.data.images.new(name=image_name,width=width,height=height,alpha=alpha, float_buffer=True)
-        #print(img)
+            img = bpy.data.images.new(name=image_name,width=width,height=height,alpha=alpha,float_buffer=True)
+
         np_buff = np.empty(len(img.pixels), dtype=np.float32)
         np_buff.shape = (-1, 4)
         np_buff[:,:] = np.array(buf)[:,np.newaxis]

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -42,22 +42,31 @@ palette_dict = {
 }
 
 size_tex_list=[
-    ('EXTRA_SMALL','extra_small','extra small tex: 64px','',0),
-    ('SMALL','small','small tex: 128px',1),
-    ('MEDIUM','medium','medium tex: 256px',2),
-    ('LARGE','large','large tex: 512px',3),
-    ('EXTRA_LARGE','extra_large','extra large tex: 1024px',4)
+    ('EXTRA_SMALL','extra_small','extra small tex: 64px','',64),
+    ('SMALL','small','small tex: 128px','',128),
+    ('MEDIUM','medium','medium tex: 256px','',256),
+    ('LARGE','large','large tex: 512px','',512),
+    ('EXTRA_LARGE','extra_large','extra large tex: 1024px','',1024)
 ]
+
+size_tex_dict = {
+    'EXTRA_SMALL': 64,
+    'SMALL': 128,
+    'MEDIUM': 256,
+    'LARGE': 512,
+    'EXTRA_LARGE': 1024
+}
 
 def simple_screen(x, y, args):
     #func = args[0]
     back_color, grid_color, line_color = args[0]
     data = args[1]
-    #size = args[2]
+    size = args[2]
+    print('size of tex inside simple screen: {0}'.format(size))
 
     texture = 1
-    width = 64
-    height = 64
+    width = size
+    height = size
     texname = 0
 
     def draw_borders(x=0, y=0, w=30, h=10, color=(0.0, 0.0, 0.0, 1.0)):
@@ -69,11 +78,8 @@ def simple_screen(x, y, args):
             bgl.glVertex2f(*coord)
         bgl.glEnd()
 
-
-
     def draw_texture(x=0, y=0, w=30, h=10, color=(0.0, 0.0, 0.0, 1.0), texname=texname):
         #function to draw a texture
-        #bgl.glClear(bgl.GL_COLOR_BUFFER_BIT | bgl.GL_DEPTH_BUFFER_BIT)
         bgl.glEnable(bgl.GL_TEXTURE_2D)
         bgl.glTexEnvf(bgl.GL_TEXTURE_ENV, bgl.GL_TEXTURE_ENV_MODE, bgl.GL_REPLACE)
         bgl.glBindTexture(bgl.GL_TEXTURE_2D, texname)
@@ -93,7 +99,6 @@ def simple_screen(x, y, args):
 
     def init_texture(width,height,texname,data):
         #function to init the texture
-        #bgl.glClearColor(0.0,0.0,0.0,0.0)
         bgl.glShadeModel(bgl.GL_SMOOTH)
         bgl.glEnable(bgl.GL_DEPTH_TEST)
 
@@ -119,9 +124,9 @@ def simple_screen(x, y, args):
 
     init_texture(width,height,texname,data)
 
-    draw_texture(x=x, y=y, w=128, h=128, color=back_color,texname=texname)
+    draw_texture(x=x, y=y, w=width, h=height, color=back_color,texname=texname)
 
-    draw_borders(x=x, y=y, w=128, h=128, color=(0.243299, 0.590403, 0.836084, 1.00))
+    draw_borders(x=x, y=y, w=width, h=height, color=(0.243299, 0.590403, 0.836084, 1.00))
 
 class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     bl_idname = 'SvTextureViewerNode'
@@ -175,15 +180,19 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
 
             palette = palette_dict.get(self.selected_theme_mode)[:]
             x, y = [int(j) for j in (self.location + Vector((self.width + 20, 0)))[:]]
-            #size_tex = size_tex_list.get(int(self.selected_mode))[:]
+            #size_tex = size_tex_dict.get('SMALL')
+            size_tex = size_tex_dict.get(self.selected_mode)
+            #size_tex = size_tex_list[0][4]
+            print(size_tex)
+            #print(self.selected_mode[1])
 
             draw_data = {
                 'tree_name': self.id_data.name[:],
                 'mode': 'custom_function',
                 'custom_function': simple_screen,
                 'loc': (x, y),
-                #'args': (palette, _data, size_tex)
-                'args': (palette, _data)
+                'args': (palette, _data, size_tex)
+                #'args': (palette, _data)
             }
             nvBGL2.callback_enable(n_id, draw_data)
 

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -41,11 +41,19 @@ palette_dict = {
 
 }
 
+size_tex_list=[
+    ('EXTRA_SMALL','extra_small','extra small tex: 64px','',0),
+    ('SMALL','small','small tex: 128px',1),
+    ('MEDIUM','medium','medium tex: 256px',2),
+    ('LARGE','large','large tex: 512px',3),
+    ('EXTRA_LARGE','extra_large','extra large tex: 1024px',4)
+]
 
 def simple_screen(x, y, args):
     #func = args[0]
     back_color, grid_color, line_color = args[0]
     data = args[1]
+    #size = args[2]
 
     texture = 1
     width = 64
@@ -125,6 +133,13 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         default=True,
         update=updateNode)
 
+    selected_mode = EnumProperty(
+        items=size_tex_list,
+        description="offers display sizing",
+        default="SMALL",
+        update=updateNode
+    )
+
     in_float = FloatProperty(
         min=0.0, max=1.0, default=0.0, name='Float Input',
         description='input for texture', update=updateNode
@@ -137,6 +152,8 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
 
     def draw_buttons(self, context, l):
         c = l.column()
+        c.label(text="set texture display")
+        c.prop(self, "selected_mode", text="")
         c.prop(self, 'activate')
 
     def draw_buttons_ext(self, context, l):
@@ -158,12 +175,14 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
 
             palette = palette_dict.get(self.selected_theme_mode)[:]
             x, y = [int(j) for j in (self.location + Vector((self.width + 20, 0)))[:]]
+            #size_tex = size_tex_list.get(int(self.selected_mode))[:]
 
             draw_data = {
                 'tree_name': self.id_data.name[:],
                 'mode': 'custom_function',
                 'custom_function': simple_screen,
                 'loc': (x, y),
+                #'args': (palette, _data, size_tex)
                 'args': (palette, _data)
             }
             nvBGL2.callback_enable(n_id, draw_data)

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -143,8 +143,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     bitmap_save = EnumProperty(
         items=bitmap_save_list,
         description="offers bitmap saving",
-        default="PNG",
-        update=updateNode
+        default="PNG"
     )
 
     in_float = FloatProperty(
@@ -252,7 +251,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     def copy(self, node):
         self.n_id = ''
 
-    def save_bitmap(self,):
+    def save_bitmap(self):
        img = bpy.data.images.new(name="depthmap", width=64,height=64,alpha=False, float_buffer=True)
        img.colorspace_settings.name = 'Linear'
        # bake() #implemented in separate function

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -164,18 +164,15 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
 
     def process(self):
         n_id = node_id(self)
-
         # end early
         nvBGL2.callback_disable(n_id)
 
         if self.activate:
 
             texture = self.get_buffer()
-
             size_tex = size_tex_dict.get(self.selected_mode)
-
             #x, y = [int(j) for j in (self.location + Vector((self.width + 20, 0)))[:]]
-            x, y = self.xy_offset()
+            x, y = self.xy_offset
 
             def init_texture(width,height,texname,texture):
                 #function to init the texture
@@ -235,21 +232,19 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
             img = bpy.data.images[image_name]
         else:
             img = bpy.data.images.new(name=image_name,width=width,height=height,alpha=alpha,float_buffer=True)
-
         np_buff = np.empty(len(img.pixels), dtype=np.float32)
         np_buff.shape = (-1, 4)
         np_buff[:,:] = np.array(buf)[:,np.newaxis]
         np_buff[:,3] = 1
         np_buff.shape = -1
         img.pixels[:] = np_buff
-
+        #get the scene context
         scene=bpy.context.scene
         scene.render.image_settings.file_format= img_format
-
+        #get the path for the file and save the image
         path = img.filepath_raw
         path = "/tmp/" + image_name
         img.save_render(path,scene)
-
         print('saved!')
 
 def register():

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -255,7 +255,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     def copy(self, node):
         self.n_id = ''
 
-    def save_bitmap(self, image_name='image_name', filepath_raw='', alpha=False,texture=texture):
+    def save_bitmap(self, image_name='image_name', filepath_raw=directory, alpha=False, texture=texture):
         import numpy as np
         buf = self.get_buffer()
         img_format = self.bitmap_save

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -16,7 +16,7 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
-from mathutils import Vector
+#from mathutils import Vector
 import numpy as np
 import bpy
 from bpy.props import FloatProperty, EnumProperty, StringProperty, BoolProperty
@@ -125,6 +125,12 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         description='Input for texture', update=updateNode
     )
 
+    @property
+    def xy_offset(self):
+        a = self.location[:]
+        b = int(self.width) + 20
+        return int(a[0] + b), int(a[1])
+
     def get_buffer(self):
         data = self.inputs['Float'].sv_get(deepcopy=False)[0]
         size_tex = size_tex_dict.get(self.selected_mode)
@@ -168,7 +174,8 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
 
             size_tex = size_tex_dict.get(self.selected_mode)
 
-            x, y = [int(j) for j in (self.location + Vector((self.width + 20, 0)))[:]]
+            #x, y = [int(j) for j in (self.location + Vector((self.width + 20, 0)))[:]]
+            x, y = self.xy_offset()
 
             def init_texture(width,height,texname,texture):
                 #function to init the texture
@@ -217,7 +224,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         self.n_id = ''
 
     def save_bitmap(self, image_name='image_name', filepath_raw='', alpha=False, texture=texture):
-
+        #save a texture in a bitmap image in different formats supported by blender
         buf = self.get_buffer()
         img_format = self.bitmap_save
         image_name = image_name + '.' + (img_format.lower().replace('targa', 'tga'))

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -23,8 +23,6 @@ from bpy.props import FloatProperty, EnumProperty, StringProperty, BoolProperty
 import blf
 import bgl
 
-from mathutils import noise
-
 from sverchok.data_structure import updateNode, node_id
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.ui import nodeview_bgl_viewer_draw_mk2 as nvBGL2
@@ -62,12 +60,12 @@ def simple_screen(x, y, args):
         bgl.glBindTexture(bgl.GL_TEXTURE_2D, texname)
 
         #bgl.glColor4f(*color)
-        bgl.glBegin(bgl.GL_POLYGON)
+        bgl.glBegin(bgl.GL_QUADS)
 
+        for coord in [(x, y), (x, y+1), (x+1, y+1), (x+1, y)]:
+            bgl.glTexCoord2f(*coord)
         for coord in [(x, y), (x+w, y), (w+x, y-h), (x, y-h)]:
             bgl.glVertex2f(*coord)
-        for coord in [(x, y), (x+1, y), (1+x, y-1), (x, y-1)]:
-            bgl.glTexCoord2f(*coord)
 
         bgl.glEnd()
 
@@ -80,6 +78,7 @@ def simple_screen(x, y, args):
         #bgl.glClearColor(0.0,0.0,0.0,0.0)
         bgl.glShadeModel(bgl.GL_FLAT)
         bgl.glEnable(bgl.GL_DEPTH_TEST)
+        bgl.glEnable(bgl.GL_TEXTURE_2D)
         Buffer = bgl.Buffer(bgl.GL_FLOAT, [width,height], data)
         bgl.glPixelStorei(bgl.GL_UNPACK_ALIGNMENT,1)
 
@@ -101,12 +100,12 @@ def simple_screen(x, y, args):
 
         bgl.glTexImage2D(
                bgl.GL_TEXTURE_2D, 0, bgl.GL_LUMINANCE, width, height, 0,
-               bgl.GL_LUMINANCE, bgl.GL_BITMAP, Buffer
+               bgl.GL_LUMINANCE, bgl.GL_FLOAT, Buffer
            )
 
     init_texture(width,height,texname,data)
 
-    draw_texture(x=x, y=y, w=140, h=140, color=back_color,texname=texname)
+    draw_texture(x=x, y=y, w=64, h=64, color=back_color,texname=texname)
 
 class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     bl_idname = 'SvTextureViewerNode'
@@ -114,7 +113,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
 
     n_id = StringProperty(default='')
     activate = BoolProperty(
-        name='Show', description='Activate drawing',
+        name='Show', description='Activate texture drawing',
         default=True,
         update=updateNode)
 

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -144,13 +144,12 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
 
     def process(self):
 
-        p = self.inputs['Float'].sv_get(deepcopy=False)
+        data = self.inputs['Float'].sv_get(deepcopy=False)[0]
         n_id = node_id(self)
 
         # end early
         nvBGL2.callback_disable(n_id)
 
-        data = p[0]
         #print(_data)
         if self.activate:
 

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -219,7 +219,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         import numpy as np
         buf = self.get_buffer()
         img_format = self.bitmap_save
-        image_name = image_name + '.' + img_format.lower()
+        image_name = image_name + '.' + img_format.lower().replace('targa', 'tga')
         dim = size_tex_dict[self.selected_mode]
         width, height = dim, dim
         img = []

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -125,11 +125,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     bl_idname = 'SvTextureViewerNode'
     bl_label = 'Texture viewer'
     texture = []
-    '''
-    def __init__(self):
-        self.texture = texture
-        #texture = self.texture
-    '''
+
     n_id = StringProperty(default='')
     activate = BoolProperty(
         name='Show', description='Activate texture drawing',
@@ -165,6 +161,10 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         items=theme_mode_options, default="default", update=updateNode
     )
 
+    def get_buffer(self,texture):
+        self.texture = texture
+        return self.texture
+
     def draw_buttons(self, context, l):
         c = l.column()
         c.label(text="set texture display")
@@ -188,11 +188,6 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     def sv_init(self, context):
         self.inputs.new('StringsSocket', "Float").prop_name = 'in_float'
 
-
-    def init(self, context):
-        #self.texture = texture
-        texture.sv_set()
-
     def process(self):
 
         data = self.inputs['Float'].sv_get(deepcopy=False)[0]
@@ -215,9 +210,8 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
                 data = data[:total_size]
             # and then in init texture
             texture = bgl.Buffer(bgl.GL_FLOAT, total_size, data)
-            #tex = [texture.to_list()]
+            self.get_buffer(texture)
             #print(tex)
-
 
             palette = palette_dict.get(self.selected_theme_mode)[:]
             x, y = [int(j) for j in (self.location + Vector((self.width + 20, 0)))[:]]
@@ -269,8 +263,9 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     def copy(self, node):
         self.n_id = ''
 
-    def save_bitmap(self, image_name='image_name', filepath_raw='', alpha=False, buf=texture):
+    def save_bitmap(self, image_name='image_name', filepath_raw='', alpha=False,texture=texture):
         import numpy as np
+        buf = self.get_buffer(texture)
         img_format = self.bitmap_save
         image_name = image_name + '.' + img_format.lower()
         dim = size_tex_dict[self.selected_mode]
@@ -279,11 +274,9 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         if image_name in bpy.data.images:
             img = bpy.data.images[image_name]
             print("A")
-            #return img
         else:
             img = bpy.data.images.new(name=image_name,width=width,height=height,alpha=alpha, float_buffer=True)
             print("B")
-
         print(img)
         #img = bpy.data.images.new(name=image_name, width=width,height=height,alpha=alpha, float_buffer=True)
         np_buff = np.empty(len(img.pixels), dtype=np.float32)

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -120,13 +120,13 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         description="offers bitmap saving",
         default="PNG"
     )
-
+    '''
     directory = StringProperty(
         maxlen=1024,
         subtype='FILE_PATH',
         options={'HIDDEN', 'SKIP_SAVE'}
     )
-
+    '''
     in_float = FloatProperty(
         min=0.0, max=1.0, default=0.0, name='Float Input',
         description='input for texture', update=updateNode
@@ -154,12 +154,12 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         c.prop(self, 'activate')
 
     def draw_buttons_ext(self, context, l):
-        l.label(text="choose a different color for the border:")
-        l.prop(self, "selected_theme_mode")
-        l.separator()
+        #l.label(text="choose a different color for the border:")
+        #l.prop(self, "selected_theme_mode")
+        #l.separator()
         l.label(text="save texture as bitmap image, choose a format:")
         l.prop(self, "bitmap_save")
-        l.operator('file.select_all_toggle', text='choose a directory')
+        #l.operator('file.select_all_toggle', text='choose a directory')
 
         row = l.row()
         #addon = context.user_preferences.addons.get(sverchok.__name__)
@@ -235,7 +235,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     def copy(self, node):
         self.n_id = ''
 
-    def save_bitmap(self, image_name='image_name', filepath_raw=directory, alpha=False, texture=texture):
+    def save_bitmap(self, image_name='image_name', filepath_raw='', alpha=False, texture=texture):
         import numpy as np
         buf = self.get_buffer()
         img_format = self.bitmap_save

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -110,6 +110,18 @@ def simple_screen(x, y, args):
 
     draw_borders(x=x, y=y, w=width, h=height, color=grid_color)
 
+#class SvSaveBitmap(bpy.types.Operator):
+#    '''Save Bitmap operator'''
+#    bl_idname = 'node.save_bitmap'
+#    bl_label = "Sverchok save bitmap utility"
+#    fn_name = bpy.props.StringProperty(default='')
+#    bl_options = {'REGISTER', 'UNDO'}
+#
+#    def execute(self, context):
+#        #main(context)
+#        getattr(context.node, self.fn_name)()
+#        return {'FINISHED'}
+
 class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     '''Texture Viewer node'''
     bl_idname = 'SvTextureViewerNode'
@@ -160,9 +172,9 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         row = l.row()
         #addon = context.user_preferences.addons.get(sverchok.__name__)
         #row.scale_y = 4.0 if addon.preferences.over_sized_buttons else 1
-        opera = row.operator('save_bitmap', text="S A V E")
-        opera.idname = self.name
-        opera.idtree = self.id_data.name
+        #opera = row.operator('node.save_bitmap', text="S A V E").fn="save_bitmap"
+        l.operator("node.scriptlite_ui_callback", text="S A V E").fn="save_bitmap"
+
 
     def sv_init(self, context):
         self.inputs.new('StringsSocket', "Float").prop_name = 'in_float'
@@ -217,8 +229,6 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
                        bgl.GL_TEXTURE_2D, 0, bgl.GL_LUMINANCE, width, height, 0,
                        bgl.GL_LUMINANCE, bgl.GL_FLOAT, texture
                    )
-            def save_bitmap(self):
-                pass
 
             texname = 0
 
@@ -242,6 +252,8 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     def copy(self, node):
         self.n_id = ''
 
+def save_bitmap(self):
+    pass
 
 def register():
     bpy.utils.register_class(SvTextureViewerNode)

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -64,7 +64,7 @@ bitmap_save_list=[
     ('BMP','bmp format','save texture in .tiff format','',3),
     ('JPEG','jpeg format','save texture in .jpeg format','',4)
 ]
-def assign_image(self,image_name, size ,buffer):
+def assign_image(image_name, size ,buffer):
     import numpy as np
     image = bpy.data.images.new(image_name, size, size, alpha=False)
     np_buff = np.empty(len(image.pixels), dtype=np.float32)
@@ -182,11 +182,6 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
 
         l.operator("node.scriptlite_ui_callback", text="S A V E").fn_name="save_bitmap"
 
-    def invoke(self, context, event):
-        wm = context.window_manager
-        wm.fileselect_add(self)
-        return {'RUNNING_MODAL'}
-
     def sv_init(self, context):
         self.inputs.new('StringsSocket', "Float").prop_name = 'in_float'
 
@@ -213,7 +208,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
             # and then in init texture
             texture = bgl.Buffer(bgl.GL_FLOAT, total_size, data)
             tex = [texture.to_list()]
-            #print(tex)
+            print(tex)
 
 
             palette = palette_dict.get(self.selected_theme_mode)[:]
@@ -257,7 +252,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
             }
 
             nvBGL2.callback_enable(n_id, draw_data)
-        return tex
+        #return tex
 
     def free(self):
         nvBGL2.callback_disable(node_id(self))
@@ -266,15 +261,16 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     def copy(self, node):
         self.n_id = ''
 
-    def save_bitmap(self,image_name='image.png',filepath_raw='',img_format='PNG',width=64,height=64,alpha=False,buf=tex):
-        #print(buf)
-        img = bpy.data.images.new(name="bitmap", width=64,height=64,alpha=False, float_buffer=True)
+    def save_bitmap(self, image_name='image_name', filepath_raw='', alpha=False, buf=tex):
+        img_format = self.bitmap_save
+        image_name = image_name + '.' + img_format.lower()
+        dim = size_tex_dict[self.selected_mode]
+        width, height = dim, dim
+        img = bpy.data.images.new(name=image_name, width=width,height=height,alpha=alpha, float_buffer=True)
+        print("buffer is:{0}".format(buf))
         img = assign_image(image_name,width*height,buf)
         img.colorspace_settings.name = 'Linear'
-        # bake() #implemented in separate function
-        img.file_format = img_format
-        # need to set to 16-bit here
-        img.filepath_raw = "/tmp/my_new_bake.png"
+        img.filepath_raw = "/tmp/" + image_name
         img.save()
         print('saved!')
 

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -57,6 +57,14 @@ size_tex_dict = {
     'EXTRA_LARGE': 1024
 }
 
+bitmap_save_list=[
+    ('PNG','png format', 'save texture in .png fromat','',0),
+    ('TGA','tga format','save texture in .tga fromat','',1),
+    ('TIFF','tiff format','save texture in .tiff format','',2),
+    ('BMP','bmp format','save texture in .tiff format','',3),
+    ('JPEG','jpeg format','save texture in .jpeg format','',4)
+]
+
 def simple_screen(x, y, args):
     #draw a simple scren display for the texture
     back_color, grid_color, line_color = args[0]
@@ -120,6 +128,13 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         update=updateNode
     )
 
+    bitmap_save = EnumProperty(
+        items=bitmap_save_list,
+        description="offers bitmap saving",
+        default="PNG",
+        update=updateNode
+    )
+
     in_float = FloatProperty(
         min=0.0, max=1.0, default=0.0, name='Float Input',
         description='input for texture', update=updateNode
@@ -138,6 +153,8 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
 
     def draw_buttons_ext(self, context, l):
         l.prop(self, "selected_theme_mode")
+        l.label(text="save texture as bitmap image, choose a format:")
+        l.prop(self, "bitmap_save")
 
     def sv_init(self, context):
         self.inputs.new('StringsSocket', "Float").prop_name = 'in_float'

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -1,0 +1,176 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+from mathutils import Vector
+import bpy
+from bpy.props import FloatProperty, EnumProperty, StringProperty, BoolProperty
+
+import blf
+import bgl
+
+from mathutils import noise
+
+from sverchok.data_structure import updateNode, node_id
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.ui import nodeview_bgl_viewer_draw_mk2 as nvBGL2
+
+palette_dict = {
+    "default": (
+        (0.243299, 0.590403, 0.836084, 1.00),  # back_color
+        (0.390805, 0.754022, 1.000000, 1.00),  # grid_color
+        (1.000000, 0.330010, 0.107140, 1.00)   # line_color
+    ),
+    "scope": (
+        (0.274677, 0.366253, 0.386430, 1.00),  # back_color
+        (0.423268, 0.558340, 0.584078, 1.00),  # grid_color
+        (0.304762, 1.000000, 0.062827, 1.00)   # line_color
+    )
+
+}
+
+
+def simple_screen(x, y, args):
+    #func = args[0]
+    back_color, grid_color, line_color = args[0]
+    data = args[1]
+
+    texture = 1
+    width = 64
+    height = 64
+    texname = 0
+
+    def draw_texture(x=0, y=0, w=30, h=10, color=(0.0, 0.0, 0.0, 1.0),texname=texname):
+
+        #bgl.glClear(bgl.GL_COLOR_BUFFER_BIT | bgl.GL_DEPTH_BUFFER_BIT)
+        bgl.glEnable(bgl.GL_TEXTURE_2D)
+        bgl.glTexEnvf(bgl.GL_TEXTURE_ENV, bgl.GL_TEXTURE_ENV_MODE, bgl.GL_REPLACE)
+        bgl.glBindTexture(bgl.GL_TEXTURE_2D, texname)
+
+        #bgl.glColor4f(*color)
+        bgl.glBegin(bgl.GL_POLYGON)
+
+        for coord in [(x, y), (x+w, y), (w+x, y-h), (x, y-h)]:
+            bgl.glVertex2f(*coord)
+        for coord in [(x, y), (x+1, y), (1+x, y-1), (x, y-1)]:
+            bgl.glTexCoord2f(*coord)
+
+        bgl.glEnd()
+
+        bgl.glDisable(bgl.GL_TEXTURE_2D)
+        #bgl.glDeleteTextures( 1, Buffer )
+        bgl.glFlush()
+
+    def init_texture(width,height,texname,data):
+
+        #bgl.glClearColor(0.0,0.0,0.0,0.0)
+        bgl.glShadeModel(bgl.GL_FLAT)
+        bgl.glEnable(bgl.GL_DEPTH_TEST)
+        Buffer = bgl.Buffer(bgl.GL_FLOAT, [width,height], data)
+        bgl.glPixelStorei(bgl.GL_UNPACK_ALIGNMENT,1)
+
+        bgl.glGenTextures(1,Buffer)
+        #bgl.glEnable(bgl.GL_TEXTURE_2D)
+        #glBindTexture(target, texture): texture (unsigned int) – Specifies the name of a texture.
+        bgl.glBindTexture(bgl.GL_TEXTURE_2D, texname)
+
+        bgl.glActiveTexture(bgl.GL_TEXTURE0)
+
+        bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_S, bgl.GL_CLAMP)
+        bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_T, bgl.GL_CLAMP)
+        bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MAG_FILTER, bgl.GL_LINEAR)
+        bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MIN_FILTER, bgl.GL_LINEAR)
+
+        #bgl.glEnable(bgl.GL_BLEND)
+        #bgl.glBlendFunc(bgl.GL_SRC_ALPHA, bgl.GL_ONE_MINUS_SRC_ALPHA)
+        #bgl.glShadeModel(bgl.GL_SMOOTH)
+
+        bgl.glTexImage2D(
+               bgl.GL_TEXTURE_2D, 0, bgl.GL_LUMINANCE, width, height, 0,
+               bgl.GL_LUMINANCE, bgl.GL_BITMAP, Buffer
+           )
+
+    init_texture(width,height,texname,data)
+
+    draw_texture(x=x, y=y, w=140, h=140, color=back_color,texname=texname)
+
+class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
+    bl_idname = 'SvTextureViewerNode'
+    bl_label = 'Texture viewer'
+
+    n_id = StringProperty(default='')
+    activate = BoolProperty(
+        name='Show', description='Activate drawing',
+        default=True,
+        update=updateNode)
+
+    in_float = FloatProperty(
+        min=0.0, max=1.0, default=0.0, name='Float Input',
+        description='input for texture', update=updateNode
+    )
+
+    theme_mode_options = [(m, m, '', idx) for idx, m in enumerate(["default", "scope"])]
+    selected_theme_mode = EnumProperty(
+        items=theme_mode_options, default="default", update=updateNode
+    )
+
+    def draw_buttons(self, context, l):
+        c = l.column()
+        c.prop(self, 'activate')
+
+    def draw_buttons_ext(self, context, l):
+        l.prop(self, "selected_theme_mode")
+
+    def sv_init(self, context):
+        self.inputs.new('StringsSocket', "Float").prop_name = 'in_float'
+
+    def process(self):
+        p = self.inputs['Float'].sv_get()
+        n_id = node_id(self)
+
+        # end early
+        nvBGL2.callback_disable(n_id)
+
+        _data = p[0]
+        #print(_data)
+        if self.activate:
+
+            palette = palette_dict.get(self.selected_theme_mode)[:]
+            x, y = [int(j) for j in (self.location + Vector((self.width + 20, 0)))[:]]
+
+            draw_data = {
+                'tree_name': self.id_data.name[:],
+                'mode': 'custom_function',
+                'custom_function': simple_screen,
+                'loc': (x, y),
+                'args': (palette, _data)
+            }
+            nvBGL2.callback_enable(n_id, draw_data)
+
+
+
+    # reset n_id on copy
+    def copy(self, node):
+        self.n_id = ''
+
+
+def register():
+    bpy.utils.register_class(SvTextureViewerNode)
+
+
+def unregister():
+    bpy.utils.unregister_class(SvTextureViewerNode)

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -27,11 +27,13 @@ from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.ui import nodeview_bgl_viewer_draw_mk2 as nvBGL2
 
 size_tex_list = [
-    ('EXTRA_SMALL','extra_small 64x64px','extra small squared tex: 64px','',64),
-    ('SMALL','small 128x128px','small squared tex: 128px','',128),
-    ('MEDIUM','medium 256x256px','medium squared tex: 256px','',256),
-    ('LARGE','large 512x512px','large squared tex: 512px','',512),
-    ('EXTRA_LARGE','extra_large 1024x1024px','extra large squared tex: 1024px','',1024)
+    ('EXTRA_SMALL', 'extra_small 64x64px',
+     'extra small squared tex: 64px', '', 64),
+    ('SMALL', 'small 128x128px', 'small squared tex: 128px', '', 128),
+    ('MEDIUM', 'medium 256x256px', 'medium squared tex: 256px', '', 256),
+    ('LARGE', 'large 512x512px', 'large squared tex: 512px', '', 512),
+    ('EXTRA_LARGE', 'extra_large 1024x1024px',
+     'extra large squared tex: 1024px', '', 1024)
 ]
 
 size_tex_dict = {
@@ -43,15 +45,16 @@ size_tex_dict = {
 }
 
 bitmap_save_list = [
-    ('PNG','png format','save texture in .png fromat','',0),
-    ('TARGA','tga format','save texture in .tga fromat','',1),
-    ('TIFF','tiff format','save texture in .tiff format','',2),
-    ('BMP','bmp format','save texture in .tiff format','',3),
-    ('JPEG','jpeg format','save texture in .jpeg format','',4)
+    ('PNG', 'png format', 'save texture in .png fromat', '', 0),
+    ('TARGA', 'tga format', 'save texture in .tga fromat', '', 1),
+    ('TIFF', 'tiff format', 'save texture in .tiff format', '', 2),
+    ('BMP', 'bmp format', 'save texture in .tiff format', '', 3),
+    ('JPEG', 'jpeg format', 'save texture in .jpeg format', '', 4)
 ]
 
+
 def simple_screen(x, y, args):
-    #draw a simple scren display for the texture
+    # draw a simple scren display for the texture
     border_color = (0.390805, 0.754022, 1.000000, 1.00)
 
     texture = args[0]
@@ -62,7 +65,7 @@ def simple_screen(x, y, args):
     height = size
 
     def draw_borders(x=0, y=0, w=30, h=10, color=(0.0, 0.0, 0.0, 1.0)):
-        #function to draw a border color around the texture
+        # function to draw a border color around the texture
         bgl.glColor4f(*color)
         bgl.glBegin(bgl.GL_LINE_LOOP)
 
@@ -72,27 +75,34 @@ def simple_screen(x, y, args):
         bgl.glEnd()
 
     def draw_texture(x=0, y=0, w=30, h=10, texname=texname):
-        #function to draw a texture
+        # function to draw a texture
         bgl.glEnable(bgl.GL_TEXTURE_2D)
-        bgl.glTexEnvf(bgl.GL_TEXTURE_ENV, bgl.GL_TEXTURE_ENV_MODE, bgl.GL_REPLACE)
+        bgl.glTexEnvf(bgl.GL_TEXTURE_ENV,
+                      bgl.GL_TEXTURE_ENV_MODE,
+                      bgl.GL_REPLACE)
         bgl.glBindTexture(bgl.GL_TEXTURE_2D, texname)
 
         bgl.glBegin(bgl.GL_QUADS)
 
-        bgl.glTexCoord2d(0, 0); bgl.glVertex2f( x, y )
-        bgl.glTexCoord2d(1, 0); bgl.glVertex2f( x + w , y )
-        bgl.glTexCoord2d(1, 1); bgl.glVertex2f( x + w, y - h )
-        bgl.glTexCoord2d(0, 1); bgl.glVertex2f( x, y - h )
+        bgl.glTexCoord2d(0, 0)
+        bgl.glVertex2f(x, y)
+        bgl.glTexCoord2d(1, 0)
+        bgl.glVertex2f(x + w, y)
+        bgl.glTexCoord2d(1, 1)
+        bgl.glVertex2f(x + w, y - h)
+        bgl.glTexCoord2d(0, 1)
+        bgl.glVertex2f(x, y - h)
 
         bgl.glEnd()
 
         bgl.glDisable(bgl.GL_TEXTURE_2D)
-        #bgl.glDeleteTextures( 1, Buffer )
+        # bgl.glDeleteTextures( 1, Buffer )
         bgl.glFlush()
 
     draw_texture(x=x, y=y, w=width, h=height, texname=texname)
 
     draw_borders(x=x, y=y, w=width, h=height, color=border_color)
+
 
 class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     '''Texture Viewer node'''
@@ -156,7 +166,8 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         layout.separator()
         layout.prop(self, "bitmap_save")
         layout.separator()
-        layout.operator("node.scriptlite_ui_callback", text="S A V E").fn_name="save_bitmap"
+        layout.operator("node.scriptlite_ui_callback",
+                        text="S A V E").fn_name = "save_bitmap"
 
     def sv_init(self, context):
         self.inputs.new('StringsSocket', "Float").prop_name = 'in_float'
@@ -173,29 +184,33 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
             x, y = self.xy_offset
 
             def init_texture(width, height, texname, texture):
-                #function to init the texture
+                # function to init the texture
                 bgl.glShadeModel(bgl.GL_SMOOTH)
 
-                bgl.glPixelStorei(bgl.GL_UNPACK_ALIGNMENT,1)
+                bgl.glPixelStorei(bgl.GL_UNPACK_ALIGNMENT, 1)
 
-                bgl.glGenTextures(1,texture)
+                bgl.glGenTextures(1, texture)
                 bgl.glEnable(bgl.GL_TEXTURE_2D)
                 bgl.glBindTexture(bgl.GL_TEXTURE_2D, texname)
                 bgl.glActiveTexture(bgl.GL_TEXTURE0)
 
-                bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_S, bgl.GL_CLAMP)
-                bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_T, bgl.GL_CLAMP)
-                bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MAG_FILTER, bgl.GL_LINEAR)
-                bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MIN_FILTER, bgl.GL_LINEAR)
+                bgl.glTexParameterf(bgl.GL_TEXTURE_2D,
+                                    bgl.GL_TEXTURE_WRAP_S, bgl.GL_CLAMP)
+                bgl.glTexParameterf(bgl.GL_TEXTURE_2D,
+                                    bgl.GL_TEXTURE_WRAP_T, bgl.GL_CLAMP)
+                bgl.glTexParameterf(bgl.GL_TEXTURE_2D,
+                                    bgl.GL_TEXTURE_MAG_FILTER, bgl.GL_LINEAR)
+                bgl.glTexParameterf(bgl.GL_TEXTURE_2D,
+                                    bgl.GL_TEXTURE_MIN_FILTER, bgl.GL_LINEAR)
 
                 bgl.glTexImage2D(
-                       bgl.GL_TEXTURE_2D, 0, bgl.GL_LUMINANCE, width, height, 0,
-                       bgl.GL_LUMINANCE, bgl.GL_FLOAT, texture
+                       bgl.GL_TEXTURE_2D, 0, bgl.GL_LUMINANCE, width, height,
+                       0, bgl.GL_LUMINANCE, bgl.GL_FLOAT, texture
                    )
 
             texname = 0
 
-            init_texture(size_tex,size_tex,texname,texture)
+            init_texture(size_tex, size_tex, texname, texture)
 
             draw_data = {
                 'tree_name': self.id_data.name[:],
@@ -214,32 +229,39 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     def copy(self, node):
         self.n_id = ''
 
-    def save_bitmap(self, image_name='image_name', filepath_raw='', alpha=False, texture=texture):
-        #save a texture in a bitmap image in different formats supported by blender
+    def save_bitmap(self, image_name='image_name', filepath_raw='',
+                    alpha=False,
+                    texture=texture):
+        # save a texture in a bitmap image
+        # in different formats supported by blender
         buf = self.get_buffer()
         img_format = self.bitmap_save
-        image_name = image_name + '.' + (img_format.lower().replace('targa', 'tga'))
+        image_name = image_name + '.'
+        + (img_format.lower().replace('targa', 'tga'))
         dim = size_tex_dict[self.selected_mode]
         width, height = dim, dim
         img = []
         if image_name in bpy.data.images:
             img = bpy.data.images[image_name]
         else:
-            img = bpy.data.images.new(name=image_name, width=width, height=height, alpha=alpha, float_buffer=True)
+            img = bpy.data.images.new(name=image_name, width=width,
+                                      height=height, alpha=alpha,
+                                      float_buffer=True)
         np_buff = np.empty(len(img.pixels), dtype=np.float32)
         np_buff.shape = (-1, 4)
-        np_buff[:,:] = np.array(buf)[:,np.newaxis]
-        np_buff[:,3] = 1
+        np_buff[:, :] = np.array(buf)[:, np.newaxis]
+        np_buff[:, 3] = 1
         np_buff.shape = -1
         img.pixels[:] = np_buff
-        #get the scene context
+        # get the scene context
         scene = bpy.context.scene
         scene.render.image_settings.file_format = img_format
-        #get the path for the file and save the image
+        # get the path for the file and save the image
         path = img.filepath_raw
         path = "/tmp/" + image_name
-        img.save_render(path,scene)
+        img.save_render(path, scene)
         print('saved!')
+
 
 def register():
     bpy.utils.register_class(SvTextureViewerNode)

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -26,7 +26,7 @@ from sverchok.data_structure import updateNode, node_id
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.ui import nodeview_bgl_viewer_draw_mk2 as nvBGL2
 
-size_tex_list=[
+size_tex_list = [
     ('EXTRA_SMALL','extra_small 64x64px','extra small squared tex: 64px','',64),
     ('SMALL','small 128x128px','small squared tex: 128px','',128),
     ('MEDIUM','medium 256x256px','medium squared tex: 256px','',256),
@@ -42,8 +42,8 @@ size_tex_dict = {
     'EXTRA_LARGE': 1024
 }
 
-bitmap_save_list=[
-    ('PNG','png format', 'save texture in .png fromat','',0),
+bitmap_save_list = [
+    ('PNG','png format','save texture in .png fromat','',0),
     ('TARGA','tga format','save texture in .tga fromat','',1),
     ('TIFF','tiff format','save texture in .tiff format','',2),
     ('BMP','bmp format','save texture in .tiff format','',3),
@@ -145,18 +145,18 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         texture = bgl.Buffer(bgl.GL_FLOAT, total_size, data)
         return texture
 
-    def draw_buttons(self, context, l):
-        c = l.column()
+    def draw_buttons(self, context, layout):
+        c = layout.column()
         c.label(text="Set texture display:")
         c.prop(self, "selected_mode", text="")
         c.prop(self, 'activate')
 
-    def draw_buttons_ext(self, context, l):
-        l.label(text="Save texture as a bitmap image, choose a format:")
-        l.separator()
-        l.prop(self, "bitmap_save")
-        l.separator()
-        l.operator("node.scriptlite_ui_callback", text="S A V E").fn_name="save_bitmap"
+    def draw_buttons_ext(self, context, layout):
+        layout.label(text="Save texture as a bitmap image, choose a format:")
+        layout.separator()
+        layout.prop(self, "bitmap_save")
+        layout.separator()
+        layout.operator("node.scriptlite_ui_callback", text="S A V E").fn_name="save_bitmap"
 
     def sv_init(self, context):
         self.inputs.new('StringsSocket', "Float").prop_name = 'in_float'
@@ -172,7 +172,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
             size_tex = size_tex_dict.get(self.selected_mode)
             x, y = self.xy_offset
 
-            def init_texture(width,height,texname,texture):
+            def init_texture(width, height, texname, texture):
                 #function to init the texture
                 bgl.glShadeModel(bgl.GL_SMOOTH)
 
@@ -225,7 +225,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         if image_name in bpy.data.images:
             img = bpy.data.images[image_name]
         else:
-            img = bpy.data.images.new(name=image_name,width=width,height=height,alpha=alpha,float_buffer=True)
+            img = bpy.data.images.new(name=image_name, width=width, height=height, alpha=alpha, float_buffer=True)
         np_buff = np.empty(len(img.pixels), dtype=np.float32)
         np_buff.shape = (-1, 4)
         np_buff[:,:] = np.array(buf)[:,np.newaxis]

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -109,20 +109,20 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
 
     selected_mode = EnumProperty(
         items=size_tex_list,
-        description="offers display sizing",
+        description="Offers display sizing",
         default="SMALL",
         update=updateNode
     )
 
     bitmap_save = EnumProperty(
         items=bitmap_save_list,
-        description="offers bitmap saving",
+        description="Offers bitmap saving",
         default="PNG"
     )
 
     in_float = FloatProperty(
         min=0.0, max=1.0, default=0.0, name='Float Input',
-        description='input for texture', update=updateNode
+        description='Input for texture', update=updateNode
     )
 
     def get_buffer(self):
@@ -142,12 +142,12 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
 
     def draw_buttons(self, context, l):
         c = l.column()
-        c.label(text="set texture display")
+        c.label(text="Set texture display:")
         c.prop(self, "selected_mode", text="")
         c.prop(self, 'activate')
 
     def draw_buttons_ext(self, context, l):
-        l.label(text="save texture as a bitmap image, choose a format:")
+        l.label(text="Save texture as a bitmap image, choose a format:")
         l.separator()
         l.prop(self, "bitmap_save")
         l.separator()

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -17,6 +17,7 @@
 # ##### END GPL LICENSE BLOCK #####
 
 from mathutils import Vector
+import numpy as np
 import bpy
 from bpy.props import FloatProperty, EnumProperty, StringProperty, BoolProperty
 
@@ -216,10 +217,10 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         self.n_id = ''
 
     def save_bitmap(self, image_name='image_name', filepath_raw='', alpha=False, texture=texture):
-        import numpy as np
+
         buf = self.get_buffer()
         img_format = self.bitmap_save
-        image_name = image_name + '.' + img_format.lower().replace('targa', 'tga')
+        image_name = image_name + '.' + (img_format.lower().replace('targa', 'tga'))
         dim = size_tex_dict[self.selected_mode]
         width, height = dim, dim
         img = []

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -58,7 +58,7 @@ size_tex_dict = {
 }
 
 def simple_screen(x, y, args):
-
+    #draw a simple scren display for the texture
     back_color, grid_color, line_color = args[0]
 
     texture = args[1]

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -42,11 +42,11 @@ palette_dict = {
 }
 
 size_tex_list=[
-    ('EXTRA_SMALL','extra_small','extra small tex: 64px','',64),
-    ('SMALL','small','small tex: 128px','',128),
-    ('MEDIUM','medium','medium tex: 256px','',256),
-    ('LARGE','large','large tex: 512px','',512),
-    ('EXTRA_LARGE','extra_large','extra large tex: 1024px','',1024)
+    ('EXTRA_SMALL','extra_small 64x64px','extra small squared tex: 64px','',64),
+    ('SMALL','small 128x128px','small squared tex: 128px','',128),
+    ('MEDIUM','medium 256x256px','medium squared tex: 256px','',256),
+    ('LARGE','large 512x512px','large squared tex: 512px','',512),
+    ('EXTRA_LARGE','extra_large 1024x1024px','extra large squared tex: 1024px','',1024)
 ]
 
 size_tex_dict = {
@@ -58,7 +58,7 @@ size_tex_dict = {
 }
 
 def simple_screen(x, y, args):
-    
+
     back_color, grid_color, line_color = args[0]
 
     texture = args[1]

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -76,6 +76,7 @@ def simple_screen(x, y, args):
 
         for coord in [(x, y), (x+w, y), (w+x, y-h), (x, y-h)]:
             bgl.glVertex2f(*coord)
+
         bgl.glEnd()
 
     def draw_texture(x=0, y=0, w=30, h=10, color=(0.0, 0.0, 0.0, 1.0), texname=texname):
@@ -129,6 +130,7 @@ def simple_screen(x, y, args):
     draw_borders(x=x, y=y, w=width, h=height, color=(0.243299, 0.590403, 0.836084, 1.00))
 
 class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
+    '''Texture Viewer node'''
     bl_idname = 'SvTextureViewerNode'
     bl_label = 'Texture viewer'
 

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -152,9 +152,17 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         c.prop(self, 'activate')
 
     def draw_buttons_ext(self, context, l):
+        l.label(text="choose a different color for the border:")
         l.prop(self, "selected_theme_mode")
+        l.separator()
         l.label(text="save texture as bitmap image, choose a format:")
         l.prop(self, "bitmap_save")
+        row = l.row()
+        #addon = context.user_preferences.addons.get(sverchok.__name__)
+        #row.scale_y = 4.0 if addon.preferences.over_sized_buttons else 1
+        opera = row.operator('save_bitmap', text="S A V E")
+        opera.idname = self.name
+        opera.idtree = self.id_data.name
 
     def sv_init(self, context):
         self.inputs.new('StringsSocket', "Float").prop_name = 'in_float'
@@ -209,10 +217,13 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
                        bgl.GL_TEXTURE_2D, 0, bgl.GL_LUMINANCE, width, height, 0,
                        bgl.GL_LUMINANCE, bgl.GL_FLOAT, texture
                    )
+            def save_bitmap(self):
+                pass
 
             texname = 0
 
             init_texture(size_tex,size_tex,texname,texture)
+
 
             draw_data = {
                 'tree_name': self.id_data.name[:],

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -52,8 +52,19 @@ def simple_screen(x, y, args):
     height = 64
     texname = 0
 
-    def draw_texture(x=0, y=0, w=30, h=10, color=(0.0, 0.0, 0.0, 1.0),texname=texname):
+    def draw_borders(x=0, y=0, w=30, h=10, color=(0.0, 0.0, 0.0, 1.0)):
+        #function to draw a border color around the texture
+        bgl.glColor4f(*color)
+        bgl.glBegin(bgl.GL_LINE_LOOP)
 
+        for coord in [(x, y), (x+w, y), (w+x, y-h), (x, y-h)]:
+            bgl.glVertex2f(*coord)
+        bgl.glEnd()
+
+
+
+    def draw_texture(x=0, y=0, w=30, h=10, color=(0.0, 0.0, 0.0, 1.0), texname=texname):
+        #function to draw a texture
         #bgl.glClear(bgl.GL_COLOR_BUFFER_BIT | bgl.GL_DEPTH_BUFFER_BIT)
         bgl.glEnable(bgl.GL_TEXTURE_2D)
         bgl.glTexEnvf(bgl.GL_TEXTURE_ENV, bgl.GL_TEXTURE_ENV_MODE, bgl.GL_REPLACE)
@@ -61,11 +72,10 @@ def simple_screen(x, y, args):
 
         bgl.glBegin(bgl.GL_QUADS)
 
-        #bgl.glNormal3f(0, 0, 1)
         bgl.glTexCoord2d(0, 0); bgl.glVertex2f( x, y )
-        bgl.glTexCoord2d(1, 0); bgl.glVertex2f( x + 64 , y )
-        bgl.glTexCoord2d(1, 1); bgl.glVertex2f( x + 64, y + 64 )
-        bgl.glTexCoord2d(0, 1); bgl.glVertex2f( x, y + 64 )
+        bgl.glTexCoord2d(1, 0); bgl.glVertex2f( x + w , y )
+        bgl.glTexCoord2d(1, 1); bgl.glVertex2f( x + w, y - h )
+        bgl.glTexCoord2d(0, 1); bgl.glVertex2f( x, y - h )
 
         bgl.glEnd()
 
@@ -74,7 +84,7 @@ def simple_screen(x, y, args):
         bgl.glFlush()
 
     def init_texture(width,height,texname,data):
-
+        #function to init the texture
         #bgl.glClearColor(0.0,0.0,0.0,0.0)
         bgl.glShadeModel(bgl.GL_SMOOTH)
         bgl.glEnable(bgl.GL_DEPTH_TEST)
@@ -101,7 +111,9 @@ def simple_screen(x, y, args):
 
     init_texture(width,height,texname,data)
 
-    draw_texture(x=x, y=y, w=64, h=64, color=back_color,texname=texname)
+    draw_texture(x=x, y=y, w=128, h=128, color=back_color,texname=texname)
+
+    draw_borders(x=x, y=y, w=128, h=128, color=(0.243299, 0.590403, 0.836084, 1.00))
 
 class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     bl_idname = 'SvTextureViewerNode'

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -58,8 +58,7 @@ def simple_screen(x, y, args):
     texture = args[0]
     size = args[1]
     texname = args[2]
-    #print('size of tex inside simple screen: {0}'.format(size))
-    texture = 1
+
     width = size
     height = size
 
@@ -158,14 +157,12 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         self.inputs.new('StringsSocket', "Float").prop_name = 'in_float'
 
     def process(self):
-
-        #data = self.inputs['Float'].sv_get(deepcopy=False)[0]
         n_id = node_id(self)
 
         # end early
         nvBGL2.callback_disable(n_id)
 
-        #print(_data)
+
         if self.activate:
 
             texture = self.get_buffer()
@@ -181,11 +178,10 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
 
                 bgl.glPixelStorei(bgl.GL_UNPACK_ALIGNMENT,1)
 
-                #bgl.glGenTextures(1,Buffer)
                 bgl.glGenTextures(1,texture)
 
                 bgl.glEnable(bgl.GL_TEXTURE_2D)
-                #glBindTexture(target, texture): texture (unsigned int) – Specifies the name of a texture.
+
                 bgl.glBindTexture(bgl.GL_TEXTURE_2D, texname)
 
                 bgl.glActiveTexture(bgl.GL_TEXTURE0)
@@ -213,7 +209,6 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
             }
 
             nvBGL2.callback_enable(n_id, draw_data)
-        #return tex
 
     def free(self):
         nvBGL2.callback_disable(node_id(self))

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -134,6 +134,12 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         default="PNG"
     )
 
+    directory = StringProperty(
+        maxlen=1024,
+        subtype='FILE_PATH',
+        options={'HIDDEN', 'SKIP_SAVE'}
+    )
+
     in_float = FloatProperty(
         min=0.0, max=1.0, default=0.0, name='Float Input',
         description='input for texture', update=updateNode
@@ -156,13 +162,18 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         l.separator()
         l.label(text="save texture as bitmap image, choose a format:")
         l.prop(self, "bitmap_save")
+        l.operator('file.select_all_toggle', text='choose a directory')
+
         row = l.row()
         #addon = context.user_preferences.addons.get(sverchok.__name__)
         #row.scale_y = 4.0 if addon.preferences.over_sized_buttons else 1
 
         l.operator("node.scriptlite_ui_callback", text="S A V E").fn_name="save_bitmap"
 
-
+    def invoke(self, context, event):
+        wm = context.window_manager
+        wm.fileselect_add(self)
+        return {'RUNNING_MODAL'}
 
     def sv_init(self, context):
         self.inputs.new('StringsSocket', "Float").prop_name = 'in_float'
@@ -250,7 +261,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     def copy(self, node):
         self.n_id = ''
 
-    def save_bitmap(self,image_name='',filepath_raw='',img_format='PNG',width=64,height=64,alpha=False):
+    def save_bitmap(self,image_name='image.png',filepath_raw='',img_format='PNG',width=64,height=64,alpha=False):
         img = bpy.data.images.new(name="bitmap", width=64,height=64,alpha=False, float_buffer=True)
         img = assign_image(image_name,width*height,self.texture)
         img.colorspace_settings.name = 'Linear'

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -63,12 +63,11 @@ def simple_screen(x, y, args):
 
     texture = args[1]
     size = args[2]
+    texname = args[3]
     #print('size of tex inside simple screen: {0}'.format(size))
-
     texture = 1
     width = size
     height = size
-    texname = 0
 
     def draw_borders(x=0, y=0, w=30, h=10, color=(0.0, 0.0, 0.0, 1.0)):
         #function to draw a border color around the texture
@@ -175,8 +174,6 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
                 bgl.glShadeModel(bgl.GL_SMOOTH)
                 bgl.glEnable(bgl.GL_DEPTH_TEST)
 
-                #Buffer = bgl.Buffer(bgl.GL_FLOAT, [width,height], data)
-                #Buffer = bgl.Buffer(bgl.GL_FLOAT,  width * height, data)
                 bgl.glPixelStorei(bgl.GL_UNPACK_ALIGNMENT,1)
 
                 #bgl.glGenTextures(1,Buffer)
@@ -206,7 +203,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
                 'mode': 'custom_function',
                 'custom_function': simple_screen,
                 'loc': (x, y),
-                'args': (palette, texture, size_tex)
+                'args': (palette, texture, size_tex, texname)
             }
 
             nvBGL2.callback_enable(n_id, draw_data)

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -16,7 +16,6 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
-#from mathutils import Vector
 import numpy as np
 import bpy
 from bpy.props import FloatProperty, EnumProperty, StringProperty, BoolProperty
@@ -171,22 +170,17 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
 
             texture = self.get_buffer()
             size_tex = size_tex_dict.get(self.selected_mode)
-            #x, y = [int(j) for j in (self.location + Vector((self.width + 20, 0)))[:]]
             x, y = self.xy_offset
 
             def init_texture(width,height,texname,texture):
                 #function to init the texture
                 bgl.glShadeModel(bgl.GL_SMOOTH)
-                bgl.glEnable(bgl.GL_DEPTH_TEST)
 
                 bgl.glPixelStorei(bgl.GL_UNPACK_ALIGNMENT,1)
 
                 bgl.glGenTextures(1,texture)
-
                 bgl.glEnable(bgl.GL_TEXTURE_2D)
-
                 bgl.glBindTexture(bgl.GL_TEXTURE_2D, texname)
-
                 bgl.glActiveTexture(bgl.GL_TEXTURE0)
 
                 bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_S, bgl.GL_CLAMP)
@@ -239,8 +233,8 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         np_buff.shape = -1
         img.pixels[:] = np_buff
         #get the scene context
-        scene=bpy.context.scene
-        scene.render.image_settings.file_format= img_format
+        scene = bpy.context.scene
+        scene.render.image_settings.file_format = img_format
         #get the path for the file and save the image
         path = img.filepath_raw
         path = "/tmp/" + image_name

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -20,7 +20,6 @@ from mathutils import Vector
 import bpy
 from bpy.props import FloatProperty, EnumProperty, StringProperty, BoolProperty
 
-import blf
 import bgl
 
 from sverchok.data_structure import updateNode, node_id

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -162,7 +162,6 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         # end early
         nvBGL2.callback_disable(n_id)
 
-
         if self.activate:
 
             texture = self.get_buffer()
@@ -236,7 +235,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         np_buff[:,3] = 1
         np_buff.shape = -1
         img.pixels[:] = np_buff
-        #print("buffer is:{0}".format(buf))
+
         img.filepath_raw = "/tmp/" + image_name
         img.save()
         print('saved!')

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -27,13 +27,11 @@ from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.ui import nodeview_bgl_viewer_draw_mk2 as nvBGL2
 
 size_tex_list = [
-    ('EXTRA_SMALL', 'extra_small 64x64px',
-     'extra small squared tex: 64px', '', 64),
+    ('EXTRA_SMALL', 'extra_small 64x64px', 'extra small squared tex: 64px', '', 64),
     ('SMALL', 'small 128x128px', 'small squared tex: 128px', '', 128),
     ('MEDIUM', 'medium 256x256px', 'medium squared tex: 256px', '', 256),
     ('LARGE', 'large 512x512px', 'large squared tex: 512px', '', 512),
-    ('EXTRA_LARGE', 'extra_large 1024x1024px',
-     'extra large squared tex: 1024px', '', 1024)
+    ('EXTRA_LARGE', 'extra_large 1024x1024px', 'extra large squared tex: 1024px', '', 1024)
 ]
 
 size_tex_dict = {
@@ -69,7 +67,7 @@ def simple_screen(x, y, args):
         bgl.glColor4f(*color)
         bgl.glBegin(bgl.GL_LINE_LOOP)
 
-        for coord in [(x, y), (x+w, y), (w+x, y-h), (x, y-h)]:
+        for coord in [(x, y), (x + w, y), (w + x, y - h), (x, y - h)]:
             bgl.glVertex2f(*coord)
 
         bgl.glEnd()
@@ -203,10 +201,8 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
                 bgl.glTexParameterf(bgl.GL_TEXTURE_2D,
                                     bgl.GL_TEXTURE_MIN_FILTER, bgl.GL_LINEAR)
 
-                bgl.glTexImage2D(
-                       bgl.GL_TEXTURE_2D, 0, bgl.GL_LUMINANCE, width, height,
-                       0, bgl.GL_LUMINANCE, bgl.GL_FLOAT, texture
-                   )
+                bgl.glTexImage2D(bgl.GL_TEXTURE_2D, 0, bgl.GL_LUMINANCE, width,
+                                 height, 0, bgl.GL_LUMINANCE, bgl.GL_FLOAT, texture)
 
             texname = 0
 
@@ -236,8 +232,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         # in different formats supported by blender
         buf = self.get_buffer()
         img_format = self.bitmap_save
-        image_name = image_name + '.'
-        + (img_format.lower().replace('targa', 'tga'))
+        image_name = image_name + '.' + (img_format.lower().replace('targa', 'tga'))
         dim = size_tex_dict[self.selected_mode]
         width, height = dim, dim
         img = []

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -79,7 +79,7 @@ def simple_screen(x, y, args):
 
         bgl.glEnd()
 
-    def draw_texture(x=0, y=0, w=30, h=10, color=(0.0, 0.0, 0.0, 1.0), texname=texname):
+    def draw_texture(x=0, y=0, w=30, h=10, texname=texname):
         #function to draw a texture
         bgl.glEnable(bgl.GL_TEXTURE_2D)
         bgl.glTexEnvf(bgl.GL_TEXTURE_ENV, bgl.GL_TEXTURE_ENV_MODE, bgl.GL_REPLACE)
@@ -98,9 +98,9 @@ def simple_screen(x, y, args):
         #bgl.glDeleteTextures( 1, Buffer )
         bgl.glFlush()
 
-    draw_texture(x=x, y=y, w=width, h=height, color=back_color,texname=texname)
+    draw_texture(x=x, y=y, w=width, h=height, texname=texname)
 
-    draw_borders(x=x, y=y, w=width, h=height, color=(0.243299, 0.590403, 0.836084, 1.00))
+    draw_borders(x=x, y=y, w=width, h=height, color=grid_color)
 
 class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     '''Texture Viewer node'''

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -154,17 +154,11 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         c.prop(self, 'activate')
 
     def draw_buttons_ext(self, context, l):
-        #l.label(text="choose a different color for the border:")
-        #l.prop(self, "selected_theme_mode")
-        #l.separator()
         l.label(text="save texture as bitmap image, choose a format:")
+        l.separator()
         l.prop(self, "bitmap_save")
-        #l.operator('file.select_all_toggle', text='choose a directory')
-
-        row = l.row()
-        #addon = context.user_preferences.addons.get(sverchok.__name__)
-        #row.scale_y = 4.0 if addon.preferences.over_sized_buttons else 1
-
+        l.separator()
+        l.row()
         l.operator("node.scriptlite_ui_callback", text="S A V E").fn_name="save_bitmap"
 
     def sv_init(self, context):


### PR DESCRIPTION
as discussed [here](https://github.com/nortikin/sverchok/issues/1248)

Now the node has:

- the ability to change the display size (64,128,256,512,1024)

- hide and unhide of texture

to do: 

- at the moment the data should be in the form of square matrix, as the buffer need this kind of data. 
how can i transform the data from a noise node or fractal node in the form of [[0.0,1.0,0.2,....ect.]] to 
a matrix like data? Does sverchok has some code utility to do this? 
the idea  in pseudocode:

````python
if data: [[....]]

    convert_to_matrix >>>> [[...],[...],[...],........]

else data:  [[...],[...],[...],........]

go straight

````

- i think there is a better way for the tex_list stuff, i'm not so smart yet with . 




 