### PR TITLE
Metaball output node

### DIFF
--- a/docs/nodes/viz/metaball_out.rst
+++ b/docs/nodes/viz/metaball_out.rst
@@ -40,7 +40,11 @@ Parameters
 This node has the following parameters:
 
 - **UPD**. The node will process data only if this button is enabled.
-- **Base name**. Base part of name for Meta object to create (or update). Default is "SvMetaBall".
+- **Hide View** (eye icon). Toggle visibility of generated object in viewport.
+- **Hide Select** (pointer icon). Toggle ability to select for generated object.
+- **Hide Render** (render icon). Toggle renderability for generated object.
+- **Base name**. Base part of name for Meta object to create (or update). Default is "Meta_Alpha".
+- **Select Toggle**. Select / deselect generated object.
 - **Material**. Material to be assigned to created object.
 - **Threshold**. Influence of meta elements. Default is 0.6.
 - **Resolution (viewport)**. Resolution of Meta object for viewport. Lesser value mean better resolution. Default is 0.2. This parameter can be set only in the N panel.

--- a/docs/nodes/viz/metaball_out.rst
+++ b/docs/nodes/viz/metaball_out.rst
@@ -60,5 +60,5 @@ Example of usage
 
 Simple example:
 
-.. image:: https://user-images.githubusercontent.com/284644/32991616-802601f0-cd60-11e7-9ad8-ea5939183fbb.png
+.. image:: https://user-images.githubusercontent.com/284644/32993860-54cdf1be-cd80-11e7-99fc-63d8f773ba70.png
 

--- a/docs/nodes/viz/metaball_out.rst
+++ b/docs/nodes/viz/metaball_out.rst
@@ -16,6 +16,11 @@ Inputs
 
 This node has the following inputs:
 
+- **Types**. Type of meta elements to create. If input is not connected, the
+  value is selected from dropdown list. Values available are: Ball, Capsule,
+  Plane, Ellipsoid, Cube. Default is Ball. When the input is used, it accepts
+  integer numbers from 1 to 5, which corresponds to the meta types in the same
+  order.
 - **Origins**. This describes location, scale and rotation of metaball
   elements. Note that for different Meta element types interpretation of
   Rotation and Scale from input matrix differs. For example, for Capsule type
@@ -36,8 +41,6 @@ This node has the following parameters:
 
 - **UPD**. The node will process data only if this button is enabled.
 - **Base name**. Base part of name for Meta object to create (or update). Default is "SvMetaBall".
-- **Meta type**. Type of meta elements to create. Available are: Ball, Capsule,
-  Plane, Ellipsoid, Cube. Default is Ball.
 - **Material**. Material to be assigned to created object.
 - **Threshold**. Influence of meta elements. Default is 0.6.
 - **Resolution (viewport)**. Resolution of Meta object for viewport. Lesser value mean better resolution. Default is 0.2. This parameter can be set only in the N panel.

