### PR TITLE
Add spin twist option to the torus node

### DIFF
--- a/nodes/generator/torus.py
+++ b/nodes/generator/torus.py
@@ -217,14 +217,12 @@ class SvTorusNode(bpy.types.Node, SverchCustomTreeNode):
     torus_rP = FloatProperty(
         name="Revolution Phase",
         default=0.0,
-        min=0.0, soft_min=0.0,
         description="Phase the revolution sections by this radian amount",
         update=updateNode)
 
     torus_sP = FloatProperty(
         name="Spin Phase",
         default=0.0,
-        min=0.0, soft_min=0.0,
         description="Phase the spin sections by this radian amount",
         update=updateNode)
 

--- a/nodes/generator/torus.py
+++ b/nodes/generator/torus.py
@@ -40,33 +40,33 @@ def torus_verts(R, r, N1, N2, rPhase, sPhase, Separate):
     listNorms = []
 
     # angle increments (cached outside of the loop for performance)
-    da1 = 2*pi/N1
-    da2 = 2*pi/N2
+    da1 = 2 * pi / N1
+    da2 = 2 * pi / N2
 
     for n1 in range(N1):
         a1 = n1 * da1
         theta = a1 + rPhase  # revolution angle
-        sin_theta = sin(theta) # caching
-        cos_theta = cos(theta) # caching
+        sin_theta = sin(theta)  # caching
+        cos_theta = cos(theta)  # caching
 
         loopVerts = []
         for n2 in range(N2):
             a2 = n2 * da2
             phi = a2 + sPhase  # spin angle
-            sin_phi = sin(phi) # caching
-            cos_phi = cos(phi) # caching
+            sin_phi = sin(phi)  # caching
+            cos_phi = cos(phi)  # caching
 
-            x = (R + r*cos_phi) * cos_theta
-            y = (R + r*cos_phi) * sin_theta
-            z = r*sin_phi
+            x = (R + r * cos_phi) * cos_theta
+            y = (R + r * cos_phi) * sin_theta
+            z = r * sin_phi
 
             # append vertex to loop
             loopVerts.append([x, y, z])
 
             # append normal
-            cx = R * cos_theta # torus tube center
-            cy = R * sin_theta # torus tube center
-            norm = [x-cx, y-cy, z]
+            cx = R * cos_theta  # torus tube center
+            cy = R * sin_theta  # torus tube center
+            norm = [x - cx, y - cy, z]
             listNorms.append(norm)
 
         if Separate:
@@ -86,16 +86,16 @@ def torus_edges(N1, N2):
 
     # spin loop EDGES : around the torus tube
     for n1 in range(N1):
-        for n2 in range(N2-1):
-            listEdges.append([N2*n1 + n2, N2*n1 + n2+1])
-        listEdges.append([N2*n1 + N2-1, N2*n1 + 0])
+        for n2 in range(N2 - 1):
+            listEdges.append([N2 * n1 + n2, N2 * n1 + n2 + 1])
+        listEdges.append([N2 * n1 + N2 - 1, N2 * n1 + 0])
 
     # revolution loop EDGES : around the torus center
-    for n1 in range(N1-1):
+    for n1 in range(N1 - 1):
         for n2 in range(N2):
-            listEdges.append([N2*n1 + n2, N2*(n1+1) + n2])
+            listEdges.append([N2 * n1 + n2, N2 * (n1 + 1) + n2])
     for n2 in range(N2):
-        listEdges.append([N2*(N1-1) + n2, N2*0 + n2])
+        listEdges.append([N2 * (N1 - 1) + n2, N2 * 0 + n2])
 
     return listEdges
 
