### PR TITLE
shift + ]  menu

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -92,7 +92,7 @@ utils_modules = [
     "text_editor_submenu", "text_editor_plugins",
     # UI operators and tools
     "sv_panels_tools", "sv_gist_tools", "sv_IO_panel_tools", "sv_load_zipped_blend",
-    "monad", "sv_help",
+    "monad", "sv_help", "sv_extra_search",
     #"loadscript",
     "debug_script", "sv_update_utils"
 ]

--- a/__init__.py
+++ b/__init__.py
@@ -92,7 +92,7 @@ utils_modules = [
     "text_editor_submenu", "text_editor_plugins",
     # UI operators and tools
     "sv_panels_tools", "sv_gist_tools", "sv_IO_panel_tools", "sv_load_zipped_blend",
-    "monad", "sv_help", "sv_extra_search",
+    "monad", "sv_help", "sv_default_macros", "sv_macro_utils", "sv_extra_search",
     #"loadscript",
     "debug_script", "sv_update_utils"
 ]

--- a/nodes/generator/random_vector_mk2.py
+++ b/nodes/generator/random_vector_mk2.py
@@ -25,7 +25,7 @@ from sverchok.data_structure import updateNode, match_long_repeat
 
 
 class RandomVectorNodeMK2(bpy.types.Node, SverchCustomTreeNode):
-    ''' Random Vectors with len=1 MK2, Unit Vectors'''
+    ''' Random unit Vectors'''
     bl_idname = 'RandomVectorNodeMK2'
     bl_label = 'Random Vector MK2'
     bl_icon = 'RNDCURVE'

--- a/nodes/generators_extended/profile.py
+++ b/nodes/generators_extended/profile.py
@@ -522,9 +522,8 @@ class SvProfileNode(bpy.types.Node, SverchCustomTreeNode):
     This node expects simple input, or vectorized input.
     - sockets with no input are automatically 0, not None
     - The longest input array will be used to extend the shorter ones, using last value repeat.
-    
-
     '''
+
     bl_idname = 'SvProfileNode'
     bl_label = 'Profile Parametric'
     bl_icon = 'OUTLINER_OB_EMPTY'

--- a/nodes/generators_extended/profile.py
+++ b/nodes/generators_extended/profile.py
@@ -514,12 +514,16 @@ class SvPrifilizer(bpy.types.Operator):
 
 class SvProfileNode(bpy.types.Node, SverchCustomTreeNode):
     '''
+    svg-like 2d profiles ///
+
     SvProfileNode generates one or more profiles / elevation segments using;
     assignments, variables, and a string descriptor similar to SVG.
 
     This node expects simple input, or vectorized input.
     - sockets with no input are automatically 0, not None
     - The longest input array will be used to extend the shorter ones, using last value repeat.
