### PR TITLE
Add new Transform Select node

### DIFF
--- a/index.md
+++ b/index.md
@@ -87,6 +87,7 @@
     SvTriangulateNode
     SvFlipNormalsNode
     SvRecalcNormalsNode
+    SvTransformSelectNode
 
 ## Modifier Make
     LineConnectNodeMK2

--- a/nodes/modifier_change/transform_select.py
+++ b/nodes/modifier_change/transform_select.py
@@ -104,11 +104,11 @@ class SvTransformSelectNode(bpy.types.Node, SverchCustomTreeNode):
 
         # print("Vertices T: ", vertListT)
         # print("Vertices F: ", vertListF)
-        outputs['Vertices'].sv_set(vertList)
-        outputs['Vertices T'].sv_set(vertListT)
-        outputs['PolyEdge T'].sv_set(polyEdgeListT)
-        outputs['Vertices F'].sv_set(vertListF)
-        outputs['PolyEdge F'].sv_set(polyEdgeListT)
+        outputs['Vertices'].sv_set([vertList])
+        outputs['Vertices T'].sv_set([vertListT])
+        outputs['PolyEdge T'].sv_set([polyEdgeListT])
+        outputs['Vertices F'].sv_set([vertListF])
+        outputs['PolyEdge F'].sv_set([polyEdgeListT])
 
 def register():
     bpy.utils.register_class(SvTransformSelectNode)

--- a/nodes/modifier_change/transform_select.py
+++ b/nodes/modifier_change/transform_select.py
@@ -86,20 +86,11 @@ class SvTransformSelectNode(bpy.types.Node, SverchCustomTreeNode):
         matrixF = matrixF[:n]
         matrixT = matrixT[:n]
 
-        # print("Mask: ", input_mask)
-        # print("Vertices: ", input_verts)
-        # print("Matrix F: ", matrixF)
-        # print("Matrix T: ", matrixT)
-
         params = match_long_repeat([input_mask, input_verts, matrixT, matrixF])
-        # print("params: ", params)
 
         # process vertices
         vertListA, vertListT, vertListF = [[], [], []]
         for ma, v, mt, mf in zip(*params):
-            # print('Vertex:', v, " has mask:", ma)
-            # print('Matrix T:', mt)
-            # print('Matrix F:', mf)
             if ma == 1:  # do some processing using Matrix T here
                 v = (mt * Vector(v))[:]
                 vertListT.append(v)
@@ -113,47 +104,21 @@ class SvTransformSelectNode(bpy.types.Node, SverchCustomTreeNode):
         vert_indexF = [i for i, m in enumerate(input_mask) if not m]
         vt = {j: i for i, j in enumerate(vert_indexT)}
         vf = {j: i for i, j in enumerate(vert_indexF)}
-        # vext = set(vt.keys())
-        # vexf = set(vf.keys())
         vext = set(vert_indexT)
         vexf = set(vert_indexF)
-        # print("vt.k = ", vt.keys())
-        # print("vf.k = ", vf.keys())
-        # print("vert_indexT = ", vert_indexT)
-        # print("vert_indexF = ", vert_indexF)
-        # print("vext = ", vext)
-        # print("vexf = ", vexf)
-        # print("vt = ", vt)
-        # print("vf = ", vf)
 
         polyEdgeListA = input_polys
         polyEdgeListT, polyEdgeListF, polyEdgeListO = [[], [], []]
-
-        # pelT = [[vt[i] for i in pe] for pe in input_polys if isSetT(set(pe))]
-        # pelF = [[vf[i] for i in pe] for pe in input_polys if isSetF(set(pe))]
 
         inSetT, inSetF = vext.issuperset, vexf.issuperset
         addPET, addPEF, addPEO = polyEdgeListT.append, polyEdgeListF.append, polyEdgeListO.append
         for pe in input_polys:
             pex = set(pe)
-            # print("pex = ", pex)
-
             if inSetT(pex):
-                # print("pex ", pex, " is in vext ", vext)
-                # pet = [vt[i] for i in pe]
-                # polyEdgeListT.append(pet)
                 addPET([vt[i] for i in pe])
-                # polyEdgeListT.append([vt[i] for i in pe])
-
             elif inSetF(pex):
