### PR TITLE
"Mesh select" by bounding box

### DIFF
--- a/docs/nodes/analyzers/mesh_select.rst
+++ b/docs/nodes/analyzers/mesh_select.rst
@@ -17,9 +17,9 @@ This node has the following inputs:
 - **Edges**
 - **Faces**
 - **Direction**. Direction vector. Used in modes: **By side**, **By normal**, **By plane**, **By cylinder**. Exact meaning depends on selected mode.
-- **Center**. Center or base point. Used in modes: **By sphere**, **By plane**, **By cylinder**.
+- **Center**. Center or base point. Used in modes: **By sphere**, **By plane**, **By cylinder**, **By bounding box**.
 - **Percent**. How many vertices to select. Used in modes: **By side**, **By normal**.
-- **Radius**. Allowed distance from center, or line, or plane, to selected vertices. Used in modes: **By sphere**, **By plane**, **By cylinder**.
+- **Radius**. Allowed distance from center, or line, or plane, to selected vertices. Used in modes: **By sphere**, **By plane**, **By cylinder**, **By bounding box**.
 
 Parameters
 ----------
@@ -35,7 +35,10 @@ This node has the following parameters:
   * **By cylinder**. Selects vertices, which are within **Radius** from specified straight line. Line is specified by providing directing vector (**Direction** input) and a point, belonging to that line (**Center** input). For example, if you specify Direction = (0, 0, 1) and Center = (0, 0, 0), the line will by Z axis. More exactly, this mode selects vertex V if `Distance(V, Line) <= Radius`.
   * **By edge direction**. Selects edges, which are nearly parallel to specified **Direction** vector. Note that this mode considers edges as non-directed; as a result, you can change sign of all coordinates of **Direction** and it will not affect output. More exactly, this mode selects edge E if `Abs(Cos(Angle(E, Direction))) >= max - Percent * (max - min)`, where max and min are maximum and minimum values of that cosine.
   * **Normal pointing outside**. Selects faces, that have normal vectors pointing outside from specified **Center**. So you can select "faces looking outside". Number of faces to select is controlled by **Percent** input. More exactly, this mode selects face F if `Angle(Center(F) - Center, Normal(F)) >= max - Percent * (max - min)`, where max and min are maximum and minimum values of that angle.
+  * **By bounding box**. Selects vertices, that are within bounding box defined by points passed into **Center** input. **Radius** is interpreted as tolerance limit. For examples:
 
+    - If one point `(0, 0, 0)` is passed, and Radius = 1, then the node will select all vertices that have `-1 <= X <= 1`, `-1 <= Y <= 1`, `-1 <= Z <= 1`.
+    - If points `(0, 0, 0)`, `(1, 2, 3)` are passed, and Radius = 0.5, then the node will select all vertices that have `-0.5 <= X <= 1.5`, `-0.5 <= Y <= 2.5`, `-0.5 <= Z <= 3.5`.
 - **Include partial selection**. Not available in **By normal** mode. All other modes select vertices first. This parameter controls either we need to select edges and faces that have **any** of vertices selected (Include partial = True), or only edges and faces that have **all** vertices selected (Include partial = False).
 
 Outputs
@@ -78,4 +81,8 @@ Bevel only edges that are parallel to Z axis:
 Select faces that are looking outside:
 
 .. image:: https://cloud.githubusercontent.com/assets/284644/23831280/62e48816-0748-11e7-887f-b9223dbbf939.png
+
+Select faces by bounding box:
+
+.. image:: https://cloud.githubusercontent.com/assets/284644/24332028/248a1026-1261-11e7-8886-f7a0f88ecb60.png
 

--- a/node_tree.py
+++ b/node_tree.py
@@ -91,6 +91,19 @@ class SvSocketCommon:
             if s == self:
                 return i
 
+    @property
+    def hide_safe(self):
+        return self.hide
+
+    @hide_safe.setter
+    def hide_safe(self, value):
+        # handles both input and output.
+        if self.is_linked:
+            for link in self.links:
+                self.id_data.links.remove(link)
+
+        self.hide = value
+
     def sv_set(self, data):
         """Set output data"""
         SvSetSocket(self, data)

--- a/nodes/analyzer/mesh_select.py
+++ b/nodes/analyzer/mesh_select.py
@@ -46,10 +46,10 @@ class SvMeshSelectNode(bpy.types.Node, SverchCustomTreeNode):
         ]
 
     def update_mode(self, context):
