### PR TITLE
SvSet purge

### DIFF
--- a/nodes/generator/cylinder.py
+++ b/nodes/generator/cylinder.py
@@ -23,7 +23,7 @@ from bpy.props import BoolProperty, IntProperty, FloatProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import (match_long_repeat, sv_zip,
-                            updateNode, SvSetSocketAnyType)
+                                     updateNode)
 
 
 def cylinder_vertices(Subd, Vertices, Height, RadiusBot, RadiusTop, Separate):
@@ -147,20 +147,17 @@ class CylinderNode(bpy.types.Node, SverchCustomTreeNode):
 
             points = [cylinder_vertices(s, v, h, rb, rt, self.Separate)
                       for s, v, h, rb, rt in zip(*params)]
-            SvSetSocketAnyType(self, 'Vertices', points)
+            self.outputs['Vertices'].sv_set(points)
 
         if self.outputs['Edges'].is_linked:
             edges = [cylinder_edges(s, v)
                      for s, v, h, rb, rt in zip(*params)]
-            SvSetSocketAnyType(self, 'Edges', edges)
+            self.outputs['Edges'].sv_set(edges)
 
         if self.outputs['Polygons'].is_linked:
             faces = [cylinder_faces(s, v, self.cap_)
                      for s, v, h, rb, rt in zip(*params)]
-            SvSetSocketAnyType(self, 'Polygons', faces)
-
-    def update_socket(self, context):
-        self.update()
+            self.outputs['Polygons'].sv_set(faces)
 
 
 def register():

--- a/nodes/generator/sphere.py
+++ b/nodes/generator/sphere.py
@@ -4,14 +4,14 @@ import bpy
 from bpy.props import IntProperty, FloatProperty, BoolProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import updateNode, match_long_repeat, SvSetSocketAnyType
+from sverchok.data_structure import updateNode, match_long_repeat
 
 
 def sphere_verts(U, V, Radius, Separate):
     theta = radians(360/U)
     phi = radians(180/(V-1))
     if Separate:
-        pts = [[ [0, 0, Radius] for i in range(U) ]]
+        pts = [[[0, 0, Radius] for i in range(U)]]
     else:
         pts = [[0, 0, Radius]]
     for i in range(1, V-1):
@@ -27,7 +27,7 @@ def sphere_verts(U, V, Radius, Separate):
         else:
             pts.extend(pts_u)
     if Separate:
-        points_top = [ [0, 0, -Radius] for i in range(U) ]
+        points_top = [[0, 0, -Radius] for i in range(U)]
         pts.append(points_top)
     else:
         pts.append([0, 0, -Radius])
@@ -108,16 +108,15 @@ class SphereNode(bpy.types.Node, SverchCustomTreeNode):
         # outputs
         if self.outputs['Vertices'].is_linked:
             verts = [sphere_verts(u, v, r, self.Separate) for u, v, r in zip(*params)]
-            SvSetSocketAnyType(self, 'Vertices', verts)
+            self.outputs['Vertices'].sv_set(verts)
 
         if self.outputs['Edges'].is_linked:
             edges = [sphere_edges(u, v) for u, v, r in zip(*params)]
-            SvSetSocketAnyType(self, 'Edges', edges)
+            self.outputs['Edges'].sv_set(edges)
 
         if self.outputs['Polygons'].is_linked:
             faces = [sphere_faces(u, v) for u, v, r in zip(*params)]
-            SvSetSocketAnyType(self, 'Polygons', faces)
-
+            self.outputs['Polygons'].sv_set(faces)
 
 
 def register():
@@ -126,6 +125,3 @@ def register():
 
 def unregister():
     bpy.utils.unregister_class(SphereNode)
-
-if __name__ == '__main__':
-    register()

