### PR TITLE
add boilerplate for custom defaults

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -79,7 +79,7 @@ root_modules = [
 
 core_modules = [
     "monad_properties",
-    "handlers", "update_system", "upgrade_nodes", "upgrade_group", "monad",
+    "handlers", "update_system", "upgrade_nodes", "upgrade_group", "monad", "node_defaults"
 ]
 
 utils_modules = [
@@ -157,6 +157,7 @@ if reload_event:
 
 import bpy
 from sverchok.utils import ascii_print
+from sverchok.core import node_defaults
 
 
 def register():
@@ -169,10 +170,12 @@ def register():
     print("** version: ", bl_info['version']," **")
     print("** Have a nice day with sverchok  **\n")
     ascii_print.logo()
+    node_defaults.register_defaults()
 
     if reload_event:
         data_structure.RELOAD_EVENT = True
         print("Sverchok is reloaded, press update")
+
 
 
 def unregister():

--- a/core/node_defaults.py
+++ b/core/node_defaults.py
@@ -28,6 +28,12 @@ node_default_dict = {}
 node_default_functions = {}
 
 
+def register_defaults():
+    # print('called')
+    node_default_dict.update(get_dict())
+    # print('____', node_default_dict)
+
+
 def get_dict():
 
     datafiles = os.path.join(bpy.utils.user_resource('DATAFILES', path='sverchok', create=True))
@@ -64,25 +70,22 @@ def get_function(func, node):
 
     else:
         if os.path.exists(path_to_function):
-            print('--- first time getting function path for ', node.bl_idname)
+            # print('--- first time getting function path for ', node.bl_idname)
             spec = getutil.spec_from_file_location(func, path_to_function)
             macro_module = getutil.module_from_spec(spec)
             spec.loader.exec_module(macro_module)
             node_default_functions[func] = getattr(macro_module, functionname)
+            return node_default_functions[func]
 
 
 def set_defaults_if_defined(node):
-    print('A')
     if not hasattr(node, 'bl_idname') and not len(node_default_dict):
         return
 
-    print('B')
-    print(node_default_dict)
     node_settings = node_default_dict.get(node.bl_idname)
     if not node_settings:
         return
 
-    print('C')
     props = node_settings.get('props')
     if props:
         for prop, value in props:
@@ -99,8 +102,5 @@ def set_defaults_if_defined(node):
             print('reason: ', repr(err))
 
 
-def register_defaults():
-    print('called')
-    node_default_dict = get_dict()
-    print(node_default_dict)
+
 

--- a/core/node_defaults.py
+++ b/core/node_defaults.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import ast
+import os
+import importlib.util as getutil
+
+import bpy
+import sverchok
+
+node_default_dict = {}
+node_default_functions = {}
+
+
+def get_dict():
+
+    datafiles = os.path.join(bpy.utils.user_resource('DATAFILES', path='sverchok', create=True))
+    extra_path = ["node_defaults", "node_defaults.json"]
+    path_to_defaults = os.path.join(datafiles, *extra_path)
+
+    if os.path.exists(path_to_defaults):
+        with open(path_to_defaults) as d:
+            print('loading default dict..')
+            my_dict = ''.join(d.readlines())
+            return ast.literal_eval(my_dict)
+
+    return {}
+
+
+def get_function(func, node):
+    """
+    this function takes func and decomposes it into filename  (minus .py ) and functionname
+    it will then look at ../datafiles/node_defaults/filename.py for a function called functionname
+    assuming it is found, it will add the func (filename.functionnme) to " node_default_functions ".
+
+    - each func lookup should only be needed once per session,
+    - repeats will be taken from " node_default_functions " dict
+
+    """
+    filename, functionname = func.split('.')
+
+    datafiles = os.path.join(bpy.utils.user_resource('DATAFILES', path='sverchok', create=True))
+    extra_path = ["node_defaults", filename + '.py']
+    path_to_function = os.path.join(datafiles, *extra_path)
+
+    if func in node_default_functions:
+        return node_default_functions[func]
+
+    else:
+        if os.path.exists(path_to_function):
+            print('--- first time getting function path for ', node.bl_idname)
+            spec = getutil.spec_from_file_location(func, path_to_function)
+            macro_module = getutil.module_from_spec(spec)
+            spec.loader.exec_module(macro_module)
+            node_default_functions[func] = getattr(macro_module, functionname)
+
+
+def set_defaults_if_defined(node):
+    print('A')
+    if not hasattr(node, 'bl_idname') and not len(node_default_dict):
+        return
+
+    print('B')
+    print(node_default_dict)
+    node_settings = node_default_dict.get(node.bl_idname)
+    if not node_settings:
+        return
+
+    print('C')
+    props = node_settings.get('props')
+    if props:
+        for prop, value in props:
+            setattr(node, prop, value)
+
+    # execute!
+    func = node_settings.get('function')
+    if func:
+        got_function = get_function(func, node)
+        try:
+            got_function(node)
+        except Exception as err:
+            print('failed to load', node.bl_idname, '\'s custom default script..')
+            print('reason: ', repr(err))
+
+
+def register_defaults():
+    print('called')
+    node_default_dict = get_dict()
+    print(node_default_dict)
+

--- a/core/node_defaults.py
+++ b/core/node_defaults.py
@@ -100,7 +100,3 @@ def set_defaults_if_defined(node):
         except Exception as err:
             print('failed to load', node.bl_idname, '\'s custom default script..')
             print('reason: ', repr(err))
-
-
-
-

--- a/node_tree.py
+++ b/node_tree.py
@@ -50,6 +50,8 @@ from sverchok.core.socket_conversions import (
     is_vector_to_matrix,
     is_matrix_to_vector)
 
+from sverchok.core.node_defaults import set_defaults_if_defined
+
 from sverchok.ui import color_def
 
 
@@ -459,12 +461,25 @@ class SverchCustomTreeNode:
         self.create_sockets()
 
     def init(self, context):
+        """
+        this function is triggered upon node creation, 
+        - freezes the node
+        - delegates further initialization information to sv_init
+        - sets node color
+        - unfreezes the node
+        - sets custom defaults (nodes, and sockets)
+
+        """
         ng = self.id_data
+
         ng.freeze()
         if hasattr(self, "sv_init"):
             self.sv_init(context)
         self.set_color()
         ng.unfreeze()
+
+        set_defaults_if_defined(self)
+
 
     def process_node(self, context):
         '''
@@ -498,6 +513,7 @@ def register():
     bpy.utils.register_class(StringsSocket)
     bpy.utils.register_class(VerticesSocket)
     bpy.utils.register_class(SvDummySocket)
+
 
 
 def unregister():


### PR DESCRIPTION
this PR allows us to write a `node_defaults.json`, with two forms of directive

1. `props`
2. `function`

it will be extended to add

3. `sockets_states` , when _`socket.set_state()`_ is implemented.

##### datafiles/sverchok/node_defaults/node_defaults.json
```
{
    "SvGenFloatRange": {"props": [["stop_", 1.0], ["count_", 20]]},
    "ViewerNode2": {"props": [], "function": "view3d.init_vdmk2"}
}

```

- it's possible to push props in sequence with a list of `prop_name`, `prop_value` pairs.
- it's possible to push a function, in the example above the function is referenced as `view3d.init_vdmk2`. read that as `filename.function`. and filename shall be located in `datafiles/sverchok/node_defaults/`.

##### datafiles/sverchok/node_defaults/view3d.py
```python
import random
import colorsys

import bpy



def init_vdmk2(node):

    def fold_color(color, shift):
        h, s, v = colorsys.rgb_to_hsv(*color)
        return colorsys.hsv_to_rgb(shift, s, v)

    A = [0.938000, 0.948000, 0.900000, 1.000000]
    B = [0.500000, 0.752000, 0.899000, 1.000000]
    C = [0.030100, 0.488000, 0.899000, 1.000000]

    shift = random.random()
    node.vertex_colors = fold_color(A[:3], shift)
    node.edge_colors = fold_color(B[:3], shift)
    node.face_colors = fold_color(C[:3], shift)

    node.edge_width = 1.0
    node.vertex_size = 2.0

```

------------------

Each time you add a node, the `node_default_dict` is checked if the `bl_idname` has an entry. 

- this has no effect on nodes that you duplicate, they clone their properties according to `self.copy()`
- this doesn't offer a visual way to set the preferences yet, that would be the next step.