-                # print("pex ", pex, " is in vexf ", vexf)
-                # pef = [vf[i] for i in pe]
-                # polyEdgeListF.append(pef)
-                # polyEdgeListF.append([vf[i] for i in pe])
                 addPEF([vf[i] for i in pe])
-
             else:
-                # polyEdgeListO.append(pe)
                 addPEO(pe)
 
         outputs['Vertices'].sv_set([vertListA])

--- a/nodes/modifier_change/transform_select.py
+++ b/nodes/modifier_change/transform_select.py
@@ -69,16 +69,16 @@ class SvTransformSelectNode(bpy.types.Node, SverchCustomTreeNode):
         input_matrixT = inputs['Matrix T'].sv_get()
         input_matrixF = inputs['Matrix F'].sv_get()
 
+        n = len(input_verts)
+
         if inputs['Mask'].is_linked:
             input_mask = inputs['Mask'].sv_get()[0]
-        else:
-            n = len(input_verts)
+        else: # if no mask input, generate a 0,1,0,1 mask
             input_mask = ([1, 0] * (int((n + 1) / 2)))[:n]
 
         matrixF = Matrix_generate(input_matrixF)
         matrixT = Matrix_generate(input_matrixT)
 
-        n = len(input_verts)
         matrixF = matrixF[:n]
         matrixT = matrixT[:n]
 
@@ -100,11 +100,11 @@ class SvTransformSelectNode(bpy.types.Node, SverchCustomTreeNode):
         vt = {}
         vf = {}
         vid = 0
-        for i, v, mt, mf in zip(*params):
-            # print('Vertex:', v, " has mask:", i)
+        for ma, v, mt, mf in zip(*params):
+            # print('Vertex:', v, " has mask:", ma)
             # print('Matrix T:', mt)
             # print('Matrix F:', mf)
-            if i == 1:  # do some processing using Matrix T here
+            if ma == 1:  # do some processing using Matrix T here
                 v = (mt * Vector(v))[:]
                 vertListT.append(v)
                 vt[vid] = len(vertListT) - 1
@@ -120,17 +120,46 @@ class SvTransformSelectNode(bpy.types.Node, SverchCustomTreeNode):
 
         polyEdgeListA = input_polys
 
+        # vert_indexT = [i for i, m in enumerate(input_mask) if m]
+        # vert_indexF = [i for i, m in enumerate(input_mask) if not m]
+
+        # vert1_indexT = [vt[i] for i, m in enumerate(input_mask) if m]
+        # vert1_indexF = [vf[i] for i, m in enumerate(input_mask) if not m]
+
+        # print("vert_indexT = ", vert_indexT)
+        # print("vert_indexF = ", vert_indexF)
+        # print("vert1_indexT = ", vert1_indexT)
+        # print("vert1_indexF = ", vert1_indexF)
+
+        vext = set(vt.keys())
+        vexf = set(vf.keys())
+
         for pe in input_polys:
-            i1, i2 = pe
+            # i1, i2 = pe
+
+            pex = set(pe)
+            # print("pex = ", pex)
+
+            if vext.issuperset(pex):
+                pet = [vt[i] for i in pe]
+                polyEdgeListT.append(pet)
+                # polyEdgeListT.append([vt[i1], vt[i2]])
+
+            if vexf.issuperset(pex):
+                pef = [vf[i] for i in pe]
+                polyEdgeListF.append(pef)
+                # polyEdgeListT.append([vf[i1], vf[i2]])
+
             # print("pe=", pe, " i1 = ", i1, " i2 = ", i2)
-            if i1 in vt and i2 in vt:
-                # print("i1 = ", i1, " i2 = ", i2, " is in vt =", vt)
-                polyEdgeListT.append([vt[i1], vt[i2]])
-            if i1 in vf and i2 in vf:
-                # print("i1 = ", i1, " i2 = ", i2, " is in vf =", vf)
-                polyEdgeListF.append([vf[i1], vf[i2]])
-            if i1 in vt and i2 in vf or i1 in vf and i2 in vt:
-                polyEdgeListO.append([i1, i2])
+            # if i1 in vt and i2 in vt:
+            #     # print("i1 = ", i1, " i2 = ", i2, " is in vt =", vt)
+            #     polyEdgeListT.append([vt[i1], vt[i2]])
+            # if i1 in vf and i2 in vf:
+            #     # print("i1 = ", i1, " i2 = ", i2, " is in vf =", vf)
+            #     polyEdgeListF.append([vf[i1], vf[i2]])
+
+            # if i1 in vt and i2 in vf or i1 in vf and i2 in vt:
+            #     polyEdgeListO.append([i1, i2])
 
         # print("Vertices T: ", vertListT)
         # print("Vertices F: ", vertListF)

