### PR TITLE
Menu refactor

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -167,6 +167,7 @@ def register():
             if hasattr(m, "register"):
                 #print("Registering module: {}".format(m.__name__))
                 m.register()
+    # We have to register menu module after all nodes are registered
     menu.register()
     # this is used to access preferences, should/could be hidden
     # in an interface

--- a/__init__.py
+++ b/__init__.py
@@ -163,8 +163,11 @@ from sverchok.core import node_defaults
 
 def register():
     for m in imported_modules + node_list:
-        if hasattr(m, "register"):
-            m.register()
+        if m.__name__ != "sverchok.menu":
+            if hasattr(m, "register"):
+                #print("Registering module: {}".format(m.__name__))
+                m.register()
+    menu.register()
     # this is used to access preferences, should/could be hidden
     # in an interface
     data_structure.SVERCHOK_NAME = __name__

--- a/__init__.py
+++ b/__init__.py
@@ -153,7 +153,6 @@ if reload_event:
     for node in node_list:
         importlib.reload(node)
     old_nodes.reload_old()
-    menu.reload_menu()
 
 import bpy
 from sverchok.utils import ascii_print, auto_gather_node_classes, node_classes
@@ -179,6 +178,7 @@ def register():
     auto_gather_node_classes()
     if reload_event:
         data_structure.RELOAD_EVENT = True
+        menu.reload_menu()
         print("Sverchok is reloaded, press update")
 
 
@@ -187,4 +187,5 @@ def unregister():
     node_classes.clear()
     for m in reversed(imported_modules + node_list):
         if hasattr(m, "unregister"):
+            #print("Unregistering module: {}".format(m.__name__))
             m.unregister()

--- a/menu.py
+++ b/menu.py
@@ -276,10 +276,19 @@ def reload_menu():
     menu, node_count, original_categories = make_categories()
     if 'SVERCHOK' in nodeitems_utils._node_categories:
         nodeitems_utils.unregister_node_categories("SVERCHOK")
+        unregister_node_add_operators()
     nodeitems_utils.register_node_categories("SVERCHOK", menu)
+    register_node_add_operators()
     
     build_help_remap(original_categories)
 
+def register_node_add_operators():
+    for idname in node_add_operators:
+        bpy.utils.register_class(node_add_operators[idname])
+
+def unregister_node_add_operators():
+    for idname in node_add_operators:
+        bpy.utils.unregister_class(node_add_operators[idname])
 
 def register():
     menu, node_count, original_categories = make_categories()
@@ -295,6 +304,5 @@ def register():
 def unregister():
     if 'SVERCHOK' in nodeitems_utils._node_categories:
         nodeitems_utils.unregister_node_categories("SVERCHOK")
-    for idname in node_add_operators:
-        bpy.utils.unregister_class(node_add_operators[idname])
+    unregister_node_add_operators()
 

--- a/menu.py
+++ b/menu.py
@@ -162,8 +162,13 @@ class SverchNodeItem(object):
                 operator.create_node(context)
                 return {'FINISHED'}
 
-        SverchNodeAddOperator.__name__ = self.get_node_class().__name__
-        SverchNodeAddOperator.__doc__ = self.get_node_class().__doc__
+        node_class = self.get_node_class()
+        SverchNodeAddOperator.__name__ = node_class.__name__
+
+        if hasattr(node_class, "get_tooltip"):
+            SverchNodeAddOperator.__doc__ = node_class.get_tooltip()
+        else:
+            SverchNodeAddOperator.__doc__ = node_class.__doc__
 
         node_add_operators[self.get_idname()] = SverchNodeAddOperator
         bpy.utils.register_class(SverchNodeAddOperator)

--- a/menu.py
+++ b/menu.py
@@ -102,9 +102,18 @@ def juggle_and_join(node_cats):
 
     return node_cats
 
+# We are creating and registering node adding operators dynamically.
+# So, we have to remember them in order to unregister them when needed.
 node_add_operators = {}
 
 class SverchNodeItem(object):
+    """
+    A local replacement of nodeitems_utils.NodeItem.
+    This calls our custom operator (see make_add_operator) instead of
+    standard node.add_node. Having this replacement item class allows us to:
+    * Have icons in the T panel
+    * Have arbitrary tooltips in the T panel.
+    """
     def __init__(self, nodetype, label=None, settings=None, poll=None):
         self.nodetype = nodetype
         self._label = label
@@ -130,6 +139,11 @@ class SverchNodeItem(object):
         return get_node_idname_for_operator(self.nodetype)
 
     def make_add_operator(self):
