### PR TITLE
Uilist in ob3

### DIFF
--- a/index.md
+++ b/index.md
@@ -240,7 +240,7 @@
     SvSCNRayCastNodeMK2
 
 ## Scene
-    SvObjectsNodeMK3
+    SvObjectsNodeMK3B
     SvObjInLite
     SvObjEdit
     SvFrameInfoNodeMK2

--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -27,6 +27,25 @@ from sverchok.utils.context_managers import hard_freeze
 from sverchok.utils.sv_bmesh_utils import pydata_from_bmesh
 
 
+
+class SvOB3NamesList(bpy.types.UIList):
+
+    def draw_item(self, context, layout, data, item, icon, active_data, active_propname):
+        # groups = datas
+        
+        # if self.layout_type in {'DEFAULT', 'COMPACT'}:
+            
+        #     layout.prop(groups, "name", text="", emboss=False, icon_value=icon)
+        #     layout.label(text="Rawr", translate=False)
+
+        # # 'GRID' layout type should be as compact as possible (typically a single icon!).
+        # elif self.layout_type in {'GRID'}:
+        #     layout.alignment = 'CENTER'
+        #     layout.label(text="", icon_value=icon)
+
+        layout.label(item.name)
+
+
 class SvOB3Callback(bpy.types.Operator):
 
     bl_idname = "node.ob3_callback"
@@ -87,6 +106,7 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
         default=True, update=updateNode)
 
     object_names = bpy.props.CollectionProperty(type=bpy.types.PropertyGroup)
+    active_obj_index = bpy.props.IntProperty()
 
 
     def sv_init(self, context):
@@ -135,15 +155,10 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
     def draw_obj_names(self, layout):
         # display names currently being tracked, stop at the first 5..
         if self.object_names:
-            remain = len(self.object_names) - 5
 
-            for i, obj_ref in enumerate(self.object_names):
-                layout.label(obj_ref.name)
-                if i > 4 and remain > 0:
-                    postfix = ('' if remain == 1 else 's')
-                    more_items = '... {0} more item' + postfix
-                    layout.label(more_items.format(remain))
-                    break
+            layout.template_list(
+                "SvOB3NamesList", "", 
+                self, "object_names", self, "active_obj_index")
         else:
             layout.label('--None--')
 
@@ -270,7 +285,7 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
         outputs['Object'].sv_set([data_objects.get(o.name) for o in self.object_names])
 
 
-classes = [SvOB3Callback, SvObjectsNodeMK3]
+classes = [SvOB3NamesList, SvOB3Callback, SvObjectsNodeMK3]
 
 
 def register():

--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -63,6 +63,12 @@ class SvOB3ItemOperator(bpy.types.Operator):
         if self.fn_name == 'REMOVE':
             node.object_names.remove(self.idx)
 
+        node.process_node(None)
+
+        #
+        # if not node.object_names:
+        #     node.process()
+
         return {'FINISHED'}
 
 

--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -118,18 +118,15 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
         default='', update=updateNode)
 
     modifiers = BoolProperty(
-        name='Modifiers',
-        description='Apply modifier geometry to import (original untouched)',
+        name='Modifiers', description='Apply modifier geometry to import (original untouched)',
         default=False, update=updateNode)
 
     vergroups = BoolProperty(
-        name='Vergroups',
-        description='Use vertex groups to nesty insertion',
+        name='Vergroups', description='Use vertex groups to nesty insertion',
         default=False, update=hide_show_versgroups)
 
     sort = BoolProperty(
-        name='sort by name',
-        description='sorting inserted objects by names',
+        name='sort by name', description='sorting inserted objects by names',
         default=True, update=updateNode)
 
     object_names = bpy.props.CollectionProperty(type=SvObj3DataCollection)
@@ -141,7 +138,7 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
         new('VerticesSocket', "Vertices")
         new('StringsSocket', "Edges")
         new('StringsSocket', "Polygons")
-        new('MatrixSocket', "Matrixes")
+        new('MatrixSocket', "Matrices")
         new('SvObjectSocket', "Object")
 
 
@@ -182,6 +179,10 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
          
 
     def draw_obj_names(self, layout):
