### PR TITLE
Feature tex viz improvement01

### DIFF
--- a/docs/nodes/viz/texture_viewer.rst
+++ b/docs/nodes/viz/texture_viewer.rst
@@ -4,15 +4,15 @@ Texture Viewer
 Functionality
 -------------
 
-This node allows viewing a list of scalar values as a texture, very useful
-to display data from fractal, noise nodes and others. before outputting to a viewer_draw_mk2.
+This node allows viewing a list of scalar values and Vectors as a texture, very useful
+to display data from fractal, noise nodes and others, before outputting to a viewer_draw_mk2.
 
 Uses OpenGl calls to display the data.
 
 Inputs
 ------
 
-float input
+Floats and Vectors input
 
 Parameters
 ----------
@@ -20,30 +20,57 @@ Parameters
 +-------------+-----------------------------------------------------------------------------------+
 | Feature     | info                                                                              |
 +=============+===================================================================================+
-| Float input | float nested list                                                                 |
+| Float input | float and Vectors nested list                                                     |
 +-------------+-----------------------------------------------------------------------------------+
-| Show        | true or false (to display or not the texture)                                     |
+| Show        | may be *true* or *false*:  display or not the texture                             |
++-------------+-----------------------------------------------------------------------------------+
+| Pass        | may be *true* or *false*: transfer data to the internal image viewer              |
 +-------------+-----------------------------------------------------------------------------------+
 | Set texture | choose the size of the texture to display:                                        |
 | display     | (64x64px,128x128px, 256x256px, 512x512px, 1024x1024px)                            |
 +-------------+-----------------------------------------------------------------------------------+
+| Set color   | set the color mode:                                                               |
+| mode        | **BW** = grayscale image,                                                         |
+|             | **RGB** = image with red, green, blu channels                                     |
+|             | **RGBA** = image with red, green, blu, alpha channels                             |
++-------------+-----------------------------------------------------------------------------------+
+| Custom tex  | may be *true* or *false*: enable custom size of texture                           |
++-------------+-----------------------------------------------------------------------------------+
+| Width tex   | must be *int*: set the width of the texture when Custom tex is enabled            |
++-------------+-----------------------------------------------------------------------------------+
+| Height tex  | must be *int*: set the height of the texture when Custom tex is enabled           |
++-------------+-----------------------------------------------------------------------------------+
+
 
 Outputs
 -------
 
-Directly into node tree view in a blue bordered square.
+Directly into node tree view in a blue bordered square or if you choose the ``Pass`` option the texture
+may be transfered to the internal image viewer/editor.
 
 Properties panel
 ----------------
 
-You can save the texture in /tmp folder. You can choose the format (jpeg, bmp, tiff, tgat, png).
-Save the texture clicking on the button SAVE.
+You can save the texture in the desired folder. You can choose the format:
+
+##### jpeg, jp2, bmp, tiff, tga, tga(raw), exr, exr(multilayer), png
+
+Save the texture clicking on the button ``SAVE``. You can save also passing the image to the blender image
+editor with option ``Pass``. This is much preferred because there are more saving options.
 
 Examples
 --------
 Basic usage:
 
-https://cloud.githubusercontent.com/assets/1275858/23259574/0ba15b60-f9ce-11e6-9fd4-75ece759929b.png
+.. image:: https://cloud.githubusercontent.com/assets/1275858/23259574/0ba15b60-f9ce-11e6-9fd4-75ece759929b.png
+
+Important notes
+---------------
+The ``Texture viewer node`` need adequate data size, this mean that number of input pixels
+should be equal to the output. If not you will receive an error. See the image below for an RGBA example:
+
+.. image:: https://cloud.githubusercontent.com/assets/1275858/23960481/62e0ea00-09a8-11e7-9640-87d9b9a0b4a9.png
+
 
 Links
 -----

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -337,10 +337,10 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         rightside = leftside.split().row(align=True)
         rightside.operator(callback_to_self, text="Save").fn_name = "save_bitmap"
         rightside.operator(directory_select, text="", icon='IMASEL').fn_name = "set_dir"
