### PR TITLE
development_io (quick_link, expander... socket props and support in IO/JSON)

### DIFF
--- a/core/monad.py
+++ b/core/monad.py
@@ -116,6 +116,9 @@ class SverchGroupTree(NodeTree, SvNodeTreeCommon):
                 self.get_current_as_default(prop_dict, other.node, prop_name)
                 prop_settings = self.int_props.add()
             elif prop_func.__name__ == "FloatVectorProperty":
+                print('floatvec prop ignored (normal behaviour since day one)')
+                print('-- prop_func:', prop_func)
+                print('-- prop_dict:', prop_dict)
                 return None # for now etc
             else: # no way to handle it
                 return None

--- a/core/socket_conversions.py
+++ b/core/socket_conversions.py
@@ -30,6 +30,7 @@ def cross_test_socket(self, A, B):
     get_type = {'v': 'VerticesSocket', 'm': 'MatrixSocket', 'q': "SvQuaternionSocket"}
     return other.bl_idname == get_type[A] and self.bl_idname == get_type[B]
 
+
 def is_vector_to_matrix(self):
     return cross_test_socket(self, 'v', 'm')
 

--- a/core/socket_conversions.py
+++ b/core/socket_conversions.py
@@ -18,22 +18,35 @@
 
 from sverchok.data_structure import get_other_socket
 
+from mathutils import Matrix, Quaternion
+from sverchok.data_structure import Matrix_listing, Matrix_generate
 
-## conversion tests, to be used in sv_get! 
+
+# conversion tests, to be used in sv_get!
 
 def cross_test_socket(self, A, B):
     """ A is origin type, B is destination type """
     other = get_other_socket(self)
-    get_type = {'v': 'VerticesSocket', 'm': 'MatrixSocket'}
+    get_type = {'v': 'VerticesSocket', 'm': 'MatrixSocket', 'q': "SvQuaternionSocket"}
     return other.bl_idname == get_type[A] and self.bl_idname == get_type[B]
 
 def is_vector_to_matrix(self):
     return cross_test_socket(self, 'v', 'm')
 
+
 def is_matrix_to_vector(self):
     return cross_test_socket(self, 'm', 'v')
 
+
+def is_matrix_to_quaternion(self):
+    return cross_test_socket(self, 'm', 'q')
+
+
+def is_quaternion_to_matrix(self):
+    return cross_test_socket(self, 'q', 'm')
+
 # ---
+
 
 def get_matrices_from_locs(data):
     location_matrices = []
@@ -50,6 +63,39 @@ def get_matrices_from_locs(data):
 
     get_all(data)
     return location_matrices
+
+
+def get_matrices_from_quaternions(data):
+    matrices = []
+    collect_matrix = matrices.append
+
+    def get_all(data):
+        for item in data:
+            if isinstance(item, (tuple, list)) and len(item) == 4 and isinstance(item[0], (float, int)):
+                mat = Quaternion(item).to_matrix().to_4x4()
+                collect_matrix(Matrix_listing([mat])[0])
+            else:
+                get_all(item)
+
+    get_all(data)
+    return matrices
+
+
+def get_quaternions_from_matrices(data):
+    quaternions = []
+    collect_quaternion = quaternions.append
+
+    def get_all(data):
+        for sublist in data:
+            if is_matrix(sublist):
+                mat = Matrix(sublist)
+                q = tuple(mat.to_quaternion())
+                collect_quaternion(q)
+            else:
+                get_all(sublist)
+
+    get_all(data)
+    return [quaternions]
 
 
 def is_matrix(mat):

--- a/node_tree.py
+++ b/node_tree.py
@@ -505,7 +505,7 @@ class StringsSocket(NodeSocket, SvSocketCommon):
 
     prop_type = StringProperty(default='')
     prop_index = IntProperty()
-    nodule_color = FloatVectorProperty(default=(0.6, 1.0, 0.6, 1.0), size=4)
+    nodule_color = FloatVectorProperty(default=socket_colors["StringsSocket"], size=4)
 
     custom_draw = StringProperty()
 
@@ -534,6 +534,9 @@ class StringsSocket(NodeSocket, SvSocketCommon):
             return default
         else:
             raise SvNoDataError(self)
+
+    def draw_color(self, context, node):
+        return self.nodule_color
 
 
 class SvLinkNewNodeInput(bpy.types.Operator):

--- a/node_tree.py
+++ b/node_tree.py
@@ -85,7 +85,6 @@ emptyQuaternion = [[(1, 0, 0, 0)]]
 def process_from_socket(self, context):
     """Update function of exposed properties in Sockets"""
     self.node.process_node(context)
-# this property group is only used by the old viewer draw
 
 class SvDocstring(object):
     """
@@ -188,6 +187,7 @@ class SvDocstring(object):
         else:
             return self.docstring.strip()
 
+# this property group is only used by the old viewer draw
 class SvColors(bpy.types.PropertyGroup):
     """ Class for colors CollectionProperty """
     color = FloatVectorProperty(

--- a/node_tree.py
+++ b/node_tree.py
@@ -86,6 +86,7 @@ def process_from_socket(self, context):
     """Update function of exposed properties in Sockets"""
     self.node.process_node(context)
 
+
 class SvDocstring(object):
     """
     A class that incapsulates parsing of Sverchok's nodes docstrings.
@@ -157,7 +158,7 @@ class SvDocstring(object):
         """
         Get shorthand to be used in search menu.
         If fallback == True, then whole docstring
-        will be returned for case when we can't 
+        will be returned for case when we can't
         find valid shorthand specification.
         """
 