+        """
+        Create operator class which adds specific type of node.
+        Tooltip (docstring) for that operator is copied from 
+        node class docstring.
+        """
 
         global node_add_operators
         
@@ -137,7 +151,7 @@ class SverchNodeItem(object):
             """Wrapper for node.add_node operator to add specific node"""
 
             bl_idname = "node.sv_add_" + self.get_idname()
-            bl_label = "Add node"
+            bl_label = "Add {} node".format(self.label)
             bl_options = {'REGISTER', 'UNDO'}
 
             def execute(self, context):
@@ -170,6 +184,7 @@ class SverchNodeItem(object):
             ops.value = setting[1]
 
 def get_node_idname_for_operator(nodetype):
+    """Select valid bl_idname for node to create node adding operator bl_idname."""
     rna = getattr(bpy.types, nodetype).bl_rna
     if hasattr(rna, 'bl_idname'):
         return rna.bl_idname.lower()
@@ -177,6 +192,11 @@ def get_node_idname_for_operator(nodetype):
         return rna.name.lower()
 
 def draw_add_node_operator(layout, nodetype, label=None, icon_name=None, params=None):
+    """
+    Draw node adding operator button.
+    This is to be used both in Shift-A menu and in T panel.
+    """
+
     default_context = bpy.app.translations.contexts.default
 
     if label is None:
@@ -283,10 +303,12 @@ def reload_menu():
     build_help_remap(original_categories)
 
 def register_node_add_operators():
+    """Register all our custom node adding operators"""
     for idname in node_add_operators:
         bpy.utils.register_class(node_add_operators[idname])
 
 def unregister_node_add_operators():
+    """Unregister all our custom node adding operators"""
     for idname in node_add_operators:
         bpy.utils.unregister_class(node_add_operators[idname])
 

--- a/menu.py
+++ b/menu.py
@@ -176,7 +176,7 @@ class SverchNodeItem(object):
 
     @staticmethod
     def draw(self, layout, context):
-        add = draw_add_node_operator(layout, self.nodetype, label=self._label, icon_name=self.get_icon())
+        add = draw_add_node_operator(layout, self.nodetype, label=self._label)
 
         for setting in self.settings.items():
             ops = add.settings.add()