-        export = layout.column(align=True)
-        export.separator()
-        export.label(text="Export to image viewer")
-        export.prop(self, 'texture_name', text='', icon='EXPORT')
+        transfer = layout.column(align=True)
+        transfer.separator()
+        transfer.label(text="Transfer to image viewer")
+        transfer.prop(self, 'texture_name', text='', icon='EXPORT')
 
     def draw_label(self):
         if self.selected_custom_tex:

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -274,7 +274,6 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         return width, height
 
     def reshape_data(self, data):
-        # reshaping data to a flatten list
         self.total_size = self.calculate_total_size()
         if len(data) < self.total_size:
             default_value = 0
@@ -283,7 +282,6 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
             data = new_data
         elif len(data) > self.total_size:
             data = data[:self.total_size]
-        return data
 
     def calculate_total_size(self):
         ''' buffer need adequate size multiplying '''
@@ -382,7 +380,6 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
             transfer_to_image(pixels, self.texture_name, width, height, mode)
 
         if self.activate:
-
             texture = self.get_buffer()
             width, height = self.texture_width_height
             x, y = self.xy_offset

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -265,6 +265,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
 
     @property
     def texture_width_height(self):
+        #  get the width and height for the texture
         if self.selected_custom_tex:
             width, height = self.get_from_c_size()
         else:
@@ -288,19 +289,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         ''' buffer need adequate size multiplying '''
         width, height = self.texture_width_height
         return width * height * factor_buffer_dict.get(self.color_mode)
-    '''
-    def get_total_size(self):
-        if self.selected_custom_tex:
-            width, height = self.get_from_c_size()
-        else:
-            size_tex = size_tex_dict.get(self.selected_mode)
-        # buffer need adequate size multiplying
-        factor_clr = factor_buffer_dict.get(self.color_mode)
-        if self.selected_custom_tex:
-            self.total_size = width * height * factor_clr
-        else:
-            self.total_size = size_tex * size_tex * factor_clr
-    '''
+
     def get_buffer(self):
         data = np.array(self.inputs['Float'].sv_get(deepcopy=False)).flatten()
         self.total_size = self.calculate_total_size()

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -22,7 +22,9 @@ import numpy as np
 
 import bgl
 import bpy
-from bpy.props import FloatProperty, EnumProperty, StringProperty, BoolProperty, IntProperty
+from bpy.props import (
+    FloatProperty, EnumProperty, StringProperty, BoolProperty, IntProperty
+)
 
 from sverchok.data_structure import updateNode, node_id
 from sverchok.node_tree import SverchCustomTreeNode
@@ -189,63 +191,53 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         items=size_tex_list,
         description="Offers display sizing",
         default="S",
-        update=updateNode
-    )
+        update=updateNode)
 
     selected_custom_tex = BoolProperty(
         name='Custom tex', description='Activate custom texture drawing',
         default=False,
-        update=updateNode
-    )
+        update=updateNode)
 
     width_custom_tex = IntProperty(
         min=0, max=1024, default=206, name='Width Tex',
         description="set the custom texture size",
-        update=updateNode
-    )
+        update=updateNode)
 
     height_custom_tex = IntProperty(
         min=0, max=1024, default=124, name='Height Tex',
         description="set the custom texture size",
-        update=updateNode
-    )
+        update=updateNode)
 
     bitmap_format = EnumProperty(
         items=bitmap_format_list,
         description="Offers bitmap saving",
-        default="PNG"
-    )
+        default="PNG")
 
     color_mode = EnumProperty(
         items=gl_color_list,
         description="Offers color options",
         default="BW",
-        update=updateNode
-    )
+        update=updateNode)
 
     color_mode_save = EnumProperty(
         items=gl_color_list,
         description="Offers color options",
         default="BW",
-        update=updateNode
-    )
+        update=updateNode)
 
     compression_level = IntProperty(
         min=0, max=100, default=0, name='compression',
         description="set compression level",
-        update=updateNode
-    )
+        update=updateNode)
 
     quality_level = IntProperty(
         min=0, max=100, default=0, name='quality',
         description="set quality level",
-        update=updateNode
-    )
+        update=updateNode)
 
     in_float = FloatProperty(
         min=0.0, max=1.0, default=0.0, name='Float Input',
-        description='Input for texture', update=updateNode
-    )
+        description='Input for texture', update=updateNode)
 
     base_dir = StringProperty(default='/tmp/')
     image_name = StringProperty(default='image_name', description='name (minus filetype)')

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -377,25 +377,14 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
             mode = self.color_mode
             self.activate = False
             pixels = np.array(self.inputs['Float'].sv_get(deepcopy=False)).flatten()