@@ -106,13 +106,13 @@ def torus_polygons(N1, N2):
         N2 : minor sections - number of spin sections around the torus tube
     '''
     listPolys = []
-    for n1 in range(N1-1):
-        for n2 in range(N2-1):
-            listPolys.append([N2*n1 + n2, N2*(n1+1) + n2, N2*(n1+1) + n2+1, N2*n1 + n2+1])
-        listPolys.append([N2*n1 + N2-1, N2*(n1+1) + N2-1, N2*(n1+1) + 0, N2*n1 + 0])
-    for n2 in range(N2-1):
-        listPolys.append([N2*(N1-1) + n2, N2*0 + n2, N2*0 + n2+1, N2*(N1-1) + n2+1])
-    listPolys.append([N2*(N1-1) + N2-1, N2*0 + N2-1, N2*0 + 0, N2*(N1-1) + 0])
+    for n1 in range(N1 - 1):
+        for n2 in range(N2 - 1):
+            listPolys.append([N2 * n1 + n2, N2 * (n1 + 1) + n2, N2 * (n1 + 1) + n2 + 1, N2 * n1 + n2 + 1])
+        listPolys.append([N2 * n1 + N2 - 1, N2 * (n1 + 1) + N2 - 1, N2 * (n1 + 1) + 0, N2 * n1 + 0])
+    for n2 in range(N2 - 1):
+        listPolys.append([N2 * (N1 - 1) + n2, N2 * 0 + n2, N2 * 0 + n2 + 1, N2 * (N1 - 1) + n2 + 1])
+    listPolys.append([N2 * (N1 - 1) + N2 - 1, N2 * 0 + N2 - 1, N2 * 0 + 0, N2 * (N1 - 1) + 0])
 
     return listPolys
 
@@ -137,8 +137,8 @@ class SvTorusNode(bpy.types.Node, SverchCustomTreeNode):
     # keep the equivalent radii pair in sync (eR,iR) => (R,r)
     def external_internal_radii_changed(self, context):
         if self.mode == "EXT_INT":
-            self.torus_R = (self.torus_eR + self.torus_iR)*0.5
-            self.torus_r = (self.torus_eR - self.torus_iR)*0.5
+            self.torus_R = (self.torus_eR + self.torus_iR) * 0.5
+            self.torus_r = (self.torus_eR - self.torus_iR) * 0.5
             updateNode(self, context)
 
     # keep the equivalent radii pair in sync (R,r) => (eR,iR)
@@ -153,7 +153,7 @@ class SvTorusNode(bpy.types.Node, SverchCustomTreeNode):
         name="Torus Dimensions",
         items=(("MAJOR_MINOR", "Major/Minor",
                 "Use the Major/Minor radii for torus dimensions."),
-                ("EXT_INT", "Exterior/Interior",
+               ("EXT_INT", "Exterior/Interior",
                 "Use the Exterior/Interior radii for torus dimensions.")),
         update=update_mode)
 
@@ -230,7 +230,6 @@ class SvTorusNode(bpy.types.Node, SverchCustomTreeNode):
         default=False,
         update=updateNode)
 
-
     def sv_init(self, context):
         self.inputs.new('StringsSocket', "R").prop_name = 'torus_R'
         self.inputs.new('StringsSocket', "r").prop_name = 'torus_r'
@@ -244,11 +243,9 @@ class SvTorusNode(bpy.types.Node, SverchCustomTreeNode):
         self.outputs.new('StringsSocket',  "Polygons")
         self.outputs.new('VerticesSocket', "Normals")
 
-
     def draw_buttons(self, context, layout):
         layout.prop(self, "Separate", text="Separate")
         layout.prop(self, 'mode', expand=True)
-
 
     def process(self):
         # return if no outputs are connected
@@ -258,10 +255,10 @@ class SvTorusNode(bpy.types.Node, SverchCustomTreeNode):
         # input values lists (single or multi value)
         input_RR = self.inputs["R"].sv_get()[0]  # list of MAJOR or EXTERIOR radii
         input_rr = self.inputs["r"].sv_get()[0]  # list of MINOR or INTERIOR radii
-        input_n1 = self.inputs["n1"].sv_get()[0] # list of number of MAJOR sections
-        input_n2 = self.inputs["n2"].sv_get()[0] # list of number of MINOR sections
-        input_rP = self.inputs["rP"].sv_get()[0] # list of REVOLUTION phases
-        input_sP = self.inputs["sP"].sv_get()[0] # list of SPIN phases
+        input_n1 = self.inputs["n1"].sv_get()[0]  # list of number of MAJOR sections
+        input_n2 = self.inputs["n2"].sv_get()[0]  # list of number of MINOR sections
+        input_rP = self.inputs["rP"].sv_get()[0]  # list of REVOLUTION phases
+        input_sP = self.inputs["sP"].sv_get()[0]  # list of SPIN phases
 
         # bound check the list values
         input_RR = list(map(lambda x: max(0, x), input_RR))
@@ -274,17 +271,17 @@ class SvTorusNode(bpy.types.Node, SverchCustomTreeNode):
             # convert radii from EXTERIOR/INTERIOR to MAJOR/MINOR
             # (extend radii lists to a matching length before conversion)
             input_RR, input_rr = match_long_repeat([input_RR, input_rr])
-            input_R = list(map(lambda x,y: (x+y)*0.5, input_RR, input_rr))
-            input_r = list(map(lambda x,y: (x-y)*0.5, input_RR, input_rr))
-        else: # values already given as MAJOR/MINOR radii
+            input_R = list(map(lambda x, y: (x + y) * 0.5, input_RR, input_rr))
+            input_r = list(map(lambda x, y: (x - y) * 0.5, input_RR, input_rr))
+        else:  # values already given as MAJOR/MINOR radii
             input_R = input_RR
             input_r = input_rr
 
         parameters = match_long_repeat([input_R, input_r, input_n1, input_n2, input_rP, input_sP])
 
         if self.outputs['Vertices'].is_linked or self.outputs['Normals'].is_linked:
-            vertList=[]
-            normList=[]
+            vertList = []
+            normList = []
             for R, r, n1, n2, rP, sP in zip(*parameters):
                 verts, norms = torus_verts(R, r, n1, n2, rP, sP, self.Separate)
                 vertList.append(verts)
@@ -293,14 +290,14 @@ class SvTorusNode(bpy.types.Node, SverchCustomTreeNode):
             self.outputs['Normals'].sv_set(normList)
 
         if self.outputs['Edges'].is_linked:
-            edgeList=[]
+            edgeList = []
             for R, r, n1, n2, rP, sP in zip(*parameters):
                 edges = torus_edges(n1, n2)
                 edgeList.append(edges)
             self.outputs['Edges'].sv_set(edgeList)
 
         if self.outputs['Polygons'].is_linked:
-            polyList=[]
+            polyList = []
             for R, r, n1, n2, rP, sP in zip(*parameters):
                 polys = torus_polygons(n1, n2)
                 polyList.append(polys)

--- a/nodes/generator/torus.py
+++ b/nodes/generator/torus.py
@@ -19,9 +19,7 @@
 import bpy
 from bpy.props import IntProperty, FloatProperty, BoolProperty, EnumProperty
 
-from math import sin, cos, pi, sqrt, radians
-from random import random
-import time
+from math import sin, cos, pi
 
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode, match_long_repeat
@@ -50,7 +48,7 @@ def torus_verts(R, r, N1, N2, rPhase, sPhase, sTwist, Separate):
         sin_theta = sin(theta)  # caching
         cos_theta = cos(theta)  # caching
 
-        twistAngle = 2 * pi / N2 * n1 / N1 * sTwist
+        twistAngle = da2 * n1 / N1 * sTwist
 
         loopVerts = []
         for n2 in range(N2):
@@ -229,7 +227,7 @@ class SvTorusNode(bpy.types.Node, SverchCustomTreeNode):
     torus_sT = IntProperty(
         name="Spin Twist",
         default=0,
-        description="Spin twist amount",
+        description="Twist the spin sections by this number of increments",
         update=updateNode)
 
     # OTHER options


### PR DESCRIPTION
The "spin twist" feature allows to rotate the spin sections of the torus such that the edges/polys appear as a continuous twist around the torus tube. The smallest spin twist is the "spin section delta angle" (= 2*pi / # spin sections). For this angle, for a complete revolution the last spin section is rotated relative to the first spin section by an angle as to shift the vertices in the spin section list by one vertex (essentially, one polygon shift in the spin direction). The total spin is typically an integer number of this smallest spin twist angle, which means in order to have the torus make a 2*pi (full) twist for a complete revolution, the "spin twist" value has to be equal to the number of spin sections T = Ns. For double full twists N = 2Ns etc.

![sv-twistedtorus-demo1](https://user-images.githubusercontent.com/2083719/30308740-4dfa2436-9755-11e7-8768-3c0c67acd3ed.gif)