--- a/docs/nodes/viz/metaball_out.rst
+++ b/docs/nodes/viz/metaball_out.rst
@@ -1,0 +1,57 @@
+Metaball Out Node
+=================
+
+Functionality
+-------------
+
+This node generates Blender's Meta objects (aka metaballs) from input data. It
+creates a new Meta object or updates existing on each update of input data or
+parameters.
+
+Please refer to Blender's documentation and tutorials for more information
+about what is metaballs and how do they work.
+
+Inputs
+------
+
+This node has the following inputs:
+
+- **Origins**. This describes location, scale and rotation of metaball
+  elements. Note that for different Meta element types interpretation of
+  Rotation and Scale from input matrix differs. For example, for Capsule type
+  only X component of scale matters. This input can also accept vectors, in this
+  case they are treated as location components of matrices.
+- **Radius**. Radiuses of metaballs. Exact interpretation also depends on meta
+  element type. This can be specified as input or as a parameter.
+- **Stiffness**. Stiffness defines how much of the element to fill.  This can
+  be specified as input or as a parameter.
+- **Negation**. This input accepts a mask. Meta elements with Negation = true
+  will be considered negative. If this input is not connected, all meta
+  elements are considered positive.
+
+Parameters
+----------
+
+This node has the following parameters:
+
+- **UPD**. The node will process data only if this button is enabled.
+- **Base name**. Base part of name for Meta object to create (or update). Default is "SvMetaBall".
+- **Meta type**. Type of meta elements to create. Available are: Ball, Capsule,
+  Plane, Ellipsoid, Cube. Default is Ball.
+- **Material**. Material to be assigned to created object.
+- **Threshold**. Influence of meta elements. Default is 0.6.
+- **Resolution (viewport)**. Resolution of Meta object for viewport. Lesser value mean better resolution. Default is 0.2. This parameter can be set only in the N panel.
+- **Resolution (render)**. Resolution of Meta object for rendering. Lesser value mean better resolution. Default is 0.1. This parameter can be set only in the N panel.
+
+Outputs
+-------
+
+This node has no outputs. Instead, it creates or updates Meta objects in Blender's scene.
+
+Example of usage
+----------------
+
+Simple example:
+
+.. image:: https://user-images.githubusercontent.com/284644/32991616-802601f0-cd60-11e7-9ad8-ea5939183fbb.png
+

--- a/index.md
+++ b/index.md
@@ -217,6 +217,7 @@
     SvBmeshViewerNodeMK2
     IndexViewerNode
     SvTextureViewerNode
+    SvMetaballOutNode
     Sv3DviewPropsNode
 
 ## Text
@@ -248,7 +249,6 @@
     SvObjEdit
     SvFrameInfoNodeMK2
     SvEmptyOutNode
-    SvMetaballOutNode
     SvInstancerNode
     SvDupliInstancesMK4
 

--- a/index.md
+++ b/index.md
@@ -248,6 +248,7 @@
     SvObjEdit
     SvFrameInfoNodeMK2
     SvEmptyOutNode
+    SvMetaballOutNode
     SvInstancerNode
     SvDupliInstancesMK4
 

--- a/nodes/viz/metaball_out.py
+++ b/nodes/viz/metaball_out.py
@@ -54,6 +54,8 @@ class SvMetaballOutNode(bpy.types.Node, SverchCustomTreeNode):
             description = "Meta object type",
             items = meta_types, update=updateNode)
 