--- a/nodes/modifier_change/transform_select.py
+++ b/nodes/modifier_change/transform_select.py
@@ -1,0 +1,121 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import bpy
+from bpy.props import IntProperty, FloatProperty, BoolProperty, EnumProperty
+
+from mathutils import Matrix, Vector
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode, match_long_repeat, Matrix_generate
+
+maskTypeItems = [("VERTICES", "V", ""), ("EDGES", "E", ""), ("POLYGONS", "P", ""), ]
+
+class SvTransformSelectNode(bpy.types.Node, SverchCustomTreeNode):
+
+    ''' Transform Select '''
+    bl_idname = 'SvTransformSelectNode'
+    bl_label = 'Transform Select'
+
+    maskType = EnumProperty(
+        name="Mask Type", description="Mask various mesh components",
+        default="VERTICES", items=maskTypeItems,
+        update=updateNode)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'maskType', expand=True)
+
+    def sv_init(self, context):
+        self.inputs.new('StringsSocket', "Mask")
+        self.inputs.new('VerticesSocket', "Vertices")
+        self.inputs.new('StringsSocket', "PolyEdge")
+        self.inputs.new('MatrixSocket', "Matrix T")
+        self.inputs.new('MatrixSocket', "Matrix F")
+
+        self.outputs.new('VerticesSocket', "Vertices")
+        self.outputs.new('StringsSocket', "PolyEdge")
+        self.outputs.new('VerticesSocket', "Vertices T")
+        self.outputs.new('StringsSocket', "PolyEdge T")
+        self.outputs.new('VerticesSocket', "Vertices F")
+        self.outputs.new('StringsSocket', "PolyEdge F")
+
+
+    def process(self):
+        # return if no outputs are connected
+        if not any(s.is_linked for s in self.outputs):
+            return
+
+        inputs = self.inputs
+        outputs = self.outputs
+
+        input_verts = inputs['Vertices'].sv_get()[0]
+        input_polys = inputs['PolyEdge'].sv_get()[0]
+        input_matrixT = inputs['Matrix T'].sv_get()
+        input_matrixF = inputs['Matrix F'].sv_get()
+
+        if inputs['Mask'].is_linked:
+            input_mask = inputs['Mask'].sv_get()[0]
+        else:
+            n = len(input_verts)
+            input_mask = ([1,0]*(int((n+1)/2)))[:n]
+
+        matrixF = Matrix_generate(input_matrixF)
+        matrixT = Matrix_generate(input_matrixT)
+
+        # print("Mask: ", input_mask)
+        # print("Vertices: ", input_verts)
+        # print("Matrix F: ", matrixF)
+        # print("Matrix T: ", matrixT)
+
+        params = match_long_repeat([input_mask, input_verts, matrixT, matrixF])
+        # print("params: ", params)
+
+        vertList = []
+        vertListT = []
+        vertListF = []
+        polyEdgeListT = []
+        polyEdgeListF = []
+        for i, v, mt, mf in zip(*params):
+            # print('Vertex:', v, " has mask:", i)
+            # print('Matrix T:', mt)
+            # print('Matrix F:', mf)
+            if i == 1: # do some processing using Matrix T here
+                v = (mt * Vector(v))[:]
+                vertListT.append(v)
+            else: # do some processing using Matrix F here
+                v = (mf * Vector(v))[:]
+                vertListF.append(v)
+            vertList.append(v)
+
+        # print("Vertices T: ", vertListT)
+        # print("Vertices F: ", vertListF)
+        outputs['Vertices'].sv_set(vertList)
+        outputs['Vertices T'].sv_set(vertListT)
+        outputs['PolyEdge T'].sv_set(polyEdgeListT)
+        outputs['Vertices F'].sv_set(vertListF)
+        outputs['PolyEdge F'].sv_set(polyEdgeListT)
+
+def register():
+    bpy.utils.register_class(SvTransformSelectNode)
+
+
+def unregister():
+    bpy.utils.unregister_class(SvTransformSelectNode)
+
+if __name__ == '__main__':
+    register()

