### PR TITLE
adds macro loading from index

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -92,7 +92,7 @@ utils_modules = [
     "text_editor_submenu", "text_editor_plugins",
     # UI operators and tools
     "sv_panels_tools", "sv_gist_tools", "sv_IO_panel_tools", "sv_load_zipped_blend",
-    "monad", "sv_help",
+    "monad", "sv_help", "sv_macro_utils",
     #"loadscript",
     "debug_script", "sv_update_utils"
 ]

--- a/index.md
+++ b/index.md
@@ -140,11 +140,11 @@
     ListFlipNode
 
 ## Number
-    SvNumberNode
+    <<< SvNumberNode
     >>> SvNumberNode Int (selected_mode="int")
     >>> SvNumberNode Float (selected_mode="float")
     Float2IntNode
-    ScalarMathNode
+    <<< ScalarMathNode
     SvScalarMathNodeMK2
     Formula2Node
     SvExecNodeMod
@@ -164,7 +164,11 @@
 ## Vector
     GenVectorsNode
     VectorsOutNode
-    SvAxisInputNodeMK2
+    <<< SvAxisInputNodeMK2
+    >>> SvAxisInputNodeMK2 Variable_Axis
+    >>> SvAxisInputNodeMK2 Axis_X (axis_x='1', axis_y='0', axis_z='0')
+    >>> SvAxisInputNodeMK2 Axis_Y (axis_x='0', axis_y='1', axis_z='0')
+    >>> SvAxisInputNodeMK2 Axis_Z (axis_x='0', axis_y='0', axis_z='1')
     SvVectorMathNodeMK2
     VertsDelDoublesNode
     SvVectorRewire
@@ -175,10 +179,10 @@
     VectorPolarOutNode
     SvAttractorNode
     ---
-    EvaluateLineNode
+    <<< EvaluateLineNode
     SvVectorLerp
     SvInterpolationStripesNode
-    SvInterpolationNode
+    <<< SvInterpolationNode
     SvInterpolationNodeMK2
     SvInterpolationNodeMK3
     ---

--- a/index.md
+++ b/index.md
@@ -141,8 +141,8 @@
 
 ## Number
     SvNumberNode
-    FloatNode
-    IntegerNode
+    >>> SvNumberNode Int (selected_mode="int")
+    >>> SvNumberNode Float (selected_mode="float")
     Float2IntNode
     ScalarMathNode
     SvScalarMathNodeMK2

--- a/menu.py
+++ b/menu.py
@@ -47,14 +47,22 @@ def make_node_cats():
         category = None
         temp_list = []
         for line in md:
-            if not line.strip():
+            stripped_line = line.strip()
+
+            if not stripped_line:
                 continue
             
-            if line.strip().startswith('>>>'):
-                temp_list.append(['macro', line.strip()[3:].strip()])
+            if stripped_line.startswith('>>>'):
+                temp_list.append(['macro', stripped_line[3:].strip()])
+                continue
+
+            if stripped_line.startswith('<<<'):
+                vroot = stripped_line[3:].strip()
+                print(vroot)
+                temp_list.append([stripped_line[3:].strip(), 'hide_from_menu'])
                 continue
             
-            if line.strip().startswith('>'):
+            if stripped_line.startswith('>'):
                 continue
             elif line.startswith('##'):
                 if category:
@@ -62,11 +70,11 @@ def make_node_cats():
                 category = line[2:].strip()
                 temp_list = []
 
-            elif line.strip() == '---':
+            elif stripped_line == '---':
                 temp_list.append(['separator'])
             else:
-                bl_idname = line.strip()
-                temp_list.append([bl_idname])
+                # get plain bl_idname
+                temp_list.append([stripped_line])
 
         # final append
         node_cats[category] = temp_list

--- a/menu.py
+++ b/menu.py
@@ -49,6 +49,11 @@ def make_node_cats():
         for line in md:
             if not line.strip():
                 continue
+            
+            if line.strip().startswith('>>>'):
+                temp_list.append(['macro', line.strip()[3:].strip()])
+                continue
+            
             if line.strip().startswith('>'):
                 continue
             elif line.startswith('##'):
@@ -168,7 +173,7 @@ def make_categories():
             SverchNodeCategory(
                 name_big,
                 category,
-                items=[NodeItem(props[0]) for props in nodes if not props[0] == 'separator']))
+                items=[NodeItem(props[0]) for props in nodes if not props[0] in {'separator', 'macro'}]))
         node_count += len(nodes)
     node_categories.append(SverchNodeCategory("SVERCHOK_GROUPS", "Groups", items=sv_group_items))
 

--- a/ui/nodeview_space_menu.py
+++ b/ui/nodeview_space_menu.py
@@ -76,12 +76,20 @@ def layout_draw_categories(layout, node_details):
     add_n_grab = 'node.add_node'
     for node_info in node_details:
 
+        if not node_info:
+            print(repr(node_info), 'is incomplete, or unparsable')
+            continue
+
         if node_info[0] == 'separator':
             layout.separator()
             continue
 
-        if not node_info:
-            print(repr(node_info), 'is incomplete, or unparsable')
+        if node_info[0] == 'macro':
+            macro_bl_idname, show_name, *props = node_info[1].split(' ')
+            node_ref = getattr(bpy.types, macro_bl_idname)
+            op = layout.operator('node.sv_macro_interpretter', text=show_name, **node_icon(node_ref))
+            op.macro_bl_idname = macro_bl_idname
+            op.settings = ' '.join(props)
             continue
 
         bl_idname = node_info[0]

--- a/ui/nodeview_space_menu.py
+++ b/ui/nodeview_space_menu.py
@@ -80,6 +80,10 @@ def layout_draw_categories(layout, node_details):
             print(repr(node_info), 'is incomplete, or unparsable')
             continue
 
+        if len(node_info) == 2 and node_info[1] == 'hide_from_menu':
+            print(node_info)
+            continue
+
         if node_info[0] == 'separator':
             layout.separator()
             continue
@@ -87,7 +91,8 @@ def layout_draw_categories(layout, node_details):
         if node_info[0] == 'macro':
             macro_bl_idname, show_name, *props = node_info[1].split(' ')
             node_ref = getattr(bpy.types, macro_bl_idname)
-            op = layout.operator('node.sv_macro_interpretter', text=show_name, **node_icon(node_ref))
+            sanitize_name = show_name.replace('_', ' ').title()
+            op = layout.operator('node.sv_macro_interpretter', text=sanitize_name, **node_icon(node_ref))
             op.macro_bl_idname = macro_bl_idname
             op.settings = ' '.join(props)
             continue


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/619340/25064084/45a9c41c-21f3-11e7-9745-6e997d76dc15.png)

```text
## Number

    # this means, register the node (bl_idname)  but hide it from custom menu
    <<< SvNumberNode

    # this means add a macro for this entry, 
    #   | bl_idname | menu label | (parameters,....)
    >>> SvNumberNode Int (selected_mode="int")
    >>> SvNumberNode Float (selected_mode="float")
    Float2IntNode
    ScalarMathNode
    SvScalarMathNodeMK2

```
![image](https://cloud.githubusercontent.com/assets/619340/25064094/9ec90454-21f3-11e7-9aa2-908db99bcaa9.png)

##### not implemented now

I think for now i'll force single string Labels... like `Int` or `Float` above.. space separated labels should be done using `some_space_separated_name` , it's easy to convert underscores to space and change it to title case. 