@@ -198,19 +198,21 @@ def draw_add_node_operator(layout, nodetype, label=None, icon_name=None, params=
     """
 
     default_context = bpy.app.translations.contexts.default
+    node_rna = getattr(bpy.types, nodetype).bl_rna
 
     if label is None:
-        rna = getattr(bpy.types, nodetype).bl_rna
-        if hasattr(rna, 'bl_label'):
-            label = rna.bl_label
+        if hasattr(node_rna, 'bl_label'):
+            label = node_rna.bl_label
         else:
-            label = rna.name
+            label = node_rna.name
 
     if params is None:
         params = dict(text=label)
     params['text_ctxt'] = default_context
     if icon_name is not None:
         params.update(**icon(icon_name))
+    else:
+        params.update(**node_icon(node_rna))
 
     add = layout.operator("node.sv_add_" + get_node_idname_for_operator(nodetype), **params)
                             

--- a/menu.py
+++ b/menu.py
@@ -154,12 +154,13 @@ class SverchNodeItem(object):
             bl_label = "Add {} node".format(self.label)
             bl_options = {'REGISTER', 'UNDO'}
 
-            def execute(self, context):
-                if self.properties.is_property_set("type"):
-                    self.create_node(context)
-                    return {'FINISHED'}
-                else:
-                    return {'CANCELLED'}
+            def execute(operator, context):
+                # please not be confused: "operator" here references to
+                # SverchNodeAddOperator instance, and "self" references to
+                # SverchNodeItem instance.
+                operator.type = self.nodetype
+                operator.create_node(context)
+                return {'FINISHED'}
 
         SverchNodeAddOperator.__name__ = self.get_node_class().__name__
         SverchNodeAddOperator.__doc__ = self.get_node_class().__doc__

--- a/menu.py
+++ b/menu.py
@@ -29,6 +29,7 @@ import bl_operators
 import sverchok
 from sverchok.utils import get_node_class_reference
 from sverchok.utils.sv_help import build_help_remap
+from sverchok.ui.sv_icons import node_icon, icon
 
 
 class SverchNodeCategory(NodeCategory):
@@ -161,7 +162,7 @@ class SverchNodeItem(object):
 
     @staticmethod
     def draw(self, layout, context):
-        add = draw_add_node_operator(layout, self.nodetype, label=self._label, icon=self.get_icon())
+        add = draw_add_node_operator(layout, self.nodetype, label=self._label, icon_name=self.get_icon())
 
         for setting in self.settings.items():
             ops = add.settings.add()
@@ -175,7 +176,7 @@ def get_node_idname_for_operator(nodetype):
     else:
         return rna.name.lower()
 
-def draw_add_node_operator(layout, nodetype, label=None, icon=None, params=None):
+def draw_add_node_operator(layout, nodetype, label=None, icon_name=None, params=None):
     default_context = bpy.app.translations.contexts.default
 
     if label is None:
@@ -188,8 +189,8 @@ def draw_add_node_operator(layout, nodetype, label=None, icon=None, params=None)
     if params is None:
         params = dict(text=label)
     params['text_ctxt'] = default_context
-    if icon is not None:
-        params['icon'] = icon
+    if icon_name is not None:
+        params.update(**icon(icon_name))
 
     add = layout.operator("node.sv_add_" + get_node_idname_for_operator(nodetype), **params)
                             

--- a/node_tree.py
+++ b/node_tree.py
@@ -67,7 +67,7 @@ class SvDocstring(object):
     As a standard, RFC822-style syntax is to be used. The docstring should
     start with headers:
 
-            Brief: This should be very short (two or three words, not much more) to be used in Ctrl-Space search menu.
+            Triggers: This should be very short (two or three words, not much more) to be used in Ctrl-Space search menu.
             Tooltip: Longer description to be present as a tooltip in UI.
 
             More detailed description with technical information or historical notes goes after empty line.
@@ -76,9 +76,9 @@ class SvDocstring(object):
     Other headers can possibly be introduced later. Unknown headers are just ignored.
     For compatibility reasons, the old docstring syntax is also supported:
 
-            Brief description /// Longer description
+            Triggers description /// Longer description
 
-    If we can't parse Brief and Tooltip from docstring, then:
+    If we can't parse Triggers and Tooltip from docstring, then:
     * The whole docstring will be used as tooltip
     * The node will not have shorthand for search.
     """
@@ -136,8 +136,8 @@ class SvDocstring(object):
         find valid shorthand specification.
         """
 
-        if 'Brief' in self.message:
-            return self.message['Brief']
+        if 'Triggers' in self.message:
+            return self.message['Triggers']
         elif not self.docstring:
             return ""
         elif '///' in self.docstring:

--- a/nodes/generator/box.py
+++ b/nodes/generator/box.py
@@ -27,7 +27,7 @@ from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata
 
 class SvBoxNode(bpy.types.Node, SverchCustomTreeNode):
     """
-    Brief: Box
+    Triggers: Box
     Tooltip: Generate a Box primitive.
     """
 

--- a/nodes/generator/box.py
+++ b/nodes/generator/box.py
@@ -26,7 +26,11 @@ from sverchok.data_structure import updateNode
 from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata
 
 class SvBoxNode(bpy.types.Node, SverchCustomTreeNode):
-    ''' Box '''
+    """
+    Brief: Box
+    Tooltip: Generate a Box primitive.
+    """
+
     bl_idname = 'SvBoxNode'
     bl_label = 'Box'
     bl_icon = 'MESH_CUBE'
@@ -143,3 +147,4 @@ def register():
 
 def unregister():
     bpy.utils.unregister_class(SvBoxNode)
+

--- a/nodes/viz/viewer_mk2.py
+++ b/nodes/viz/viewer_mk2.py
@@ -161,7 +161,12 @@ class SvObjBakeMK2(bpy.types.Operator):
 
 
 class ViewerNode2(bpy.types.Node, SverchCustomTreeNode):
-    ''' vd View Geometry /// ViewerNode2 '''
+    """
+    Triggers: vd View Geometry
+    Tooltip: Viewer Node (Mk2) to view geometry and matrices
+     in the viewport
+    """
+
     bl_idname = 'ViewerNode2'
     bl_label = 'Viewer Draw'
     bl_icon = 'RETOPO'

--- a/ui/nodeview_space_menu.py
+++ b/ui/nodeview_space_menu.py
@@ -26,51 +26,16 @@ but massively condensed for sanity.
 
 import bpy
 
-import sverchok
 from sverchok.menu import make_node_cats, draw_add_node_operator
 from sverchok.utils import get_node_class_reference
-from sverchok.ui.sv_icons import custom_icon
+from sverchok.ui.sv_icons import node_icon, icon, get_icon_switch
 # from nodeitems_utils import _node_categories
 
 sv_tree_types = {'SverchCustomTreeType', 'SverchGroupTreeType'}
 node_cats = make_node_cats()
-addon_name = sverchok.__name__
-menu_prefs = {}
+#menu_prefs = {}
 
 # _items_to_remove = {}
-
-def get_icon_switch():
-    addon = bpy.context.user_preferences.addons.get(addon_name)
-
-    if addon and hasattr(addon, "preferences"):
-        return addon.preferences.show_icons
-
-
-def icon(display_icon):
-    '''returns empty dict if show_icons is False, else the icon passed'''
-    kws = {}
-    if menu_prefs.get('show_icons'):
-        if display_icon.startswith('SV_'):
-            kws = {'icon_value': custom_icon(display_icon)}
-        else: 
-            kws = {'icon': display_icon}
-    return kws
-
-
-def node_icon(node_ref):
-    '''returns empty dict if show_icons is False, else the icon passed'''
-    if not menu_prefs.get('show_icons'):
-        return {}
-    else:
-        if hasattr(node_ref, 'sv_icon'):
-            iconID = custom_icon(node_ref.sv_icon)
-            return {'icon_value': iconID} if iconID else {}
-        elif hasattr(node_ref, 'bl_icon') and node_ref.bl_icon != 'OUTLINER_OB_EMPTY':
-            iconID = node_ref.bl_icon
-            return {'icon': iconID} if iconID else {}
-        else:
-            return {}
-
 
 def layout_draw_categories(layout, node_details):
 
@@ -118,7 +83,7 @@ class NODEVIEW_MT_Dynamic_Menu(bpy.types.Menu):
     def poll(cls, context):
         tree_type = context.space_data.tree_type
         if tree_type in sv_tree_types:
-            menu_prefs['show_icons'] = get_icon_switch()
+            #menu_prefs['show_icons'] = get_icon_switch()
             # print('showing', menu_prefs['show_icons'])
             return True
 

--- a/ui/nodeview_space_menu.py
+++ b/ui/nodeview_space_menu.py
@@ -27,7 +27,7 @@ but massively condensed for sanity.
 import bpy
 
 import sverchok
-from sverchok.menu import make_node_cats
+from sverchok.menu import make_node_cats, draw_add_node_operator
 from sverchok.utils import get_node_class_reference
 from sverchok.ui.sv_icons import custom_icon
 # from nodeitems_utils import _node_categories
@@ -74,7 +74,6 @@ def node_icon(node_ref):
 
 def layout_draw_categories(layout, node_details):
 
-    add_n_grab = 'node.add_node'
     for node_info in node_details:
 
         if node_info[0] == 'separator':
@@ -95,10 +94,7 @@ def layout_draw_categories(layout, node_details):
         else:
             continue
 
-        node_op = layout.operator(add_n_grab, **layout_params)
-        node_op.type = bl_idname
-        node_op.use_transform = True
-
+        node_op = draw_add_node_operator(layout, bl_idname, params=layout_params)
 
 # does not get registered
 class NodeViewMenuTemplate(bpy.types.Menu):

--- a/ui/sv_icons.py
+++ b/ui/sv_icons.py
@@ -58,7 +58,7 @@ def icon(display_icon):
     if get_icon_switch():
         if display_icon.startswith('SV_'):
             kws = {'icon_value': custom_icon(display_icon)}
-        else: 
+        elif display_icon != 'OUTLINER_OB_EMPTY':
             kws = {'icon': display_icon}
     return kws
 

--- a/ui/sv_icons.py
+++ b/ui/sv_icons.py
@@ -3,9 +3,11 @@ import os
 import glob
 import bpy.utils.previews
 
+import sverchok
+
 # custom icons dictionary
 _icon_collection = {}
-
+addon_name = sverchok.__name__
 
 def custom_icon(name):
     load_custom_icons()  # load in case they custom icons not already loaded
@@ -42,6 +44,38 @@ def remove_custom_icons():
         bpy.utils.previews.remove(custom_icons)
     _icon_collection.clear()
 
+def get_icon_switch():
+    """Return show_icons setting from addon preferences"""
+
+    addon = bpy.context.user_preferences.addons.get(addon_name)
+
+    if addon and hasattr(addon, "preferences"):
+        return addon.preferences.show_icons
+
+def icon(display_icon):
+    '''returns empty dict if show_icons is False, else the icon passed'''
+    kws = {}
+    if get_icon_switch():
+        if display_icon.startswith('SV_'):
+            kws = {'icon_value': custom_icon(display_icon)}
+        else: 
+            kws = {'icon': display_icon}
+    return kws
+
+
+def node_icon(node_ref):
+    '''returns empty dict if show_icons is False, else the icon passed'''
+    if not get_icon_switch():
+        return {}
+    else:
+        if hasattr(node_ref, 'sv_icon'):
+            iconID = custom_icon(node_ref.sv_icon)
+            return {'icon_value': iconID} if iconID else {}
+        elif hasattr(node_ref, 'bl_icon') and node_ref.bl_icon != 'OUTLINER_OB_EMPTY':
+            iconID = node_ref.bl_icon
+            return {'icon': iconID} if iconID else {}
+        else:
+            return {}
 
 def register():
     load_custom_icons()

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -63,7 +63,7 @@ def ensure_valid_show_string(item):
     # nodetype = getattr(bpy.types, item[0])
     nodetype = get_node_class_reference(item[0])
     loop_reverse[nodetype.bl_label] = item[0]
-    description = slice_docstring(nodetype.bl_rna.description).strip()
+    description = nodetype.bl_rna.get_shorthand()
     return nodetype.bl_label + ensure_short_description(description)
 
 def function_iterator(module_file):

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -23,6 +23,7 @@ import nodeitems_utils
 
 import sverchok
 from sverchok.menu import make_node_cats
+from sverchok.node_tree import SvDocstring
 from sverchok.utils import get_node_class_reference
 from sverchok.ui.sv_icons import custom_icon
 from sverchok.utils.sv_default_macros import macros, DefaultMacros
@@ -47,11 +48,7 @@ def format_macro_item(k, v):
     return '< ' + k.replace('_', ' ') + " | " + slice_docstring(v)
 
 def slice_docstring(desc):
-    if not desc:
-        return ''
-    if '///' in desc:
-        desc = desc.strip().split('///')[0]
-    return desc
+    return SvDocstring(desc).get_shorthand()
 
 def ensure_short_description(description):
     '''  the font is not fixed width, it makes litle sense to calculate chars '''
@@ -72,7 +69,7 @@ def ensure_valid_show_string(item):
 def function_iterator(module_file):
     for name in ddir(module_file):
         obj = getattr(module_file, name)
-        if callable(obj) and obj.__doc__ and '///' in obj.__doc__:
+        if callable(obj) and SvDocstring(obj.__doc__).has_shorthand():
             yield name, obj.__doc__
 
 def get_main_macro_module(fullpath):


### PR DESCRIPTION
I'm not sure if this is ready to merge yet, but at least we need to discuss, I think.

## What this adds is:

* Icons to node creation buttons in T panel
* Proper tooltips (from node docstrings) to buttons in T panel
* Proper tooltips for items in Shift-A menu.
* Possibility to create nodes from standard Blender's Space menu (obviously only in node editor context).

![screenshot_20171128_201320](https://user-images.githubusercontent.com/284644/33327147-9d2b9c64-d478-11e7-8205-8ae535f7f434.png)


## More technical description of changes:

* Special operator class is registered for each node class. This is done in menu.py.
* Icons for operators are taken from node's bl_icon property. All icon-handling methods are moved from menu.py to sverchok.ui.sv_icons. This is done to use exactly the same code both for menu and for T panel: these functions are called both from sverchok.menu and from sverchok.ui.nodeview_space_menu.
* A new, more regular syntax is introduced for node class docstrings. RFC-822 is to be used as a standard, at least for new nodes:

      class SvBoxNode(bpy.types.Node, SverchCustomTreeNode):
          """
          Triggers: Box
          Tooltip: Generate a Box primitive
  
          This is the long description in free form, it can include technical
          or historical remarks.
          """
  
          bl_idname = 'SvBoxNode'
          ...

* For now, only two headers are used: Triggers is a shorthand to be used in Ctrl-Space search menu, and Tooltip is used as a tooltip. Other headers probably will be added in the future. Unknown headers are just ignored. Standard Python's `email` module is used to parse docstrings, so we can be more or less sure that we correctly understand RFC-822 subtle moments (multiline headers, escaping and so on).
* Old `///` syntax for search shorthands is also supported for compatibility.
* To incapsulate docstring parsing logic, there is SvDocstring class in node_tree.py introduced.
* An instance of SvDocstring is associated with each node class and can be obtained with `node_class.get_docstring()`.
* New classmethods are introduced for SverchCustomTreeNode: `get_shorthand()` and `get_tooltip()`. In the default implementation, they parse node class docstring as described above. Author of specific node can override these methods if he needs to. These new methods are used by sv_extra_search.py, menu.py and nodeview_space_menu.py.
* Box node docstring is updated to be an example of what docstrings should look like.

What I'm not sure about is:

* [x] Should "enable icons" setting in preferences affect T panel also?
* [x] Will current code play nicely with reloads?
* [ ] Can we simplify current code, or make it more robust against upcoming blender API changes (if any)?