### PR TITLE
Mesh eval update 2

### DIFF
--- a/docs/nodes/generators_extended/mesh_eval.rst
+++ b/docs/nodes/generators_extended/mesh_eval.rst
@@ -24,10 +24,23 @@ For generic description of JSON, please refer to https://en.wikipedia.org/wiki/J
 
 Mesh Expression node uses JSON, which should be a dictionary with following keys:
 
-* "vertices". This should be a list, containing 3-item lists, which are vertex coordinates. Each coordinate should be either integer or floating-point number, or a string with valid expression (see expression syntax below).
+* "vertices". This should be a list, containing 3- or 4- item lists:
+  
+  * First 3 items of each list are vertex coordinates. Each coordinate should be either integer or floating-point number, or a string with valid expression (see expression syntax below).
+  * 4th item, if present, may be either string of list of strings. These strings denote vertex groups, to which this vertex belongs.
+
+  Examples of valid vertex definition are:
+  
+  * `[0, 0, 0]` 
+  * `["X", "Y", 1.0]`
+  * `[1, 2, 3, "Selected"]`
+  * `[3, 2, 1, ["Top", "Right"]]`
 * "edges". This should be a list, containing 2-item lists of integer numbers, which are edges description in Sverchok's native format.
 * "faces". This should be a list, containint lists of integer nubmers, which are mesh faces description in Sverchok's native format.
-* "defaults". This should be a dictionary. Keys are variable names, and values are default variable values. Values can be only integer or floating-point numbers.
+* "defaults". This should be a dictionary. Keys are variable names, and values are default variable values. Values can be:
+  
+  * integer or floating-point numbers;
+  * string expressions (see expression syntax below). Note that expressions in "defaults" section are evaluated in alphabetical order of variable names. So, you can express "Y" in terms of "Y", but not vice versa.
 
 See also JSON examples below.
 
@@ -72,14 +85,20 @@ Operators
 
 This node has one button: **from selection**. This button takes currently selected Blender's mesh object and puts it's JSON description into newly created text buffer. Name of created buffer is assigned to **File name** parameter.
 
+For each vertex, if it belongs to some vertex groups in initial mesh object, these group names will be added to vertex definition.
+
+If vertex is selected in edit mode, then special group named "Selected" will be added to vertex definition.
+
 Outputs
 -------
 
-This node has the following outputs:
+This node always has the following outputs:
 
 * **Vertices**
 * **Edges**
 * **Faces**
+
+Apart from these, a separate output is created for each name of vertex group mentioned in "vertices" section of JSON definition. Each of these outputs contain a mask for **Vertices**, which selects vertices from corresponding group.
 
 Examples of usage
 -----------------

--- a/nodes/generators_extended/mesh_eval.py
+++ b/nodes/generators_extended/mesh_eval.py
@@ -209,11 +209,24 @@ class SvMeshEvalNode(bpy.types.Node, SverchCustomTreeNode):
         variables = self.get_variables()
         defaults = self.get_defaults()
         result = {}
+        default_results = {}
+
+        for var in defaults.keys():
+            d = defaults[var]
+            if isinstance(d, (int, float)):
+                default_results[var] = d
+
         for var in variables:
             if var in self.inputs and self.inputs[var].is_linked:
                 result[var] = self.inputs[var].sv_get()[0]
+                default_results[var] = result[var][0]
             else:
-                result[var] = [defaults.get(var, 1.0)]
+                value = defaults.get(var, 1.0)
+                if isinstance(value, str):
+                    #print("Eval: {} = {}, {}".format(var, value, default_results))
+                    value = safe_eval(value, default_results)
+                    default_results[var] = value
+                result[var] = [value]
             #print("get_input: {} => {}".format(var, result[var]))
         return result
 

--- a/nodes/generators_extended/mesh_eval.py
+++ b/nodes/generators_extended/mesh_eval.py
@@ -153,7 +153,7 @@ class SvMeshEvalNode(bpy.types.Node, SverchCustomTreeNode):
     bl_icon = 'OUTLINER_OB_EMPTY'
 
     def on_update(self, context):
-        self.adjust_inputs()
+        self.adjust_sockets()
         updateNode(self, context)
 
     filename = StringProperty(default="", update=on_update)
@@ -237,9 +237,9 @@ class SvMeshEvalNode(bpy.types.Node, SverchCustomTreeNode):
             return result
         return json['defaults']
 
-    def adjust_inputs(self):
+    def adjust_sockets(self):
         variables = self.get_variables()
-        #print("adjust_input:" + str(variables))
+        #print("adjust_sockets:" + str(variables))
         #print("inputs:" + str(self.inputs.keys()))
         for key in self.inputs.keys():
             if key not in variables:
@@ -272,7 +272,7 @@ class SvMeshEvalNode(bpy.types.Node, SverchCustomTreeNode):
         if not (self.filename in bpy.data.texts):
             return
 
-        self.adjust_inputs()
+        self.adjust_sockets()
 
     def get_input(self):
         variables = self.get_variables()

--- a/nodes/generators_extended/mesh_eval.py
+++ b/nodes/generators_extended/mesh_eval.py
@@ -109,11 +109,26 @@ class SvJsonFromMesh(bpy.types.Operator):
             self.report({'INFO'}, 'It is not a mesh selected')
             return
 
-        object = bpy.context.selected_objects[0].data
+        object = bpy.context.selected_objects[0]
+        mesh = object.data
         result = {}
-        result['vertices'] = list([v.co[:] for v in object.vertices])
-        result['edges'] = object.edge_keys
-        result['faces'] = [list(p.vertices) for p in object.polygons]
+        verts = []
+        for v in mesh.vertices:
+            names = set()
+            for grp in v.groups:
+                name = object.vertex_groups[grp.group].name
+                names.add(name)
+            if v.select:
+                names.add('Selected')
+            if names:
+                vertex = list(v.co[:]) + [list(sorted(names))]
+            else:
+                vertex = list(v.co[:])
+            verts.append(vertex)
+
+        result['vertices'] = verts
+        result['edges'] = mesh.edge_keys
+        result['faces'] = [list(p.vertices) for p in mesh.polygons]
 
         self.write_values(self.nodename, json.dumps(result, indent=2))
         bpy.data.node_groups[self.treename].nodes[self.nodename].filename = self.nodename

--- a/nodes/generators_extended/mesh_eval.py
+++ b/nodes/generators_extended/mesh_eval.py
@@ -257,7 +257,7 @@ class SvMeshEvalNode(bpy.types.Node, SverchCustomTreeNode):
             if key not in groups:
                 print("Output {} not in groups {}, remove it".format(key, str(groups)))
                 self.outputs.remove(self.outputs[key])
-        for name in groups:
+        for name in sorted(groups):
             if name not in self.outputs:
                 print("Group {} not in outputs {}, add it".format(name, str(self.outputs.keys())))
                 self.outputs.new('StringsSocket', name)


### PR DESCRIPTION
*  	Add possibility to use expressions in "defaults" section. 
* Add support for vertex groups and selection. In JSON, each vertex can be now marked as belonging to some groups, like `[0, 0, 0, "Group1"]`. Special output is created for selection mask of each group.
* When creating JSON from selected mesh, vertex groups are written to JSON. Selected vertices are marked with "Selected" group.