### PR TITLE
Subdivide node

### DIFF
--- a/docs/nodes/modifier_change/modifier_change_index.rst
+++ b/docs/nodes/modifier_change/modifier_change_index.rst
@@ -6,6 +6,7 @@ Modifier Change
    :maxdepth: 2
 
    bevel
+   subdivide
    delete_loose
    edges_intersect
    extrude_edges

--- a/docs/nodes/modifier_change/subdivide.rst
+++ b/docs/nodes/modifier_change/subdivide.rst
@@ -66,3 +66,19 @@ This node has the following outputs:
 Examples of usage
 -----------------
 
+The simplest example, subdivide a cube:
+
+.. image:: https://cloud.githubusercontent.com/assets/284644/25096716/476682dc-23c3-11e7-8788-624be2573d3b.png
+
+Subdivide one face of a cube, with smoothing:
+
+.. image:: https://cloud.githubusercontent.com/assets/284644/25096718/47976654-23c3-11e7-8da8-87ea420d8355.png
+
+Subdivide a cube, with smooth falloff type = Smooth:
+
+.. image:: https://cloud.githubusercontent.com/assets/284644/25096717/4794fed2-23c3-11e7-8c53-28fb1d18b69d.png
+
+Subdivide a torus, with smooth falloff type = Sphere:
+
+.. image:: https://cloud.githubusercontent.com/assets/284644/25096721/479a2c72-23c3-11e7-9012-612ce3fd1039.png
+

--- a/docs/nodes/modifier_change/subdivide.rst
+++ b/docs/nodes/modifier_change/subdivide.rst
@@ -1,0 +1,68 @@
+Subdivide Node
+==============
+
+Functionality
+-------------
+
+This node applies Blender's Subvidide operation to the input mesh. Please note that of options available differs from usual editing operator.
+
+Inputs
+------
+
+This node has the following inputs:
+
+- **Vertrices**
+- **Edges**. For this node to produce interesting result, this input must be provided.
+- **Faces**
+- **EdgeMask**. Selected edges to be subdivided. Faces surrounded by subdivided edges can optionally be subdivided too.
+- **Number of Cuts**
+- **Smooth**
+- **Fractal**
+- **Along normal**
+- **Seed**
+
+Parameters
+----------
+
+This node has the following parameters:
+
+- **Show Old**. If checked, then outputs with "old" geometry will be shown. By default not checked.
+- **Show New**. If checked, then outputs with newly created geometry will be shown. By default not checked.
+- **Show Options**. If checked, then following parameters will be shown on the node itself. Otherwise, they will be available only in the N panel. By default not checked.
+- **Falloff**. Smooth falloff type. Please refer to examples below for demonstration.
+- **Corner cut type**. This controls the way quads with only two adjacent selected edges are subdivided. Available values are:
+
+  - **Inner vertices**
+  - **Path**
+  - **Fan**
+  - **Straight Cut**
+- **Grid fill**. If checked, then fully-selected faces will be filled with a grid (subdivided). Otherwise, only edges will be subdiveded, not faces. Checked by default.
+- **Only Quads**. If checked, then only quad faces will be subdivided, other will not. By default not checked.
+- **Single edge**. If checked, tessellate the case of one edge selected in a quad or triangle. By default not checked.
+- **Even smooth**. Maintain even offset when smoothing. By default not checked.
+- **Number of Cuts**. Specifies the number of cuts per edge to make. By default this is 1, cutting edges in half. A value of 2 will cut it into thirds, and so on. This parameter can be also provided as input.
+- **Smooth**. Displaces subdivisions to maintain approximate curvature, The effect is similar to the way the Subdivision Surface Modifier might deform the mesh. This parameter can be also provided as input.
+- **Fractal**. Displaces the vertices in random directions after the mesh is subdivided. This parameter can be also provided as input.
+- **Along normal**. If set to 1, causes the vertices to move along the their normals, instead of random directions. Values between 0 and 1 lead to intermediate results. This parameter can be also provided as input.
+- **Seed**. Random seed. This parameter can be also provided as input.
+
+Outputs
+-------
+
+This node has the following outputs:
+
+- **Vertices**. All vertices of resulting mesh.
+- **Edges**. All edges of resulting mesh.
+- **Faces**. All faces of resulting mesh.
+- **NewVertices**. All vertices that were created by subdivision. This output is only visible when **Show New** parameter is checked.
+- **NewEdges**. Edges that were created by subdividing faces. This output is only visible when **Show New** parameter is checked.
+- **NewFaces**. Faces that were created by subdividing faces. This output is only visible when **Show New** parameter is checked.
+- **OldVertices**. Only vertices that were created on previously existing edges. This output is only visible when **Show Old** parameter is checked.
+- **OldEdges**. Only edges that were created by subdividing existing edges. This output is only visible when **Show Old** parameter is checked.
+- **OldFaces**. Only faces that were created by subdividing existing faces. This output is only visible when **Show Old** parameter is checked.
+
+**Note**: Indicies in **NewEdges**, **NewFaces**, **OldEdges**, **OldFaces** outputs relate to vertices in **Vertices** output.
+
+Examples of usage
+-----------------
+

