### PR TITLE
"Attraction vectors" node

### DIFF
--- a/docs/nodes/vector/attractor.rst
+++ b/docs/nodes/vector/attractor.rst
@@ -1,0 +1,68 @@
+Attraction Vectors
+==================
+
+Functionality
+-------------
+
+This node calculates vectors directed from input vertices to specified attractor. Vector lengths are calculated by one of physics-like falloff laws (like 1/R^2), so it looks like attractor attracts vertices, similar to gravity force, for example.
+Output vectors can be used to move vertices along them, for example.
+
+Inputs
+------
+
+This node has the following inputs:
+
+- **Vertices**
+- **Center**. Center of used attractor. Exact meaning depends on selected attractor type.
+- **Direction**. Direction of used attractor. Exact meaning depends on selected attractor type. Not available if attractor type is **Point**.
+- **Amplitude**. Coefficient of attractor power. Zero means that all output vectors will be zero. If many values are provided, each value will be matched to one vertex.
+- **Coefficient**. Scale coefficient for falloff law. Exact meaning depends on selected falloff type. Available only for falloff types **Inverse exponent** and **Gauss**. If many values are provided, each value will be matched to one vertex.
+
+Parameters
+----------
+
+This node has the following parameters:
+
+- **Attractor type**. Selects form of used attractor. Available values are:
+  - **Point**. Default value. In simple case, attractor is just one point specified in **Center** input. Several points can be passed in that input; in this case, attracting force for each vertex will be calculated as average of attracting forces towards each attractor point.
+  - **Line**. Attractor is a straight line, defined by a point belonging to this line (**Center** input) and directing vector (**Direction** input).
+  - **Plane**. Attractor is a plane, defined by a point belonging to this line (**Center** input) and normal vector (**Direction** input).
+- **Falloff type**. Used falloff law. Avalable values are:
+  - **Inverse**. Falloff law is 1/R, where R is distance from vertex to attractor.
+  - **Inverse square**. Falloff law is 1/R^2. This law is most common in physics (gravity and electromagnetizm), so this is the default value.
+  - **Inverse cubic**. Falloff law is 1/R^2.
+  - **Inverse exponent**. Falloff law is `exp(- C * R)`, where R is distance from vertex to attractor, and C is value from **Coefficient** input.
+  - **Gauss**. Falloff law is `exp(- C * R^2 / 2)`, where R is distance from vertex to attractor, and C is value from **Coefficient** input.
+
+Outputs
+-------
+
+This node has the following outputs:
+
+- **Vectors**. Calculated attraction force vectors. 
+- **Directions**. Unit vectors in the same directions as attracting force.
+- **Coeffs**. Lengths of calculated attraction force vectors.
+
+Examples of usage
+-----------------
+
+Most obvious case, just a plane attracted by single point:
+
+.. image:: https://cloud.githubusercontent.com/assets/284644/23908413/28c3d12a-08fe-11e7-9995-58fef78910b3.png
+
+Not so obvious, plane attracted by circle (red points):
+
+.. image:: https://cloud.githubusercontent.com/assets/284644/23908410/283bd220-08fe-11e7-96e3-7b895a801e8e.png
+
+Coefficients can be used without directions:
+
+.. image:: https://cloud.githubusercontent.com/assets/284644/23908414/28d14b02-08fe-11e7-8bb5-585a6226c4f1.png
+
+Torus attracted by a line along X axis:
+
+.. image:: https://cloud.githubusercontent.com/assets/284644/23908411/28ab67ac-08fe-11e7-8659-5ebb90771864.png
+
+Sphere attracted by a plane:
+
+.. image:: https://cloud.githubusercontent.com/assets/284644/23908415/28e0d950-08fe-11e7-8695-3aa3bd249710.png
+

--- a/index.md
+++ b/index.md
@@ -159,6 +159,7 @@
     SvInterpolationNode
     SvInterpolationNodeMK2
     SvInterpolationNodeMK3
+    SvAttractorNode
     SvVertSortNode
     SvNoiseNodeMK2
     SvVectorFractal