@@ -171,7 +172,7 @@ class SvDocstring(object):
             return self.docstring
         else:
             return None
-    
+
     def has_shorthand(self):
         return self.get_shorthand() is not None
 
@@ -188,6 +189,8 @@ class SvDocstring(object):
             return self.docstring.strip()
 
 # this property group is only used by the old viewer draw
+
+
 class SvColors(bpy.types.PropertyGroup):
     """ Class for colors CollectionProperty """
     color = FloatVectorProperty(
@@ -326,6 +329,7 @@ class SvSocketCommon:
 
     def draw_color(self, context, node):
         return socket_colors[self.bl_idname]
+
 
 class MatrixSocket(NodeSocket, SvSocketCommon):
     '''4x4 matrix Socket type'''
@@ -641,7 +645,6 @@ class SverchCustomTree(NodeTree, SvNodeTreeCommon):
     sv_process = BoolProperty(name="Process", default=True, description='Process layout')
     sv_user_colors = StringProperty(default="")
 
-
     def update(self):
         '''
         Tags tree for update for handle
@@ -763,7 +766,7 @@ class SverchCustomTreeNode:
         """
 
         return cls.get_docstring().get_tooltip()
-    
+
     @classmethod
     def get_shorthand(cls):
         """
@@ -801,7 +804,6 @@ class SverchCustomTreeNode:
             # print('applying default for', self.name)
             set_defaults_if_defined(self)
 
-
     def process_node(self, context):
         '''
         Doesn't work as intended, inherited functions can't be used for bpy.props
@@ -837,7 +839,6 @@ classes = [
 def register():
     for cls in classes:
         bpy.utils.register_class(cls)
-
 
 
 def unregister():

--- a/node_tree.py
+++ b/node_tree.py
@@ -75,12 +75,6 @@ socket_colors = {
     "TextSocket": (0.68, 0.85, 0.90, 1),
 }
 
-# default values returned when no input is connected to socket
-identityMatrix = [[tuple(v) for v in Matrix()]]
-emptyVertex = [[(0, 0, 0)]]
-emptyColor = [[(0, 0, 0, 1)]]
-emptyQuaternion = [[(1, 0, 0, 0)]]
-
 
 def process_from_socket(self, context):
     """Update function of exposed properties in Sockets"""
@@ -404,7 +398,7 @@ class VerticesSocket(NodeSocket, SvSocketCommon):
         elif self.use_prop:
             return [[self.prop[:]]]
         elif default is sentinel:
-            return emptyVertex
+            raise SvNoDataError(self)
         else:
             return default
 
@@ -445,7 +439,7 @@ class SvQuaternionSocket(NodeSocket, SvSocketCommon):
         elif self.use_prop:
             return [[self.prop[:]]]
         elif default is sentinel:
-            return emptyQuaternion
+            raise SvNoDataError(self)
         else:
             return default
 
@@ -477,7 +471,7 @@ class SvColorSocket(NodeSocket, SvSocketCommon):
         elif self.use_prop:
             return [[self.prop[:]]]
         elif default is sentinel:
-            return emptyColor
+            raise SvNoDataError(self)
         else:
             return default
 

--- a/node_tree.py
+++ b/node_tree.py
@@ -277,6 +277,7 @@ class SvSocketCommon:
                 layout.template_component_menu(prop_origin, prop_name, name=self.name)
 
     def draw_quick_link(self, context, layout, node):
+
         if self.use_quicklink:
             if self.bl_idname == "MatrixSocket":
                 new_node_idname = "SvMatrixGenNodeMK2"
@@ -293,6 +294,14 @@ class SvSocketCommon:
             op.new_node_offsety = -30 * self.index
 
     def draw(self, context, layout, node, text):
+
+        # just handle custom draw..be it input or output.
+        # hasattr may be excessive here
+        if self.bl_idname == 'StringsSocket' and hasattr(self, 'custom_draw'):
+            if self.custom_draw and hasattr(node, self.custom_draw):
+                getattr(node, self.custom_draw)(self, context, layout)
+                return
+
         if self.is_linked:  # linked INPUT or OUTPUT
             info_text = text + '. ' + SvGetSocketInfo(self)
             info_text += self.extra_info

--- a/node_tree.py
+++ b/node_tree.py
@@ -255,24 +255,27 @@ class SvSocketCommon:
         return ""
 
     def draw_expander_template(self, context, layout, prop_origin, prop_name="prop"):
-        if self.use_expander and self.bl_idname != "StringsSocket":
-            split = layout.split(percentage=.2, align=True)
-            c1 = split.column(align=True)
-            c2 = split.column(align=True)
-            if self.expanded:
-                c1.prop(self, "expanded", icon='TRIA_UP', text='')
-                c1.label(text=self.name[0])
-                c2.prop(prop_origin, prop_name, text="", expand=True)
-            else:  # collapsed
-                c1.prop(self, "expanded", icon='TRIA_DOWN', text="")
-                row = c2.row(align=True)
-                if self.bl_idname == "SvColorSocket":
-                    row.prop(prop_origin, prop_name)
-                else:
-                    row.template_component_menu(prop_origin, prop_name, name=self.name)
+
+        if self.bl_idname == "StringsSocket":
+            layout.prop(prop_origin, prop_name)
         else:
-            if self.bl_idname == "StringsSocket":
-                layout.prop(prop_origin, prop_name)
+            if self.use_expander:
+                split = layout.split(percentage=.2, align=True)
+                c1 = split.column(align=True)
+                c2 = split.column(align=True)
+
+                if self.expanded:
+                    c1.prop(self, "expanded", icon='TRIA_UP', text='')
+                    c1.label(text=self.name[0])
+                    c2.prop(prop_origin, prop_name, text="", expand=True)
+                else:
+                    c1.prop(self, "expanded", icon='TRIA_DOWN', text="")
+                    row = c2.row(align=True)
+                    if self.bl_idname == "SvColorSocket":
+                        row.prop(prop_origin, prop_name)
+                    else:
+                        row.template_component_menu(prop_origin, prop_name, name=self.name)
+
             else:
                 layout.template_component_menu(prop_origin, prop_name, name=self.name)
 

--- a/node_tree.py
+++ b/node_tree.py
@@ -298,16 +298,18 @@ class SvSocketCommon:
         # just handle custom draw..be it input or output.
         # hasattr may be excessive here
         if self.bl_idname == 'StringsSocket':
-            if hasattr(self, 'custom_draw'):
-                if self.custom_draw and hasattr(node, self.custom_draw):
+            if hasattr(self, 'custom_draw') and self.custom_draw:
+
+                # does the node have the draw function referred to by 
+                # the string stored in socket's custom_draw attribute
+                if hasattr(node, self.custom_draw):
                     getattr(node, self.custom_draw)(self, context, layout)
                     return
 
             if node.bl_idname in {'SvScriptNodeLite', 'SvScriptNode'}:
-                if not self.is_output and not self.is_linked:
+                if not self.is_output and not self.is_linked and self.prop_type:
                     layout.prop(node, self.prop_type, index=self.prop_index, text=self.name)
                     return
-
 
         if self.is_linked:  # linked INPUT or OUTPUT
             info_text = text + '. ' + SvGetSocketInfo(self)

--- a/node_tree.py
+++ b/node_tree.py
@@ -297,15 +297,17 @@ class SvSocketCommon:
 
         # just handle custom draw..be it input or output.
         # hasattr may be excessive here
-        if self.bl_idname == 'StringsSocket' and hasattr(self, 'custom_draw'):
-            if self.custom_draw and hasattr(node, self.custom_draw):
-                getattr(node, self.custom_draw)(self, context, layout)
-                return
+        if self.bl_idname == 'StringsSocket':
+            if hasattr(self, 'custom_draw'):
+                if self.custom_draw and hasattr(node, self.custom_draw):
+                    getattr(node, self.custom_draw)(self, context, layout)
+                    return
 
-        if self.bl_idname == 'StringsSocket' and node.bl_idname in {'SvScriptNodeLite'}:
-            if not self.is_output and not self.is_linked:
-                layout.prop(node, self.prop_type, index=self.prop_index, text=self.name)
-                return
+            if node.bl_idname in {'SvScriptNodeLite', 'SvScriptNode'}:
+                if not self.is_output and not self.is_linked:
+                    layout.prop(node, self.prop_type, index=self.prop_index, text=self.name)
+                    return
+
 
         if self.is_linked:  # linked INPUT or OUTPUT
             info_text = text + '. ' + SvGetSocketInfo(self)

--- a/node_tree.py
+++ b/node_tree.py
@@ -70,7 +70,7 @@ socket_colors = {
     "SvQuaternionSocket": (0.9, 0.4, 0.7, 1.0),
     "SvColorSocket": (0.9, 0.8, 0.0, 1.0),
     "MatrixSocket": (0.2, 0.8, 0.8, 1.0),
-    "DummySocket": (0.8, 0.8, 0.8, 0.3),
+    "SvDummySocket": (0.8, 0.8, 0.8, 0.3),
     "ObjectSocket": (0.69, 0.74, 0.73, 1.0),
     "TextSocket": (0.68, 0.85, 0.90, 1),
 }
@@ -362,7 +362,7 @@ class MatrixSocket(NodeSocket, SvSocketCommon):
 
             return SvGetSocket(self, deepcopy)
         elif default is sentinel:
-            return identityMatrix
+            raise SvNoDataError(self)
         else:
             return default
 

--- a/node_tree.py
+++ b/node_tree.py
@@ -551,10 +551,10 @@ class SvLinkNewNodeInput(bpy.types.Operator):
         nodes, links = tree.nodes, tree.links
 
         caller_node = nodes.get(self.origin)
-        mat_node = nodes.new(self.new_node_idname)
-        mat_node.location[0] = caller_node.location[0] + self.new_node_offsetx
-        mat_node.location[1] = caller_node.location[1] + self.new_node_offsety
-        links.new(mat_node.outputs[0], caller_node.inputs[self.socket_index])
+        new_node = nodes.new(self.new_node_idname)
+        new_node.location[0] = caller_node.location[0] + self.new_node_offsetx
+        new_node.location[1] = caller_node.location[1] + self.new_node_offsety
+        links.new(new_node.outputs[0], caller_node.inputs[self.socket_index])
 
         return {'FINISHED'}
 

--- a/node_tree.py
+++ b/node_tree.py
@@ -302,6 +302,11 @@ class SvSocketCommon:
                 getattr(node, self.custom_draw)(self, context, layout)
                 return
 
+        if self.bl_idname == 'StringsSocket' and node.bl_idname in {'SvScriptNodeLite'}:
+            if not self.is_output and not self.is_linked:
+                layout.prop(node, self.prop_type, index=self.prop_index, text=self.name)
+                return
+
         if self.is_linked:  # linked INPUT or OUTPUT
             info_text = text + '. ' + SvGetSocketInfo(self)
             info_text += self.extra_info

--- a/node_tree.py
+++ b/node_tree.py
@@ -26,6 +26,8 @@ import bpy
 from bpy.props import StringProperty, BoolProperty, FloatVectorProperty, IntProperty
 from bpy.types import NodeTree, NodeSocket, NodeSocketStandard
 
+from mathutils import Matrix
+
 from sverchok import data_structure
 from sverchok.data_structure import (
     updateNode,
@@ -49,18 +51,41 @@ from sverchok.core.update_system import (
 from sverchok.core.socket_conversions import (
     get_matrices_from_locs,
     get_locs_from_matrices,
+    get_matrices_from_quaternions,
+    get_quaternions_from_matrices,
+    is_matrix_to_quaternion,
+    is_quaternion_to_matrix,
     is_vector_to_matrix,
     is_matrix_to_vector)
 
 from sverchok.core.node_defaults import set_defaults_if_defined
 
+from sverchok.utils.context_managers import sv_preferences
 from sverchok.ui import color_def
 import sverchok.utils.logging
+
+socket_colors = {
+    "StringsSocket": (0.6, 1.0, 0.6, 1.0),
+    "VerticesSocket": (0.9, 0.6, 0.2, 1.0),
+    "SvQuaternionSocket": (0.9, 0.4, 0.7, 1.0),
+    "SvColorSocket": (0.9, 0.8, 0.0, 1.0),
+    "MatrixSocket": (0.2, 0.8, 0.8, 1.0),
+    "DummySocket": (0.8, 0.8, 0.8, 0.3),
+    "ObjectSocket": (0.69, 0.74, 0.73, 1.0),
+    "TextSocket": (0.68, 0.85, 0.90, 1),
+}
+
+# default values returned when no input is connected to socket
+identityMatrix = [[tuple(v) for v in Matrix()]]
+emptyVertex = [[(0, 0, 0)]]
+emptyColor = [[(0, 0, 0, 1)]]
+emptyQuaternion = [[(1, 0, 0, 0)]]
 
 
 def process_from_socket(self, context):
     """Update function of exposed properties in Sockets"""
     self.node.process_node(context)
+# this property group is only used by the old viewer draw
 
 class SvDocstring(object):
     """
@@ -163,7 +188,6 @@ class SvDocstring(object):
         else:
             return self.docstring.strip()
 
-# this property group is only used by the old viewer draw
 class SvColors(bpy.types.PropertyGroup):
     """ Class for colors CollectionProperty """
     color = FloatVectorProperty(
@@ -174,6 +198,12 @@ class SvColors(bpy.types.PropertyGroup):
 
 
 class SvSocketCommon:
+    """ Base class for all Sockets """
+    use_prop = BoolProperty(default=False)
+
+    use_expander = BoolProperty(default=True)
+    use_quicklink = BoolProperty(default=True)
+    expanded = BoolProperty(default=False)
 
     @property
     def other(self):
@@ -219,6 +249,71 @@ class SvSocketCommon:
         return the new socket, the old reference might be invalid"""
         return replace_socket(self, new_type, new_name)
 
+    @property
+    def extra_info(self):
+        # print("getting base extra info")
+        return ""
+
+    def draw_expander_template(self, context, layout, prop_origin, prop_name="prop"):
+        if self.use_expander and self.bl_idname != "StringsSocket":
+            split = layout.split(percentage=.2, align=True)
+            c1 = split.column(align=True)
+            c2 = split.column(align=True)
+            if self.expanded:
+                c1.prop(self, "expanded", icon='TRIA_UP', text='')
+                c1.label(text=self.name[0])
+                c2.prop(prop_origin, prop_name, text="", expand=True)
+            else:  # collapsed
+                c1.prop(self, "expanded", icon='TRIA_DOWN', text="")
+                row = c2.row(align=True)
+                if self.bl_idname == "SvColorSocket":
+                    row.prop(prop_origin, prop_name)
+                else:
+                    row.template_component_menu(prop_origin, prop_name, name=self.name)
+        else:
+            if self.bl_idname == "StringsSocket":
+                layout.prop(prop_origin, prop_name)
+            else:
+                layout.template_component_menu(prop_origin, prop_name, name=self.name)
+
+    def draw_quick_link(self, context, layout, node):
+        if self.use_quicklink:
+            if self.bl_idname == "MatrixSocket":
+                new_node_idname = "SvMatrixGenNodeMK2"
+            elif self.bl_idname == "VerticesSocket":
+                new_node_idname = "GenVectorsNode"
+            else:
+                return
+
+            op = layout.operator('node.sv_quicklink_new_node_input', text="", icon="PLUGIN")
+            op.socket_index = self.index
+            op.origin = node.name
+            op.new_node_idname = new_node_idname
+            op.new_node_offsetx = -200 - 40 * self.index
+            op.new_node_offsety = -30 * self.index
+
+    def draw(self, context, layout, node, text):
+        if self.is_linked:  # linked INPUT or OUTPUT
+            info_text = text + '. ' + SvGetSocketInfo(self)
+            info_text += self.extra_info
+            layout.label(info_text)
+
+        elif self.is_output:  # unlinked OUTPUT
+            layout.label(text)
+
+        else:  # unlinked INPUT
+            if self.prop_name:  # has property
+                self.draw_expander_template(context, layout, prop_origin=node, prop_name=self.prop_name)
+
+            elif self.use_prop:  # no property but use default prop
+                self.draw_expander_template(context, layout, prop_origin=self)
+
+            else:  # no property and not use default prop
+                self.draw_quick_link(context, layout, node)
+                layout.label(text)
+
+    def draw_color(self, context, node):
+        return socket_colors[self.bl_idname]
 
 class MatrixSocket(NodeSocket, SvSocketCommon):
     '''4x4 matrix Socket type'''
@@ -226,6 +321,15 @@ class MatrixSocket(NodeSocket, SvSocketCommon):
     bl_label = "Matrix Socket"
     prop_name = StringProperty(default='')
     num_matrices = IntProperty(default=0)
+
+    @property
+    def extra_info(self):
+        # print("getting matrix extra info")
+        info = ""
+        if is_vector_to_matrix(self):
+            info = (" (" + str(self.num_matrices) + ")")
+
+        return info
 
     def get_prop_data(self):
         return {}
@@ -241,26 +345,16 @@ class MatrixSocket(NodeSocket, SvSocketCommon):
                 self.num_matrices = len(out)
                 return out
 
+            if is_quaternion_to_matrix(self):
+                out = get_matrices_from_quaternions(SvGetSocket(self, deepcopy=True))
+                self.num_matrices = len(out)
+                return out
+
             return SvGetSocket(self, deepcopy)
         elif default is sentinel:
-            raise SvNoDataError(self)
+            return identityMatrix
         else:
             return default
-
-    def draw(self, context, layout, node, text):
-        if self.is_linked:
-            draw_string = text + '. ' + SvGetSocketInfo(self)
-            if is_vector_to_matrix(self):
-                draw_string += (" (" + str(self.num_matrices) + ")")
-            layout.label(draw_string)
-        else:
-            layout.label(text)
-
-    def draw_color(self, context, node):
-        '''if self.is_linked:
-            return(.8,.3,.75,1.0)
-        else: '''
-        return (.2, .8, .8, 1.0)
 
 
 class VerticesSocket(NodeSocket, SvSocketCommon):
@@ -294,25 +388,82 @@ class VerticesSocket(NodeSocket, SvSocketCommon):
         elif self.use_prop:
             return [[self.prop[:]]]
         elif default is sentinel:
-            raise SvNoDataError(self)
+            return emptyVertex
         else:
             return default
 
-    def draw(self, context, layout, node, text):
-        if not self.is_output and not self.is_linked:
-            if self.prop_name:
-                layout.template_component_menu(node, self.prop_name, name=self.name)
-            elif self.use_prop:
-                layout.template_component_menu(self, "prop", name=self.name)
-            else:
-                layout.label(text)
-        elif self.is_linked:
-            layout.label(text + '. ' + SvGetSocketInfo(self))
-        else:
-            layout.label(text)
 
-    def draw_color(self, context, node):
-        return (0.9, 0.6, 0.2, 1.0)
+class SvQuaternionSocket(NodeSocket, SvSocketCommon):
+    '''For quaternion data'''
+    bl_idname = "SvQuaternionSocket"
+    bl_label = "Quaternion Socket"
+
+    prop = FloatVectorProperty(default=(1, 0, 0, 0), size=4, subtype='QUATERNION', update=process_from_socket)
+    prop_name = StringProperty(default='')
+    use_prop = BoolProperty(default=False)
+
+    def get_prop_data(self):
+        if self.prop_name:
+            return {"prop_name": socket.prop_name}
+        elif self.use_prop:
+            return {"use_prop": True,
+                    "prop": self.prop[:]}
+        else:
+            return {}
+
+    def sv_get(self, default=sentinel, deepcopy=True):
+        if self.is_linked and not self.is_output:
+
+            if is_matrix_to_quaternion(self):
+                out = get_quaternions_from_matrices(SvGetSocket(self, deepcopy=True))
+                return out
+
+            # if is_vector_to_quaternion(self):
+            #     out = vector_to_quaternion(SvGetSocket(self, deepcopy=True))
+            #     return out
+
+            return SvGetSocket(self, deepcopy)
+
+        if self.prop_name:
+            return [[getattr(self.node, self.prop_name)[:]]]
+        elif self.use_prop:
+            return [[self.prop[:]]]
+        elif default is sentinel:
+            return emptyQuaternion
+        else:
+            return default
+
+
+class SvColorSocket(NodeSocket, SvSocketCommon):
+    '''For color data'''
+    bl_idname = "SvColorSocket"
+    bl_label = "Color Socket"
+
+    prop = FloatVectorProperty(default=(0, 0, 0, 1), size=4, subtype='COLOR', min=0, max=1, update=process_from_socket)
+    prop_name = StringProperty(default='')
+    use_prop = BoolProperty(default=False)
+
+    def get_prop_data(self):
+        if self.prop_name:
+            return {"prop_name": socket.prop_name}
+        elif self.use_prop:
+            return {"use_prop": True,
+                    "prop": self.prop[:]}
+        else:
+            return {}
+
+    def sv_get(self, default=sentinel, deepcopy=True):
+        if self.is_linked and not self.is_output:
+            return SvGetSocket(self, deepcopy)
+
+        if self.prop_name:
+            return [[getattr(self.node, self.prop_name)[:]]]
+        elif self.use_prop:
+            return [[self.prop[:]]]
+        elif default is sentinel:
+            return emptyColor
+        else:
+            return default
 
 
 class SvDummySocket(NodeSocket, SvSocketCommon):
@@ -333,12 +484,6 @@ class SvDummySocket(NodeSocket, SvSocketCommon):
 
     def sv_type_conversion(self, new_self):
         self = new_self
-
-    def draw(self, context, layout, node, text):
-        layout.label(text)
-
-    def draw_color(self, context, node):
-        return (0.8, 0.8, 0.8, 0.3)
 
 
 class StringsSocket(NodeSocket, SvSocketCommon):
@@ -380,36 +525,29 @@ class StringsSocket(NodeSocket, SvSocketCommon):
         else:
             raise SvNoDataError(self)
 
-    def draw(self, context, layout, node, text):
 
-        # just handle custom draw..be it input or output.
-        if hasattr(self, 'custom_draw'):
-            if self.custom_draw and hasattr(node, self.custom_draw):
-                getattr(node, self.custom_draw)(self, context, layout)
-                return
+class SvLinkNewNodeInput(bpy.types.Operator):
+    ''' Spawn and link new node to the left of the caller node'''
+    bl_idname = "node.sv_quicklink_new_node_input"
+    bl_label = "Add a new node to the left"
 
-        if self.prop_name:
-            prop = node.rna_type.properties.get(self.prop_name, None)
-            t = prop.name if prop else text
-        else:
-            t = text
+    socket_index = bpy.props.IntProperty()
+    origin = bpy.props.StringProperty()
+    new_node_idname = bpy.props.StringProperty()
+    new_node_offsetx = bpy.props.IntProperty(default=-200)
+    new_node_offsety = bpy.props.IntProperty(default=0)
 
-        if not self.is_output and not self.is_linked:
-            if self.prop_name and not self.prop_type:
+    def execute(self, context):
+        tree = context.space_data.edit_tree
+        nodes, links = tree.nodes, tree.links
 
-                layout.prop(node, self.prop_name)
+        caller_node = nodes.get(self.origin)
+        mat_node = nodes.new(self.new_node_idname)
+        mat_node.location[0] = caller_node.location[0] + self.new_node_offsetx
+        mat_node.location[1] = caller_node.location[1] + self.new_node_offsety
+        links.new(mat_node.outputs[0], caller_node.inputs[self.socket_index])
 
-            elif self.prop_type:
-                layout.prop(node, self.prop_type, index=self.prop_index, text=self.name)
-            else:
-                layout.label(t)
-        elif self.is_linked:
-            layout.label(t + '. ' + SvGetSocketInfo(self))
-        else:
-            layout.label(t)
-
-    def draw_color(self, context, node):
-        return self.nodule_color
+        return {'FINISHED'}
 
 
 class SvNodeTreeCommon(object):
@@ -631,7 +769,7 @@ class SverchCustomTreeNode:
 
     def init(self, context):
         """
-        this function is triggered upon node creation, 
+        this function is triggered upon node creation,
         - freezes the node
         - delegates further initialization information to sv_init
         - sets node color
@@ -676,21 +814,20 @@ class SverchCustomTreeNode:
         else:
             pass
 
+classes = [
+    SvColors, SverchCustomTree,
+    VerticesSocket, MatrixSocket, StringsSocket,
+    SvColorSocket, SvQuaternionSocket, SvDummySocket,
+    SvLinkNewNodeInput,
+]
+
 
 def register():
-    bpy.utils.register_class(SvColors)
-    bpy.utils.register_class(SverchCustomTree)
-    bpy.utils.register_class(MatrixSocket)
-    bpy.utils.register_class(StringsSocket)
-    bpy.utils.register_class(VerticesSocket)
-    bpy.utils.register_class(SvDummySocket)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
 
 
 def unregister():
-    bpy.utils.unregister_class(SvDummySocket)
-    bpy.utils.unregister_class(VerticesSocket)
-    bpy.utils.unregister_class(StringsSocket)
-    bpy.utils.unregister_class(MatrixSocket)
-    bpy.utils.unregister_class(SverchCustomTree)
-    bpy.utils.unregister_class(SvColors)
+    for cls in classes:
+        bpy.utils.unregister_class(cls)

--- a/utils/sv_IO_monad_helpers.py
+++ b/utils/sv_IO_monad_helpers.py
@@ -86,7 +86,13 @@ def unpack_monad(nodes, node_ref):
                 continue
 
             for k, v in data_list.items():
-                setattr(node, k, params[k])
+                if hasattr(node, k):
+                    if k in params:
+                        setattr(node, k, params[k])
+                    # else:
+                    #    print(k, 'not in', params)
+                #else:
+                #    print('node name:', node, node.name, 'has no property called', k, 'yet..')
 
 
         # node.output_template = cls_dict['output_template']

--- a/utils/sv_IO_panel_tools.py
+++ b/utils/sv_IO_panel_tools.py
@@ -151,7 +151,6 @@ def collect_custom_socket_properties(node, node_dict):
     input_socket_storage = {}
     for socket in node.inputs:
 
-        # if not tracked_socket(socket): continue
         print("Socket %d of %d" % (socket.index + 1, len(node.inputs)))
 
         storable = {}
@@ -162,6 +161,10 @@ def collect_custom_socket_properties(node, node_dict):
                 continue
 
             value = getattr(socket, tracked_prop_name)
+            defaultValue = socket.bl_rna.properties[tracked_prop_name].default
+            # property value same as default ? => don't store it
+            if value == defaultValue:
+                continue
 
             print("Processing custom property: ", tracked_prop_name, " value = ", value)
             storable[tracked_prop_name] = value

--- a/utils/sv_IO_panel_tools.py
+++ b/utils/sv_IO_panel_tools.py
@@ -104,7 +104,6 @@ def compile_socket(link):
 
 def write_json(layout_dict, destination_path):
 
-
     try:
         m = json.dumps(layout_dict, sort_keys=True, indent=2)
     except Exception as err:
@@ -149,11 +148,11 @@ def get_superficial_props(node_dict, node):
 
 def collect_custom_socket_properties(node, node_dict):
     print("** PROCESSING custom properties for node: ", node.bl_idname)
-    input_socket_storage = { }
+    input_socket_storage = {}
     for socket in node.inputs:
 
         # if not tracked_socket(socket): continue
-        print("Socket %d of %d" % (socket.index+1, len(node.inputs)))
+        print("Socket %d of %d" % (socket.index + 1, len(node.inputs)))
 
         storable = {}
         tracked_props = 'use_expander', 'use_quicklink', 'expanded', 'use_prop'
@@ -176,7 +175,7 @@ def collect_custom_socket_properties(node, node_dict):
 
     if input_socket_storage:
         node_dict['custom_socket_props'] = input_socket_storage
-    print("**\n")    
+    print("**\n")
 
 
 def create_dict_of_tree(ng, skip_set={}, selected=False):
@@ -297,10 +296,9 @@ def create_dict_of_tree(ng, skip_set={}, selected=False):
 
         collect_custom_socket_properties(node, node_dict)
 
-        #if node.bl_idname == 'NodeFrame':
+        # if node.bl_idname == 'NodeFrame':
         #    frame_props = 'shrink', 'use_custom_color', 'label_size'
         #    node_dict['params'].update({fpv: getattr(node, fpv) for fpv in frame_props})
-
 
         if IsMonadInstanceNode:
             node_dict['bl_idname'] = 'SvMonadGenericNode'
@@ -514,7 +512,7 @@ def apply_socket_props(socket, info):
             sys.stderr.write('ERROR: %s\n' % str(err))
             print(sys.exc_info()[-1].tb_frame.f_code)
             print('Error on line {}'.format(sys.exc_info()[-1].tb_lineno))
-            print('while setting node socket:', node.name,'|', socket.index)
+            print('while setting node socket:', node.name, '|', socket.index)
             print("the following failed |", tracked_prop_name, '<-', tracked_prop_value)
 
 
@@ -611,7 +609,6 @@ def add_nodes(ng, nodes_to_import, nodes, create_texts):
     return name_remap
 
 
-
 def add_groups(groups_to_import):
     '''
     return the dictionary that tracks which groups got renamed due to conflicts
@@ -666,7 +663,6 @@ def import_tree(ng, fullpath='', nodes_json=None, create_texts=True):
             print(failed_connections)
         else:
             print('no failed connections! awesome.')
-
 
     def generate_layout(fullpath, nodes_json):
         '''cummulative function '''
@@ -876,7 +872,6 @@ class SvNodeTreeImportFromGist(bpy.types.Operator):
             self.report({'ERROR'}, 'unspecified error, check your internet connection')
 
         return
-
 
     def obtain_json(self, gist_id):
 

--- a/utils/sv_IO_panel_tools.py
+++ b/utils/sv_IO_panel_tools.py
@@ -17,6 +17,7 @@
 # ##### END GPL LICENSE BLOCK #####
 
 import json
+import sys
 import os
 import re
 import zipfile
@@ -520,27 +521,17 @@ def apply_socket_props(socket, info):
             print("the following failed |", tracked_prop_name, '<-', tracked_prop_value)
 
 
-def apply_node_props(node, node_ref):
+def apply_custom_socket_props(node, node_ref):
     print("applying node props for node: ", node.bl_idname)
     socket_properties = node_ref.get('custom_socket_props')
     if socket_properties:
         for idx, info in socket_properties.items():
-            print("\n")
-            print("idx=", idx)
-            print("info=", info)
-            print("num inputs=", len(node.inputs))
-            print("inputs type=", type(node.inputs))
-            print("inputs keys=", node.inputs.keys())
-            # socket = node.inputs[idx]
-            for key, socket in node.inputs.items():
-                print("socket: <", key, "> has index: ", socket.index)
-                # print(type(socket.index))
-                # print(type(idx))
-                if socket.index == int(idx):
-                    print("found matching socket at index:", idx)
-                    apply_socket_props(socket, info)
-                else:
-                    print("did not find matching socket for idx=", idx)
+            try:
+                socket = node.inputs[idx]
+                apply_socket_props(socket, info)
+            except Exception as err:
+                print(repr(err))
+                print('socket index:', idx, 'trying to pass:', info, 'num_sockets', len(node.inputs))
 
 
 def add_texts(node, node_ref):
@@ -603,7 +594,8 @@ def add_node_to_tree(nodes, n, nodes_to_import, name_remap, create_texts):
     apply_core_props(node, node_ref)
     apply_superficial_props(node, node_ref)
     apply_post_processing(node, node_ref)
-    apply_node_props(node, node_ref)
+    apply_custom_socket_props(node, node_ref)
+
 
 def add_nodes(ng, nodes_to_import, nodes, create_texts):
     '''

--- a/utils/sv_IO_panel_tools.py
+++ b/utils/sv_IO_panel_tools.py
@@ -147,11 +147,11 @@ def get_superficial_props(node_dict, node):
 
 
 def collect_custom_socket_properties(node, node_dict):
-    print("** PROCESSING custom properties for node: ", node.bl_idname)
+    # print("** PROCESSING custom properties for node: ", node.bl_idname)
     input_socket_storage = {}
     for socket in node.inputs:
 
-        print("Socket %d of %d" % (socket.index + 1, len(node.inputs)))
+        # print("Socket %d of %d" % (socket.index + 1, len(node.inputs)))
 
         storable = {}
         tracked_props = 'use_expander', 'use_quicklink', 'expanded', 'use_prop'
@@ -166,11 +166,11 @@ def collect_custom_socket_properties(node, node_dict):
             if value == defaultValue:
                 continue
 
-            print("Processing custom property: ", tracked_prop_name, " value = ", value)
+            # print("Processing custom property: ", tracked_prop_name, " value = ", value)
             storable[tracked_prop_name] = value
 
             if tracked_prop_name == 'use_prop' and value:
-                print("prop type:", type(socket.prop))
+                # print("prop type:", type(socket.prop))
                 storable['prop'] = socket.prop[:]
 
         if storable:
@@ -178,7 +178,7 @@ def collect_custom_socket_properties(node, node_dict):
 
     if input_socket_storage:
         node_dict['custom_socket_props'] = input_socket_storage
-    print("**\n")
+    # print("**\n")
 
 
 def create_dict_of_tree(ng, skip_set={}, selected=False):

--- a/utils/sv_IO_panel_tools.py
+++ b/utils/sv_IO_panel_tools.py
@@ -158,20 +158,18 @@ def collect_custom_socket_properties(node, node_dict):
         storable = {}
         tracked_props = 'use_expander', 'use_quicklink', 'expanded', 'use_prop'
 
-        for tracked_prop in tracked_props:
-            if hasattr(socket, tracked_prop):
-                value = getattr(socket, tracked_prop)
+        for tracked_prop_name in tracked_props:
+            if not hasattr(socket, tracked_prop_name):
+                continue
 
-                print("Processing custom property: ", tracked_prop, " value = ", value)
+            value = getattr(socket, tracked_prop_name)
 
-                storable[tracked_prop] = value
+            print("Processing custom property: ", tracked_prop_name, " value = ", value)
+            storable[tracked_prop_name] = value
 
-                if tracked_prop == 'use_prop' and value:
-                    print("prop type:", type(socket.prop))
-                    storable['prop'] = socket.prop[:]
-                    # storable['socket_prop_value'] = socket.prop[:]
-                    # storable['socket_prop_value'] = serialize_prop(socket.prop)
-                    print("supposed to store prop value")
+            if tracked_prop_name == 'use_prop' and value:
+                print("prop type:", type(socket.prop))
+                storable['prop'] = socket.prop[:]
 
         if storable:
             input_socket_storage[socket.index] = storable
@@ -509,11 +507,10 @@ def apply_socket_props(socket, info):
     print("applying socket props")
     for tracked_prop_name, tracked_prop_value in info.items():
         try:
-            print("trying to set property name/value: ", tracked_prop_name, " / ", tracked_prop_value)
-
             setattr(socket, tracked_prop_name, tracked_prop_value)
 
         except Exception as err:
+            print("trying to set property name/value: ", tracked_prop_name, " / ", tracked_prop_value)
             sys.stderr.write('ERROR: %s\n' % str(err))
             print(sys.exc_info()[-1].tb_frame.f_code)
             print('Error on line {}'.format(sys.exc_info()[-1].tb_lineno))
@@ -527,7 +524,7 @@ def apply_custom_socket_props(node, node_ref):
     if socket_properties:
         for idx, info in socket_properties.items():
             try:
-                socket = node.inputs[idx]
+                socket = node.inputs[int(idx)]
                 apply_socket_props(socket, info)
             except Exception as err:
                 print(repr(err))

--- a/utils/sv_IO_panel_tools.py
+++ b/utils/sv_IO_panel_tools.py
@@ -568,8 +568,6 @@ def apply_post_processing(node, node_ref):
         socket_kinds = node_ref.get(node.node_kind)
         node.repopulate(socket_kinds)
 
-    apply_node_props(node, node_ref)
-
 
 def add_node_to_tree(nodes, n, nodes_to_import, name_remap, create_texts):
     node_ref = nodes_to_import[n]
@@ -605,7 +603,7 @@ def add_node_to_tree(nodes, n, nodes_to_import, name_remap, create_texts):
     apply_core_props(node, node_ref)
     apply_superficial_props(node, node_ref)
     apply_post_processing(node, node_ref)
-
+    apply_node_props(node, node_ref)
 
 def add_nodes(ng, nodes_to_import, nodes, create_texts):
     '''


### PR DESCRIPTION
Things that are still issues before hitting master

- [x] socket custom props are stored, but isn't sparse.
- [x] nodule_color  (but only used in `color-nodes` for a limited period from this point...and `gp node`
- [x] restore custom_draw
- [x] correctly store use_custom_color



condensed changelog.

* Return zero vector for no input in VerticesSocket
* Add Sv prefix to Color and Quaternion socket classes
* Add "link matrix" UI/operator for MatrixSocket
* Add "link vector" UI/operator for VerticesSocket
* Add quaternion to matrix socket conversion
* Update collapse expander for color to use SvColorSocket name
* Add matrix to quaternion socket conversion
*Add draw_link_new_node to socket base (common) to allow various inputs to add button to spawn and link different input nodes.
* Minor class/idname changes to the link new node
* Add "use quicklink" flag (To allow the quick link feature to be turned on/off if needed.)
* Socket specific draw calls were replaced by the draw call in the base class.
* adjust the quicklink new node offset to avoid overlapping new nodes (new nodes are now offset based on their index).
* Add code to handle export/import of socket custom props
* Optimization to `draw_expander_template`