### PR TITLE
"Objects along edge" update

### DIFF
--- a/docs/nodes/modifier_change/objects_along_edge.rst
+++ b/docs/nodes/modifier_change/objects_along_edge.rst
@@ -1,16 +1,29 @@
 Duplicate along Edge
 ====================
 
-*destination after Beta: Modifier Change*
-
 Functionality
 -------------
 
-This node creates an array of copies of one (donor) mesh and aligns it along given recipient segment (edge). Count of objects in array can be specified by user or detected automatically, based on size of donor mesh and length of recipient edge. Donor mesh can be scaled automatically to fill all length of recipient edge.
+This node creates an array of copies of one (donor) mesh and aligns it along
+given recipient segment (edge). Count of objects in array can be specified by
+user or detected automatically, based on size of donor mesh and length of
+recipient edge. Donor mesh can be scaled automatically to fill all length of
+recipient edge.
 
 Donor objects are rotated so that specified axis of object is aligned to recipient edge.
 
-This node also can output transformation matrices, which should be applied to donor object to be aligned along recipient edge. By default, this node already applies that matrices to donor object; but you can turn this off, and apply matrices to donor object in another node, or apply them to different objects.
+It is in general not a trivial task to rotate a 3D object along a vector,
+because there are always 2 other axes of object and it is not clear where
+should they be directed to. So, this node supports 3 different algorithms of
+object rotation calculation. In many simple cases, all these algorithms will
+give exactly the same result. But in more complex setups, or in some corner
+cases, results can be very different. So, just try all algorithms and see which
+one fits you better.
+
+This node also can output transformation matrices, which should be applied to
+donor object to be aligned along recipient edge. By default, this node already
+applies that matrices to donor object; but you can turn this off, and apply
+matrices to donor object in another node, or apply them to different objects.
 
 Inputs
 ------
@@ -50,6 +63,20 @@ This node has the following parameters:
 | **Orientation**  | X or Y or Z    | X           | Which axis of donor object should be aligned to direction of the |
 |                  |                |             | recipient edge.                                                  |
 +------------------+----------------+-------------+------------------------------------------------------------------+
+| **Algorithm**    | Householder    | Householder | * Householder: calculate rotation by using Householder's         |
+|                  |                |             |   reflection matrix (see Wikipedia_ article).                    |
+|                  | or Tracking    |             | * Tracking: use the same algorithm as in Blender's "TrackTo"     |
+|                  |                |             |   kinematic constraint. This algorithm gives you a bit more      |
+|                  |                |             |   flexibility comparing to other, by allowing to select the Up   |
+|                  |                |             |   axis.                                                          |
+|                  | or Rotation    |             | * Rotation difference: calculate rotation as rotation difference |
+|                  | Difference     |             |   between two vertices.                                          |
++------------------+----------------+-------------+------------------------------------------------------------------+
+| **Up axis**      | X or Y or Z    | Z           | Axis of donor object that should point up in result. This        |
+|                  |                |             | parameter is available only when Tracking algorithm is selected. |
+|                  |                |             | Value of this parameter must differ from **Orientation**         |
+|                  |                |             | parameter, otherwise you will get an error.                      |
++------------------+----------------+-------------+------------------------------------------------------------------+
 | **Input mode**   | Edges or Fixed | Edges       | * Edges: recipient edges will be determined as all edges from    |
 |                  |                |             |   the ``EdgesR`` input between vertices from ``VerticesR``       |
 |                  |                |             |   input.                                                         |
@@ -72,6 +99,8 @@ This node has the following parameters:
 |                  |                |             | from both sides. Default value of zero means fill whole length   |
 |                  |                |             | available. Maximum value 0.49 means use only central 1% of edge. |
 +------------------+----------------+-------------+------------------------------------------------------------------+
+
+.. _Wikipedia: https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 
 Outputs
 -------

--- a/docs/nodes/modifier_change/objects_along_edge.rst
+++ b/docs/nodes/modifier_change/objects_along_edge.rst
@@ -30,15 +30,23 @@ Inputs
 
 This node has the following inputs:
 
-- **Vertices**. Vertices of the donor mesh. The node will produce nothing if this input is not connected.
+- **Vertices**. Vertices of the donor mesh. The node will produce nothing if
+  this input is not connected.
 - **Edges**. Edges of the donor mesh.
 - **Polygons**. Faces of the donor mesh.
