### PR TITLE
Dev IO - Socket Custom Props Import/Export (WIP)

### DIFF
--- a/core/socket_conversions.py
+++ b/core/socket_conversions.py
@@ -18,22 +18,35 @@
 
 from sverchok.data_structure import get_other_socket
 
+from mathutils import Matrix, Quaternion
+from sverchok.data_structure import Matrix_listing, Matrix_generate
 
-## conversion tests, to be used in sv_get! 
+
+# conversion tests, to be used in sv_get!
 
 def cross_test_socket(self, A, B):
     """ A is origin type, B is destination type """
     other = get_other_socket(self)
-    get_type = {'v': 'VerticesSocket', 'm': 'MatrixSocket'}
+    get_type = {'v': 'VerticesSocket', 'm': 'MatrixSocket', 'q': "SvQuaternionSocket"}
     return other.bl_idname == get_type[A] and self.bl_idname == get_type[B]
 
 def is_vector_to_matrix(self):
     return cross_test_socket(self, 'v', 'm')
 
+
 def is_matrix_to_vector(self):
     return cross_test_socket(self, 'm', 'v')
 
+
+def is_matrix_to_quaternion(self):
+    return cross_test_socket(self, 'm', 'q')
+
+
+def is_quaternion_to_matrix(self):
+    return cross_test_socket(self, 'q', 'm')
+
 # ---
+
 
 def get_matrices_from_locs(data):
     location_matrices = []
@@ -50,6 +63,39 @@ def get_matrices_from_locs(data):
 
     get_all(data)
     return location_matrices
+
+
+def get_matrices_from_quaternions(data):
+    matrices = []
+    collect_matrix = matrices.append
+
+    def get_all(data):
+        for item in data:
+            if isinstance(item, (tuple, list)) and len(item) == 4 and isinstance(item[0], (float, int)):
+                mat = Quaternion(item).to_matrix().to_4x4()
+                collect_matrix(Matrix_listing([mat])[0])
+            else:
+                get_all(item)
+
+    get_all(data)
+    return matrices
+
+
+def get_quaternions_from_matrices(data):
+    quaternions = []
+    collect_quaternion = quaternions.append
+
+    def get_all(data):
+        for sublist in data:
+            if is_matrix(sublist):
+                mat = Matrix(sublist)
+                q = tuple(mat.to_quaternion())
+                collect_quaternion(q)
+            else:
+                get_all(sublist)
+
+    get_all(data)
+    return [quaternions]
 
 
 def is_matrix(mat):

--- a/docs/nodes/beta_nodes/spiralNode.rst
+++ b/docs/nodes/beta_nodes/spiralNode.rst
@@ -4,7 +4,7 @@ Spiral
 Functionality
 -------------
 
-Generates various types of spirals: Archimedean, Logarithmic, Spherical, Cornu, Ovoidal, Exo (to coin the term) and Spirangle.
+Generates various types of spirals: Archimedean, Logarithmic, Spherical, Cornu (Euler), Ovoidal, Exo (to coin the term) and Spirangle.
 
 All spirals are defined as smooth curves (given enough curve resolution per turn) except the Spirangle spiral, which is a polygonal type of spiral.
 
@@ -109,7 +109,7 @@ where a, b, c are constants.
 see: http://mathworld.wolfram.com/SphericalSpiral.html
 
 **Cornu**
-The cornu spiral is given the by the formula:
+The Cornu spiral (also known as Euler spiral) is given the by the formula:
 
   x(L) = integral(cos(s^2), 0, L)
   y(L) = integral(sin(s^2), 0, L)

--- a/docs/nodes/matrix/matrix_math.rst
+++ b/docs/nodes/matrix/matrix_math.rst
@@ -1,0 +1,81 @@
+Matrix Math
+===========
+
+Functionality
+-------------
+
+Matrix Math node allows for various matrix operations to be performed on the input matrices, such as: Multiply, Invert and Filter.
+
+Inputs
+------
+
+All inputs are vectorized and they will accept single or multiple values.
+
+- **A**
+- **B**  [1]
+
+Notes:
+[1] : The second input is only available for the operations that require a second operand, like Multiply.
+
+Parameters
+----------
+
+The **Operation** parameter allows to select one of following operations: Multiply, Invert, Filter.
+
+All parameters except **Operation**, **PrePost** and **Filter T/R/S** can be given as an external input.
+
++---------------+------------+----------+--------------------------------------------------+
+| Param         | Type       | Default  | Description                                      |
++===============+============+==========+==================================================+
+| **Operation** | Enum:      | Multiply | Multiply: A,B => C = A*B  [1]                    |
+|               |  Multiply  |          |   Invert: A => C = A^-1                          |
+|               |  Invert    |          |   Filter: A => C = [AT]*[AR]*[AS]                |
+|               |  Filter    |          |                                                  |
++---------------+------------+----------+--------------------------------------------------+
+| **PrePost**   | Enum:      | Pre      | Determines the order the operands  [2]           |
+|               |  Pre       |          |                                                  |
+|               |  Post      |          |                                                  |
++---------------+------------+----------+--------------------------------------------------+
+| **Filter T**  | Bool       | False    | Filter out the Translation component  [3]        |
++---------------+------------+----------+--------------------------------------------------+
+| **Filter R**  | Bool       | False    | Filter out the Rotation component  [3]           |
++---------------+------------+----------+--------------------------------------------------+
+| **Filter S**  | Bool       | False    | Filter out the Scale component  [3]              |
++---------------+------------+----------+--------------------------------------------------+
+| **A**         | Matrix     | identity | First matrix input                               |
++---------------+------------+----------+--------------------------------------------------+
+| **B**         | Matrix     | identity | Second matrix input  [4]                         |
++---------------+------------+----------+--------------------------------------------------+
+
+Notes:
+ [1] : The order of multiplication is given by the PrePost setting.
+ [2] : The PrePost setting is only available for the Multiply operation.
+ [3] : The Filter T/R/S toggle settings are only available for the Filter operation.
+ [4] : Second input is only available for Multiply operation.
+
+Operations
+----------
+**Multiply**
+The multiplication of the 4x4 homogeneous matrices result in a composite 4x4 homogeneous matrix having a composed Translation, a composed Rotation and a composed Scale. The order of multiplication is given by the PrePost setting, which is set to PRE-multiplication by default (C = A*B). The POST multiplication reverses the order of multiplication (C = B*A).
+
+Note: When using a PRE multiply composition A*B to transform a mesh, essentially the overall operation is equivalent to applying the matrix B to the mesh first, then matrix A.
+
+**Filter**
+A 4x4 homogeneous matrix is composed by a translation (T), rotation (R) and a scale (S) matrix and is defined as: T*R*S. The filter operation allows you to set the individual components T, R and/or S to the identity matrix so that they are filtered out of the output composite matrix.
+
+Note: filtering out all components will result in an identity matrix output.
+
+**Invert**
+The inversion of a 4x4 homogeneous matrix A is a 4x4 homogenous matrix A' for which A * A' is the identity matrix.
+
+
+Outputs
+-------
+
+**Matrix**
+Outputs will be generated when connected.
+
+
+Example of usage
+----------------
+

--- a/index.md
+++ b/index.md
@@ -273,6 +273,7 @@
     ---
     SvMatrixNormalNode
     SvMatrixTrackToNode
+    SvMatrixMathNode
     ---
     SvSculptMaskNode
     SvGreasePencilStrokes

--- a/node_tree.py
+++ b/node_tree.py
@@ -24,6 +24,8 @@ import bpy
 from bpy.props import StringProperty, BoolProperty, FloatVectorProperty, IntProperty
 from bpy.types import NodeTree, NodeSocket, NodeSocketStandard
 