+    
+
     '''
     bl_idname = 'SvProfileNode'
     bl_label = 'Profile Parametric'

--- a/nodes/matrix/apply_and_join.py
+++ b/nodes/matrix/apply_and_join.py
@@ -25,8 +25,12 @@ from sverchok.utils.sv_mesh_utils import mesh_join
 
 
 class SvMatrixApplyJoinNode(bpy.types.Node, SverchCustomTreeNode):
-    ''' Multiply vectors on matrices with several objects in output,
-        and process edges & faces too '''
+    '''
+    M * verts (optional join)  ///
+
+    Multiply vectors on matrices with several objects in output,
+    and process edges & faces too 
+    '''
     bl_idname = 'SvMatrixApplyJoinNode'
     bl_label = 'Matrix Apply'
     bl_icon = 'OUTLINER_OB_EMPTY'

--- a/nodes/text/debug_print.py
+++ b/nodes/text/debug_print.py
@@ -24,7 +24,7 @@ from sverchok.data_structure import multi_socket, updateNode
 
 
 class SvDebugPrintNode(bpy.types.Node, SverchCustomTreeNode):
-    ''' SvDebugPrintNode '''
+    ''' print socket data to terminal '''
     bl_idname = 'SvDebugPrintNode'
     bl_label = 'Debug print'
     bl_icon = 'OUTLINER_OB_EMPTY'

--- a/nodes/vector/axis_input_mk2.py
+++ b/nodes/vector/axis_input_mk2.py
@@ -27,7 +27,7 @@ class SvAxisInputNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     ''' Generator for X, Y or Z axis. '''
 
     bl_idname = 'SvAxisInputNodeMK2'
-    bl_label = 'Vector X | Y | Z'
+    bl_label = 'Vector X/Y/Z'
     bl_icon = 'MANIPUL'
 
     m = [("-1", "-1", "", 0), ("0", "0", "", 1), ("1", "1", "", 2)]

--- a/nodes/vector/axis_input_mk2.py
+++ b/nodes/vector/axis_input_mk2.py
@@ -24,7 +24,7 @@ from sverchok.data_structure import updateNode
 
 
 class SvAxisInputNodeMK2(bpy.types.Node, SverchCustomTreeNode):
-    ''' Generator for X, Y or Z axis. '''
+    ''' axis input '''
 
     bl_idname = 'SvAxisInputNodeMK2'
     bl_label = 'Vector X/Y/Z'

--- a/nodes/vector/color_in.py
+++ b/nodes/vector/color_in.py
@@ -36,7 +36,7 @@ def fprop_generator(**altprops):
 
 
 class SvColorsInNode(bpy.types.Node, SverchCustomTreeNode):
-    ''' Generator for Color data , color combine'''
+    ''' rgb(a) ---> color /// Generator for Color data'''
     bl_idname = 'SvColorsInNode'
     bl_label = 'Color in'
     sv_icon = 'SV_COMBINE_IN'

--- a/nodes/vector/color_out.py
+++ b/nodes/vector/color_out.py
@@ -31,7 +31,7 @@ nodule_color = (0.899, 0.8052, 0.0, 1.0)
 
 
 class SvColorsOutNode(bpy.types.Node, SverchCustomTreeNode):
-    ''' Generator for Color data , color separate'''
+    ''' color ---> rgb(a) /// Generator for Color data'''
     bl_idname = 'SvColorsOutNode'
     bl_label = 'Color Out'
     sv_icon = 'SV_COMBINE_OUT'

--- a/ui/nodeview_keymaps.py
+++ b/ui/nodeview_keymaps.py
@@ -51,6 +51,11 @@ def add_keymap():
         kmi.properties.name = "NODEVIEW_MT_Dynamic_Menu"
         nodeview_keymaps.append((km, kmi))
 
+        # TAB           | enter or exit monad depending on selection and edit_tree type
+        kmi = km.keymap_items.new('node.sv_extra_search', 'RIGHT_BRACKET', 'PRESS', shift=True)
+        nodeview_keymaps.append((km, kmi))
+
+
 
 def remove_keymap():
 

--- a/utils/sv_default_macros.py
+++ b/utils/sv_default_macros.py
@@ -8,7 +8,7 @@ macros = {
     "> objs vd": {
         'display_name': "multi obj in + vdmk2",
         'file':'macro', 
-        'ident': ['verbose_macro_handler', 'ob3_and_vd']}
+        'ident': ['verbose_macro_handler', 'objs vd']}
 }
 
 sv_types = {'SverchCustomTreeType', 'SverchGroupTreeType'}
@@ -52,4 +52,13 @@ class DefaultMacros():
             
             links.new(obj_in_node.outputs[0], vd_node.inputs[0])
             links.new(obj_in_node.outputs[2], vd_node.inputs[1])
-            links.new(obj_in_node.outputs[3], vd_node.inputs[2])        
+            links.new(obj_in_node.outputs[3], vd_node.inputs[2])
+        elif term == 'objs vd':
+            obj_in_node = nodes.new('SvObjectsNodeMK3')
+            obj_in_node.get_objects_from_scene(operator)
+            vd_node = nodes.new('ViewerNode2')
+            vd_node.location = obj_in_node.location.x + 180, obj_in_node.location.y
+            
+            links.new(obj_in_node.outputs[0], vd_node.inputs[0])
+            links.new(obj_in_node.outputs[2], vd_node.inputs[1])
+            links.new(obj_in_node.outputs[3], vd_node.inputs[2])            