--- a/index.md
+++ b/index.md
@@ -76,6 +76,7 @@
     SvMeshJoinNode
     ---
     SvBevelNode
+    SvSubdivideNode
     SvIntersectEdgesNodeMK2
     SvOffsetNode
     SvFillsHoleNode

--- a/nodes/modifier_change/subdivide.py
+++ b/nodes/modifier_change/subdivide.py
@@ -1,0 +1,197 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import bpy
+from bpy.props import IntProperty, FloatProperty, BoolProperty, EnumProperty
+import bmesh.ops
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode, match_long_repeat, fullList, Matrix_generate
+from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata, pydata_from_bmesh
+
+class SvSubdivideNode(bpy.types.Node, SverchCustomTreeNode):
+    '''Subdivide'''
+    
+    bl_idname = 'SvSubdivideNode'
+    bl_label = 'Subdivide'
+    bl_icon = 'OUTLINER_OB_EMPTY'
+
+    falloff_types = [
+            ("0", "Smooth", "", 'SMOOTHCURVE', 0),
+            ("1", "Sphere", "", 'SPHERECURVE', 1),
+            ("2", "Root", "", 'ROOTCURVE', 2),
+            ("3", "Sharp", "", 'SHARPCURVE', 3),
+            ("4", "Linear", "", 'LINCURVE', 4),
+            ("7", "Inverse Square", "", 'ROOTCURVE', 7)
+        ]
+
+    corner_types = [
+            ("0", "Inner Vertices", "", 0),
+            ("1", "Path", "", 1),
+            ("2", "Fan", "", 2),
+            ("3", "Straight Cut", "", 3)
+        ]
+
+    def update_mode(self, context):
+        updateNode(self, context)
+
+    falloff_type = EnumProperty(name = "Falloff",
+            items = falloff_types,
+            default = "4",
+            update=update_mode)
+    corner_type = EnumProperty(name = "Corner Cut Type",
+            items = corner_types,
+            default = "0",
+            update=update_mode)
+
+    cuts = IntProperty(name = "Number of Cuts",
+            description = "Specifies the number of cuts per edge to make",
+            min=1, default=1,
+            update=updateNode)
+    smooth = FloatProperty(name = "Smooth",
+            description = "Displaces subdivisions to maintain approximate curvature",
+            min=0.0, max=1.0, default=0.0,
+            update=updateNode)
+    fractal = FloatProperty(name = "Fractal",
+            description = "Displaces the vertices in random directions after the mesh is subdivided",
+            min=0.0, max=1.0, default=0.0,
+            update=updateNode)
+    along_normal = FloatProperty(name = "Along normal",
+            description = "Causes the vertices to move along the their normals, instead of random directions",
+            min=0.0, max=1.0, default=0.0,
+            update=updateNode)
+    seed = IntProperty(name = "Seed",
+            description = "Random seed",
+            default = 0,
+            update=updateNode)
+    grid_fill = BoolProperty(name = "Grid fill",
+            description = "fill in fully-selected faces with a grid",
+            default = True,
+            update=updateNode)
+    single_edge = BoolProperty(name = "Single edge",
+            description = "tessellate the case of one edge selected in a quad or triangle",
+            default = False,
+            update=updateNode)
+    only_quads = BoolProperty(name = "Only Quads",
+            description = "only subdivide quads (for loopcut)",
+            default = False,
+            update=updateNode)
+    smooth_even = BoolProperty(name = "Even smooth",
+            description = "maintain even offset when smoothing",
+            default = False,
+            update=updateNode)
+
+    def draw_buttons(self, context, layout):
+        pass
+
+    def draw_buttons_ext(self, context, layout):
+        self.draw_buttons(context, layout)
+        layout.prop(self, "falloff_type")
+        layout.prop(self, "corner_type")
+
+        col = layout.column()
+        col.prop(self, "grid_fill")
+        col.prop(self, "single_edge")
+        col.prop(self, "only_quads")
+        col.prop(self, "smooth_even")
+
+    def sv_init(self, context):
+        self.inputs.new('VerticesSocket', "Vertices", "Vertices")
+        self.inputs.new('StringsSocket', 'Edges', 'Edges')
+        self.inputs.new('StringsSocket', 'Faces', 'Faces')
+        self.inputs.new('StringsSocket', 'Mask')
+
+        self.inputs.new('StringsSocket', 'Cuts').prop_name = "cuts"
+        self.inputs.new('StringsSocket', 'Smooth').prop_name = "smooth"
+        self.inputs.new('StringsSocket', 'Fractal').prop_name = "fractal"
+        self.inputs.new('StringsSocket', 'AlongNormal').prop_name = "along_normal"
+        self.inputs.new('StringsSocket', 'Seed').prop_name = "seed"
+
+        self.outputs.new('VerticesSocket', 'Vertices')
+        self.outputs.new('StringsSocket', 'Edges')
+        self.outputs.new('StringsSocket', 'Faces')
+
+        self.update_mode(context)
+
+    def process(self):
+        if not any(output.is_linked for output in self.outputs):
+            return
+
+        vertices_s = self.inputs['Vertices'].sv_get()
+        edges_s = self.inputs['Edges'].sv_get(default=[[]])
+        faces_s = self.inputs['Faces'].sv_get(default=[[]])
+        masks_s = self.inputs['Mask'].sv_get(default=[[1]])
+
+        cuts_s = self.inputs['Cuts'].sv_get()[0]
+        smooth_s = self.inputs['Smooth'].sv_get()[0]
+        fractal_s = self.inputs['Fractal'].sv_get()[0]
+        along_normal_s = self.inputs['AlongNormal'].sv_get()[0]
+        seed_s = self.inputs['Seed'].sv_get()[0]
+
+        result_vertices = []
+        result_edges = []
+        result_faces = []
+
+        meshes = match_long_repeat([vertices_s, edges_s, faces_s, masks_s, cuts_s, smooth_s, fractal_s, along_normal_s, seed_s])
+        for vertices, edges, faces, masks, cuts, smooth, fractal, along_normal, seed in zip(*meshes):
+            fullList(masks,  len(edges))
+
+            bm = bmesh_from_pydata(vertices, edges, faces, normal_update=True)
+
+            selected_edges = []
+            for m, edge in zip(masks, edges):
+                if not m:
+                    continue
+                found = False
+                for bmesh_edge in bm.edges:
+                    if set(v.index for v in bmesh_edge.verts) == set(edge):
+                        found = True
+                        break
+                if found:
+                    selected_edges.append(bmesh_edge)
+                else:
+                    print("Cant find edge: " + str(edge))
+
+            geom = bmesh.ops.subdivide_edges(bm, edges = selected_edges,
+                    smooth = smooth,
+                    smooth_falloff = int(self.falloff_type),
+                    fractal = fractal, along_normal = along_normal,
+                    cuts = cuts, seed = seed,
+                    use_grid_fill = self.grid_fill,
+                    use_single_edge = self.single_edge,
+                    use_only_quads = self.only_quads,
+                    use_smooth_even = self.smooth_even)
+            new_vertices, new_edges, new_faces = pydata_from_bmesh(bm)
+            bm.free()
+
+            result_vertices.append(new_vertices)
+            result_edges.append(new_edges)
+            result_faces.append(new_faces)
+
+        self.outputs['Vertices'].sv_set(result_vertices)
+        self.outputs['Edges'].sv_set(result_edges)
+        self.outputs['Faces'].sv_set(result_faces)
+
+
+def register():
+    bpy.utils.register_class(SvSubdivideNode)
+
+
+def unregister():
+    bpy.utils.unregister_class(SvSubdivideNode)
+