--- a/nodes/generator/torus.py
+++ b/nodes/generator/torus.py
@@ -24,7 +24,7 @@ from random import random
 import time
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import updateNode, match_long_repeat, SvSetSocketAnyType
+from sverchok.data_structure import updateNode, match_long_repeat
 
 
 def torus_verts(R, r, N1, N2, rPhase, sPhase, Separate):

--- a/nodes/generator/torusKnot.py
+++ b/nodes/generator/torusKnot.py
@@ -26,7 +26,7 @@ from random import random
 import time
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import updateNode, match_long_repeat, SvSetSocketAnyType
+from sverchok.data_structure import updateNode, match_long_repeat
 
 DEBUG=False
 

--- a/nodes/matrix/input.py
+++ b/nodes/matrix/input.py
@@ -20,7 +20,7 @@ import bpy
 from bpy.props import FloatVectorProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import updateNode, Matrix_listing, SvSetSocketAnyType
+from sverchok.data_structure import updateNode, Matrix_listing
 
 
 class SvMatrixValueIn(bpy.types.Node, SverchCustomTreeNode):
@@ -55,8 +55,7 @@ class SvMatrixValueIn(bpy.types.Node, SverchCustomTreeNode):
     def process(self):
         if 'Matrix' in self.outputs and self.outputs['Matrix'].is_linked:
             m_out = Matrix_listing([self.matrix])
-            SvSetSocketAnyType(self, 'Matrix', m_out)
-
+            self.outputs[0].sv_set(m_out)
 
 
 def register():

--- a/nodes/number/list_input.py
+++ b/nodes/number/list_input.py
@@ -21,7 +21,7 @@ from bpy.props import (EnumProperty, FloatVectorProperty,
                        IntProperty, IntVectorProperty)
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import updateNode, SvSetSocketAnyType
+from sverchok.data_structure import updateNode
 
 
 class SvListInputNode(bpy.types.Node, SverchCustomTreeNode):
@@ -101,6 +101,7 @@ class SvListInputNode(bpy.types.Node, SverchCustomTreeNode):
                 v_l = list(self.vector_list)
                 data = [list(zip(v_l[0:c:3], v_l[1:c:3], v_l[2:c:3]))]
             self.outputs[0].sv_set(data)
+
 
 def register():
     bpy.utils.register_class(SvListInputNode)

--- a/nodes/number/random.py
+++ b/nodes/number/random.py
@@ -22,7 +22,7 @@ import bpy
 from bpy.props import IntProperty, FloatProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import updateNode, match_long_repeat, SvSetSocketAnyType
+from sverchok.data_structure import updateNode, match_long_repeat
 
 
 class RandomNode(bpy.types.Node, SverchCustomTreeNode):
@@ -47,14 +47,14 @@ class RandomNode(bpy.types.Node, SverchCustomTreeNode):
     def process(self):
         if not self.outputs[0].is_linked:
             return
-            
+
         Coun = self.inputs['Count'].sv_get()[0]
 
         Seed = self.inputs['Seed'].sv_get()[0]
 
         # outputs
 
-        
+
         Random = []
         if len(Seed) == 1:
             random.seed(Seed[0])
@@ -65,7 +65,7 @@ class RandomNode(bpy.types.Node, SverchCustomTreeNode):
             for s, c in zip(*param):
                 random.seed(s)
                 Random.append([random.random() for i in range(int(c))])
-        
+
         self.outputs[0].sv_set(Random)
 
 

--- a/nodes/scene/frame_info.py
+++ b/nodes/scene/frame_info.py
@@ -36,7 +36,7 @@ class SvFrameInfoNode(bpy.types.Node, SverchCustomTreeNode):
         # outputs
         scene = bpy.context.scene
         if self.outputs['Current Frame'].is_linked:
-            self.outputs['Current Frame'].sv.set([[scene.frame_current]])
+            self.outputs['Current Frame'].sv_set([[scene.frame_current]])
         if self.outputs['Start Frame'].is_linked:
             self.outputs['Start Frame'].sv_set([[scene.frame_start]])
         if self.outputs['End Frame'].is_linked:

--- a/nodes/scene/frame_info.py
+++ b/nodes/scene/frame_info.py
@@ -19,7 +19,6 @@
 import bpy
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import SvSetSocketAnyType
 
 
 class SvFrameInfoNode(bpy.types.Node, SverchCustomTreeNode):
@@ -35,12 +34,14 @@ class SvFrameInfoNode(bpy.types.Node, SverchCustomTreeNode):
 
     def process(self):
         # outputs
+        scene = bpy.context.scene
         if self.outputs['Current Frame'].is_linked:
-            SvSetSocketAnyType(self, 'Current Frame', [[bpy.context.scene.frame_current]])
+            self.outputs['Current Frame'].sv.set([[scene.frame_current]])
         if self.outputs['Start Frame'].is_linked:
-            SvSetSocketAnyType(self, 'Start Frame', [[bpy.context.scene.frame_start]])
+            self.outputs['Start Frame'].sv_set([[scene.frame_start]])
         if self.outputs['End Frame'].is_linked:
-            SvSetSocketAnyType(self, 'End Frame', [[bpy.context.scene.frame_end]])
+            self.outputs['End Frame'].sv_set([[scene.frame_end]])
+
 
 def register():
     bpy.utils.register_class(SvFrameInfoNode)

--- a/nodes/vector/axis_input.py
+++ b/nodes/vector/axis_input.py
@@ -20,7 +20,7 @@ import bpy
 from bpy.props import StringProperty, EnumProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import updateNode, SvSetSocketAnyType
+from sverchok.data_structure import updateNode
 
 
 class svAxisInputNode(bpy.types.Node, SverchCustomTreeNode):
@@ -78,7 +78,8 @@ class svAxisInputNode(bpy.types.Node, SverchCustomTreeNode):
                 'Z': (0, 0, 1)
             }.get(self.current_axis, None)
 
-            SvSetSocketAnyType(self, 'Vectors', [[axial_vector]])
+            self.outputs[0].sv_set([[axial_vector]])
+
 
 def register():
     bpy.utils.register_class(svAxisInputNode)
@@ -86,6 +87,3 @@ def register():
 
 def unregister():
     bpy.utils.unregister_class(svAxisInputNode)
-
-if __name__ == '__main__':
-    register()

--- a/nodes/vector/axis_input_mk2.py
+++ b/nodes/vector/axis_input_mk2.py
@@ -20,7 +20,7 @@ import bpy
 from bpy.props import StringProperty, EnumProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import updateNode, SvSetSocketAnyType
+from sverchok.data_structure import updateNode
 
 
 class SvAxisInputNodeMK2(bpy.types.Node, SverchCustomTreeNode):

--- a/nodes/vector/noise.py
+++ b/nodes/vector/noise.py
@@ -24,8 +24,7 @@ from bpy.props import EnumProperty
 from mathutils import noise
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import (updateNode, Vector_generate, Vector_degenerate,
-                            SvSetSocketAnyType, SvGetSocketAnyType)
+from sverchok.data_structure import (updateNode, Vector_generate, Vector_degenerate)
 
 # noise nodes
 # from http://www.blender.org/documentation/blender_python_api_2_70_release/mathutils.noise.html
@@ -92,7 +91,7 @@ class SvNoiseNode(bpy.types.Node, SverchCustomTreeNode):
         if not self.outputs[0].is_linked:
             return
 
-        
+
         verts = Vector_generate(self.inputs['Vertices'].sv_get())
         out = []
         n_t = self.noise_dict[self.noise_type]


### PR DESCRIPTION
Our earlier effort missed a few cases.

- [x] Cylinder
- [x] sphere
- [x] Frame info
- [x] Axis input, old move to old nodes?
- [x] Matrix input

Import but not used in 
- [x] Torus
- [x] Torus Knot
- [x] list input
- [x]  random data
- [x] axis input mk2
- [x]  noise, old. Move to old nodes?