-- **Vertex1**. First vertex of recipient edge. This input is used only when "Fixed" input mode is used (see description of ``Input mode`` parameter below).
-- **Vertex2**. Second vertex of recipient edge. This input is used only when "Fixed" input mode is used.
-- **VerticesR**. Vertices of the recipient mesh. This input is used only when "Edges" input mode is used.
-- **EdgesR**. Edges of the recipient mesh. These edges will be actually used as recipient edges.  This input is used only when "Edges" input mode is used.
-- **Count**. Number of objects in array. This input is used only in "Count" scaling mode (see description of ``Scale mode`` parameter below).
-- **Padding**. Portion of the recipient edge length that should be left empty from both sides. Default value of zero means fill whole available length.
+- **Vertex1**. First vertex of recipient edge. This input is used only when
+  "Fixed" input mode is used (see description of ``Input mode`` parameter
+  below).
+- **Vertex2**. Second vertex of recipient edge. This input is used only when
+  "Fixed" input mode is used.
+- **VerticesR**. Vertices of the recipient mesh. This input is used only when
+  "Edges" input mode is used.
+- **EdgesR**. Edges of the recipient mesh. These edges will be actually used as
+  recipient edges.  This input is used only when "Edges" input mode is used.
+- **Count**. Number of objects in array. This input is used only in "Count"
+  scaling mode (see description of ``Scale mode`` parameter below).
+- **Padding**. Portion of the recipient edge length that should be left empty
+  from both sides. Default value of zero means fill whole available length.
 
 Parameters
 ----------
@@ -111,7 +119,9 @@ This node has the following outputs:
 - **Vertices**
 - **Edges**
 - **Polygons**
-- **Matrices**. Matrices that should be applied to created objects to align them along recipient edge. By default, this node already applies these matrices, so you do not need to do it second time.
+- **Matrices**. Matrices that should be applied to created objects to align
+  them along recipient edge. By default, this node already applies these
+  matrices, so you do not need to do it second time.
 
 This node will output something only when ``Vertices`` or ``Matrices`` output is connected.
 
@@ -120,11 +130,19 @@ Examples of usage
 
 Cylinders duplicated along the segment between two specified points:
 
-.. image:: https://cloud.githubusercontent.com/assets/284644/5741079/bcfcd4e2-9c2a-11e4-9f89-95ba59be8bd9.png
+.. image:: https://user-images.githubusercontent.com/284644/33512207-00a41ef2-d74d-11e7-9ce2-e8f21b6342c8.png
 
-Spheres duplicated along the edges of Box:
+Suzannes duplicated along the edges of Box:
 
-.. image:: https://cloud.githubusercontent.com/assets/284644/5741080/bd30e0ac-9c2a-11e4-95f3-aa075ef3d7eb.png
+.. image:: https://user-images.githubusercontent.com/284644/33512211-066ab80a-d74d-11e7-9907-3c2cf7c4894e.png
+
+Complex object duplicated along circle, with Householder algorithm:
+
+.. image:: https://user-images.githubusercontent.com/284644/33388133-e9a1c4b4-d550-11e7-9df2-e5c7899d6ca1.png
+
+The same setup, but with Tracking algorithm:
+
+.. image:: https://user-images.githubusercontent.com/284644/33388143-f1740dbe-d550-11e7-8d05-82cc8fa95934.png
 
 You can also find more examples and some discussion `in the development thread <https://github.com/portnov/sverchok/issues/6>`_.
 

--- a/docs/nodes/modifier_change/objects_along_edge.rst
+++ b/docs/nodes/modifier_change/objects_along_edge.rst
@@ -87,9 +87,10 @@ This node has the following parameters:
 | **Scale all      | Bool           | False       | If False, then donor object  will be scaled only along axis      |
 | axes**           |                |             | is aligned with recipient edge direction. If True, objects will  |
 |                  |                |             | be scaled along all axes (by the same factor).                   |
+|                  |                |             | This parameter is available only in the N panel.                 |
 +------------------+----------------+-------------+------------------------------------------------------------------+
 | **Apply          | Bool           | True        | Whether to apply calculated matrices to created objects.         |
-| matrces**        |                |             |                                                                  |
+| matrces**        |                |             | This parameter is available only in the N panel.                 |
 +------------------+----------------+-------------+------------------------------------------------------------------+
 | **Count**        | Int            | 3           | Number of objects in array. This parameter can be determined     |
 |                  |                |             | from the corresponding input. It is used only in "Count" scaling |

--- a/nodes/modifier_change/objects_along_edge.py
+++ b/nodes/modifier_change/objects_along_edge.py
@@ -274,6 +274,9 @@ class SvDuplicateAlongEdgeNode(bpy.types.Node, SverchCustomTreeNode):
         if self.algorithm == 'track':
             layout.prop(self, "up_axis")
         layout.prop(self, "input_mode", expand=True)
+
+    def draw_buttons_ext(self, context, layout):
+        self.draw_buttons(context, layout)
         if not self.scale_off:
             layout.prop(self, "scale_all")
         layout.prop(self, "apply_matrices")

--- a/nodes/modifier_change/objects_along_edge.py
+++ b/nodes/modifier_change/objects_along_edge.py
@@ -33,21 +33,20 @@ def householder(u):
     h = Matrix() - 2*m
     return h
 
-def autorotate(e1, xx):
+def autorotate_householder(e1, xx):
     ''' A matrix of transformation which will transform xx vector into e1. 
     See http://en.wikipedia.org/wiki/QR_decomposition '''
 