+from mathutils import Matrix
+
 from sverchok import data_structure
 from sverchok.data_structure import (
     updateNode,
@@ -47,20 +49,42 @@ from sverchok.core.update_system import (
 from sverchok.core.socket_conversions import (
     get_matrices_from_locs,
     get_locs_from_matrices,
+    get_matrices_from_quaternions,
+    get_quaternions_from_matrices,
+    is_matrix_to_quaternion,
+    is_quaternion_to_matrix,
     is_vector_to_matrix,
     is_matrix_to_vector)
 
 from sverchok.core.node_defaults import set_defaults_if_defined
 
+from sverchok.utils.context_managers import sv_preferences
 from sverchok.ui import color_def
+
+socket_colors = {
+    "StringsSocket": (0.6, 1.0, 0.6, 1.0),
+    "VerticesSocket": (0.9, 0.6, 0.2, 1.0),
+    "SvQuaternionSocket": (0.9, 0.4, 0.7, 1.0),
+    "SvColorSocket": (0.9, 0.8, 0.0, 1.0),
+    "MatrixSocket": (0.2, 0.8, 0.8, 1.0),
+    "DummySocket": (0.8, 0.8, 0.8, 0.3),
+    "ObjectSocket": (0.69, 0.74, 0.73, 1.0),
+    "TextSocket": (0.68, 0.85, 0.90, 1),
+}
+
+# default values returned when no input is connected to socket
+identityMatrix = [[tuple(v) for v in Matrix()]]
+emptyVertex = [[(0, 0, 0)]]
+emptyColor = [[(0, 0, 0, 1)]]
+emptyQuaternion = [[(1, 0, 0, 0)]]
 
 
 def process_from_socket(self, context):
     """Update function of exposed properties in Sockets"""
     self.node.process_node(context)
-
-
 # this property group is only used by the old viewer draw
+
+
 class SvColors(bpy.types.PropertyGroup):
     """ Class for colors CollectionProperty """
     color = FloatVectorProperty(
@@ -71,6 +95,12 @@ class SvColors(bpy.types.PropertyGroup):
 
 
 class SvSocketCommon:
+    """ Base class for all Sockets """
+    use_prop = BoolProperty(default=False)
+
+    use_expander = BoolProperty(default=True)
+    use_quicklink = BoolProperty(default=True)
+    expanded = BoolProperty(default=False)
 
     @property
     def other(self):
@@ -116,6 +146,71 @@ class SvSocketCommon:
         return the new socket, the old reference might be invalid"""
         return replace_socket(self, new_type, new_name)
 
+    @property
+    def extra_info(self):
+        # print("getting base extra info")
+        return ""
+
+    def draw_expander_template(self, context, layout, prop_origin, prop_name="prop"):
+        if self.use_expander and self.bl_idname != "StringsSocket":
+            split = layout.split(percentage=.2, align=True)
+            c1 = split.column(align=True)
+            c2 = split.column(align=True)
+            if self.expanded:
+                c1.prop(self, "expanded", icon='TRIA_UP', text='')
+                c1.label(text=self.name[0])
+                c2.prop(prop_origin, prop_name, text="", expand=True)
+            else:  # collapsed
+                c1.prop(self, "expanded", icon='TRIA_DOWN', text="")
+                row = c2.row(align=True)
+                if self.bl_idname == "SvColorSocket":
+                    row.prop(prop_origin, prop_name)
+                else:
+                    row.template_component_menu(prop_origin, prop_name, name=self.name)
+        else:
+            if self.bl_idname == "StringsSocket":
+                layout.prop(prop_origin, prop_name)
+            else:
+                layout.template_component_menu(prop_origin, prop_name, name=self.name)
+
+    def draw_quick_link(self, context, layout, node):
+        if self.use_quicklink:
+            if self.bl_idname == "MatrixSocket":
+                new_node_idname = "SvMatrixGenNodeMK2"
+            elif self.bl_idname == "VerticesSocket":
+                new_node_idname = "GenVectorsNode"
+            else:
+                return
+
+            op = layout.operator('node.sv_quicklink_new_node_input', text="", icon="PLUGIN")
+            op.socket_index = self.index
+            op.origin = node.name
+            op.new_node_idname = new_node_idname
+            op.new_node_offsetx = -200 - 40 * self.index
+            op.new_node_offsety = -30 * self.index
+
+    def draw(self, context, layout, node, text):
+        if self.is_linked:  # linked INPUT or OUTPUT
+            info_text = text + '. ' + SvGetSocketInfo(self)
+            info_text += self.extra_info
+            layout.label(info_text)
+
+        elif self.is_output:  # unlinked OUTPUT
+            layout.label(text)
+
+        else:  # unlinked INPUT
+            if self.prop_name:  # has property
+                self.draw_expander_template(context, layout, prop_origin=node, prop_name=self.prop_name)
+
+            elif self.use_prop:  # no property but use default prop
+                self.draw_expander_template(context, layout, prop_origin=self)
+
+            else:  # no property and not use default prop
+                self.draw_quick_link(context, layout, node)
+                layout.label(text)
+
+    def draw_color(self, context, node):
+        return socket_colors[self.bl_idname]
 
 class MatrixSocket(NodeSocket, SvSocketCommon):
     '''4x4 matrix Socket type'''
@@ -123,6 +218,15 @@ class MatrixSocket(NodeSocket, SvSocketCommon):
     bl_label = "Matrix Socket"
     prop_name = StringProperty(default='')
     num_matrices = IntProperty(default=0)
+
+    @property
+    def extra_info(self):
+        # print("getting matrix extra info")
+        info = ""
+        if is_vector_to_matrix(self):
+            info = (" (" + str(self.num_matrices) + ")")
+
+        return info
 
     def get_prop_data(self):
         return {}
@@ -138,26 +242,16 @@ class MatrixSocket(NodeSocket, SvSocketCommon):
                 self.num_matrices = len(out)
                 return out
 
+            if is_quaternion_to_matrix(self):
+                out = get_matrices_from_quaternions(SvGetSocket(self, deepcopy=True))
+                self.num_matrices = len(out)
+                return out
+
             return SvGetSocket(self, deepcopy)
         elif default is sentinel:
-            raise SvNoDataError
+            return identityMatrix
         else:
             return default
-
-    def draw(self, context, layout, node, text):
-        if self.is_linked:
-            draw_string = text + '. ' + SvGetSocketInfo(self)
-            if is_vector_to_matrix(self):
-                draw_string += (" (" + str(self.num_matrices) + ")")
-            layout.label(draw_string)
-        else:
-            layout.label(text)
-
-    def draw_color(self, context, node):
-        '''if self.is_linked:
-            return(.8,.3,.75,1.0)
-        else: '''
-        return (.2, .8, .8, 1.0)
 
 
 class VerticesSocket(NodeSocket, SvSocketCommon):
@@ -191,25 +285,82 @@ class VerticesSocket(NodeSocket, SvSocketCommon):
         elif self.use_prop:
             return [[self.prop[:]]]
         elif default is sentinel:
-            raise SvNoDataError
+            return emptyVertex
         else:
             return default
 
-    def draw(self, context, layout, node, text):
-        if not self.is_output and not self.is_linked:
-            if self.prop_name:
-                layout.template_component_menu(node, self.prop_name, name=self.name)
-            elif self.use_prop:
-                layout.template_component_menu(self, "prop", name=self.name)
-            else:
-                layout.label(text)
-        elif self.is_linked:
-            layout.label(text + '. ' + SvGetSocketInfo(self))
-        else:
-            layout.label(text)
 
-    def draw_color(self, context, node):
-        return (0.9, 0.6, 0.2, 1.0)
+class SvQuaternionSocket(NodeSocket, SvSocketCommon):
+    '''For quaternion data'''
+    bl_idname = "SvQuaternionSocket"
+    bl_label = "Quaternion Socket"
+
+    prop = FloatVectorProperty(default=(1, 0, 0, 0), size=4, subtype='QUATERNION', update=process_from_socket)
+    prop_name = StringProperty(default='')
+    use_prop = BoolProperty(default=False)
+
+    def get_prop_data(self):
+        if self.prop_name:
+            return {"prop_name": socket.prop_name}
+        elif self.use_prop:
+            return {"use_prop": True,
+                    "prop": self.prop[:]}
+        else:
+            return {}
+
+    def sv_get(self, default=sentinel, deepcopy=True):
+        if self.is_linked and not self.is_output:
+
+            if is_matrix_to_quaternion(self):
+                out = get_quaternions_from_matrices(SvGetSocket(self, deepcopy=True))
+                return out
+
+            # if is_vector_to_quaternion(self):
+            #     out = vector_to_quaternion(SvGetSocket(self, deepcopy=True))
+            #     return out
+
+            return SvGetSocket(self, deepcopy)
+
+        if self.prop_name:
+            return [[getattr(self.node, self.prop_name)[:]]]
+        elif self.use_prop:
+            return [[self.prop[:]]]
+        elif default is sentinel:
+            return emptyQuaternion
+        else:
+            return default
+
+
+class SvColorSocket(NodeSocket, SvSocketCommon):
+    '''For color data'''
+    bl_idname = "SvColorSocket"
+    bl_label = "Color Socket"
+
+    prop = FloatVectorProperty(default=(0, 0, 0, 1), size=4, subtype='COLOR', min=0, max=1, update=process_from_socket)
+    prop_name = StringProperty(default='')
+    use_prop = BoolProperty(default=False)
+
+    def get_prop_data(self):
+        if self.prop_name:
+            return {"prop_name": socket.prop_name}
+        elif self.use_prop:
+            return {"use_prop": True,
+                    "prop": self.prop[:]}
+        else:
+            return {}
+
+    def sv_get(self, default=sentinel, deepcopy=True):
+        if self.is_linked and not self.is_output:
+            return SvGetSocket(self, deepcopy)
+
+        if self.prop_name:
+            return [[getattr(self.node, self.prop_name)[:]]]
+        elif self.use_prop:
+            return [[self.prop[:]]]
+        elif default is sentinel:
+            return emptyColor
+        else:
+            return default
 
 
 class SvDummySocket(NodeSocket, SvSocketCommon):
@@ -230,12 +381,6 @@ class SvDummySocket(NodeSocket, SvSocketCommon):
 
     def sv_type_conversion(self, new_self):
         self = new_self
-
-    def draw(self, context, layout, node, text):
-        layout.label(text)
-
-    def draw_color(self, context, node):
-        return (0.8, 0.8, 0.8, 0.3)
 
 
 class StringsSocket(NodeSocket, SvSocketCommon):
@@ -277,36 +422,29 @@ class StringsSocket(NodeSocket, SvSocketCommon):
         else:
             raise SvNoDataError
 
-    def draw(self, context, layout, node, text):
 
-        # just handle custom draw..be it input or output.
-        if hasattr(self, 'custom_draw'):
-            if self.custom_draw and hasattr(node, self.custom_draw):
-                getattr(node, self.custom_draw)(self, context, layout)
-                return
+class SvLinkNewNodeInput(bpy.types.Operator):
+    ''' Spawn and link new node to the left of the caller node'''
+    bl_idname = "node.sv_quicklink_new_node_input"
+    bl_label = "Add a new node to the left"
 
-        if self.prop_name:
-            prop = node.rna_type.properties.get(self.prop_name, None)
-            t = prop.name if prop else text
-        else:
-            t = text
+    socket_index = bpy.props.IntProperty()
+    origin = bpy.props.StringProperty()
+    new_node_idname = bpy.props.StringProperty()
+    new_node_offsetx = bpy.props.IntProperty(default=-200)
+    new_node_offsety = bpy.props.IntProperty(default=0)
 
-        if not self.is_output and not self.is_linked:
-            if self.prop_name and not self.prop_type:
+    def execute(self, context):
+        tree = context.space_data.edit_tree
+        nodes, links = tree.nodes, tree.links
 
-                layout.prop(node, self.prop_name)
+        caller_node = nodes.get(self.origin)
+        mat_node = nodes.new(self.new_node_idname)
+        mat_node.location[0] = caller_node.location[0] + self.new_node_offsetx
+        mat_node.location[1] = caller_node.location[1] + self.new_node_offsety
+        links.new(mat_node.outputs[0], caller_node.inputs[self.socket_index])
 
-            elif self.prop_type:
-                layout.prop(node, self.prop_type, index=self.prop_index, text=self.name)
-            else:
-                layout.label(t)
-        elif self.is_linked:
-            layout.label(t + '. ' + SvGetSocketInfo(self))
-        else:
-            layout.label(t)
-
-    def draw_color(self, context, node):
-        return self.nodule_color
+        return {'FINISHED'}
 
 
 class SvNodeTreeCommon(object):
@@ -420,6 +558,7 @@ class SverchCustomTree(NodeTree, SvNodeTreeCommon):
 
 
 class SverchCustomTreeNode:
+
     @classmethod
     def poll(cls, ntree):
         return ntree.bl_idname in ['SverchCustomTreeType', 'SverchGroupTreeType']
@@ -462,7 +601,7 @@ class SverchCustomTreeNode:
 
     def init(self, context):
         """
-        this function is triggered upon node creation, 
+        this function is triggered upon node creation,
         - freezes the node
         - delegates further initialization information to sv_init
         - sets node color
@@ -507,21 +646,20 @@ class SverchCustomTreeNode:
         else:
             pass
 
+classes = [
+    SvColors, SverchCustomTree,
+    VerticesSocket, MatrixSocket, StringsSocket,
+    SvColorSocket, SvQuaternionSocket, SvDummySocket,
+    SvLinkNewNodeInput,
+]
+
 
 def register():
-    bpy.utils.register_class(SvColors)
-    bpy.utils.register_class(SverchCustomTree)
-    bpy.utils.register_class(MatrixSocket)
-    bpy.utils.register_class(StringsSocket)
-    bpy.utils.register_class(VerticesSocket)
-    bpy.utils.register_class(SvDummySocket)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
 
 
 def unregister():
-    bpy.utils.unregister_class(SvDummySocket)
-    bpy.utils.unregister_class(VerticesSocket)
-    bpy.utils.unregister_class(StringsSocket)
-    bpy.utils.unregister_class(MatrixSocket)
-    bpy.utils.unregister_class(SverchCustomTree)
-    bpy.utils.unregister_class(SvColors)
+    for cls in classes:
+        bpy.utils.unregister_class(cls)

--- a/nodes/generators_extended/spiral.py
+++ b/nodes/generators_extended/spiral.py
@@ -28,15 +28,15 @@ from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode, match_long_repeat
 from sverchok.utils.sv_easing_functions import *
 
-# exponent for the Fibonacci (golden) spiral
-PhiPi = 2 * log((sqrt(5) + 1) / 2) / pi
+PHI = (sqrt(5) + 1) / 2  # the golden ratio
+PHIPI = 2 * log(PHI) / pi  # exponent for the Fibonacci (golden) spiral
 
 spiralTypeItems = [
     ("ARCHIMEDEAN", "Archimedean", "Generate an archimedean spiral.", 0),
     ("LOGARITHMIC", "Logarithmic", "Generate a logarithmic spiral.", 1),
     ("SPHERICAL", "Spherical", "Generate a spherical spiral.", 2),
     ("OVOIDAL", "Ovoidal", "Generate an ovoidal spiral.", 3),
-    ("CORNU", "Cronu", "Generate a cornu spiral.", 4),
+    ("CORNU", "Cornu", "Generate a cornu spiral.", 4),
     ("EXO", "Exo", "Generate an exo spiral.", 5),
     ("SPIRANGLE", "Spirangle", "Generate a spirangle spiral.", 6)
 ]
@@ -44,20 +44,25 @@ spiralTypeItems = [
 # name : [ type, eR, iR, exponent, turns, resolution, scale, height ]
 spiralPresets = {
     " ":            ["", 0.0, 0.0, 0.0, 0, 0, 0.0, 0.0],
-    "FIBONACCI":    ["LOGARITHMIC", 0.1, 0.0, PhiPi, 4, 100, 0.1, 0.0],
-    "HELIX":        ["LOGARITHMIC", 1.0, 1.0, 0.0, 7, 100, 1.0, 7.0],
-    "ARCHIMEDEAN":  ["ARCHIMEDEAN", 0.1, 0.0, 1.0, 7, 100, 1.0, 0.0],
-    "CONICAL":      ["ARCHIMEDEAN", 0.1, 0.0, 1.0, 7, 100, 1.0, 10.0],
-    "PARABOLIC":    ["ARCHIMEDEAN", 1.0, 0.0, 2.0, 5, 100, 0.75, 0.0],
-    "HYPERBOLIC":   ["ARCHIMEDEAN", 10.0, 0.0, -1.0, 11, 100, 2.0, 0.0],
-    "LITUUS":       ["ARCHIMEDEAN", 7.0, 0.0, -2.0, 11, 100, 1.0, 0.0],
-    "SPHERICAL":    ["SPHERICAL", 4.0, 0.0, 0.0, 11, 55, 1.0, 0.0],
-    "OVOIDAL":      ["OVOIDAL", 11.0, 4.0, 0.0, 7, 55, 1.0, 0.0],
-    "CORNU":        ["CORNU", 1.0, 0.0, 0.0, 7, 111, 5.0, 0.0],
-    "EXO":          ["EXO", 5.0, 1.0, 13.0, 11, 101, 1.0, 0.0],
+    "FIBONACCI":    ["LOGARITHMIC", 1.0, 0.5, PHIPI, 3, 100, 1.0, 0.0],
+    "HELIX":        ["LOGARITHMIC", 1.0, 0.0, 0.0, 7, 100, 1.0, 4.0],
+    "ARCHIMEDEAN":  ["ARCHIMEDEAN", 1.0, 0.0, 1.0, 7, 100, 1.0, 0.0],
+    "CONICAL":      ["ARCHIMEDEAN", 1.0, 0.0, 1.0, 7, 100, 1.0, 3.0],
+    "PARABOLIC":    ["ARCHIMEDEAN", 1.0, 0.0, 2.0, 5, 100, 1.0, 0.0],
+    "HYPERBOLIC":   ["ARCHIMEDEAN", 1.0, 0.0, -1.0, 11, 100, 1.0, 0.0],
+    "LITUUS":       ["ARCHIMEDEAN", 1.0, 0.0, -2.0, 11, 100, 1.0, 0.0],
+    "SPHERICAL":    ["SPHERICAL", 1.0, 0.0, 0.0, 11, 55, 1.0, 0.0],
+    "OVOIDAL":      ["OVOIDAL", 5.0, 1.0, 0.0, 7, 55, 1.0, 6.0],
+    "CORNU":        ["CORNU", 1.0, 1.0, 1.0, 5, 55, 1.0, 0.0],
+    "EXO":          ["EXO", 1.0, 0.1, PHI, 11, 101, 1.0, 0.0],
     "SPIRANGLE SC": ["SPIRANGLE", 1.0, 0.0, 0.0, 8, 4, 1.0, 0.0],
-    "SPIRANGLE HX": ["SPIRANGLE", 1.0, 0.0, 0.5, 7, 6, 0.1, 0.0]
+    "SPIRANGLE HX": ["SPIRANGLE", 1.0, 0.0, 0.5, 7, 6, 1.0, 0.0]
 }
+
+normalizeItems = [
+    ("ER", "eR", "Normalize the external radius.", 0),
+    ("IR", "iR", "Normalize the internal radius.", 1)
+]
 
 
 def make_archimedean_spiral(flags, settings):
@@ -66,7 +71,7 @@ def make_archimedean_spiral(flags, settings):
 
         eR       : exterior radius (end radius)
         iR       : interior radius (start radius)
-        exponent : rate of growth
+        exponent : rate of growth (between iR and eR)
         turns    : number of turns in the spiral
         N        : curve resolution per turn
         scale    : overall scale of the curve
@@ -74,7 +79,7 @@ def make_archimedean_spiral(flags, settings):
         phase    : phase the spiral around its center
         flip     : flip the spiral direction (default is CLOCKWISE)
     '''
-    cn, nn, ct, nt = flags # compute/normalize normal/tangent (UNUSED)
+    cn, nn, ct, nt = flags  # compute/normalize normal/tangent (UNUSED)
 
     eR, iR, exponent, turns, N, scale, height, phase, flip = settings
 
@@ -83,7 +88,9 @@ def make_archimedean_spiral(flags, settings):
     maxPhi = 2 * pi * turns * sign
 
     epsilon = 1e-5 if exponent < 0 else 0  # to avoid raising zero to negative power
-    exponent = 1e-2 if exponent == 0 else exponent # to avoid division by zero
+    exponent = 1e-2 if exponent == 0 else exponent  # to avoid division by zero
+    dR = eR - iR  # radius range : cached for performance
+    ex = 1 / exponent  # inverse exponent : cached for performance
 
     N = N * turns  # total number of points in the spiral
 
@@ -93,12 +100,10 @@ def make_archimedean_spiral(flags, settings):
     addNorm = norms.append
     for n in range(N + 1):
         t = n / N  # t : [0, 1]
-        phi = maxPhi * t + epsilon
-        r = iR + eR * abs(phi) ** (1 / exponent) * scale
-        sin_phi = sin(phi + phase)
-        cos_phi = cos(phi + phase)
-        x = r * cos_phi
-        y = r * sin_phi
+        phi = maxPhi * t + phase
+        r = (iR + dR * (t + epsilon) ** ex) * scale  # essentially: r = a * t ^ (1/b)
+        x = r * cos(phi)
+        y = r * sin(phi)
         z = height * t
         addVert([x, y, z])
 
@@ -121,7 +126,7 @@ def make_logarithmic_spiral(flags, settings):
         phase    : phase the spiral around its center
         flip     : flip the spiral direction (default is CLOCKWISE)
     '''
-    cn, nn, ct, nt = flags # compute/normalize normal/tangent (UNUSED)
+    cn, nn, ct, nt = flags  # compute/normalize normal/tangent (UNUSED)
 
     eR, iR, exponent, turns, N, scale, height, phase, flip = settings
 
@@ -129,7 +134,7 @@ def make_logarithmic_spiral(flags, settings):
 
     maxPhi = 2 * pi * turns
 
-    N = N * turns
+    N = N * turns  # total number of points in the spiral
 
     verts = []
     norms = []
@@ -138,8 +143,8 @@ def make_logarithmic_spiral(flags, settings):
     for n in range(N + 1):
         t = n / N  # t : [0, 1]
         phi = maxPhi * t
-        r = iR + eR * exp(exponent * phi) * scale
-        pho = phi * sign + phase  # cached for performance
+        r = eR * exp(exponent * phi) * scale  # essentially: r = a * e ^ (b*t)
+        pho = phi * sign + phase  # final angle : cached for performance
         x = r * sin(pho)
         y = r * cos(pho)
         z = height * t
@@ -150,58 +155,12 @@ def make_logarithmic_spiral(flags, settings):
     return verts, edges, norms
 
 
-def make_spherical_spiral_0(flags, settings):
+def make_spherical_spiral(flags, settings):
     '''
         Make a SPHERICAL spiral
 
-        This is the accurate spherical spiral, which has an infinite length
-        as it asymptotically approaches the poles.
-
-        eR       : exterior radius
-        iR       : interior radius (UNUSED)
-        exponent : rate of growth (sigmoid in & out)
-        turns    : number of turns in the spiral
-        N        : the curve resolution of one turn
-        scale    : overall scale of the curve
-        height   : the height of the spiral along z (UNUSED)
-        phase    : phase the spiral around its center
-        flip     : flip the spiral direction (default is CLOCKWISE)
-    '''
-    cn, nn, ct, nt = flags # compute/normalize normal/tangent (UNUSED)
-
-    eR, iR, exponent, turns, N, scale, height, phase, flip = settings
-
-    sign = -1 if flip else 1  # flip direction ?
-
-    maxPhi = 2 * pi * turns * sign
-
-    N = N * turns
-
-    verts = []
-    norms = []
-    addVert = verts.append
-    addNorm = norms.append
-    for n in range(N + 1):
-        t = 2 * n / N - 1  # t = [-1,1]
-        phi = maxPhi * t + phase
-        c = atan(exponent * phi)
-        RxCosC = eR * cos(c)  # cached for performance
-        x = RxCosC * cos(phi)
-        y = RxCosC * sin(phi)
-        z = -eR * sin(c)
-        addVert([x, y, z])
-
-    edges = [[i, i + 1] for i in range(len(verts) - 1)]
-
-    return verts, edges, norms
-
-
-def make_spherical_spiral(flags, settings):
-    '''
-        Make a (pseudo) SPHERICAL spiral
-
         This is the approximate sperical spiral that has a finite length,
-        where the phi & theta angles sweep their ranges at constant rate.
+        where the phi & theta angles sweep their ranges at constant rates.
 
         eR       : exterior radius
         iR       : interior radius (UNUSED)
@@ -213,7 +172,7 @@ def make_spherical_spiral(flags, settings):
         phase    : phase the spiral around its center
         flip     : flip the spiral direction (default is CLOCKWISE)
     '''
-    cn, nn, ct, nt = flags # compute/normalize normal/tangent (UNUSED)
+    cn, nn, ct, nt = flags  # compute/normalize normal/tangent (UNUSED)
 
     eR, iR, exponent, turns, N, scale, height, phase, flip = settings
 
@@ -221,9 +180,9 @@ def make_spherical_spiral(flags, settings):
 
     maxPhi = 2 * pi * turns * sign
 
-    N = N * turns
+    N = N * turns  # total number of points in the spiral
 
-    es = prepareExponentialSettings(2, exponent + 1e-5)
+    es = prepareExponentialSettings(2, exponent + 1e-5)  # used for easing
 
     verts = []
     norms = []
@@ -232,7 +191,7 @@ def make_spherical_spiral(flags, settings):
     for n in range(N + 1):
         t = n / N  # t : [0, 1]
         phi = maxPhi * t + phase
-        a = ExponentialEaseInOut(t, es)
+        a = ExponentialEaseInOut(t, es)  # ease theta variation
         theta = -pi / 2 + pi * a
         RxCosTheta = (iR + eR * cos(theta)) * scale  # cached for performance
         x = cos(phi) * RxCosTheta
@@ -249,8 +208,8 @@ def make_ovoidal_spiral(flags, settings):
     '''
         Make a OVOIDAL spiral
 
-        eR       : exterior radius
-        iR       : interior radius
+        eR       : exterior radius (vertical cross section circles)
+        iR       : interior radius (horizontal cross section circle)
         exponent : rate of growth (sigmoid in & out)
         turns    : number of turns in the spiral
         N        : the curve resolution of one turn
@@ -259,7 +218,7 @@ def make_ovoidal_spiral(flags, settings):
         phase    : phase the spiral around its center
         flip     : flip the spiral direction (default is CLOCKWISE)
     '''
-    cn, nn, ct, nt = flags # compute/normalize normal/tangent (UNUSED)
+    cn, nn, ct, nt = flags  # compute/normalize normal/tangent (UNUSED)
 
     eR, iR, exponent, turns, N, scale, height, phase, flip = settings
 
@@ -267,13 +226,15 @@ def make_ovoidal_spiral(flags, settings):
 
     maxPhi = 2 * pi * turns * sign
 
-    H = sqrt(iR * (2 * eR - iR))  # H2 = 2*r*R - r2 -> R = (H2+r2)/(2*r)
-    # H = height
-    # eR = (H*H+iR*iR)/(2*iR)
+    # derive eR based on iR and height (the main parameters)
+    # eR = [iR - (H/2)^2/iR]/2 ::: H = 2 * sqrt(2*iR*eR - iR*iR)
+    eR = 0.5 * (iR + 0.25 * height * height / iR)
+    eR2 = eR * eR  # cached for performance
+    dR = eR - iR # cached for performance
 
-    N = N * turns
+    N = N * turns  # total number of points in the spiral
 
-    es = prepareExponentialSettings(2, exponent + 1e-5)
+    es = prepareExponentialSettings(2, exponent + 1e-5)  # used for easing
 
     verts = []
     norms = []
@@ -282,10 +243,10 @@ def make_ovoidal_spiral(flags, settings):
     for n in range(N + 1):
         t = n / N  # t : [0, 1]
         phi = maxPhi * t + phase
-        a = ExponentialEaseInOut(t, es)
+        a = ExponentialEaseInOut(t, es)  # ease theta variation
         theta = -pi / 2 + pi * a
-        h = H * sin(theta)
-        r = sqrt(eR * eR - h * h) - (eR - iR)
+        h = 0.5 * height * sin(theta)  # [-H/2, +H/2]
+        r = sqrt(eR2 - h * h) - dR  # [0 -> iR -> 0]
         x = r * cos(phi) * scale
         y = r * sin(phi) * scale
         z = h * scale
@@ -310,38 +271,64 @@ def make_cornu_spiral(flags, settings):
 
         TODO : refine the math (smoother curve, adaptive res, faster computation)
     '''
-    cn, nn, ct, nt = flags # compute/normalize normal/tangent (UNUSED)
+    cn, nn, ct, nt = flags  # compute/normalize normal/tangent (UNUSED)
 
     eR, iR, exponent, turns, N, scale, height, phase, flip = settings
 
     sign = -1 if flip else 1  # flip direction ?
 
-    N = N * turns
-    L = eR * turns  # length
-    M = 100
-    S = scale
+    N = N * turns  # total number of points in the spiral
+    L = iR * turns  # length
+    S = eR * scale  # overall scale
 
-    verts = []
+    es = prepareExponentialSettings(2, exponent + 1e-5)  # used for easing
+
+    verts1 = []  # pozitive spiral verts
+    verts2 = []  # nagative spiral verts
     norms = []
-    addVert = verts.append
+    addVert1 = verts1.append
+    addVert2 = verts2.append
     addNorm = norms.append
+    l1 = 0
+    x = 0
+    y = 0
     for n in range(N + 1):
-        t = 2 * n / N - 1  # t = [-1,1]
-        l = L * t  # l = [-L, +L]
-        x = 0
-        y = 0
-        M = 100 + int(200 * abs(t))
-        du = l / M
+        t = n / N  # t = [0,1]
+
+        a = QuadraticEaseOut(t)
+        # a = ExponentialEaseOut(t, es)
+
+        l = L * a  # l = [0, +L]
+
+        r = x * x + y * y
+        # print("r=", r)
+        # M = 100 + int(300 * pow(r, exponent)) # integral steps
+        M = 100 + int(100 * a)  # integral steps
+        l2 = l
+
+        # integral from l1 to l2
+        u = l1
+        du = (l2 - l1) / M
         for m in range(M + 1):
-            u = l * m / M  # u = [0, l]
-            phi = pi * u * u / 2
+            u = u + du  # u = [l1, l2]
+            phi = u * u * pi / 2
             x = x + cos(phi) * du
             y = y + sin(phi) * du
+        l1 = l2
 
-        px = x * S
-        py = y * S
+        # scale and flip
+        xx = x * S
+        yy = y * S * sign
+
+        # rotate by phase amount
+        px = xx * cos(phase) - yy * sin(phase)
+        py = xx * sin(phase) + yy * cos(phase)
         pz = height * t
-        addVert([px, py, pz])
+
+        addVert1([px, py, pz])  # positive spiral verts
+        addVert2([-px, -py, -pz])  # netative spiral verts
+
+    verts = verts2[::-1] + verts1
 
     edges = [[i, i + 1] for i in range(len(verts) - 1)]
 
@@ -356,7 +343,7 @@ def make_exo_spiral(flags, settings):
 
         eR       : exterior radius
         iR       : interior radius
-        exponent : rate of growth (SIGMOID in & out)
+        exponent : rate of growth (SIGMOID : exponential in & out)
         turns    : number of turns in the spiral
         N        : the curve resolution of one turn
         scale    : overall scale of the curve
@@ -364,7 +351,7 @@ def make_exo_spiral(flags, settings):
         phase    : phase the spiral around its center
         flip     : flip the spiral direction (default is CLOCKWISE)
     '''
-    cn, nn, ct, nt = flags # compute/normalize normal/tangent (UNUSED)
+    cn, nn, ct, nt = flags  # compute/normalize normal/tangent (UNUSED)
 
     eR, iR, exponent, turns, N, scale, height, phase, flip = settings
 
@@ -372,7 +359,9 @@ def make_exo_spiral(flags, settings):
 
     maxPhi = 2 * pi * turns * sign
 
-    N = N * turns
+    N = N * turns  # total number of points in the spiral
+
+    es = prepareExponentialSettings(11, exponent + 1e-5)  # used for easing
 
     verts = []
     norms = []
@@ -380,7 +369,7 @@ def make_exo_spiral(flags, settings):
     addNorm = norms.append
     for n in range(N + 1):
         t = n / N  # t : [0, 1]
-        a = 1.0 / (1.0 + exp(-exponent * (t - 0.5)))  # SIGMOID function
+        a = ExponentialEaseInOut(t, es)  # ease radius variation (SIGMOID)
         r = (iR + (eR - iR) * a) * scale
         phi = maxPhi * t + phase
         x = r * cos(phi)
@@ -407,20 +396,20 @@ def make_spirangle_spiral(flags, settings):
         phase    : phase the spiral around its center
         flip     : flip the spiral direction (default is CLOCKWISE)
     '''
-    cn, nn, ct, nt = flags # compute/normalize normal/tangent (UNUSED)
+    cn, nn, ct, nt = flags  # compute/normalize normal/tangent (UNUSED)
 
     eR, iR, exponent, turns, N, scale, height, phase, flip = settings
 
     sign = -1 if flip else 1  # flip direction ?
 
-    deltaA = 2 * pi / N * sign # angle increment
+    deltaA = 2 * pi / N * sign  # angle increment
     deltaE = exponent / N  # exponent increment
-    deltaR = (eR + iR) / N # radius increment
-    deltaZ = height / (N*turns) # z increment
+    deltaR = (eR + iR)  # radius increment
+    deltaZ = height / (N * turns)  # z increment
     e = 0
     r = iR
     phi = phase
-    x, y, z = [0, 0, 0]
+    x, y, z = [0, 0, -deltaZ]
 
     N = N * turns  # total number of points in the spiral
 
@@ -440,6 +429,28 @@ def make_spirangle_spiral(flags, settings):
     edges = [[i, i + 1] for i in range(len(verts) - 1)]
 
     return verts, edges, norms
+
+
+def normalize_spiral(verts, normalize_eR, eR, iR, scale):
+    '''
+        Normalize the spiral (XY) to either exterior or interior radius
+    '''
+    if normalize_eR:  # normalize exterior radius (ending radius)
+        psx = verts[-1][0]
+        psy = verts[-1][1]
+        r = sqrt(psx * psx + psy * psy)
+        ss = eR / r * scale if eR != 0 else 1
+    else:  # normalize interior radius (starting radius)
+        psx = verts[0][0]
+        psy = verts[0][1]
+        r = sqrt(psx * psx + psy * psy)
+        ss = iR / r * scale if iR != 0 else 1
+
+    for n in range(len(verts)):
+        verts[n][0] *= ss
+        verts[n][1] *= ss
+
+    return verts
 
 
 class SvSpiralNode(bpy.types.Node, SverchCustomTreeNode):
@@ -486,13 +497,17 @@ class SvSpiralNode(bpy.types.Node, SverchCustomTreeNode):
         name="Type", items=spiralTypeItems,
         default="ARCHIMEDEAN", update=update_spiral)
 
+    normalize = EnumProperty(
+        name="Normalize Radius", items=normalizeItems,
+        default="ER", update=update_spiral)
+
     iRadius = FloatProperty(
         name="Interior Radius", description="Interior radius",
-        default=1.0, min=0.0, max=100.0, update=update_spiral)
+        default=1.0, min=0.0, update=update_spiral)
 
     eRadius = FloatProperty(
         name="Exterior Radius", description="Exterior radius",
-        default=2.0, min=0.0, max=100.0, update=update_spiral)
+        default=2.0, min=0.0, update=update_spiral)
 
     turns = IntProperty(
         name="Turns", description="Number of turns",
@@ -512,7 +527,7 @@ class SvSpiralNode(bpy.types.Node, SverchCustomTreeNode):
 
     height = FloatProperty(
         name="Height", description="Height of the spiral along z",
-        default=1.0, update=update_spiral)
+        default=0.0, update=update_spiral)
 
     phase = FloatProperty(
         name="Phase", description="Phase amount in radians around spiral center",
@@ -524,7 +539,7 @@ class SvSpiralNode(bpy.types.Node, SverchCustomTreeNode):
 
     resolution = IntProperty(
         name="Turn Resolution", description="Number of vertices in one turn in the spiral",
-        default=100, min=3, soft_min=3, update=update_spiral)
+        default=100, min=3, update=update_spiral)
 
     adaptive_resolution = BoolProperty(
         name="Adaptive Resolution",
@@ -563,14 +578,14 @@ class SvSpiralNode(bpy.types.Node, SverchCustomTreeNode):
         layout.prop(self, 'presets')
         layout.prop(self, 'stype', text="")
         layout.prop(self, 'flip')
+        if self.stype in ("LOGARITHMIC", "ARCHIMEDEAN", "SPIRANGLE"):
+            layout.prop(self, 'normalize', expand=True)
 
     # def draw_buttons_ext(self, context, layout):
     #     box = layout.box()
-    #     box.prop(self, 'presets')
     #     box.prop(self, 'adaptive_resolution')
     #     box.prop(self, 'normalize_normals')
     #     box.prop(self, 'normalize_tangents')
-    #     box.prop(self, 'arms')
 
     def process(self):
         outputs = self.outputs
@@ -590,6 +605,11 @@ class SvSpiralNode(bpy.types.Node, SverchCustomTreeNode):
         input_p = inputs["p"].sv_get()[0]  # list of phases
         input_a = inputs["a"].sv_get()[0]  # list of arms
 
+        # sanitize the input
+        input_t = list(map(lambda x: max(1, int(x)), input_t))
+        input_n = list(map(lambda x: max(3, int(x)), input_n))
+        input_a = list(map(lambda x: max(1, int(x)), input_a))
+
         # extra parameters
         f = self.flip  # flip direction
 
@@ -599,7 +619,8 @@ class SvSpiralNode(bpy.types.Node, SverchCustomTreeNode):
         # compute_tangents = outputs["Tangents"].is_linked
         # normalize_tangents = self.normalize_tangents
         # flags = [compute_normals, normalize_normals, False, False]
-        flags = [False, False, False, False] # UNUSED # TODO
+        normalize_eR = True if self.normalize == "ER" else False
+        flags = [False, False, False, False]
 
         parameters = match_long_repeat([input_R, input_r, input_e, input_t,
                                         input_n, input_s, input_h, input_p, input_a])
@@ -608,21 +629,21 @@ class SvSpiralNode(bpy.types.Node, SverchCustomTreeNode):
 
         vertList = []
         edgeList = []
-        normList = []
+        # normList = []
         for R, r, e, t, n, s, h, p, a in zip(*parameters):
 
-            # if self.adaptive_resolution: # TODO
-            #     # adjust n based on curve parameters (length)
-            #     n = n
-
-            for i in range(a):
+            for i in range(a):  # generate each arm
                 p = p + 2 * pi / a
                 settings = [R, r, e, t, n, s, h, p, f]  # spiral settings
 
                 verts, edges, norms = make_spiral(flags, settings)
+
+                if self.stype in ("LOGARITHMIC", "ARCHIMEDEAN", "SPIRANGLE"):
+                    normalize_spiral(verts, normalize_eR, R, r, s)
+
                 vertList.append(verts)
                 edgeList.append(edges)
-                normList.append(norms)
+                # normList.append(norms)
 
         self.outputs['Vertices'].sv_set(vertList)
         self.outputs['Edges'].sv_set(edgeList)

--- a/nodes/matrix/matrix_math.py
+++ b/nodes/matrix/matrix_math.py
@@ -1,0 +1,185 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import bpy
+from bpy.props import IntProperty, FloatProperty, BoolProperty, EnumProperty
+
+from mathutils import Matrix
+import re
+
+from sverchok.node_tree import SverchCustomTreeNode, MatrixSocket, StringsSocket
+from sverchok.data_structure import (updateNode, fullList, match_long_repeat,
+                                     Matrix_listing, Matrix_generate)
+
+operationItems = [
+    ("MULTIPLY", "Multiply", "Multiply two matrices", 0),
+    ("INVERT", "Invert", "Invert matrix", 1),
+    ("FILTER", "Filter", "Filter matrix components", 2)
+]
+
+prePostItems = [
+    ("PRE", "Pre", "Calculate A op B", 0),
+    ("POST", "Post", "Calculate B op A", 1)
+]
+
+
+class SvMatrixMathNode(bpy.types.Node, SverchCustomTreeNode):
+    ''' Math operation on matrices '''
+    bl_idname = 'SvMatrixMathNode'
+    bl_label = 'Matrix Math'
+    bl_icon = 'OUTLINER_OB_EMPTY'
+
+    def update_operation(self, context):
+        self.label = "Matrix " + self.operation.title()
+        self.update_sockets()
+        updateNode(self, context)
+
+    prePost = EnumProperty(
+        name='Pre Post',
+        description='Order of operations PRE = A op B vs POST = B op A)',
+        items=prePostItems,
+        default="PRE",
+        update=updateNode)
+
+    operation = EnumProperty(
+        name="Operation",
+        description="Operation to apply on the given matrices",
+        items=operationItems,
+        default="MULTIPLY",
+        update=update_operation)
+
+    filter_t = BoolProperty(
+        name="Filter Translation",
+        description="Filter out the translation component of the matrix",
+        default=False,
+        update=updateNode)
+
+    filter_r = BoolProperty(
+        name="Filter Rotation",
+        description="Filter out the rotation component of the matrix",
+        default=False,
+        update=updateNode)
+
+    filter_s = BoolProperty(
+        name="Filter Scale",
+        description="Filter out the scale component of the matrix",
+        default=False,
+        update=updateNode)
+
+    def sv_init(self, context):
+        self.inputs.new('MatrixSocket', "A", "A")
+        self.inputs.new('MatrixSocket', "B", "B")
+
+        self.outputs.new('MatrixSocket', "C", "C")
+
+        self.operation = "MULTIPLY"
+
+    def update_sockets(self):
+        inputs = self.inputs
+
+        if self.operation == "MULTIPLY":
+            # two matrix inputs available
+            if not "B" in inputs:
+                inputs.new("MatrixSocket", "B")
+        else:
+            # one matrix input available
+            if "B" in inputs:
+                inputs.remove(inputs["B"])
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "operation", text = "")
+        if self.operation == "MULTIPLY":
+            layout.prop(self, "prePost", expand=True)
+        elif self.operation == "FILTER":
+            row = layout.row(align=True)
+            row.prop(self, "filter_t", toggle=True, text="T")
+            row.prop(self, "filter_r", toggle=True, text="R")
+            row.prop(self, "filter_s", toggle=True, text="S")
+
+    def operation_filter(self, a):
+        T, R, S = a.decompose()
+
+        if self.filter_t:
+            mat_t = Matrix().Identity(4)
+        else:
+            mat_t = Matrix().Translation(T)
+
+        if self.filter_r:
+            mat_r = Matrix().Identity(4)
+        else:
+            mat_r = R.to_matrix().to_4x4()
+
+        if self.filter_s:
+            mat_s = Matrix().Identity(4)
+        else:
+            mat_s = Matrix().Identity(4)
+            mat_s[0][0] = S[0]
+            mat_s[1][1] = S[1]
+            mat_s[2][2] = S[2]
+
+        m = mat_t * mat_r * mat_s
+
+        return m
+
+    def get_operation(self):
+        if self.operation == "MULTIPLY":
+            return lambda a, b: a * b
+        elif self.operation == "FILTER":
+            return self.operation_filter
+        elif self.operation == "INVERT":
+            return lambda a: a.inverted()
+
+    def process(self):
+        outputs = self.outputs
+        if not outputs['C'].is_linked:
+            return
+
+        inputs = self.inputs
+        id_mat = Matrix_listing([Matrix.Identity(4)])
+        A = Matrix_generate(inputs['A'].sv_get(default=id_mat))
+
+        if self.operation in  { "MULTIPLY" }:
+            # two matrix inputs available
+            B = Matrix_generate(inputs['B'].sv_get(default=id_mat))
+
+            if self.prePost == "PRE":
+                parameters = match_long_repeat([A, B])
+            else:
+                parameters = match_long_repeat([B, A])
+        else:
+            # one matrix input available
+            parameters = [A]
+
+        operation = self.get_operation()
+
+        matrixList = []
+        for params in zip(*parameters):
+            c = operation(*params)
+            matrixList.append(c)
+
+        matrices = Matrix_listing(matrixList)
+
+        outputs['C'].sv_set(matrices)
+
+
+def register():
+    bpy.utils.register_class(SvMatrixMathNode)
+
+
+def unregister():
+    bpy.utils.unregister_class(SvMatrixMathNode)

--- a/utils/sv_IO_panel_tools.py
+++ b/utils/sv_IO_panel_tools.py
@@ -199,7 +199,7 @@ def create_dict_of_tree(ng, skip_set={}, selected=False):
 
             if k in {'n_id', 'typ', 'newsock', 'dynamic_strings', 'frame_collection_name', 'type_collection_name'}:
                 """
-                n_id: 
+                n_id:
                     used to store the hash of the current Node,
                     this is created along with the Node anyway. skip.
                 typ, newsock:
@@ -272,11 +272,44 @@ def create_dict_of_tree(ng, skip_set={}, selected=False):
 
         node_dict['params'] = node_items
 
+        # collect custom socket properties
+        print("** PROCESSING custom properties for node: ", node.bl_idname)
+        input_socket_storage = { }
+        for socket in node.inputs:
+
+            # if not tracked_socket(socket): continue
+            print("Socket %d of %d" % (socket.index+1, len(node.inputs)))
+
+            storable = {}
+            tracked_props = 'use_expander', 'use_quicklink', 'expanded', 'use_prop'
+
+            for tracked_prop in tracked_props:
+                if hasattr(socket, tracked_prop):
+                    value = getattr(socket, tracked_prop)
+
+                    print("Processing custom property: ", tracked_prop, " value = ", value)
+
+                    storable[tracked_prop] = value
+
+                    if tracked_prop == 'use_prop' and value:
+                        print("prop type:", type(socket.prop))
+                        storable['prop'] = socket.prop[:]
+                        # storable['socket_prop_value'] = socket.prop[:]
+                        # storable['socket_prop_value'] = serialize_prop(socket.prop)
+                        print("supposed to store prop value")
+
+            if storable:
+                input_socket_storage[socket.index] = storable
+
+        if input_socket_storage:
+            node_dict['custom_socket_props'] = input_socket_storage
+        print("**\n")
+
         #if node.bl_idname == 'NodeFrame':
         #    frame_props = 'shrink', 'use_custom_color', 'label_size'
         #    node_dict['params'].update({fpv: getattr(node, fpv) for fpv in frame_props})
 
-        
+
         if IsMonadInstanceNode:
             node_dict['bl_idname'] = 'SvMonadGenericNode'
         else:
@@ -370,7 +403,7 @@ def perform_scripted_node_inject(node, node_ref):
                 new_text = texts.new(script_name)
                 new_text.from_string(script_content)
                 script_name = new_text.name
-                print('SN text named replaced with', script_name)        
+                print('SN text named replaced with', script_name)
 
         node.script_name = script_name
         node.script_str = script_content
@@ -399,7 +432,7 @@ def perform_svtextin_node_object(node, node_ref):
     as it's a beta service, old IO json may not be compatible - in this interest
     of neat code we assume it finds everything.
     '''
-    texts = bpy.data.texts    
+    texts = bpy.data.texts
     params = node_ref.get('params')
     current_text = params['current_text']
 
@@ -475,6 +508,44 @@ def apply_core_props(node, node_ref):
                 setattr(node, p, [bool(i) for i in val])
 
 
+def apply_socket_props(socket, info):
+    print("applying socket props")
+    for tracked_prop_name, tracked_prop_value in info.items():
+        try:
+            print("trying to set property name/value: ", tracked_prop_name, " / ", tracked_prop_value)
+
+            setattr(socket, tracked_prop_name, tracked_prop_value)
+
+        except Exception as err:
+            sys.stderr.write('ERROR: %s\n' % str(err))
+            print(sys.exc_info()[-1].tb_frame.f_code)
+            print('Error on line {}'.format(sys.exc_info()[-1].tb_lineno))
+            print('while setting node socket:', node.name,'|', socket.index)
+            print("the following failed |", tracked_prop_name, '<-', tracked_prop_value)
+
+
+def apply_node_props(node, node_ref):
+    print("applying node props for node: ", node.bl_idname)
+    socket_properties = node_ref.get('custom_socket_props')
+    if socket_properties:
+        for idx, info in socket_properties.items():
+            print("\n")
+            print("idx=", idx)
+            print("info=", info)
+            print("num inputs=", len(node.inputs))
+            print("inputs type=", type(node.inputs))
+            print("inputs keys=", node.inputs.keys())
+            # socket = node.inputs[idx]
+            for key, socket in node.inputs.items():
+                print("socket: <", key, "> has index: ", socket.index)
+                # print(type(socket.index))
+                # print(type(idx))
+                if socket.index == int(idx):
+                    print("found matching socket at index:", idx)
+                    apply_socket_props(socket, info)
+                else:
+                    print("did not find matching socket for idx=", idx)
+
 
 def add_texts(node, node_ref):
     if node.bl_idname in SCRIPTED_NODES:
@@ -501,6 +572,8 @@ def apply_post_processing(node, node_ref):
         socket_kinds = node_ref.get(node.node_kind)
         node.repopulate(socket_kinds)
 
+    apply_node_props(node, node_ref)
+
 
 def add_node_to_tree(nodes, n, nodes_to_import, name_remap, create_texts):
     node_ref = nodes_to_import[n]
@@ -524,7 +597,7 @@ def add_node_to_tree(nodes, n, nodes_to_import, name_remap, create_texts):
 
     if create_texts:
         add_texts(node, node_ref)
-    
+
     if bl_idname in {'SvObjInLite', 'SvExecNodeMod', 'SvMeshEvalNode'}:
         node.storage_set_data(node_ref)
 
@@ -550,7 +623,7 @@ def add_nodes(ng, nodes_to_import, nodes, create_texts):
             add_node_to_tree(nodes, n, nodes_to_import, name_remap, create_texts)
     except Exception as err:
         print(repr(err))
-    
+
     ng.limited_init = False
     return name_remap
 
@@ -595,7 +668,7 @@ def import_tree(ng, fullpath='', nodes_json=None, create_texts=True):
 
     def make_links(update_lists, name_remap):
         print_update_lists(update_lists)
-    
+
         failed_connections = []
         for link in update_lists:
             try:
@@ -613,8 +686,8 @@ def import_tree(ng, fullpath='', nodes_json=None, create_texts=True):
 
 
     def generate_layout(fullpath, nodes_json):
-        '''cummulative function ''' 
-        
+        '''cummulative function '''
+
         # it may be necessary to store monads as dicts instead of string/json
         # this will handle both scenarios
         if isinstance(nodes_json, str):
@@ -627,7 +700,7 @@ def import_tree(ng, fullpath='', nodes_json=None, create_texts=True):
         update_lists = nodes_json['update_lists']
         nodes_to_import = nodes_json['nodes']
         groups_to_import = nodes_json.get('groups', {})
-        
+
         add_groups(groups_to_import)  # this return is not used yet
         name_remap = add_nodes(ng, nodes_to_import, nodes, create_texts)
 
@@ -810,7 +883,7 @@ class SvNodeTreeImportFromGist(bpy.types.Operator):
         try:
             content_at_url = urlopen(url)
             found_json = content_at_url.read().decode()
-            return found_json        
+            return found_json
         except urllib.error.HTTPError as err:
             if err.code == 404:
                 self.report({'ERROR'}, 'url: ' + str(url) + ' doesn\'t appear to be a valid url, copy it again from your source')
@@ -880,7 +953,7 @@ class SvNodeTreeExportToGist(bpy.types.Operator):
         gist_description = 'to do later?'
         layout_dict = create_dict_of_tree(ng, skip_set={}, selected=False)
 
-        try:       
+        try:
             gist_body = json.dumps(layout_dict, sort_keys=True, indent=2)
         except Exception as err:
             if 'not JSON serializable' in repr(err):

--- a/utils/sv_IO_panel_tools.py
+++ b/utils/sv_IO_panel_tools.py
@@ -146,7 +146,8 @@ def get_superficial_props(node_dict, node):
     node_dict['hide'] = node.hide
     node_dict['location'] = node.location[:]
     node_dict['color'] = node.color[:]
-
+    if node.use_custom_color:
+        node_dict['use_custom_color'] = True
 
 def create_dict_of_tree(ng, skip_set={}, selected=False):
     nodes = ng.nodes


### PR DESCRIPTION
As per @zeffii suggestion (PR #1561) the IO tools were extended to export/import socket custom properties.

Note: This branch is branched off the socketExpander branch developed/discussed in PR #1561

With this addition the socket prop (used via use_prop) as well as newly added custom props (use_expander, use_quicklink and expanded) are exported and imported properly via gist.

More testing is necessary to prove it works in all case + better/more robust implementation + cleanup is needed. E.g. the exporting/importing of the socket “prop may have to be done via a proper serialize/deserialize prop method.