+        """
+            Helper function used by draw_buttons, to specifically deal with drawing 
+            the object bames, either as None or in a UI list.
+        """
 
         if self.object_names:
             layout.template_list(
@@ -189,6 +190,7 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
                 self, "object_names", self, "active_obj_index")
         else:
             layout.label('--None--')
+
 
     def draw_buttons(self, context, layout):
 
@@ -218,19 +220,6 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
 
         row = col.row(align=True)
         row.operator(callback, text="Select Objects").fn_name = 'select_objs'
-
-        # OR !!
-
-        # col = layout.column(align=True)
-        # row = col.row(align=True)
-        # row.prop(self, 'sort', text='', toggle=True, icon='SORTALPHA')  # sort alpha
-        # row.prop(self, "modifiers", text='', toggle=True, icon='MODIFIER')  # post modifier
-        # row.prop(self, "vergroups", text='', toggle=True, icon='GROUP_VERTEX') # vertex groups
-        # row.operator(callback, text="Select").fn_name = 'select_objs'
-        
-        # self.draw_obj_names(layout)
-
-
         
         self.draw_obj_names(layout)
 
@@ -322,7 +311,7 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
             if 'Vers_grouped' in outputs and self.vergroups:
                 outputs['Vers_grouped'].sv_set(vers_out_grouped)
 
-        outputs['Matrixes'].sv_set(mtrx_out)
+        outputs['Matrices'].sv_set(mtrx_out)
         outputs['Object'].sv_set([data_objects.get(o.name) for o in self.object_names])
 
 

--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -65,12 +65,10 @@ class SvOB3ItemOperator(bpy.types.Operator):
 
         node.process_node(None)
 
-        #
         # if not node.object_names:
         #     node.process()
 
         return {'FINISHED'}
-
 
 
 class SvOB3Callback(bpy.types.Operator):