--- a/nodes/modifier_change/transform_select.py
+++ b/nodes/modifier_change/transform_select.py
@@ -62,7 +62,7 @@ class SvTransformSelectNode(bpy.types.Node, SverchCustomTreeNode):
         inputs = self.inputs
         outputs = self.outputs
 
-        identityMatrix = [[(1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1)]]
+        identityMatrix = [[tuple(v) for v in Matrix()]]
         input_verts = inputs['Vertices'].sv_get()[0]
         input_polys = inputs['PolyEdge'].sv_get()[0]
         input_matrixT = inputs['Matrix T'].sv_get(default=identityMatrix)

--- a/nodes/modifier_change/transform_select.py
+++ b/nodes/modifier_change/transform_select.py
@@ -94,13 +94,7 @@ class SvTransformSelectNode(bpy.types.Node, SverchCustomTreeNode):
         params = match_long_repeat([input_mask, input_verts, matrixT, matrixF])
         # print("params: ", params)
 
-        vert_indexT = [i for i, m in enumerate(input_mask) if m]
-        vert_indexF = [i for i, m in enumerate(input_mask) if not m]
-        vt = {j: i for i, j in enumerate(vert_indexT)}
-        vf = {j: i for i, j in enumerate(vert_indexF)}
-        # print("vt = ", vt)
-        # print("vf = ", vf)
-
+        # process vertices
         vertListA, vertListT, vertListF = [[], [], []]
         for ma, v, mt, mf in zip(*params):
             # print('Vertex:', v, " has mask:", ma)
@@ -114,31 +108,53 @@ class SvTransformSelectNode(bpy.types.Node, SverchCustomTreeNode):
                 vertListF.append(v)
             vertListA.append(v)
 
+        # process polyEdges
+        vert_indexT = [i for i, m in enumerate(input_mask) if m]
+        vert_indexF = [i for i, m in enumerate(input_mask) if not m]
+        vt = {j: i for i, j in enumerate(vert_indexT)}
+        vf = {j: i for i, j in enumerate(vert_indexF)}
+        # vext = set(vt.keys())
+        # vexf = set(vf.keys())
+        vext = set(vert_indexT)
+        vexf = set(vert_indexF)
+        # print("vt.k = ", vt.keys())
+        # print("vf.k = ", vf.keys())
+        # print("vert_indexT = ", vert_indexT)
+        # print("vert_indexF = ", vert_indexF)
+        # print("vext = ", vext)
+        # print("vexf = ", vexf)
+        # print("vt = ", vt)
+        # print("vf = ", vf)
+
         polyEdgeListA = input_polys
         polyEdgeListT, polyEdgeListF, polyEdgeListO = [[], [], []]
 
-        vext = set(vt.keys())
-        vexf = set(vf.keys())
-        # print("vt.k = ", vt.keys())
-        # print("vf.k = ", vf.keys())
-        # print("vext = ", vext)
-        # print("vexf = ", vexf)
+        # pelT = [[vt[i] for i in pe] for pe in input_polys if isSetT(set(pe))]
+        # pelF = [[vf[i] for i in pe] for pe in input_polys if isSetF(set(pe))]
+
+        inSetT, inSetF = vext.issuperset, vexf.issuperset
+        addPET, addPEF, addPEO = polyEdgeListT.append, polyEdgeListF.append, polyEdgeListO.append
         for pe in input_polys:
             pex = set(pe)
             # print("pex = ", pex)
 
-            if vext.issuperset(pex):
+            if inSetT(pex):
                 # print("pex ", pex, " is in vext ", vext)
-                pet = [vt[i] for i in pe]
-                polyEdgeListT.append(pet)
+                # pet = [vt[i] for i in pe]
+                # polyEdgeListT.append(pet)
+                addPET([vt[i] for i in pe])
+                # polyEdgeListT.append([vt[i] for i in pe])
 
-            elif vexf.issuperset(pex):
+            elif inSetF(pex):
                 # print("pex ", pex, " is in vexf ", vexf)
