### PR TITLE
Add separate node color for the extended generator nodes

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -110,6 +110,12 @@ class SverchokPreferences(AddonPreferences):
         default=(0, 0.5, 0.5), subtype='COLOR',
         update=update_theme)
 
+    color_genx = FloatVectorProperty(
+        name="Generator Extended", description='',
+        size=3, min=0.0, max=1.0,
+        default=(0.4, 0.7, 0.7), subtype='COLOR',
+        update=update_theme)
+
     #  frame change
     frame_change_modes = [
         ("PRE", "Pre", "Update Sverchok before frame change", 0),
@@ -173,7 +179,7 @@ class SverchokPreferences(AddonPreferences):
             r = col1.row()
             r.prop(self, name)
         col2 = split.column()
-        for name in ['color_lay', 'color_gen']:
+        for name in ['color_lay', 'color_gen', 'color_genx']:
             r = col2.row()
             r.prop(self, name)
 

--- a/ui/color_def.py
+++ b/ui/color_def.py
@@ -35,6 +35,7 @@ default_theme = {
     "Scene": (0, 0.5, 0.2),
     "Layout": (0.674, 0.242, 0.363),
     "Generators": (0, 0.5, 0.5),
+    "Generators Extended": (0.4, 0.7, 0.7),
 }
 
 nipon_blossom = {
@@ -43,6 +44,7 @@ nipon_blossom = {
     "Scene": (0.904933, 1.000000, 0.883421),
     "Layout": (0.602957, 0.674000, 0.564277),
     "Generators": (0.92, 0.92, 0.92),
+    "Generators Extended": (0.95, 0.95, 0.95),
 }
 
 
@@ -57,6 +59,7 @@ def color_callback(self, context):
         ("Scene", "color_sce"),
         ("Layout", "color_lay"),
         ("Generators", "color_gen"),
+        ("Generators Extended", "color_genx"),
     ]
     # stop theme from auto updating and do one call instead of many
     auto_apply_theme = self.auto_apply_theme
@@ -79,6 +82,7 @@ def sv_colors_definition():
             "Scene": prefs.color_sce,
             "Layout": prefs.color_lay,
             "Generators": prefs.color_gen,
+            "Generators Extended": prefs.color_genx,
             }
     else:
         sv_node_colors = default_theme


### PR DESCRIPTION
The extended generator nodes have a color slightly off the color of the main generators (greenish for the default theme). This way we can distinguish the extended generators apart from the rest of the nodes including the main generators.

![genx-vs-gen-nodecolors](https://cloud.githubusercontent.com/assets/2083719/23834859/96ba6864-0733-11e7-9071-901a35bd3c59.png)