--- a/utils/sv_default_macros.py
+++ b/utils/sv_default_macros.py
@@ -1,4 +1,30 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import os
+import webbrowser
+
 import bpy
+
+from sverchok.utils.sv_update_utils import sv_get_local_path
+
+
+
 
 macros = {
     "> obj vd": {
@@ -8,10 +34,19 @@ macros = {
     "> objs vd": {
         'display_name': "multi obj in + vdmk2",
         'file':'macro', 
-        'ident': ['verbose_macro_handler', 'objs vd']}
+        'ident': ['verbose_macro_handler', 'objs vd']},
+    "> zen": {
+        'display_name': "zen of Sverchok",
+        'file':'macro', 
+        'ident': ['verbose_macro_handler', 'zen']},
+    "> sn petal": {
+        'display_name': "load snlite w/ petalsine",
+        'file':'macro', 
+        'ident': ['verbose_macro_handler', 'sn petal']}        
 }
 
 sv_types = {'SverchCustomTreeType', 'SverchGroupTreeType'}
+
 
 class DefaultMacros():
 
@@ -62,3 +97,17 @@ class DefaultMacros():
             links.new(obj_in_node.outputs[0], vd_node.inputs[0])
             links.new(obj_in_node.outputs[2], vd_node.inputs[1])
             links.new(obj_in_node.outputs[3], vd_node.inputs[2])            
+        elif term == 'zen':
+            full_url_term = 'https://blenderpython.tumblr.com/post/91951323209/zen-of-sverchok'
+            webbrowser.open(full_url_term)
+        elif term == 'sn petal':
+            snlite = nodes.new('SvScriptNodeLite')
+            # set location of snlite based on mouse?
+
+            sv_path = os.path.dirname(sv_get_local_path()[0])
+            snlite_template_path = os.path.join(sv_path, 'node_scripts', 'SNLite_templates')
+            fullpath = os.path.join(snlite_template_path, 'petal_sine.py')
+            
+            txt = bpy.data.texts.load(fullpath)
+            snlite.script_name = os.path.basename(txt.name)
+            snlite.load()

--- a/utils/sv_default_macros.py
+++ b/utils/sv_default_macros.py
@@ -24,8 +24,6 @@ import bpy
 from sverchok.utils.sv_update_utils import sv_get_local_path
 
 
-
-
 macros = {
     "> obj vd": {
         'display_name': "active_obj into objlite + vdmk2", 
@@ -65,7 +63,7 @@ class DefaultMacros():
             msg_two = 'added new node tree'
             print(msg_one)
             operator.report({"WARNING"}, msg_one)
-            ng_params = {'name': 'unnamed_tree', 'type': 'SverchCustomTreeType'}
+            ng_params = {'name': 'NodeTree', 'type': 'SverchCustomTreeType'}
             ng = bpy.data.node_groups.new(**ng_params)
             ng.use_fake_user = True
             context.space_data.node_tree = ng

--- a/utils/sv_default_macros.py
+++ b/utils/sv_default_macros.py
@@ -1,13 +1,55 @@
+import bpy
+
 macros = {
     "> obj vd": {
         'display_name': "active_obj into objlite + vdmk2", 
         'file': 'macro', 
-        'ident': 'obj_in_lite_and_vd'},
+        'ident': ['verbose_macro_handler', 'obj vd']},
     "> objs vd": {
         'display_name': "multi obj in + vdmk2",
         'file':'macro', 
-        'ident': 'ob3_and_vd'}
+        'ident': ['verbose_macro_handler', 'ob3_and_vd']}
 }
 
+sv_types = {'SverchCustomTreeType', 'SverchGroupTreeType'}
 
+class DefaultMacros():
 
+    @classmethod
+    def ensure_nodetree(cls, operator, context):
+        '''
+        if no active nodetree
+        add new empty node tree, set fakeuser immediately
+        '''
+        if not context.space_data.tree_type in sv_types:
+            print('not running from a sv nodetree')
+            return
+
+        if not hasattr(context.space_data.edit_tree, 'nodes'):
+            msg_one = 'going to add a new empty node tree'
+            msg_two = 'added new node tree'
+            print(msg_one)
+            operator.report({"WARNING"}, msg_one)
+            ng_params = {'name': 'unnamed_tree', 'type': 'SverchCustomTreeType'}
+            ng = bpy.data.node_groups.new(**ng_params)
+            ng.use_fake_user = True
+            context.space_data.node_tree = ng
+            operator.report({"WARNING"}, msg_two)        
+
+    @classmethod
+    def verbose_macro_handler(cls, operator, context, term):
+
+        cls.ensure_nodetree(operator, context)
+
+        tree = context.space_data.edit_tree
+        nodes, links = tree.nodes, tree.links
+
+        if term == 'obj vd':
+            obj_in_node = nodes.new('SvObjInLite')
+            obj_in_node.dget()
+            vd_node = nodes.new('ViewerNode2')
+            vd_node.location = obj_in_node.location.x + 180, obj_in_node.location.y
+            
+            links.new(obj_in_node.outputs[0], vd_node.inputs[0])
+            links.new(obj_in_node.outputs[2], vd_node.inputs[1])
+            links.new(obj_in_node.outputs[3], vd_node.inputs[2])        

--- a/utils/sv_default_macros.py
+++ b/utils/sv_default_macros.py
@@ -1,0 +1,12 @@
+macros = {
+    # trigger:  [descriptor, action route]
+    "> obj vd": [
+        "active_obj into objlite + vdmk2",
+        "<file:macro> <ident:obj_in_lite_and_vd>"],
+    "> objs vd": [
+        "multi obj in",
+        "<file:macro> <ident:ob3_and_vd>"]
+}
+
+
+

--- a/utils/sv_default_macros.py
+++ b/utils/sv_default_macros.py
@@ -1,11 +1,12 @@
 macros = {
-    # trigger:  [descriptor, action route]
-    "> obj vd": [
-        "active_obj into objlite + vdmk2",
-        "<file:macro> <ident:obj_in_lite_and_vd>"],
-    "> objs vd": [
-        "multi obj in",
-        "<file:macro> <ident:ob3_and_vd>"]
+    "> obj vd": {
+        'display_name': "active_obj into objlite + vdmk2", 
+        'file': 'macro', 
+        'ident': 'obj_in_lite_and_vd'},
+    "> objs vd": {
+        'display_name': "multi obj in + vdmk2",
+        'file':'macro', 
+        'ident': 'ob3_and_vd'}
 }
 
 

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -48,6 +48,8 @@ def gather_items():
                 continue
             nodetype = getattr(bpy.types, item[0])
             desc = nodetype.bl_rna.description
+            if '///' in desc:
+                desc = desc.strip().split('///')[0]
             show_string = nodetype.bl_label + ((' | ' + desc) if desc else '')
             fx.append((str(idx), show_string, '', idx))
             idx += 1

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -81,8 +81,8 @@ def get_main_macro_module(fullpath):
         return macro_module
 
 def fx_extend(idx, datastorage, filepath):
-    # shall be dynamic
-    datafiles = r'C:\Users\zeffi\AppData\Roaming\Blender Foundation\Blender\2.78' 
+
+    datafiles = os.path.join(bpy.utils.user_resource('DATAFILES', path='sverchok', create=True))
     fullpath = os.path.join(datafiles, filepath)
 
     # load from previous obtained module, else get from fullpath.
@@ -112,7 +112,7 @@ def gather_items():
         fx.append((k, format_item(k, v), '', idx))
         idx += 1
     
-    fx_extend(idx, fx, 'datafiles/sverchok/user_macros/macros.py')
+    fx_extend(idx, fx, 'user_macros/macros.py')
 
     return fx
 

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -32,6 +32,9 @@ addon_name = sverchok.__name__
 
 # pylint: disable=c0326
 
+def format_item(k, v):
+    return k + " | " + v['display_name']
+
 
 def gather_items():
     fx = []
@@ -49,7 +52,7 @@ def gather_items():
             idx += 1
 
     for k, v in macros.items():
-        fx.append((k, k + " | " + v[0], '', idx))
+        fx.append((k, format_item(k, v), '', idx))
         idx += 1
 
     # extend(idx, fx, '/datafiles/sverchok/user_macros.fx')

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -131,13 +131,6 @@ class SvExtraSearch(bpy.types.Operator):
 
     def bl_idname_from_bl_label(self, context):
         macro_result = loop['results'][int(self.my_enum)]
-        """
-        if ' | ' in macro_result[1]:
-            bl_label = macro_result[1].split(' | ')[0].strip()
-        else:
-            bl_label = macro_result[1].strip()
-        """
-
         bl_label = macro_result[1].split(' | ')[0].strip()
         return loop_reverse[bl_label]
 

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -44,12 +44,11 @@ def ensure_valid_show_string(item):
     '''  the font is not fixed width, it makes litle sense to calculate chars'''
     hardcoded_maxlen = 20
     nodetype = getattr(bpy.types, item[0])
-    desc = slice_docstring(nodetype.bl_rna.description)
+    description = slice_docstring(nodetype.bl_rna.description).strip()
 
-    # this needs revision
-    description = ((' | ' + desc) if desc else '').strip()
-    if len(description) > hardcoded_maxlen:
-        description = description[hardcoded_maxlen:]
+    # ensure it's not too long
+    if description and len(description) > hardcoded_maxlen:
+        description = ' | ' + description[:hardcoded_maxlen]
     
     return nodetype.bl_label + description
 

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -30,6 +30,12 @@ node_cats = make_node_cats()
 addon_name = sverchok.__name__
 
 
+macros = {
+    "obj vd": ["active_obj into objlite + vdmk2","<file:macro> <ident:obj_in_lite_and_vd>"],
+    "objs vd": ["multi obj in","<file:macro> <ident:ob3_and_vd>"]
+}
+
+
 def gather_items():
     fx = []
     idx = 0
@@ -38,8 +44,13 @@ def gather_items():
             if item[0] in {'separator', 'NodeReroute'}:
                 continue
             nodetype = getattr(bpy.types, item[0])
-            fx.append((str(idx), nodetype.bl_label, nodetype.bl_rna.description, idx))
+            fx.append((str(idx), nodetype.bl_label, '', idx))
             idx += 1
+
+    for k, v in macros.items():
+        fx.append((k, k + " | " + v[0], '', idx))
+        idx += 1
+
     return fx
 
 loop = {}
@@ -58,7 +69,10 @@ class SvExtraSearch(bpy.types.Operator):
 
     def execute(self, context):
         self.report({'INFO'}, "Selected: %s" % self.my_enum)
-        print(loop['results'][int(self.my_enum)])
+        if self.my_enum.isnumeric():
+            print(loop['results'][int(self.my_enum)])
+        else:
+            print(self.my_enum)
         return {'FINISHED'}
 
     def invoke(self, context, event):

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -32,12 +32,6 @@ addon_name = sverchok.__name__
 
 # pylint: disable=c0326
 
-macros = {
-    # trigger:  [descriptor, action route]
-    "> obj vd": ["active_obj into objlite + vdmk2","<file:macro> <ident:obj_in_lite_and_vd>"],
-    "> objs vd": ["multi obj in","<file:macro> <ident:ob3_and_vd>"]
-}
-
 
 def gather_items():
     fx = []
@@ -51,7 +45,7 @@ def gather_items():
             if '///' in desc:
                 desc = desc.strip().split('///')[0]
             show_string = nodetype.bl_label + ((' | ' + desc) if desc else '')
-            fx.append((str(idx), show_string, '', idx))
+            fx.append((str(idx), show_string.strip(), '', idx))
             idx += 1
 
     for k, v in macros.items():

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -35,6 +35,15 @@ addon_name = sverchok.__name__
 def format_item(k, v):
     return k + " | " + v['display_name']
 
+def slice_docstring(desc):
+    if '///' in desc:
+        desc = desc.strip().split('///')[0]
+    return desc
+
+def ensure_valid_show_string(item):
+    nodetype = getattr(bpy.types, item[0])
+    desc = slice_docstring(nodetype.bl_rna.description)
+    return nodetype.bl_label + ((' | ' + desc) if desc else '').strip()
 
 def gather_items():
     fx = []
@@ -43,12 +52,8 @@ def gather_items():
         for item in node_list:
             if item[0] in {'separator', 'NodeReroute'}:
                 continue
-            nodetype = getattr(bpy.types, item[0])
-            desc = nodetype.bl_rna.description
-            if '///' in desc:
-                desc = desc.strip().split('///')[0]
-            show_string = nodetype.bl_label + ((' | ' + desc) if desc else '')
-            fx.append((str(idx), show_string.strip(), '', idx))
+            
+            fx.append((str(idx), ensure_valid_show_string(item), '', idx))
             idx += 1
 
     for k, v in macros.items():

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -47,8 +47,10 @@ def ensure_valid_show_string(item):
     description = slice_docstring(nodetype.bl_rna.description).strip()
 
     # ensure it's not too long
-    if description and len(description) > hardcoded_maxlen:
-        description = ' | ' + description[:hardcoded_maxlen]
+    if description:
+        if len(description) > hardcoded_maxlen:
+            description = description[:hardcoded_maxlen]
+        description = ' | ' + description
     
     return nodetype.bl_label + description
 

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -44,7 +44,9 @@ def gather_items():
             if item[0] in {'separator', 'NodeReroute'}:
                 continue
             nodetype = getattr(bpy.types, item[0])
-            fx.append((str(idx), nodetype.bl_label, '', idx))
+            desc = nodetype.bl_rna.description
+            show_string = nodetype.bl_label + ((' | ' + desc) if desc else '')
+            fx.append((str(idx), show_string, '', idx))
             idx += 1
 
     for k, v in macros.items():

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -33,7 +33,6 @@ addon_name = sverchok.__name__
 
 loop = {}
 loop_reverse = {}
-
 # pylint: disable=c0326
 
 
@@ -77,6 +76,7 @@ def get_main_macro_module(fullpath):
         spec = getutil.spec_from_file_location("macro_module.name", fullpath)
         macro_module = getutil.module_from_spec(spec)
         spec.loader.exec_module(macro_module)
+        globals()['sv_macro_module'] = macro_module
         return macro_module
 
 def fx_extend(idx, datastorage, filepath):
@@ -144,11 +144,16 @@ class SvExtraSearch(bpy.types.Operator):
             DefaultMacros.ensure_nodetree(self, context)
             bpy.ops.node.sv_macro_interpretter(macro_bl_idname=macro_bl_idname)
         else:
-            print(self.my_enum)
             macro_reference = macros.get(self.my_enum)
+
             if macro_reference:
                 handler, term = macro_reference.get('ident')
                 getattr(DefaultMacros, handler)(self, context, term)
+
+            elif hasattr(globals()['sv_macro_module'], self.my_enum):
+                func = getattr(globals()['sv_macro_module'], self.my_enum)
+                func(self, context)
+
 
         return {'FINISHED'}
 

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -23,6 +23,7 @@ import sverchok
 import nodeitems_utils
 from sverchok.menu import make_node_cats
 from sverchok.ui.sv_icons import custom_icon
+from sverchok.utils.sv_default_macros import macros
 from nodeitems_utils import _node_categories
 
 sv_tree_types = {'SverchCustomTreeType', 'SverchGroupTreeType'}
@@ -33,8 +34,8 @@ addon_name = sverchok.__name__
 
 macros = {
     # trigger:  [descriptor, action route]
-    "obj vd": ["active_obj into objlite + vdmk2","<file:macro> <ident:obj_in_lite_and_vd>"],
-    "objs vd": ["multi obj in","<file:macro> <ident:ob3_and_vd>"]
+    "> obj vd": ["active_obj into objlite + vdmk2","<file:macro> <ident:obj_in_lite_and_vd>"],
+    "> objs vd": ["multi obj in","<file:macro> <ident:ob3_and_vd>"]
 }
 
 

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -41,9 +41,17 @@ def slice_docstring(desc):
     return desc
 
 def ensure_valid_show_string(item):
+    '''  the font is not fixed width, it makes litle sense to calculate chars'''
+    hardcoded_maxlen = 20
     nodetype = getattr(bpy.types, item[0])
     desc = slice_docstring(nodetype.bl_rna.description)
-    return nodetype.bl_label + ((' | ' + desc) if desc else '').strip()
+
+    # this needs revision
+    description = ((' | ' + desc) if desc else '').strip()
+    if len(description) > hardcoded_maxlen:
+        description = description[hardcoded_maxlen:]
+    
+    return nodetype.bl_label + description
 
 def gather_items():
     fx = []

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -29,8 +29,10 @@ sv_tree_types = {'SverchCustomTreeType', 'SverchGroupTreeType'}
 node_cats = make_node_cats()
 addon_name = sverchok.__name__
 
+# pylint: disable=c0326
 
 macros = {
+    # trigger:  [descriptor, action route]
     "obj vd": ["active_obj into objlite + vdmk2","<file:macro> <ident:obj_in_lite_and_vd>"],
     "objs vd": ["multi obj in","<file:macro> <ident:ob3_and_vd>"]
 }
@@ -39,8 +41,8 @@ macros = {
 def gather_items():
     fx = []
     idx = 0
-    for catname, node_list in node_cats.items():
-        for index, item in enumerate(node_list):
+    for _, node_list in node_cats.items():
+        for item in node_list:
             if item[0] in {'separator', 'NodeReroute'}:
                 continue
             nodetype = getattr(bpy.types, item[0])
@@ -52,6 +54,8 @@ def gather_items():
     for k, v in macros.items():
         fx.append((k, k + " | " + v[0], '', idx))
         idx += 1
+
+    # extend(idx, fx, '/datafiles/sverchok/user_macros.fx')
 
     return fx
 

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -103,7 +103,7 @@ class SvExtraSearch(bpy.types.Operator):
         return loop_reverse[bl_label]
 
     def execute(self, context):
-        self.report({'INFO'}, "Selected: %s" % self.my_enum)
+        # self.report({'INFO'}, "Selected: %s" % self.my_enum)
         if self.my_enum.isnumeric():
             macro_bl_idname = self.bl_idname_from_bl_label(self)
             DefaultMacros.ensure_nodetree(self, context)

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -23,7 +23,7 @@ import sverchok
 import nodeitems_utils
 from sverchok.menu import make_node_cats
 from sverchok.ui.sv_icons import custom_icon
-from sverchok.utils.sv_default_macros import macros
+from sverchok.utils.sv_default_macros import macros, DefaultMacros
 from nodeitems_utils import _node_categories
 
 sv_tree_types = {'SverchCustomTreeType', 'SverchGroupTreeType'}
@@ -84,6 +84,11 @@ class SvExtraSearch(bpy.types.Operator):
             print(loop['results'][int(self.my_enum)])
         else:
             print(self.my_enum)
+            macro_reference = macros.get(self.my_enum)
+            if macro_reference:
+                handler, term = macro_reference.get('ident')
+                getattr(DefaultMacros, handler)(self, context, term)
+
         return {'FINISHED'}
 
     def invoke(self, context, event):

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -101,6 +101,7 @@ class SvExtraSearch(bpy.types.Operator):
         return {'FINISHED'}
 
     def invoke(self, context, event):
+        # event contains mouse xy, can pass too! 
         loop['results'] = gather_items()
         wm = context.window_manager
         wm.invoke_search_popup(self)

--- a/utils/sv_macro_utils.py
+++ b/utils/sv_macro_utils.py
@@ -1,0 +1,94 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import re
+
+import bpy
+from bpy.props import StringProperty
+
+import sverchok
+
+
+# pylint: disable=w0141
+# pylint: disable=w0123
+
+def convert_string_to_settings(arguments):
+
+    # expects       (varname=value,....)
+    # for example   (selected_mode="int", fruits=20, alama=[0,0,0])
+    def deform_args(**args):
+        return args
+
+    unsorted_dict = eval('deform_args{arguments}'.format(**vars()), locals(), locals())
+    pattern = r'(\w+\s*)='
+    results = re.findall(pattern, arguments)
+    return [(varname, unsorted_dict[varname]) for varname in results]
+
+
+class SvMacroInterpretter(bpy.types.Operator):
+    """ Launch menu item as a macro """
+    bl_idname = "node.sv_macro_interpretter"
+    bl_label = "Sverchok check for new minor version"
+    bl_options = {'REGISTER'}
+
+    macro_bl_idname = StringProperty()
+    settings = StringProperty()
+
+    def create_node(self, context, node_type):
+        space = context.space_data
+        tree = space.edit_tree
+
+        # select only the new node
+        for n in tree.nodes:
+            n.select = False
+
+        node = tree.nodes.new(type=node_type)
+
+        if self.settings:
+            settings = convert_string_to_settings(self.settings)
+            for name, value in settings:
+                try:
+                    setattr(node, name, value)
+                except AttributeError as e:
+                    self.report({'ERROR_INVALID_INPUT'}, "Node has no attribute " + name)
+                    print(str(e))
+
+        node.select = True
+        tree.nodes.active = node
+        node.location = space.cursor_location
+        return node
+
+
+    def execute(self, context):
+        self.create_node(context, self.macro_bl_idname)    
+        bpy.ops.node.translate_attach_remove_on_cancel('INVOKE_DEFAULT')
+        return {'FINISHED'}
+
+
+classes = (SvMacroInterpretter,)
+
+
+def register():
+    for class_name in classes:
+        bpy.utils.register_class(class_name)
+
+
+def unregister():
+    for class_name in classes:
+        bpy.utils.unregister_class(class_name)
+

--- a/utils/sv_macro_utils.py
+++ b/utils/sv_macro_utils.py
@@ -27,6 +27,8 @@ import sverchok
 # pylint: disable=w0141
 # pylint: disable=w0123
 
+
+
 def convert_string_to_settings(arguments):
 
     # expects       (varname=value,....)


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/619340/25071250/9c8f10ba-22b2-11e7-9e95-87387a8693c0.png)


### Usage

- `shift+]` will trigger a new search bar.  
- The search database is loaded with 
    - All nodes (shows Node Name (bl_label) and Description
    - Several default macros ( shown by `>` )
    - optionally User Driven Macros ( shown by `<` )
        These need to be created by the user in `/datafiles/sverchok/user_macros/macros.py` . See an example of such a file here



### Implementation details

- [x] implement macro searching
     - ( i can not control the width of the window.. unless there's a trick somewhere...)
- [x] select / place node
- [x] implement default macros
    - [x] `obj vd`   (single object to vdmk2)
    - [x] `objs vd`   (multi object to vdmk2)
    - [x] `sn petal`  (auto loads petalsine in snlite)
    - [x] `zen` (the zen of sverchok, shows [my tumblr post about the zen of it all](http://blenderpython.tumblr.com/post/91951323209/zen-of-sverchok))
    /- [ ] swap viewer  (hot swap viewer nodes  vdmk3 <-->  bmeshview )
- [x] Auto Line splitting on `///` for description
- [x] `>` will indicate the result is a macro
- [x] `<` will indicate the result is a user macro
- [x] Auto Line wrapping for description
- [x] implement user driven macro definitions.
- [x] pass mouse location.