-                pef = [vf[i] for i in pe]
-                polyEdgeListF.append(pef)
+                # pef = [vf[i] for i in pe]
+                # polyEdgeListF.append(pef)
+                # polyEdgeListF.append([vf[i] for i in pe])
+                addPEF([vf[i] for i in pe])
 
             else:
-                polyEdgeListO.append(pe)
+                # polyEdgeListO.append(pe)
+                addPEO(pe)
 
         outputs['Vertices'].sv_set([vertListA])
         outputs['PolyEdge'].sv_set([polyEdgeListA])

--- a/nodes/modifier_change/transform_select.py
+++ b/nodes/modifier_change/transform_select.py
@@ -91,28 +91,17 @@ class SvTransformSelectNode(bpy.types.Node, SverchCustomTreeNode):
         # print("Matrix F: ", matrixF)
         # print("Matrix T: ", matrixT)
 
-        # endTime = time.time()
-        # print("Computing Time: ", endTime-startTime)
-        # return
-
         params = match_long_repeat([input_mask, input_verts, matrixT, matrixF])
         # print("params: ", params)
 
         vert_indexT = [i for i, m in enumerate(input_mask) if m]
         vert_indexF = [i for i, m in enumerate(input_mask) if not m]
-        vt1 = { j:i for i, j in enumerate(vert_indexT) }
-        vf1 = { j:i for i, j in enumerate(vert_indexF) }
+        vt = {j: i for i, j in enumerate(vert_indexT)}
+        vf = {j: i for i, j in enumerate(vert_indexF)}
+        # print("vt = ", vt)
+        # print("vf = ", vf)
 
-        vertListA = []
-        vertListT = []
-        vertListF = []
-        polyEdgeListA = []
-        polyEdgeListT = []
-        polyEdgeListF = []
-        polyEdgeListO = []
-        # vt = {}
-        # vf = {}
-        # vid = 0
+        vertListA, vertListT, vertListF = [[], [], []]
         for ma, v, mt, mf in zip(*params):
             # print('Vertex:', v, " has mask:", ma)
             # print('Matrix T:', mt)
@@ -120,75 +109,37 @@ class SvTransformSelectNode(bpy.types.Node, SverchCustomTreeNode):
             if ma == 1:  # do some processing using Matrix T here
                 v = (mt * Vector(v))[:]
                 vertListT.append(v)
-                # vt[vid] = len(vertListT) - 1
             else:  # do some processing using Matrix F here
                 v = (mf * Vector(v))[:]
                 vertListF.append(v)
-                # vf[vid] = len(vertListF) - 1
             vertListA.append(v)
-            # vid = vid + 1
-
-        # print("vt = ", vt)
-        # print("vf = ", vf)
-        # print("vt1 = ", vt1)
-        # print("vf1 = ", vf1)
 
         polyEdgeListA = input_polys
+        polyEdgeListT, polyEdgeListF, polyEdgeListO = [[], [], []]
 
-        # vert_indexT = [i for i, m in enumerate(input_mask) if m]
-        # vert_indexF = [i for i, m in enumerate(input_mask) if not m]
-
-        # vert1_indexT = [vt[i] for i, m in enumerate(input_mask) if m]
-        # vert1_indexF = [vf[i] for i, m in enumerate(input_mask) if not m]
-
-        # print("vert_indexT = ", vert_indexT)
-        # print("vert_indexF = ", vert_indexF)
+        vext = set(vt.keys())
+        vexf = set(vf.keys())
         # print("vt.k = ", vt.keys())
         # print("vf.k = ", vf.keys())
-        # print("vert1_indexT = ", vert1_indexT)
-        # print("vert1_indexF = ", vert1_indexF)
-
-        vext = set(vt1.keys())
-        vexf = set(vf1.keys())
-        # vext = set(vert_indexT)
-        # vexf = set(vert_indexF)
         # print("vext = ", vext)
         # print("vexf = ", vexf)
         for pe in input_polys:
-            # i1, i2 = pe
-
             pex = set(pe)
             # print("pex = ", pex)
 
             if vext.issuperset(pex):
                 # print("pex ", pex, " is in vext ", vext)
-                pet = [vt1[i] for i in pe]
-                # pet = [vt[i] for i in pe]
+                pet = [vt[i] for i in pe]
                 polyEdgeListT.append(pet)