@@ -183,11 +181,8 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
             Helper function used by draw_buttons, to specifically deal with drawing 
             the object bames, either as None or in a UI list.
         """
-
         if self.object_names:
-            layout.template_list(
-                "SvOB3NamesList", "", 
-                self, "object_names", self, "active_obj_index")
+            layout.template_list("SvOB3NamesList", "", self, "object_names", self, "active_obj_index")
         else:
             layout.label('--None--')
 
@@ -226,8 +221,10 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
 
     def draw_sv3dpanel_ob3(self, col, little_width):
         callback = 'node.ob3_callback'
+        
         row = col.row(align=True)
         row.label(text=self.label if self.label else self.name)
+        
         colo = row.row(align=True)
         colo.scale_x = little_width * 5
         op = colo.operator(callback, text="Get")

--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -218,6 +218,19 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
 
         row = col.row(align=True)
         row.operator(callback, text="Select Objects").fn_name = 'select_objs'
+
+        # OR !!
+
+        # col = layout.column(align=True)
+        # row = col.row(align=True)
+        # row.prop(self, 'sort', text='', toggle=True, icon='SORTALPHA')  # sort alpha
+        # row.prop(self, "modifiers", text='', toggle=True, icon='MODIFIER')  # post modifier
+        # row.prop(self, "vergroups", text='', toggle=True, icon='GROUP_VERTEX') # vertex groups
+        # row.operator(callback, text="Select").fn_name = 'select_objs'
+        
+        # self.draw_obj_names(layout)
+
+
         
         self.draw_obj_names(layout)
 

--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -34,7 +34,7 @@ class SvOB3BDataCollection(bpy.types.PropertyGroup):
 
 class SvOB3BNamesList(bpy.types.UIList):
 
-    def draw_item(self, context, layout, data, item, icon, active_data, active_propname):
+    def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
 
         layout.label(item.name, icon=item.icon)
         
@@ -44,7 +44,7 @@ class SvOB3BNamesList(bpy.types.UIList):
         action.tree_name = data.id_data.name
         action.node_name = data.name
         action.fn_name = 'REMOVE'
-        action.idx = data.active_obj_index
+        action.idx = index #data.active_obj_index
 
 
 class SvOB3BItemOperator(bpy.types.Operator):

--- a/old_nodes/__init__.py
+++ b/old_nodes/__init__.py
@@ -44,6 +44,7 @@ old_bl_idnames = {
     'SvGetDataObjectNode': 'get_blenddata',
     'ObjectsNode': "objects",
     'ObjectsNodeMK2': "objects_mk2",
+    'SvObjectsNodeMK3': "objects_mk3_old",
     'RandomVectorNode': 'random_vector',
     'svAxisInputNode': 'axis_input',
     'SvIntersectEdgesNode': 'edges_intersect',

--- a/old_nodes/objects_mk3_old.py
+++ b/old_nodes/objects_mk3_old.py
@@ -27,54 +27,10 @@ from sverchok.utils.context_managers import hard_freeze
 from sverchok.utils.sv_bmesh_utils import pydata_from_bmesh
 
 
-class SvOB3BDataCollection(bpy.types.PropertyGroup):
-    name = bpy.props.StringProperty()
-    icon = bpy.props.StringProperty(default="BLANK1")
+class SvOB3Callback(bpy.types.Operator):
 
-
-class SvOB3BNamesList(bpy.types.UIList):
-
-    def draw_item(self, context, layout, data, item, icon, active_data, active_propname):
-
-        layout.label(item.name, icon=item.icon)
-        
-        # This is needed to help disambiguate the origin of this click. The receiver needs
-        # to know from which node tree and node it originated.
-        action = layout.operator("node.sv_ob3b_collection_operator", icon='X', text='')
-        action.tree_name = data.id_data.name
-        action.node_name = data.name
-        action.fn_name = 'REMOVE'
-        action.idx = data.active_obj_index
-
-
-class SvOB3BItemOperator(bpy.types.Operator):
-
-    bl_idname = "node.sv_ob3b_collection_operator"
-    bl_label = "bladibla"
-
-    tree_name = bpy.props.StringProperty(default='')
-    node_name = bpy.props.StringProperty(default='')
-    fn_name = bpy.props.StringProperty(default='')
-    idx = bpy.props.IntProperty()
-
-    def execute(self, context):
-        node = bpy.data.node_groups[self.tree_name].nodes[self.node_name]
-
-        if self.fn_name == 'REMOVE':
-            node.object_names.remove(self.idx)
-
-        node.process_node(None)
-
-        # if not node.object_names:
-        #     node.process()
-
-        return {'FINISHED'}
-
-
-class SvOB3BCallback(bpy.types.Operator):
-
-    bl_idname = "node.ob3b_callback"
-    bl_label = "Object In mk3b callback"
+    bl_idname = "node.ob3_callback"
+    bl_label = "Object In mk3 callback"
 
     fn_name = StringProperty(default='')
     node_name = StringProperty(default='')
@@ -96,10 +52,10 @@ class SvOB3BCallback(bpy.types.Operator):
 
 
 
-class SvObjectsNodeMK3B(bpy.types.Node, SverchCustomTreeNode):
-    ''' ob3 Objects to pydata '''
-    bl_idname = 'SvObjectsNodeMK3B'
-    bl_label = 'Objects in mk3b'
+class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
+    ''' Objects Input slot MK3'''
+    bl_idname = 'SvObjectsNodeMK3'
+    bl_label = 'Objects in mk3'
     bl_icon = 'OUTLINER_OB_EMPTY'
 
     def hide_show_versgroups(self, context):
@@ -116,19 +72,21 @@ class SvObjectsNodeMK3B(bpy.types.Node, SverchCustomTreeNode):
         default='', update=updateNode)
 
     modifiers = BoolProperty(
-        name='Modifiers', description='Apply modifier geometry to import (original untouched)',
+        name='Modifiers',
+        description='Apply modifier geometry to import (original untouched)',
         default=False, update=updateNode)
 
     vergroups = BoolProperty(
-        name='Vergroups', description='Use vertex groups to nesty insertion',
+        name='Vergroups',
+        description='Use vertex groups to nesty insertion',
         default=False, update=hide_show_versgroups)
 
     sort = BoolProperty(
-        name='sort by name', description='sorting inserted objects by names',
+        name='sort by name',
+        description='sorting inserted objects by names',
         default=True, update=updateNode)
 
-    object_names = bpy.props.CollectionProperty(type=SvOB3BDataCollection)
-    active_obj_index = bpy.props.IntProperty()
+    object_names = bpy.props.CollectionProperty(type=bpy.types.PropertyGroup)
 
 
     def sv_init(self, context):
@@ -136,7 +94,7 @@ class SvObjectsNodeMK3B(bpy.types.Node, SverchCustomTreeNode):
         new('VerticesSocket', "Vertices")
         new('StringsSocket', "Edges")
         new('StringsSocket', "Polygons")
-        new('MatrixSocket', "Matrices")
+        new('MatrixSocket', "Matrixes")
         new('SvObjectSocket', "Object")
 
 
@@ -156,9 +114,7 @@ class SvObjectsNodeMK3B(bpy.types.Node, SverchCustomTreeNode):
             names.sort()
 
         for name in names:
-            item = self.object_names.add()
-            item.name = name
-            item.icon = 'OUTLINER_OB_' + bpy.data.objects[name].type
+            self.object_names.add().name = name
 
         if not self.object_names:
             ops.report({'WARNING'}, "Warning, no selected objects in the scene")
@@ -177,15 +133,19 @@ class SvObjectsNodeMK3B(bpy.types.Node, SverchCustomTreeNode):
          
 
     def draw_obj_names(self, layout):
-        """
-            Helper function used by draw_buttons, to specifically deal with drawing 
-            the object bames, either as None or in a UI list.
-        """
+        # display names currently being tracked, stop at the first 5..
         if self.object_names:
-            layout.template_list("SvOB3BNamesList", "", self, "object_names", self, "active_obj_index")
+            remain = len(self.object_names) - 5
+
+            for i, obj_ref in enumerate(self.object_names):
+                layout.label(obj_ref.name)
+                if i > 4 and remain > 0:
+                    postfix = ('' if remain == 1 else 's')
+                    more_items = '... {0} more item' + postfix
+                    layout.label(more_items.format(remain))
+                    break
         else:
             layout.label('--None--')
-
 
     def draw_buttons(self, context, layout):
 
@@ -204,7 +164,7 @@ class SvObjectsNodeMK3B(bpy.types.Node, SverchCustomTreeNode):
         except:
             pass
 
-        callback = 'node.ob3b_callback'
+        callback = 'node.ob3_callback'
         row.operator(callback, text=op_text).fn_name = 'get_objects_from_scene'
 
         col = layout.column(align=True)
@@ -220,11 +180,9 @@ class SvObjectsNodeMK3B(bpy.types.Node, SverchCustomTreeNode):
 
 
     def draw_sv3dpanel_ob3(self, col, little_width):
-        callback = 'node.ob3b_callback'
-        
+        callback = 'node.ob3_callback'
         row = col.row(align=True)
         row.label(text=self.label if self.label else self.name)
-        
         colo = row.row(align=True)
         colo.scale_x = little_width * 5
         op = colo.operator(callback, text="Get")
@@ -308,14 +266,11 @@ class SvObjectsNodeMK3B(bpy.types.Node, SverchCustomTreeNode):
             if 'Vers_grouped' in outputs and self.vergroups:
                 outputs['Vers_grouped'].sv_set(vers_out_grouped)
 
-        outputs['Matrices'].sv_set(mtrx_out)
+        outputs['Matrixes'].sv_set(mtrx_out)
         outputs['Object'].sv_set([data_objects.get(o.name) for o in self.object_names])
 
 
-classes = [
-    SvOB3BItemOperator, SvOB3BDataCollection, SvOB3BNamesList, SvOB3BCallback,
-    SvObjectsNodeMK3B
-]
+classes = [SvOB3Callback, SvObjectsNodeMK3]
 
 
 def register():
@@ -324,4 +279,3 @@ def register():
 
 def unregister():
     _ = [bpy.utils.unregister_class(c) for c in classes]
-

--- a/ui/sv_panels.py
+++ b/ui/sv_panels.py
@@ -24,7 +24,7 @@ import sverchok
 from sverchok.utils.sv_update_utils import version_and_sha
 from sverchok.core.update_system import process_from_nodes
 
-objects_nodes_set = {'ObjectsNode', 'ObjectsNodeMK2', 'SvObjectsNodeMK3'}
+objects_nodes_set = {'ObjectsNode', 'ObjectsNodeMK2', 'SvObjectsNodeMK3', 'SvObjectsNodeMK3B'}
 
 
 
@@ -217,7 +217,7 @@ class Sv3DPanel(bpy.types.Panel):
                             op.tree_name = tree.name
                             op.grup_name = node.groupname
                             op.sort = node.sort
-                        elif node.bl_idname == 'SvObjectsNodeMK3':
+                        elif node.bl_idname in {'SvObjectsNodeMK3', 'SvObjectsNodeMK3B'}:
                             node.draw_sv3dpanel_ob3(col, little_width)
 
                         elif node.bl_idname in {"IntegerNode", "FloatNode", "SvNumberNode"}:

--- a/utils/sv_IO_panel_tools.py
+++ b/utils/sv_IO_panel_tools.py
@@ -171,7 +171,7 @@ def create_dict_of_tree(ng, skip_set={}, selected=False):
         node_enums = find_enumerators(node)
 
         ObjectsNode = (node.bl_idname == 'ObjectsNode')
-        ObjectsNode3 = (node.bl_idname == 'SvObjectsNodeMK3')
+        ObjectsNode3 = (node.bl_idname in {'SvObjectsNodeMK3', 'SvObjectsNodeMK3B'})
         ObjNodeLite = (node.bl_idname == 'SvObjInLite')
         MeshEvalNode = (node.bl_idname == 'SvMeshEvalNode')
 
@@ -521,7 +521,7 @@ def add_node_to_tree(nodes, n, nodes_to_import, name_remap, create_texts):
     if bl_idname in {'SvObjInLite', 'SvExecNodeMod', 'SvMeshEvalNode'}:
         node.storage_set_data(node_ref)
 
-    if bl_idname == 'SvObjectsNodeMK3':
+    if bl_idname in {'SvObjectsNodeMK3', 'SvObjectsNodeMK3B'}:
         for named_object in node_ref.get('object_names', []):
             node.object_names.add().name = named_object
 

--- a/utils/sv_default_macros.py
+++ b/utils/sv_default_macros.py
@@ -108,7 +108,7 @@ class DefaultMacros():
             links.new(obj_in_node.outputs[3], vd_node.inputs[2])
 
         elif term == 'objs vd':
-            obj_in_node = nodes.new('SvObjectsNodeMK3')
+            obj_in_node = nodes.new('SvObjectsNodeMK3B')
             obj_in_node.get_objects_from_scene(operator)
             vd_node = nodes.new('ViewerNode2')
             vd_node.location = obj_in_node.location.x + 180, obj_in_node.location.y

--- a/utils/sv_panels_tools.py
+++ b/utils/sv_panels_tools.py
@@ -196,7 +196,7 @@ class SvLayoutScanProperties(bpy.types.Operator):
             for node in tree.nodes:
                 idname = node.bl_idname
    
-                if idname in {'ObjectsNodeMK2', 'SvObjectsNodeMK3'}:
+                if idname in {'ObjectsNodeMK2', 'SvObjectsNodeMK3', 'SvObjectsNodeMK3B'}:
                     print('scans for get option ', node.label, node.name)
                     if any((s.links for s in node.outputs)):
                         templist.append([node.label, node.name, ""])


### PR DESCRIPTION
- [x] auto self update after operator removes items (Doesn't work for the last object.. not sure why yet)
- [x] fix "Matrixes" typo in socket name
- [ ] Sort is not used for ui list display order
- [ ] maybe (want) : objs which are not connected from their verts,edges,polygons sockets, shall only do work to obtain their matrix. 
   - this might mean adding an explicit `def update` to detect a change in socket connections.. -- remember, when you disconnect outgoing sockets on node X, node X's process function is not called.

~maybe : display VEFM (Vectors, Edges, Faces, Matrix) icons~