-    def get_sign():
-        for x in e1:
-            if x != 0.0:
-                return -copysign(1, x)
-        return 1
-
-    alpha = xx.length * get_sign()
+    sign = -1
+    alpha = xx.length * sign
     u = xx - alpha*e1
     v = u.normalized()
     q = householder(v)
     return q
+
+def autorotate_track(e1, xx, up):
+    rotation = xx.to_track_quat(e1, up)
+    return rotation.to_matrix().to_4x4()
 
 def diameter(vertices, axis):
     xs = [vertex[axis] for vertex in vertices]
@@ -107,6 +106,17 @@ class SvDuplicateAlongEdgeNode(bpy.types.Node, SverchCustomTreeNode):
         default = "count",
         items = count_modes, update=count_mode_change)
 
+    algorithms = [
+            ("householder", "Householder", "Use Householder reflection matrix", 1),
+            ("track", "Tracking", "Use quaternion-based tracking", 2),
+            ("diff", "Rotation difference", "Use rotational difference calculation", 3)
+        ]
+
+    algorithm = EnumProperty(name = "Algorithm",
+        description = "Rotation calculation algorithm",
+        default = "householder",
+        items = algorithms, update=updateNode)
+
     axes = [
             ("X", "X", "X axis", 1),
             ("Y", "Y", "Y axis", 2),
@@ -121,10 +131,18 @@ class SvDuplicateAlongEdgeNode(bpy.types.Node, SverchCustomTreeNode):
         default = "X",
         items = axes, update=orient_axis_change)
 
-    def get_axis_idx(self):
-        return 'XYZ'.index(self.orient_axis_)
+    up_axis = EnumProperty(name = "Up axis",
+        description = "Which axis of donor objects should look up",
+        default = 'Z',
+        items = axes, update=updateNode)
 
-    orient_axis = property(get_axis_idx)
+    def get_axis_idx(self, letter):
+        return 'XYZ'.index(letter)
+
+    def get_orient_axis_idx(self):
+        return self.get_axis_idx(self.orient_axis_)
+
+    orient_axis = property(get_orient_axis_idx)
 
     count_ = IntProperty(name='Count',
         description='Number of copies',
@@ -203,11 +221,23 @@ class SvDuplicateAlongEdgeNode(bpy.types.Node, SverchCustomTreeNode):
                 scale = Matrix.Scale(x_scale, 4)
             else:
                 scale = Matrix.Scale(x_scale, 4, x)
-        rot = autorotate(x, direction).inverted()
-        #rot = direction.rotation_difference(x).to_matrix().to_4x4()
 
-        # Since Householder transformation is reflection, we need to reflect things back
-        flip = Matrix([[-1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,1]])
+        need_flip = False
+        if self.algorithm == 'householder':
+            rot = autorotate_householder(x, direction).inverted()
+            # Since Householder transformation is reflection, we need to reflect things back
+            need_flip = True
+        elif self.algorithm == 'track':
+            rot = autorotate_track(self.orient_axis_, direction, self.up_axis)
+        elif self.algorithm == 'diff':
+            rot = direction.rotation_difference(x).to_matrix().to_4x4().inverted()
+        else:
+            raise Exception("Unsupported algorithm")
+
+        if need_flip:
+            flip = Matrix([[-1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,1]])
+        else:
+            flip = Matrix.Identity(4)
         if scale is None:
             matrices = [Matrix.Translation(o)*rot*flip for o in origins]
         else:
@@ -238,8 +268,11 @@ class SvDuplicateAlongEdgeNode(bpy.types.Node, SverchCustomTreeNode):
         self.input_mode_change(context)
   
     def draw_buttons(self, context, layout):
-        layout.prop(self, "count_mode", expand=True)
+        layout.prop(self, "count_mode")
         layout.prop(self, "orient_axis_", expand=True)
+        layout.prop(self, "algorithm")
+        if self.algorithm == 'track':
+            layout.prop(self, "up_axis")
         layout.prop(self, "input_mode", expand=True)
         if not self.scale_off:
             layout.prop(self, "scale_all")


### PR DESCRIPTION
* Simplify default algorithm a bit.
* Introduce 2 new algorithms of object rotation calculation. It is in general not a trivial task to rotate a 3D object along a vector, because there are always 2 other axes of object and it is not clear where should they be directed to. So, this node supports 3 different algorithms of object rotation calculation: Householder, Tracking and Rotation Difference. In many simple cases, all these algorithms will give exactly the same result. But in more complex setups, or in some corner cases, results can be very different. So, just try all algorithms and see which one fits you better.
* For Tracking algorithm, "Up axis" parameter is introduced.
* Clean up UI a bit.

Default algorithm is the Householder, which was the only algorithm previously available. So the changes are fully backwards compatible, the new code should work in old scenes exactly the same way.

I'm more or less sure in this code, but gonna wait a couple of days before merging, in case someone has some ideas about code or smth.