--- a/nodes/modifier_change/subdivide.py
+++ b/nodes/modifier_change/subdivide.py
@@ -237,6 +237,7 @@ class SvSubdivideNode(bpy.types.Node, SverchCustomTreeNode):
                     smooth_falloff = int(self.falloff_type),
                     fractal = fractal, along_normal = along_normal,
                     cuts = cuts, seed = seed,
+                    quad_corner_type = int(self.corner_type),
                     use_grid_fill = self.grid_fill,
                     use_single_edge = self.single_edge,
                     use_only_quads = self.only_quads,

--- a/nodes/modifier_change/subdivide.py
+++ b/nodes/modifier_change/subdivide.py
@@ -114,7 +114,7 @@ class SvSubdivideNode(bpy.types.Node, SverchCustomTreeNode):
         self.inputs.new('VerticesSocket', "Vertices", "Vertices")
         self.inputs.new('StringsSocket', 'Edges', 'Edges')
         self.inputs.new('StringsSocket', 'Faces', 'Faces')
-        self.inputs.new('StringsSocket', 'Mask')
+        self.inputs.new('StringsSocket', 'EdgeMask')
 
         self.inputs.new('StringsSocket', 'Cuts').prop_name = "cuts"
         self.inputs.new('StringsSocket', 'Smooth').prop_name = "smooth"
@@ -135,7 +135,7 @@ class SvSubdivideNode(bpy.types.Node, SverchCustomTreeNode):
         vertices_s = self.inputs['Vertices'].sv_get()
         edges_s = self.inputs['Edges'].sv_get(default=[[]])
         faces_s = self.inputs['Faces'].sv_get(default=[[]])
-        masks_s = self.inputs['Mask'].sv_get(default=[[1]])
+        masks_s = self.inputs['EdgeMask'].sv_get(default=[[1]])
 
         cuts_s = self.inputs['Cuts'].sv_get()[0]
         smooth_s = self.inputs['Smooth'].sv_get()[0]


### PR DESCRIPTION
This is actually an interface for bmesh.ops.subdivide_edges.

Interesting, that for some reason bmesh's operator has different options set from blender editing mode one. Some features are only present in bmesh interface, for example "falloff type".

Please review.