-        self.inputs['Radius'].hide = (self.mode not in ['BySphere', 'ByPlane', 'ByCylinder', 'BBox'])
-        self.inputs['Center'].hide = (self.mode not in ['BySphere', 'ByPlane', 'ByCylinder', 'Outside', 'BBox'])
-        self.inputs['Percent'].hide = (self.mode not in ['BySide', 'ByNormal', 'EdgeDir', 'Outside'])
-        self.inputs['Direction'].hide = (self.mode not in ['BySide', 'ByNormal', 'ByPlane', 'ByCylinder', 'EdgeDir'])
+        self.inputs['Radius'].hide_safe = (self.mode not in ['BySphere', 'ByPlane', 'ByCylinder', 'BBox'])
+        self.inputs['Center'].hide_safe = (self.mode not in ['BySphere', 'ByPlane', 'ByCylinder', 'Outside', 'BBox'])
+        self.inputs['Percent'].hide_safe = (self.mode not in ['BySide', 'ByNormal', 'EdgeDir', 'Outside'])
+        self.inputs['Direction'].hide_safe = (self.mode not in ['BySide', 'ByNormal', 'ByPlane', 'ByCylinder', 'EdgeDir'])
 
         updateNode(self, context)
 

--- a/nodes/analyzer/mesh_select.py
+++ b/nodes/analyzer/mesh_select.py
@@ -41,12 +41,13 @@ class SvMeshSelectNode(bpy.types.Node, SverchCustomTreeNode):
             ("ByPlane", "By plane", "Select vertices within specified distance from plane defined by point and normal vector", 3),
             ("ByCylinder", "By cylinder", "Select vertices within specified distance from straight line defined by point and direction vector", 4),
             ("EdgeDir", "By edge direction", "Select edges that are nearly parallel to specified direction", 5),
-            ("Outside", "Normal pointing outside", "Select faces with normals pointing outside", 6)
+            ("Outside", "Normal pointing outside", "Select faces with normals pointing outside", 6),
+            ("BBox", "By bounding box", "Select vertices within bounding box of specified points", 7)
         ]
 
     def update_mode(self, context):
-        self.inputs['Radius'].hide = (self.mode not in ['BySphere', 'ByPlane', 'ByCylinder'])
-        self.inputs['Center'].hide = (self.mode not in ['BySphere', 'ByPlane', 'ByCylinder', 'Outside'])
+        self.inputs['Radius'].hide = (self.mode not in ['BySphere', 'ByPlane', 'ByCylinder', 'BBox'])
+        self.inputs['Center'].hide = (self.mode not in ['BySphere', 'ByPlane', 'ByCylinder', 'Outside', 'BBox'])
         self.inputs['Percent'].hide = (self.mode not in ['BySide', 'ByNormal', 'EdgeDir', 'Outside'])
         self.inputs['Direction'].hide = (self.mode not in ['BySide', 'ByNormal', 'ByPlane', 'ByCylinder', 'EdgeDir'])
 
@@ -255,6 +256,29 @@ class SvMeshSelectNode(bpy.types.Node, SverchCustomTreeNode):
 
         return out_verts_mask, out_edges_mask, out_face_mask
 
+    def by_bbox(self, vertices, edges, faces):
+        points = self.inputs['Center'].sv_get()[0]
+        radius = self.inputs['Radius'].sv_get(default=[1.0])[0][0]
+
+        # bounding box
+        mins = tuple(min([point[i] for point in points]) for i in range(3))
+        maxs = tuple(max([point[i] for point in points]) for i in range(3))
+
+        # plus radius
+        mins = tuple(mins[i] - radius for i in range(3))
+        maxs = tuple(maxs[i] + radius for i in range(3))
+
+        out_verts_mask = []
+        for vertex in vertices:
+            min_ok = all(mins[i] <= vertex[i] for i in range(3))
+            max_ok = all(vertex[i] <= maxs[i] for i in range(3))
+            out_verts_mask.append(min_ok and max_ok)
+
+        out_edges_mask = self.select_edges_by_verts(out_verts_mask, edges)
+        out_faces_mask = self.select_faces_by_verts(out_verts_mask, faces)
+
+        return out_verts_mask, out_edges_mask, out_faces_mask
+
     def process(self):
 
         if not any(output.is_linked for output in self.outputs):
@@ -284,6 +308,8 @@ class SvMeshSelectNode(bpy.types.Node, SverchCustomTreeNode):
                 vs, es, fs = self.by_edge_dir(vertices, edges, faces)
             elif self.mode == 'Outside':
                 vs, es, fs = self.by_outside(vertices, edges, faces)
+            elif self.mode == 'BBox':
+                vs, es, fs = self.by_bbox(vertices, edges, faces)
             else:
                 raise ValueError("Unknown mode: " + self.mode)
 


### PR DESCRIPTION
Add "By bounding box" mode for "select mesh elements by location" node:

* If one point `(0, 0, 0)` is passed, and Radius = 1, then the node will select all vertices that have `-1 <= X <= 1`, `-1 <= Y <= 1`, `-1 <= Z <= 1`.
* If points `(0, 0, 0)`, `(1, 2, 3)` are passed, and Radius = 0.5, then the node will select all vertices that have `-0.5 <= X <= 1.5`, `-0.5 <= Y <= 2.5`, `-0.5 <= Z <= 3.5`.