-                # polyEdgeListT.append([vt[i1], vt[i2]])
 
             elif vexf.issuperset(pex):
                 # print("pex ", pex, " is in vexf ", vexf)
-                pef = [vf1[i] for i in pe]
-                # pef = [vf[i] for i in pe]
+                pef = [vf[i] for i in pe]
                 polyEdgeListF.append(pef)
-                # polyEdgeListT.append([vf[i1], vf[i2]])
 
             else:
                 polyEdgeListO.append(pe)
-            # print("pe=", pe, " i1 = ", i1, " i2 = ", i2)
-            # if i1 in vt and i2 in vt:
-            #     # print("i1 = ", i1, " i2 = ", i2, " is in vt =", vt)
-            #     polyEdgeListT.append([vt[i1], vt[i2]])
-            # if i1 in vf and i2 in vf:
-            #     # print("i1 = ", i1, " i2 = ", i2, " is in vf =", vf)
-            #     polyEdgeListF.append([vf[i1], vf[i2]])
 
-            # if i1 in vt and i2 in vf or i1 in vf and i2 in vt:
-            #     polyEdgeListO.append([i1, i2])
-
-        # print("Vertices T: ", vertListT)
-        # print("Vertices F: ", vertListF)
         outputs['Vertices'].sv_set([vertListA])
         outputs['PolyEdge'].sv_set([polyEdgeListA])
         outputs['PolyEdge O'].sv_set([polyEdgeListO])
@@ -198,7 +149,8 @@ class SvTransformSelectNode(bpy.types.Node, SverchCustomTreeNode):
         outputs['PolyEdge F'].sv_set([polyEdgeListF])
 
         endTime = time.time()
-        print("Computing Time: ", endTime-startTime)
+        print("Computing Time: ", endTime - startTime)
+
 
 def register():
     bpy.utils.register_class(SvTransformSelectNode)

--- a/nodes/modifier_change/transform_select.py
+++ b/nodes/modifier_change/transform_select.py
@@ -20,7 +20,6 @@ import bpy
 from bpy.props import IntProperty, FloatProperty, BoolProperty, EnumProperty
 
 from mathutils import Matrix, Vector
-import time
 
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode, match_long_repeat, Matrix_generate
@@ -58,8 +57,6 @@ class SvTransformSelectNode(bpy.types.Node, SverchCustomTreeNode):
         self.outputs.new('StringsSocket', "PolyEdge F")
 
     def process(self):
-        startTime = time.time()
-
         # return if no outputs are connected
         if not any(s.is_linked for s in self.outputs):
             return
@@ -128,9 +125,6 @@ class SvTransformSelectNode(bpy.types.Node, SverchCustomTreeNode):
         outputs['PolyEdge T'].sv_set([polyEdgeListT])
         outputs['Vertices F'].sv_set([vertListF])
         outputs['PolyEdge F'].sv_set([polyEdgeListF])
-
-        endTime = time.time()
-        print("Computing Time: ", endTime - startTime)
 
 
 def register():


### PR DESCRIPTION
Behold the “Transform Select” node 🙌 😋 This sort of expands on the “mask vertices” node but it adds more to it to make it easier not only to separate/group the vertices but also to transform them (see the following demos). 

**Inputs**:

- **mask** # mask 0/1 with default repeat 0,1,0,1 if mask input is not linked
- **vertices**
- **polyEdges**
- **matrix T** # matrix to transform the True (mask=1) verts
- **matrix F** # matrix to transform the False (mask=0) verts

**Outputs**:

- **Vertices** # Original Vertices but transformed by MT and MF
- **PolyEdges** # original polyEdges (pass through)
- **PolyEdges O** # polyEdges in the original set connecting the T set with the F set
- **Vertices T** # vertices transformed by MT
- **PolyEdges T** # polyEdges in original set that are also in T set
- **Vertices F** # vertices transformed by MF
- **PolyEdges F** # polyEdges in original set that are also in F set

Note: The VEP selection does not work yet. This mode is to allow to mask either vertices, edges or polygons. 

![transofrmselectnode-ui](https://cloud.githubusercontent.com/assets/2083719/23840983/48f2d1d2-0780-11e7-8449-be197df0a35d.png)