+    material = StringProperty(name="Material", default='', update=updateNode)
+
     radius = FloatProperty(
         name='Radius',
         description='Metaball radius',
@@ -118,6 +120,9 @@ class SvMetaballOutNode(bpy.types.Node, SverchCustomTreeNode):
     def draw_buttons(self, context, layout):
         layout.prop(self, "meta_name")
         layout.prop(self, "meta_type")
+        layout.prop_search(
+                self, 'material', bpy.data, 'materials',
+                icon='MATERIAL_DATA')
 
     def draw_buttons_ext(self, context, layout):
         self.draw_buttons(context, layout)
@@ -129,6 +134,12 @@ class SvMetaballOutNode(bpy.types.Node, SverchCustomTreeNode):
         meta = self.create_metaball()
         self.label = meta.name
 
+    def update_material(self):
+        if bpy.data.materials.get(self.material):
+            metaball_object = self.find_metaball()
+            if metaball_object:
+                metaball_object.active_material = bpy.data.materials[self.material]
+
     def process(self):
         if not self.inputs['Origins'].is_linked:
             return
@@ -137,6 +148,8 @@ class SvMetaballOutNode(bpy.types.Node, SverchCustomTreeNode):
         if not metaball_object:
             metaball_object = self.create_metaball()
             print("Created new metaball")
+
+        self.update_material()
 
         metaball_object.data.resolution = self.view_resolution
         metaball_object.data.render_resolution = self.render_resolution
@@ -166,12 +179,12 @@ class SvMetaballOutNode(bpy.types.Node, SverchCustomTreeNode):
             element.use_negative = bool(negate)
 
         if len(items) == len(metaball_object.data.elements):
-            print('Updating existing metaball data')
+            #print('Updating existing metaball data')
 
             for (item, element) in zip(items, metaball_object.data.elements):
                 setup_element(element, item)
         else:
-            print('Recreating metaball data')
+            #print('Recreating metaball data')
             metaball_object.data.elements.clear()
 
             for item in items:

--- a/nodes/viz/metaball_out.py
+++ b/nodes/viz/metaball_out.py
@@ -38,6 +38,12 @@ class SvMetaballOutNode(bpy.types.Node, SverchCustomTreeNode):
     n_id = StringProperty(default='')
     metaball_ref_name = StringProperty(default='')
 
+    activate = BoolProperty(
+        name='Activate',
+        default=True,
+        description='When enabled this will process incoming data',
+        update=updateNode)
+
     meta_name = StringProperty(default='SvMetaBall', name="Base name",
                                 description="Base name of metaball",
                                 update=rename_metaball)
@@ -123,6 +129,9 @@ class SvMetaballOutNode(bpy.types.Node, SverchCustomTreeNode):
         self.inputs.new('StringsSocket', 'Negation')
 
     def draw_buttons(self, context, layout):
+        view_icon = 'BLENDER' if self.activate else 'ERROR'
+
+        layout.prop(self, "activate", text="UPD", toggle=True, icon=view_icon)
         layout.prop(self, "meta_name")
         layout.prop(self, "meta_type")
         layout.prop_search(
@@ -147,6 +156,9 @@ class SvMetaballOutNode(bpy.types.Node, SverchCustomTreeNode):
                 metaball_object.active_material = bpy.data.materials[self.material]
 
     def process(self):
+        if not self.activate:
+            return
+
         if not self.inputs['Origins'].is_linked:
             return
 

--- a/nodes/viz/metaball_out.py
+++ b/nodes/viz/metaball_out.py
@@ -184,7 +184,7 @@ class SvMetaballOutNode(bpy.types.Node, SverchCustomTreeNode):
         row.operator(show_hide, text='', icon=icons('hide_render')).fn_name = 'hide_render'
 
         col = layout.column(align=True)
-        col.prop(self, "meta_name", text='')
+        col.prop(self, "meta_name", text='', icon='OUTLINER_OB_META')
         col.operator(show_hide, text='Select Toggle').fn_name = 'mesh_select'
 
         layout.prop_search(

--- a/nodes/viz/metaball_out.py
+++ b/nodes/viz/metaball_out.py
@@ -22,6 +22,7 @@ from bpy.props import StringProperty, BoolProperty, FloatProperty, EnumProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import SvGetSocketAnyType, node_id, Matrix_generate, match_long_repeat, updateNode
+from sverchok.utils.sv_viewer_utils import greek_alphabet
 
 class SvMetaballOperator(bpy.types.Operator):
 
@@ -154,7 +155,14 @@ class SvMetaballOutNode(bpy.types.Node, SverchCustomTreeNode):
                 return obj
         return None
 
+    def get_next_name(self):
+        gai = bpy.context.scene.SvGreekAlphabet_index
+        bpy.context.scene.SvGreekAlphabet_index += 1
+        return 'Meta_' + greek_alphabet[gai]
+
     def sv_init(self, context):
+        self.meta_name = self.get_next_name()
+
         self.create_metaball()
         self.inputs.new('StringsSocket', 'Types').prop_name = "meta_type"
         self.inputs.new('MatrixSocket', 'Origins')
@@ -200,6 +208,7 @@ class SvMetaballOutNode(bpy.types.Node, SverchCustomTreeNode):
 
     def copy(self, node):
         self.n_id = ''
+        self.meta_name = self.get_next_name()
         meta = self.create_metaball()
         self.label = meta.name
 

--- a/nodes/viz/metaball_out.py
+++ b/nodes/viz/metaball_out.py
@@ -1,0 +1,188 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import bpy
+from mathutils import Matrix
+from bpy.props import StringProperty, BoolProperty, FloatProperty, EnumProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import SvGetSocketAnyType, node_id, Matrix_generate, match_long_repeat, updateNode
+
+class SvMetaballOutNode(bpy.types.Node, SverchCustomTreeNode):
+    '''Create Blender's metaball object'''
+    bl_idname = 'SvMetaballOutNode'
+    bl_label = 'Metaball'
+    bl_icon = 'META_BALL'
+
+    def rename_metaball(self, context):
+        meta = self.find_metaball()
+        if meta:
+            meta.name = self.metaball_ref_name
+            self.label = meta.name
+
+    n_id = StringProperty(default='')
+    metaball_ref_name = StringProperty(default='')
+
+    meta_name = StringProperty(default='SvMetaBall', name="Base name",
+                                description="Base name of metaball",
+                                update=rename_metaball)
+
+    meta_types = [
+            ("BALL", "Ball", "Ball", "META_BALL", 1),
+            ("CAPSULE", "Capsule", "Capsule", "META_CAPSULE", 2),
+            ("PLANE", "Plane", "Plane", "META_PLANE", 3),
+            ("ELLIPSOID", "Ellipsoid", "Ellipsoid", "META_ELLIPSOID", 4),
+            ("CUBE", "Cube", "Cube", "META_CUBE", 5)
+        ]
+
+    meta_type = EnumProperty(name='Meta type',
+            description = "Meta object type",
+            items = meta_types, update=updateNode)
+
+    radius = FloatProperty(
+        name='Radius',
+        description='Metaball radius',
+        default=1.0, min=0.0, update=updateNode)
+
+    stiffness = FloatProperty(
+        name='Stiffness',
+        description='Metaball stiffness',
+        default=2.0, min=0.0, update=updateNode)
+
+    view_resolution = FloatProperty(
+        name='Resolution (viewport)',
+        description='Resolution for viewport',
+        default=0.2, min=0.0, max=1.0, update=updateNode)
+
+    render_resolution = FloatProperty(
+        name='Resolution (render)',
+        description='Resolution for rendering',
+        default=0.1, min=0.0, max=1.0, update=updateNode)
+
+    def create_metaball(self):
+        n_id = node_id(self)
+        scene = bpy.context.scene
+        objects = bpy.data.objects
+        metaball_data = bpy.data.metaballs.new("MetaBall")
+        metaball_object = bpy.data.objects.new(self.meta_name, metaball_data)
+        scene.objects.link(metaball_object)
+        scene.update()
+
+        metaball_object["SVERCHOK_REF"] = n_id
+        self.metaball_ref_name = metaball_object.name
+
+        return metaball_object
+
+    def find_metaball(self):
+        n_id = node_id(self)
+
+        def check_metaball(obj):
+            """ Check that it is the correct metaball """
+            if obj.type == 'META':
+                return "SVERCHOK_REF" in obj and obj["SVERCHOK_REF"] == n_id
+            return False
+
+        objects = bpy.data.objects
+        if self.metaball_ref_name in objects:
+            obj = objects[self.metaball_ref_name]
+            if check_metaball(obj):
+                return obj
+        for obj in objects:
+            if check_metaball(obj):
+                self.metaball_ref_name = obj.name
+                return obj
+        return None
+
+    def sv_init(self, context):
+        self.create_metaball()
+        self.inputs.new('MatrixSocket', 'Origins')
+        self.inputs.new('StringsSocket', "Radius").prop_name = "radius"
+        self.inputs.new('StringsSocket', "Stiffness").prop_name = "stiffness"
+        self.inputs.new('StringsSocket', 'Negation')
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "meta_name")
+        layout.prop(self, "meta_type")
+
+    def draw_buttons_ext(self, context, layout):
+        self.draw_buttons(context, layout)
+        layout.prop(self, "view_resolution")
+        layout.prop(self, "render_resolution")
+
+    def copy(self, node):
+        self.n_id = ''
+        meta = self.create_metaball()
+        self.label = meta.name
+
+    def process(self):
+        if not self.inputs['Origins'].is_linked:
+            return
+
+        metaball_object = self.find_metaball()
+        if not metaball_object:
+            metaball_object = self.create_metaball()
+            print("Created new metaball")
+
+        metaball_object.data.resolution = self.view_resolution
+        metaball_object.data.render_resolution = self.render_resolution
+
+        self.label = metaball_object.name
+
+        origins = self.inputs['Origins'].sv_get()
+        origins = Matrix_generate(origins)
+        radiuses = self.inputs['Radius'].sv_get()[0]
+        stiffnesses = self.inputs['Stiffness'].sv_get()[0]
+        negation = self.inputs['Negation'].sv_get(default=[[0]])[0]
+
+        items = match_long_repeat([origins, radiuses, stiffnesses, negation])
+        items = list(zip(*items))
+
+        def setup_element(element, item):
+            (origin, radius, stiffness, negate) = item
+            center, rotation, scale = origin.decompose()
+            element.co = center[:3]
+            element.type = self.meta_type
+            element.radius = radius
+            element.stiffness = stiffness
+            element.rotation = rotation
+            element.size_x = scale[0]
+            element.size_y = scale[1]
+            element.size_z = scale[2]
+            element.use_negative = bool(negate)
+
+        if len(items) == len(metaball_object.data.elements):
+            print('Updating existing metaball data')
+
+            for (item, element) in zip(items, metaball_object.data.elements):
+                setup_element(element, item)
+        else:
+            print('Recreating metaball data')
+            metaball_object.data.elements.clear()
+
+            for item in items:
+                element = metaball_object.data.elements.new()
+                setup_element(element, item)
+
+
+def register():
+    bpy.utils.register_class(SvMetaballOutNode)
+
+
+def unregister():
+    bpy.utils.unregister_class(SvMetaballOutNode)
+

--- a/nodes/viz/metaball_out.py
+++ b/nodes/viz/metaball_out.py
@@ -76,6 +76,11 @@ class SvMetaballOutNode(bpy.types.Node, SverchCustomTreeNode):
         description='Resolution for rendering',
         default=0.1, min=0.0, max=1.0, update=updateNode)
 
+    threshold = FloatProperty(
+        name='Threshold',
+        description='Influence of meta elements',
+        default=0.6, min=0.0, max=5.0, update=updateNode)
+
     def create_metaball(self):
         n_id = node_id(self)
         scene = bpy.context.scene
@@ -123,6 +128,7 @@ class SvMetaballOutNode(bpy.types.Node, SverchCustomTreeNode):
         layout.prop_search(
                 self, 'material', bpy.data, 'materials',
                 icon='MATERIAL_DATA')
+        layout.prop(self, "threshold")
 
     def draw_buttons_ext(self, context, layout):
         self.draw_buttons(context, layout)
@@ -153,6 +159,7 @@ class SvMetaballOutNode(bpy.types.Node, SverchCustomTreeNode):
 
         metaball_object.data.resolution = self.view_resolution
         metaball_object.data.render_resolution = self.render_resolution
+        metaball_object.data.threshold = self.threshold
 
         self.label = metaball_object.name
 


### PR DESCRIPTION
Inspired by this video: https://www.youtube.com/watch?v=PP14rVhgX9M

Unfortunately, Blender does not have API for metaballs similar for bmesh for meshes; Metaballs can only exist in scene. So we cannot "process" metaballs, but we can create them.

This PR introduces a new node, "Metaball out". It has almost all parameters that can be set for metaballs through python API. I put it directly to the Viz category, because I do not think it gonna change a lot.

Documentation is pending.