### PR TITLE
A bit better handling for SvNoDataError

### DIFF
--- a/core/socket_data.py
+++ b/core/socket_data.py
@@ -103,12 +103,36 @@ def SvGetSocket(socket, deepcopy=True):
         else:
             if data_structure.DEBUG_MODE:
                 print("cache miss:", socket.node.name, "->", socket.name, "from:", other.node.name, "->", other.name)
-            raise SvNoDataError
+            raise SvNoDataError(socket)
     # not linked
-    raise SvNoDataError
+    raise SvNoDataError(socket)
 
 class SvNoDataError(LookupError):
-    pass
+    def __init__(self, socket=None, node=None):
+        if node is None and socket is not None:
+            node = socket.node
+        self.node = node
+        self.socket = socket
+
+        super(LookupError, self).__init__(self.get_message())
+
+    def get_message(self):
+        if not self.node and not self.socket:
+            return "SvNoDataError"
+        else:
+            return "No data passed into socket `{}'".format(self.socket.name)
+    
+    def __repr__(self):
+        return self.get_message()
+    
+    def __str__(self):
+        return repr(self)
+
+    def __unicode__(self):
+        return repr(self)
+    
+    def __format__(self, spec):
+        return repr(self)
 
 def reset_socket_cache(ng):
     """

--- a/core/update_system.py
+++ b/core/update_system.py
@@ -334,7 +334,7 @@ def do_update_general(node_list, nodes, procesed_nodes=set()):
             ng = nodes.id_data
             update_error_nodes(ng, node_name, err)
             traceback.print_tb(err.__traceback__)
-            print("Node {0} had exception {1}".format(node_name, err))
+            print("Node {0} had exception: {1}".format(node_name, err))
             return None
     graphs.append(graph)
     if data_structure.DEBUG_MODE:

--- a/node_tree.py
+++ b/node_tree.py
@@ -140,7 +140,7 @@ class MatrixSocket(NodeSocket, SvSocketCommon):
 
             return SvGetSocket(self, deepcopy)
         elif default is sentinel:
-            raise SvNoDataError
+            raise SvNoDataError(self)
         else:
             return default
 
@@ -191,7 +191,7 @@ class VerticesSocket(NodeSocket, SvSocketCommon):
         elif self.use_prop:
             return [[self.prop[:]]]
         elif default is sentinel:
-            raise SvNoDataError
+            raise SvNoDataError(self)
         else:
             return default
 
@@ -275,7 +275,7 @@ class StringsSocket(NodeSocket, SvSocketCommon):
         elif default is not sentinel:
             return default
         else:
-            raise SvNoDataError
+            raise SvNoDataError(self)
 
     def draw(self, context, layout, node, text):
 

--- a/sockets.py
+++ b/sockets.py
@@ -96,10 +96,10 @@ class SvObjectSocket(NodeSocket, SvSocketCommon):
         elif self.object_ref:
             obj_ref = bpy.data.objects.get(self.object_ref)
             if not obj_ref:
-                raise SvNoDataError
+                raise SvNoDataError(self)
             return [obj_ref]
         elif default is sentinel:
-            raise SvNoDataError
+            raise SvNoDataError(self)
         else:
             return default
 
@@ -124,7 +124,7 @@ class SvTextSocket(NodeSocket, SvSocketCommon):
         elif self.text:
             return [self.text]
         elif default is sentinel:
-            raise SvNoDataError
+            raise SvNoDataError(self)
         else:
             return default
 


### PR DESCRIPTION
At least print name of missed socket.

Was:

      File "/home/portnov/.config/blender/2.79/scripts/addons/sverchok-master/core/update_system.py", line 322, in do_update_general
        node.process()
      File "/home/portnov/.config/blender/2.79/scripts/addons/sverchok-master/nodes/transforms/apply.py", line 43, in process
        mats_ = self.inputs['Matrixes'].sv_get(deepcopy=False)
      File "/home/portnov/.config/blender/2.79/scripts/addons/sverchok-master/node_tree.py", line 143, in sv_get
        raise SvNoDataError
    Node Matrix Apply (verts) had exception

now:

      File "/home/portnov/.config/blender/2.79/scripts/addons/sverchok-master/core/update_system.py", line 322, in do_update_general
        node.process()
      File "/home/portnov/.config/blender/2.79/scripts/addons/sverchok-master/nodes/transforms/apply.py", line 43, in process
        mats_ = self.inputs['Matrixes'].sv_get(deepcopy=False)
      File "/home/portnov/.config/blender/2.79/scripts/addons/sverchok-master/node_tree.py", line 143, in sv_get
        raise SvNoDataError(self)
    Node Matrix Apply (verts) had exception: No data passed into socket `Matrixes'