### PR TITLE
Vector In: get 3D cursor location

### DIFF
--- a/docs/nodes/vector/vector_in.rst
+++ b/docs/nodes/vector/vector_in.rst
@@ -18,6 +18,11 @@ Outputs
 
 **Vector** - Vertex or series of vertices
 
+Operators
+---------
+
+This node has one button: **3D Cursor**. This button is available only when no of inputs are connected. When pressed, this button assigns current location of Blender's 3D Cursor to X, Y, Z parameters.
+
 Examples
 --------
 


### PR DESCRIPTION
This adds a button to Vector In node, which assigns current location of 3D Cursor to X,Y, Z parameters of node. This button is available only when no inputs are connected.