### PR TITLE
this is less code and seems to work

### DIFF
--- a/core/handlers.py
+++ b/core/handlers.py
@@ -18,10 +18,19 @@ from sverchok.ui import (
 )
 
 
+_state = {'frame': None}
+
 def sverchok_trees():
     for ng in bpy.data.node_groups:
         if ng.bl_idname == 'SverchCustomTreeType':
             yield ng
+
+
+def has_frame_changed(scene):
+    last_frame = _state['frame']
+    _state['frame'] = scene.frame_current
+    current_frame = scene.frame_current
+    return not last_frame == current_frame
 
 
 @persistent
@@ -29,15 +38,10 @@ def sv_update_handler(scene):
     """
     Update sverchok node groups on frame change events.
     """
-    screen = bpy.context.screen
-    if screen and not screen.is_animation_playing:
-        # manual scrub causes this to be triggered twice, 
-        # - once with is_animation_playing True
-        # - once with is_animation_playing False
-        # print('sv_update_handler : returns early')
+    if not has_frame_changed(scene):
         return
-
-    # print('sv_update_handler')
+    
+    print('sv_update_handler')
     for ng in sverchok_trees():
         try:
             ng.process_ani()

--- a/core/handlers.py
+++ b/core/handlers.py
@@ -40,9 +40,9 @@ def sv_update_handler(scene):
     if not has_frame_changed(scene):
         return
     
-    print('sv_update_handler')
     for ng in sverchok_trees():
         try:
+            # print('sv_update_handler')
             ng.process_ani()
         except Exception as e:
             print('Failed to update:', name, str(e))

--- a/core/handlers.py
+++ b/core/handlers.py
@@ -29,8 +29,7 @@ def sverchok_trees():
 def has_frame_changed(scene):
     last_frame = _state['frame']
     _state['frame'] = scene.frame_current
-    current_frame = scene.frame_current
-    return not last_frame == current_frame
+    return not last_frame == scene.frame_current
 
 
 @persistent


### PR DESCRIPTION
this addresses two problems that manifest in _sv_update_handler_

- suppresses double update upon timeline scrubbing
- allows arrow keys to function as normal (nudging current keyframe)

how? by tracking if the _sv_update_handler_ is being triggered on a different 'current_frame' than the previous trigger. The mechanism is currently a dict, but could be switched out for a scene property,, something like 'scene.sv_current_frame`.  If we go with this. 

I'll leave this for a while before pushing.