--- a/nodes/vector/attractor.py
+++ b/nodes/vector/attractor.py
@@ -1,0 +1,231 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import bpy
+from bpy.props import IntProperty, FloatProperty, BoolProperty, EnumProperty
+from mathutils import Vector, Matrix
+import math
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode, match_long_repeat, fullList
+
+def get_avg_vector(vectors):
+    result = Vector((0,0,0))
+    for vector in vectors:
+        result += vector
+    result = (1.0/float(len(vectors))) * result
+    return result
+
+def inverse(c, x):
+    return 1.0/x
+
+def inverse_square(c, x):
+    return 1.0/(x*x)
+
+def inverse_cubic(c, x):
+    return 1.0/(x*x*x)
+
+def inverse_exp(c, x):
+    return math.exp(-c*x)
+
+def gauss(c, x):
+    return math.exp(-c*x*x/2.0)
+
+class SvAttractorNode(bpy.types.Node, SverchCustomTreeNode):
+    '''Attraction vectors calculator'''
+    bl_idname = 'SvAttractorNode'
+    bl_label = 'Attraction vectors'
+    bl_icon = 'OUTLINER_OB_EMPTY'
+
+    types = [
+            ("Point", "Point", "Attraction to single or multiple points", 0),
+            ("Line", "Line", "Attraction to straight line", 1),
+            ("Plane", "Plane", "Attraction to plane", 2)
+        ]
+
+    falloff_types = [
+            ("inverse", "Inverse - 1/R", "", 0),
+            ("inverse_square", "Inverse square - 1/R^2", "Similar to gravitation or electromagnetizm", 1),
+            ("inverse_cubic", "Inverse cubic - 1/R^3", "", 2),
+            ("inverse_exp", "Inverse exponent - Exp(-R)", "", 3),
+            ("gauss", "Gauss - Exp(-R^2/2)", "", 4)
+        ]
+    
+    def update_type(self, context):
+        self.inputs['Direction'].hide = (self.attractor_type == 'Point')
+        self.inputs['Coefficient'].hide = (self.falloff_type not in ['inverse_exp', 'gauss'])
+        updateNode(self, context)
+
+    attractor_type = EnumProperty(name="Attractor type",
+            items=types,
+            default='Point',
+            update=update_type)
+    
+    falloff_type = EnumProperty(name="Falloff type",
+            items=falloff_types,
+            default='inverse_square',
+            update=update_type)
+
+    amplitude = FloatProperty(name="Amplitude", 
+            default=0.5, min=0.0,
+            update=updateNode)
+
+    coefficient = FloatProperty(name="Coefficient",
+            default=0.5,
+            update=updateNode)
+    
+    def sv_init(self, context):
+        self.inputs.new('VerticesSocket', "Vertices")
+        c = self.inputs.new('VerticesSocket', "Center")
+        c.use_prop = True
+        c.prop = (0.0, 0.0, 0.0)
+
+        d = self.inputs.new('VerticesSocket', "Direction")
+        d.use_prop = True
+        d.prop = (0.0, 0.0, 1.0)
+
+        self.inputs.new('StringsSocket', 'Amplitude').prop_name = 'amplitude'
+        self.inputs.new('StringsSocket', 'Coefficient').prop_name = 'coefficient'
+
+        self.outputs.new('VerticesSocket', "Vectors")
+
+        self.update_type(context)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'attractor_type')
+        layout.prop(self, 'falloff_type')
+        #layout.prop(self, 'amplitude')
+        #if self.falloff_type in ['inverse_exp', 'gauss']:
+        #    layout.prop(self, 'coefficient')
+
+    def _falloff(self, coefficient, rho):
+        func = globals()[self.falloff_type]
+        return func(coefficient, rho)
+
+    def falloff(self, amplitude, coefficient, rho):
+        if rho == 0:
+            return 1.0
+        result = amplitude * self._falloff(coefficient, rho)
+        if result <= 0:
+            return 0.0
+        if result >= rho:
+            return rho
+        return result
+
+    def to_point(self, amplitude, coefficient, vertex, centers, direction):
+        vertex = Vector(vertex)
+        vectors = []
+        for center in centers:
+            vector = Vector(center) - vertex
+            vector = self.falloff(amplitude, coefficient, vector.length) * vector.normalized()
+            vectors.append(vector)
+        return get_avg_vector(vectors)
+
+    def to_line(self, vertex, centers, direction):
+        center = Vector(centers[0])
+        direction = Vector(direction)
+        dirlength = direction.length
+        if dirlength <= 0:
+            raise ValueError("Direction vector must have nonzero length!")
+        vertex = Vector(vertex)
+
+        to_center = center - vertex
+        # cosine of angle between to_center and direction
+        cos_phi = to_center.dot(direction) / (to_center.length * dirlength)
+        # projection of to_center on direction
+        to_center_projection = to_center.length * cos_phi * direction.normalized()
+        # projection of vertex on direction
+        projection = center - to_center_projection
+        vector = projection - vertex
+        return self.falloff(amplitude, coefficient, vector.length) * vector.normalized()
+    
+    def to_plane(self, amplitude, coefficient, vertex, centers, direction):
+        center = Vector(centers[0])
+        direction = Vector(direction)
+        vertex = Vector(vertex)
+        dirlength = direction.length
+        if dirlength <= 0:
+            raise ValueError("Direction vector must have nonzero length!")
+
+        d = - direction.dot(center)
+        # distance from vertex to plane
+        rho = abs(vertex.dot(direction) + d) / dirlength
+
+        from_center = center - vertex
+
+        # vector is either direction or negative direction
+        if from_center.dot(direction) >= 0:
+            vector = direction.normalized()
+        else:
+            # for some reason mathutil's Vector does not have .negated()
+            # thankfully we do not need direction itself anymore.
+            direction.negate()
+            vector = direction.normalized()
+
+        return self.falloff(amplitude, coefficient, rho) * vector
+
+
+    def process(self):
+        if not any(output.is_linked for output in self.outputs):
+            return
+
+        vertices_s = self.inputs['Vertices'].sv_get(default=[[]])
+        centers = self.inputs['Center'].sv_get(default=[[]])[0]
+        directions_s = self.inputs['Direction'].sv_get(default=[[(0,0,1)]])
+        amplitudes_s = self.inputs['Amplitude'].sv_get(default=[0.5])
+        coefficients_s = self.inputs['Coefficient'].sv_get(default=[0.5])
+
+        out_vectors = []
+
+        meshes = match_long_repeat([vertices_s, directions_s, amplitudes_s, coefficients_s])
+        for vertices, directions, amplitudes, coefficients in zip(*meshes):
+            if isinstance(directions, (tuple, list)) and len(directions) == 3 and all([isinstance(x, (int, float)) for x in directions]):
+                direction = directions
+            else:
+                direction = directions[0]
+
+            if isinstance(amplitudes, (int, float)):
+                amplitudes = [amplitudes]
+            if isinstance(coefficients, (int, float)):
+                coefficients = [coefficients]
+
+            fullList(amplitudes, len(vertices))
+            fullList(coefficients, len(vertices))
+
+            vectors = []
+            for vertex, amplitude, coefficient in zip(vertices, amplitudes, coefficients):
+                if self.attractor_type == 'Point':
+                    vector = self.to_point(amplitude, coefficient, vertex, centers, direction)
+                elif self.attractor_type == 'Line':
+                    vector = self.to_line(amplitude, coefficient, vertex, centers, direction)
+                elif self.attractor_type == 'Plane':
+                    vector = self.to_plane(amplitude, coefficient, vertex, centers, direction)
+                else:
+                    raise ValueError("Unknown attractor type: " + self.attractor_type)
+                vectors.append(vector)
+            out_vectors.append(vectors)
+
+        self.outputs['Vectors'].sv_set(out_vectors)
+
+def register():
+    bpy.utils.register_class(SvAttractorNode)
+
+
+def unregister():
+    bpy.utils.unregister_class(SvAttractorNode)
+


### PR DESCRIPTION
This node calculates vectors directed from given vertices to the attractor. Vector lengths are calculated by one of physics-like falloff laws (like 1/R^2), so it looks like attractor attracts vertices. 
Attractor can be specified as:
* single point or set of points
* straight line (specified by point lying on the line and directing vector)
* plane (specified by point lying on the plane and normal vector).

Documentation is in progress, will push it in near time.