-            if self.selected_custom_tex:
-                width, height = self.get_from_c_size()
-            else:
-                width = height = size_tex_dict.get(self.selected_mode)
+            width, height = self.texture_width_height
 
             transfer_to_image(pixels, self.texture_name, width, height, mode)
 
         if self.activate:
 
             texture = self.get_buffer()
-            if self.selected_custom_tex:
-                width, height = self.get_from_c_size()
-                print('custom texture selected!')
-                print('tex size is', width, height)
-
-            else:
-                size_tex = size_tex_dict.get(self.selected_mode)
-                width = height = size_tex
-
+            width, height = self.texture_width_height
             x, y = self.xy_offset
             gl_color_constant = gl_color_dict.get(self.color_mode)
             name = bgl.Buffer(bgl.GL_INT, 1)
@@ -451,13 +440,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         else:
             extension = '.' + img_format.lower()
         image_name = image_name + extension
-        dim = 0
-        if self.selected_custom_tex:
-            width, height = self.get_from_c_size()
-        else:
-            dim = size_tex_dict[self.selected_mode]
-            width, height = dim, dim
-
+        width, height = self.texture_width_height
         if image_name in bpy.data.images:
             img = bpy.data.images[image_name]
         else:

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -96,6 +96,7 @@ factor_buffer_dict = {
 
 
 def transfer_to_image(pixels, name, width, height, mode):
+    # transfer pixels(data) from Node tree to image viewer
     image = bpy.data.images.get(name)
     if not image:
         image = bpy.data.images.new(name, width, height, alpha=False)
@@ -321,7 +322,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         layout.separator()
         # row = layout.row()
         # row.prop(self, 'color_mode_save', expand=True)
-        layout.separator()
+        # layout.separator()
         if img_format == 'PNG':
             row = layout.row()
             row.prop(self, 'compression_level', text='set compression')
@@ -397,7 +398,6 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
             def init_texture(width, height, texname, texture):
                 # function to init the texture
                 clr = gl_color_dict.get(self.color_mode)
-                # print('color mode is: {0}'.format(clr))
 
                 bgl.glPixelStorei(bgl.GL_UNPACK_ALIGNMENT, 1)
 
@@ -419,7 +419,6 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
             name = bgl.Buffer(bgl.GL_INT, 1)
             bgl.glGenTextures(1, name)
             self.texture[n_id] = name[0]
-            # init_texture(size_tex, size_tex, name[0], texture)
             init_texture(width, height, name[0], texture)
 
             draw_data = {
@@ -459,11 +458,11 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         buf = self.get_buffer()
         img_format = self.bitmap_format
         col_mod = self.color_mode
-        col_mod_s = self.color_mode_save
+        # col_mod_s = self.color_mode_save
         quality = self.quality_level
         compression = self.compression_level
         print('col_mod is: {0}'.format(col_mod))
-        print('col_mod_s is: {0}'.format(col_mod_s))
+        # print('col_mod_s is: {0}'.format(col_mod_s))
         print('img_format is: {0}'.format(img_format))
         if img_format in format_mapping:
             extension = '.' + format_mapping.get(img_format, img_format.lower())
@@ -500,7 +499,6 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         scene = bpy.context.scene
         # set the scene quality to the maximum
         scene.render.image_settings.quality = quality
-        # set different color depth
         if img_format in {'JPEG', 'JPEG2000'}:
             scene.render.image_settings.color_depth = '16'
         else:
@@ -512,7 +510,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         print('settings done!')
         # get the path for the file and save the image
         desired_path = os.path.join(self.base_dir, self.image_name + extension)
-
+        # saving the image
         img.save_render(desired_path, scene)
 
         print('Bitmap saved!  path is:', desired_path)

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -357,6 +357,8 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
             bgl.glDeleteTextures(1, names)
 
     def process(self):
+        if not self.inputs['Float'].is_linked:
+            return
         n_id = node_id(self)
         size_tex = 0
         width = 0

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -266,14 +266,13 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     def texture_width_height(self):
         #  get the width and height for the texture
         if self.selected_custom_tex:
-            # width, height = self.get_from_c_size()
             width, height = self.custom_size
         else:
             size_tex = size_tex_dict.get(self.selected_mode)
             width, height = size_tex, size_tex
         return width, height
 
-    def reshape_data(self, data):
+    def make_data_correct_length(self, data):
         self.total_size = self.calculate_total_size()
         if len(data) < self.total_size:
             default_value = 0
@@ -291,7 +290,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     def get_buffer(self):
         data = np.array(self.inputs['Float'].sv_get(deepcopy=False)).flatten()
         self.total_size = self.calculate_total_size()
-        self.reshape_data(data)
+        self.make_data_correct_length(data)
         texture = bgl.Buffer(bgl.GL_FLOAT, self.total_size, data)
         return texture
 

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -406,9 +406,6 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         print('new base dir:', self.base_dir)
         return {'FINISHED'}
 
-    def set_compression(self):
-        pass
-
     def push_image_settings(self, scene):
         img_format = self.bitmap_format
         print('img_format is: {0}'.format(img_format))

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -330,7 +330,13 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         rightside.operator(directory_select, text="", icon='IMASEL').fn_name = "set_dir"
 
     def draw_label(self):
-        return (self.label or self.name) + ' ' + str(size_tex_dict.get(self.selected_mode)) + "^2"
+        if self.selected_custom_tex:
+            width = self.inputs['Width'].sv_get(deepcopy=False)[0][0]
+            height = self.inputs['Height'].sv_get(deepcopy=False)[0][0]
+            label = (self.label or self.name) + ' {0} x {1}'.format(width, height)
+        else:
+            label = (self.label or self.name) + ' ' + str(size_tex_dict.get(self.selected_mode)) + "^2"
+        return label
 
     def sv_init(self, context):
         self.inputs.new('StringsSocket', "Float").prop_name = 'in_float'

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -255,12 +255,21 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         b = int(self.width) + 20
         return int(a[0] + b), int(a[1])
 
+    def get_from_c_size(self, string):
+        if string is 'Width':
+            data = self.inputs['Width'].sv_get(deepcopy=False)[0][0]
+        elif string is 'Height':
+            data = self.inputs['Height'].sv_get(deepcopy=False)[0][0]
+        else:
+            print('get_from_c_size() error: not conforming format label size')
+        return data
+
     def get_buffer(self):
         data = np.array(self.inputs['Float'].sv_get(deepcopy=False)).flatten()
 
         if self.selected_custom_tex:
-            width = self.inputs['Width'].sv_get(deepcopy=False)[0][0]
-            height = self.inputs['Height'].sv_get(deepcopy=False)[0][0]
+            width = self. get_from_c_size('Width')
+            height = self. get_from_c_size('Height')
             print('get width and height')
             print('size_tex ok!')
         else:
@@ -331,8 +340,8 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
 
     def draw_label(self):
         if self.selected_custom_tex:
-            width = self.inputs['Width'].sv_get(deepcopy=False)[0][0]
-            height = self.inputs['Height'].sv_get(deepcopy=False)[0][0]
+            width = self. get_from_c_size('Width')
+            height = self. get_from_c_size('Height')
             label = (self.label or self.name) + ' {0} x {1}'.format(width, height)
         else:
             label = (self.label or self.name) + ' ' + str(size_tex_dict.get(self.selected_mode)) + "^2"
@@ -363,8 +372,8 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
             self.activate = False
             pixels = np.array(self.inputs['Float'].sv_get(deepcopy=False)).flatten()
             if self.selected_custom_tex:
-                width = self.inputs['Width'].sv_get(deepcopy=False)[0][0]
-                height = self.inputs['Height'].sv_get(deepcopy=False)[0][0]
+                width = self. get_from_c_size('Width')
+                height = self. get_from_c_size('Height')
             else:
                 width = height = size_tex_dict.get(self.selected_mode)
 
@@ -374,8 +383,8 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
 
             texture = self.get_buffer()
             if self.selected_custom_tex:
-                width = self.inputs['Width'].sv_get(deepcopy=False)[0][0]
-                height = self.inputs['Height'].sv_get(deepcopy=False)[0][0]
+                width = self. get_from_c_size('Width')
+                height = self. get_from_c_size('Height')
                 print('custom texture selected!')
                 print('tex size is', width, height)
 
@@ -463,8 +472,8 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         image_name = image_name + extension
         dim=0
         if self.selected_custom_tex:
-            width = self.inputs['Width'].sv_get(deepcopy=False)[0][0]
-            height = self.inputs['Height'].sv_get(deepcopy=False)[0][0]
+            width = self. get_from_c_size('Width')
+            height = self. get_from_c_size('Height')
         else:
             dim = size_tex_dict[self.selected_mode]
             width, height = dim, dim

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -257,17 +257,17 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         b = int(self.width) + 20
         return int(a[0] + b), int(a[1])
 
-    def get_from_c_size(self):
-        return [
-            self.inputs['Width'].sv_get(deepcopy=False)[0][0],
-            self.inputs['Height'].sv_get(deepcopy=False)[0][0]
-        ]
+    @property
+    def custom_size(self):
+        sockets = self.inputs["Width"], self.inputs["Height"]
+        return [s.sv_get(deepcopy=False)[0][0] for s in sockets]
 
     @property
     def texture_width_height(self):
         #  get the width and height for the texture
         if self.selected_custom_tex:
-            width, height = self.get_from_c_size()
+            # width, height = self.get_from_c_size()
+            width, height = self.custom_size
         else:
             size_tex = size_tex_dict.get(self.selected_mode)
             width, height = size_tex, size_tex

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -248,6 +248,9 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
 
     base_dir = StringProperty(default='/tmp/')
     image_name = StringProperty(default='image_name', description='name (minus filetype)')
+    texture_name = StringProperty(
+        default='texture',
+        description='set name (minus filetype) for exporting to image viewer')
 
     @property
     def xy_offset(self):
@@ -316,8 +319,8 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         layout.separator()
         layout.prop(self, "bitmap_format", text='format')
         layout.separator()
-        row = layout.row()
-        row.prop(self, 'color_mode_save', expand=True)
+        # row = layout.row()
+        # row.prop(self, 'color_mode_save', expand=True)
         layout.separator()
         if img_format == 'PNG':
             row = layout.row()
@@ -333,6 +336,10 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         rightside = leftside.split().row(align=True)
         rightside.operator(callback_to_self, text="Save").fn_name = "save_bitmap"
         rightside.operator(directory_select, text="", icon='IMASEL').fn_name = "set_dir"
+        export = layout.column(align=True)
+        export.separator()
+        export.label(text="Export to image viewer")
+        export.prop(self, 'texture_name', text='', icon='EXPORT')
 
     def draw_label(self):
         if self.selected_custom_tex:
@@ -371,7 +378,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
             else:
                 width = height = size_tex_dict.get(self.selected_mode)
 
-            transfer_to_image(pixels, 'texture', width, height, mode)
+            transfer_to_image(pixels, self.texture_name, width, height, mode)
 
         if self.activate:
 

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -105,13 +105,7 @@ def transfer_to_image(pixels, name, width, height, mode):
         image.pack
     else:
         image.scale(width, height)
-    if mode == 'BW':
-        svIMG.assign_BW_image(image, pixels)
-    elif mode == 'RGB':
-        new = svIMG.array_as(pixels, (width * height * 3,))
-        svIMG.assign_RGB_image(image, width, height, new)
-    else:
-        image.pixels[:] = pixels
+    svIMG.pass_buffer_to_image(mode, image, pixels, width, height)
     image.update_tag()
 
 
@@ -133,6 +127,7 @@ def init_texture(width, height, texname, texture, clr):
         0, clr, width, height,
         0, clr, bgl.GL_FLOAT, texture
     )
+
 
 def simple_screen(x, y, args):
     # draw a simple scren display for the texture

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -103,7 +103,7 @@ def transfer_to_image(pixels, name, width, height, mode):
     else:
         image.scale(width, height)
     if mode == 'BW':
-        svIMG.assign_BW_image(image, new)
+        svIMG.assign_BW_image(image, pixels)
     elif mode == 'RGB':
         new = svIMG.array_as(pixels, (width * height * 3,))
         svIMG.assign_RGB_image(image, width, height, new)
@@ -255,21 +255,17 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         b = int(self.width) + 20
         return int(a[0] + b), int(a[1])
 
-    def get_from_c_size(self, string):
-        if string is 'Width':
-            data = self.inputs['Width'].sv_get(deepcopy=False)[0][0]
-        elif string is 'Height':
-            data = self.inputs['Height'].sv_get(deepcopy=False)[0][0]
-        else:
-            print('get_from_c_size() error: not conforming format label size')
-        return data
+    def get_from_c_size(self):
+        return [
+            self.inputs['Width'].sv_get(deepcopy=False)[0][0],
+            self.inputs['Height'].sv_get(deepcopy=False)[0][0]
+        ]
 
     def get_buffer(self):
         data = np.array(self.inputs['Float'].sv_get(deepcopy=False)).flatten()
 
         if self.selected_custom_tex:
-            width = self. get_from_c_size('Width')
-            height = self. get_from_c_size('Height')
+            width, height = self.get_from_c_size()
             print('get width and height')
             print('size_tex ok!')
         else:
@@ -340,8 +336,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
 
     def draw_label(self):
         if self.selected_custom_tex:
-            width = self. get_from_c_size('Width')
-            height = self. get_from_c_size('Height')
+            width, height = self.get_from_c_size()
             label = (self.label or self.name) + ' {0} x {1}'.format(width, height)
         else:
             label = (self.label or self.name) + ' ' + str(size_tex_dict.get(self.selected_mode)) + "^2"
@@ -372,8 +367,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
             self.activate = False
             pixels = np.array(self.inputs['Float'].sv_get(deepcopy=False)).flatten()
             if self.selected_custom_tex:
-                width = self. get_from_c_size('Width')
-                height = self. get_from_c_size('Height')
+                width, height = self.get_from_c_size()
             else:
                 width = height = size_tex_dict.get(self.selected_mode)
 
@@ -383,8 +377,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
 
             texture = self.get_buffer()
             if self.selected_custom_tex:
-                width = self. get_from_c_size('Width')
-                height = self. get_from_c_size('Height')
+                width, height = self.get_from_c_size()
                 print('custom texture selected!')
                 print('tex size is', width, height)
 
@@ -470,10 +463,9 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         else:
             extension = '.' + img_format.lower()
         image_name = image_name + extension
-        dim=0
+        dim = 0
         if self.selected_custom_tex:
-            width = self. get_from_c_size('Width')
-            height = self. get_from_c_size('Height')
+            width, height = self.get_from_c_size()
         else:
             dim = size_tex_dict[self.selected_mode]
             width, height = dim, dim

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -179,61 +179,47 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
     n_id = StringProperty(default='')
     to_image_viewer = BoolProperty(
         name='Pass', description='Transfer pixels to image viewer',
-        default=False,
-        update=updateNode)
+        default=False, update=updateNode)
 
     activate = BoolProperty(
         name='Show', description='Activate texture drawing',
-        default=True,
-        update=updateNode)
+        default=True, update=updateNode)
 
     selected_mode = EnumProperty(
-        items=size_tex_list,
-        description="Offers display sizing",
-        default="S",
-        update=updateNode)
+        items=size_tex_list, description="Offers display sizing",
+        default="S", update=updateNode)
 
     selected_custom_tex = BoolProperty(
         name='Custom tex', description='Activate custom texture drawing',
-        default=False,
-        update=updateNode)
+        default=False, update=updateNode)
 
     width_custom_tex = IntProperty(
         min=0, max=1024, default=206, name='Width Tex',
-        description="set the custom texture size",
-        update=updateNode)
+        description="set the custom texture size", update=updateNode)
 
     height_custom_tex = IntProperty(
         min=0, max=1024, default=124, name='Height Tex',
-        description="set the custom texture size",
-        update=updateNode)
+        description="set the custom texture size", update=updateNode)
 
     bitmap_format = EnumProperty(
         items=bitmap_format_list,
-        description="Offers bitmap saving",
-        default="PNG")
+        description="Offers bitmap saving", default="PNG")
 
     color_mode = EnumProperty(
-        items=gl_color_list,
-        description="Offers color options",
-        default="BW",
-        update=updateNode)
+        items=gl_color_list, description="Offers color options",
+        default="BW", update=updateNode)
 
     color_mode_save = EnumProperty(
-        items=gl_color_list,
-        description="Offers color options",
-        default="BW",
-        update=updateNode)
+        items=gl_color_list, description="Offers color options",
+        default="BW", update=updateNode)
 
     compression_level = IntProperty(
         min=0, max=100, default=0, name='compression',
-        description="set compression level",
-        update=updateNode)
+        description="set compression level", update=updateNode)
 
     quality_level = IntProperty(
         min=0, max=100, default=0, name='quality',
-        description="set quality level",
-        update=updateNode)
+        description="set quality level", update=updateNode)
 
     in_float = FloatProperty(
         min=0.0, max=1.0, default=0.0, name='Float Input',

--- a/ui/sv_image.py
+++ b/ui/sv_image.py
@@ -31,3 +31,25 @@ def assign_RGB_image(image, width, height, buffer):
     rgba = np.concatenate((rgb_res, alpha_res), axis=1)
     final = rgba[:, 0:4]
     image.pixels = final.flatten()
+
+
+def get_extension(img_format):
+    # img_format = self.bitmap_format
+    if img_format in format_mapping:
+        extension = '.' + format_mapping.get(img_format, img_format.lower())
+    else:
+        extension = '.' + img_format.lower()
+    return extension
+
+
+def pass_buffer_to_image(self, img, buf, width, height):
+    # width, height = self.texture_width_height
+    print('width is: {0}'.format(width))
+    print('length img pixels: {0}'.format(len(img.pixels)))
+    # print("passing data from buf to pixels ", self.color_mode)
+    if self.color_mode == 'BW':
+        assign_BW_image(img, buf)
+    elif self.color_mode == 'RGB':
+        assign_RGB_image(img, width, height, buf)
+    elif self.color_mode == 'RGBA':
+        img.pixels[:] = buf

--- a/ui/sv_image.py
+++ b/ui/sv_image.py
@@ -1,0 +1,48 @@
+import bpy
+import numpy as np
+
+
+def array_as(a, shape):
+    if a.shape == shape:
+        return a
+    new_a = np.empty(shape, dtype=a.dtype)
+    new_a[:len(a)] = a
+    new_a[len(a):] = a[-1]
+    return new_a
+
+
+'''from sverchok redux
+def assign_BW_image(image, buffer):
+    np_buff = np.empty(len(image.pixels), dtype=np.float32)
+    np_buff.shape = (-1, 4)
+    np_buff[:, :] = buffer[:, np.newaxis]
+    np_buff[:, 3] = 1
+    np_buff.shape = -1
+    image.pixels[:] = np_buff
+    return image
+'''
+
+
+def assign_BW_image(image, buffer):
+    np_buff = np.empty(len(image.pixels), dtype=np.float32)
+    np_buff.shape = (-1, 4)
+    np_buff[:, :] = np.array(buffer)[:, np.newaxis]
+    np_buff[:, 3] = 1
+    np_buff.shape = -1
+    image.pixels[:] = np_buff
+    return image
+
+
+def assign_RGB_image(image, width, height, buffer):
+    rgb = np.array(buffer)
+    rgb_res = rgb.reshape(width * height, 3)
+    alpha = np.empty(len(buffer), dtype=np.float32)
+    alpha.fill(1)
+    print('alpha filled')
+    alpha_res = alpha.reshape(width * height, 3)
+    print('concatenate rgb > alpha')
+    rgba = np.concatenate((rgb_res, alpha_res), axis=1)
+    final = rgba[:, 0:4]
+    # print(final)
+    print('filling pixels from openGl buffer')
+    image.pixels = final.flatten()

--- a/ui/sv_image.py
+++ b/ui/sv_image.py
@@ -34,7 +34,6 @@ def assign_RGB_image(image, width, height, buffer):
 
 
 def get_extension(img_format):
-    # img_format = self.bitmap_format
     if img_format in format_mapping:
         extension = '.' + format_mapping.get(img_format, img_format.lower())
     else:
@@ -42,14 +41,13 @@ def get_extension(img_format):
     return extension
 
 
-def pass_buffer_to_image(self, img, buf, width, height):
-    # width, height = self.texture_width_height
+def pass_buffer_to_image(color_mode, img, buf, width, height):
     print('width is: {0}'.format(width))
     print('length img pixels: {0}'.format(len(img.pixels)))
     # print("passing data from buf to pixels ", self.color_mode)
-    if self.color_mode == 'BW':
+    if color_mode == 'BW':
         assign_BW_image(img, buf)
-    elif self.color_mode == 'RGB':
+    elif color_mode == 'RGB':
         assign_RGB_image(img, width, height, buf)
-    elif self.color_mode == 'RGBA':
+    elif color_mode == 'RGBA':
         img.pixels[:] = buf

--- a/ui/sv_image.py
+++ b/ui/sv_image.py
@@ -11,19 +11,8 @@ def array_as(a, shape):
     return new_a
 
 
-'''from sverchok redux
 def assign_BW_image(image, buffer):
-    np_buff = np.empty(len(image.pixels), dtype=np.float32)
-    np_buff.shape = (-1, 4)
-    np_buff[:, :] = buffer[:, np.newaxis]
-    np_buff[:, 3] = 1
-    np_buff.shape = -1
-    image.pixels[:] = np_buff
-    return image
-'''
-
-
-def assign_BW_image(image, buffer):
+    # from sverchok redux, modified version
     np_buff = np.empty(len(image.pixels), dtype=np.float32)
     np_buff.shape = (-1, 4)
     np_buff[:, :] = np.array(buffer)[:, np.newaxis]
@@ -38,11 +27,7 @@ def assign_RGB_image(image, width, height, buffer):
     rgb_res = rgb.reshape(width * height, 3)
     alpha = np.empty(len(buffer), dtype=np.float32)
     alpha.fill(1)
-    print('alpha filled')
     alpha_res = alpha.reshape(width * height, 3)
-    print('concatenate rgb > alpha')
     rgba = np.concatenate((rgb_res, alpha_res), axis=1)
     final = rgba[:, 0:4]
-    # print(final)
-    print('filling pixels from openGl buffer')
     image.pixels = final.flatten()


### PR DESCRIPTION
I added the functionality of transfer the data pixels texture to the internal blender image viewer. I created also a image ui utility file `sv_image.py` for transfer pixels array, in this way compacting the Texture viewer node. and so as well code could be reused.
Added also custom tex size label (see draw_label func)
I think also to delete the the color mod selection in the properties panel. the initial idea was to save an image, from the node itself, in a different color image format from the original. But since we can transfer to the image viewer, this option has not much sense for me.
@zeffii you were saying also something about `updateNode` see [here](https://github.com/nortikin/sverchok/pull/1267) 

> use a wrapper for updateNode like in the Turbulence node. def changeMode(self, context):

>call self.process() at the end of your wrapper if the code inside the wrapper didn't already cause a process call.

can you explain me which property need this?