### PR TITLE
Spline interpolation refactoring

### DIFF
--- a/nodes/vector/interpolation_mk3.py
+++ b/nodes/vector/interpolation_mk3.py
@@ -28,116 +28,172 @@ from sverchok.data_structure import updateNode, dataCorrect, repeat_last
 # spline function modifed from
 # from looptools 4.5.2 done by Bart Crouch
 
+class Spline(object):
+    @classmethod
+    def create_knots(cls, pts, metric="DISTANCE"):
+        if metric == "DISTANCE":
+            tmp = np.linalg.norm(pts[:-1] - pts[1:], axis=1)
+            tknots = np.insert(tmp, 0, 0).cumsum()
+            tknots = tknots / tknots[-1]
+        elif metric == "MANHATTAN":
+            tmp = np.sum(np.absolute(pts[:-1] - pts[1:]), 1)
+            tknots = np.insert(tmp, 0, 0).cumsum()
+            tknots = tknots / tknots[-1]
+        elif metric == "POINTS":
+            tknots = np.linspace(0, 1, len(pts))
+        elif metric == "CHEBYSHEV":
+            tknots = np.max(np.absolute(pts[1:] - pts[:-1]), 1)
+            tmp = np.insert(tmp, 0, 0).cumsum()
+            tknots = tknots / tknots[-1]
 
-# calculates natural cubic splines through all given knots
-def cubic_spline(locs, tknots):
-    """    locs is and np.array with shape (n,3) and tknots has shape (n-1,)
-    creates a cubic spline thorugh the locations given in locs
-
-    """
-    n = len(locs)
-    if n < 2:
-        return False
-
-    # a = locs
-    h = tknots[1:] - tknots[:-1]
-    h[h == 0] = 1e-8
-    q = np.zeros((n - 1, 3))
-    q[1:] = 3 / h[1:, np.newaxis] * (locs[2:] - locs[1:-1]) - 3 / \
-        h[:-1, np.newaxis] * (locs[1:-1] - locs[:-2])
-
-    l = np.zeros((n, 3))
-    l[0, :] = 1.0
-    u = np.zeros((n - 1, 3))
-    z = np.zeros((n, 3))
-
-    for i in range(1, n - 1):
-        l[i] = 2 * (tknots[i + 1] - tknots[i - 1]) - h[i - 1] * u[i - 1]
-        l[i, l[i] == 0] = 1e-8
-        u[i] = h[i] / l[i]
-        z[i] = (q[i] - h[i - 1] * z[i - 1]) / l[i]
-    l[-1, :] = 1.0
-    z[-1] = 0.0
-
-    b = np.zeros((n - 1, 3))
-    c = np.zeros((n, 3))
-
-    for i in range(n - 2, -1, -1):
-        c[i] = z[i] - u[i] * c[i + 1]
-    b = (locs[1:] - locs[:-1]) / h[:, np.newaxis] - h[:, np.newaxis] * (c[1:] + 2 * c[:-1]) / 3
-    d = (c[1:] - c[:-1]) / (3 * h[:, np.newaxis])
-
-    splines = np.zeros((n - 1, 5, 3))
-    splines[:, 0] = locs[:-1]
-    splines[:, 1] = b
-    splines[:, 2] = c[:-1]
-    splines[:, 3] = d
-    splines[:, 4] = tknots[:-1, np.newaxis]
-    return splines
+        return tknots
 
 
-def eval_spline(splines, tknots, t_in):
-    """
-    Evaluate the spline at the points in t_in, which must be an array
-    with values in [0,1]
-    returns and np array with the corresponding points
-    """
-    index = tknots.searchsorted(t_in, side='left') - 1
-    index = index.clip(0, len(splines) - 1)
-    to_calc = splines[index]
-    ax, bx, cx, dx, tx = np.swapaxes(to_calc, 0, 1)
-    t_r = t_in[:, np.newaxis] - tx
-    out = ax + t_r * (bx + t_r * (cx + t_r * dx))
-    return out
+class CubicSpline(Spline):
+    def __init__(self, vertices, tknots = None, metric = None, is_cyclic = False):
+        """    locs is and np.array with shape (n,3) and tknots has shape (n-1,)
+        creates a cubic spline thorugh the locations given in locs
 
+        """
 
-def calc_spline_tanget(spline, tknots, t_in, h):
-    """
-    Calc numerical tangents for spline at t_in
-    """
-    t_ph = t_in + h
-    t_mh = t_in - h
-    t_less_than_0 = t_mh < 0.0
-    t_great_than_1 = t_ph > 1.0
-    t_mh[t_less_than_0] += h
-    t_ph[t_great_than_1] -= h
-    tanget_ph = eval_spline(spline, tknots, t_ph)
-    tanget_mh = eval_spline(spline, tknots, t_mh)
-    tanget = tanget_ph - tanget_mh
-    tanget[t_less_than_0 | t_great_than_1] *= 2
-    return tanget
+        if is_cyclic:
 
+            locs = np.array(vertices[-4:] + vertices + vertices[:4])
+            if tknots is None:
+                if metric is None:
+                    raise Exception("CubicSpline: either tknots or metric must be specified")
+                tknots = Spline.create_knots(locs, metric)
+                scale = 1 / (tknots[-4] - tknots[4])
+                base = tknots[4]
+                tknots -= base
+                tknots *= scale
+        else:
+            locs = np.array(vertices)
+            if tknots is None:
+                if metric is None:
+                    raise Exception("CubicSpline: either tknots or metric must be specified")
+                tknots = Spline.create_knots(locs, metric)
 
-def create_knots(pts, metric="DISTANCE"):
-    if metric == "DISTANCE":
-        tmp = np.linalg.norm(pts[:-1] - pts[1:], axis=1)
-        tknots = np.insert(tmp, 0, 0).cumsum()
-        tknots = tknots / tknots[-1]
-    elif metric == "MANHATTAN":
-        tmp = np.sum(np.absolute(pts[:-1] - pts[1:]), 1)
-        tknots = np.insert(tmp, 0, 0).cumsum()
-        tknots = tknots / tknots[-1]
-    elif metric == "POINTS":
-        tknots = np.linspace(0, 1, len(pts))
-    elif metric == "CHEBYSHEV":
-        tknots = np.max(np.absolute(pts[1:] - pts[:-1]), 1)
-        tmp = np.insert(tmp, 0, 0).cumsum()
-        tknots = tknots / tknots[-1]
+        self.tknots = tknots
+        self.is_cyclic = is_cyclic
 
-    return tknots
+        n = len(locs)
+        if n < 2:
+            return
 
+        # a = locs
+        h = tknots[1:] - tknots[:-1]
+        h[h == 0] = 1e-8
+        q = np.zeros((n - 1, 3))
+        q[1:] = 3 / h[1:, np.newaxis] * (locs[2:] - locs[1:-1]) - 3 / \
+            h[:-1, np.newaxis] * (locs[1:-1] - locs[:-2])
 
-def eval_linear_spline(pts, tknots, t_in):
-    """
-    Eval the liner spline f(t) = x,y,z through the points
-    in pts given the knots in tknots at the point in t_in
-    """
-    ptsT = pts.T
-    out = np.zeros((3, len(t_in)))
-    for i in range(3):
-        out[i] = np.interp(t_in, tknots, ptsT[i])
-    return out.T
+        l = np.zeros((n, 3))
+        l[0, :] = 1.0
+        u = np.zeros((n - 1, 3))
+        z = np.zeros((n, 3))
 
+        for i in range(1, n - 1):
+            l[i] = 2 * (tknots[i + 1] - tknots[i - 1]) - h[i - 1] * u[i - 1]
+            l[i, l[i] == 0] = 1e-8
+            u[i] = h[i] / l[i]
+            z[i] = (q[i] - h[i - 1] * z[i - 1]) / l[i]
+        l[-1, :] = 1.0
+        z[-1] = 0.0
+
+        b = np.zeros((n - 1, 3))
+        c = np.zeros((n, 3))
+
+        for i in range(n - 2, -1, -1):
+            c[i] = z[i] - u[i] * c[i + 1]
+        b = (locs[1:] - locs[:-1]) / h[:, np.newaxis] - h[:, np.newaxis] * (c[1:] + 2 * c[:-1]) / 3
+        d = (c[1:] - c[:-1]) / (3 * h[:, np.newaxis])
+
+        splines = np.zeros((n - 1, 5, 3))
+        splines[:, 0] = locs[:-1]
+        splines[:, 1] = b
+        splines[:, 2] = c[:-1]
+        splines[:, 3] = d
+        splines[:, 4] = tknots[:-1, np.newaxis]
+        
+        self.splines = splines
+
+    def eval(self, t_in, tknots = None):
+        """
+        Evaluate the spline at the points in t_in, which must be an array
+        with values in [0,1]
+        returns and np array with the corresponding points
+        """
+
+        if tknots is None:
+            tknots = self.tknots
+
+        index = tknots.searchsorted(t_in, side='left') - 1
+        index = index.clip(0, len(self.splines) - 1)
+        to_calc = self.splines[index]
+        ax, bx, cx, dx, tx = np.swapaxes(to_calc, 0, 1)
+        t_r = t_in[:, np.newaxis] - tx
+        out = ax + t_r * (bx + t_r * (cx + t_r * dx))
+        return out
+
+    def calc_tangent(self, t_in, h, tknots=None):
+        """
+        Calc numerical tangents for spline at t_in
+        """
+
+        if tknots is None:
+            tknots = self.tknots
+
+        t_ph = t_in + h
+        t_mh = t_in - h
+        t_less_than_0 = t_mh < 0.0
+        t_great_than_1 = t_ph > 1.0
+        t_mh[t_less_than_0] += h
+        t_ph[t_great_than_1] -= h
+        tanget_ph = self.eval(t_ph)
+        tanget_mh = self.eval(t_mh)
+        tanget = tanget_ph - tanget_mh
+        tanget[t_less_than_0 | t_great_than_1] *= 2
+        return tanget
+
+class LinearSpline(Spline):
+    def __init__(self, vertices, tknots = None, metric = None, is_cyclic = False):
+
+        if is_cyclic:
+            pts = np.array(vertices + [vertices[0]])
+        else:
+            pts = np.array(vertices)
+
+        if tknots is None:
+            if metric is None:
+                raise Exception("LinearSpline: either tknots or metric must be specified")
+            tknots = Spline.create_knots(pts, metric)
+
+        self.pts = pts
+        self.tknots = tknots
+        self.is_cyclic = is_cyclic
+
+    def eval(self, t_in, tknots = None):
+        """
+        Eval the liner spline f(t) = x,y,z through the points
+        in pts given the knots in tknots at the point in t_in
+        """
+
+        if tknots is None:
+            tknots = self.tknots
+            
+        ptsT = self.pts.T
+        out = np.zeros((3, len(t_in)))
+        for i in range(3):
+            out[i] = np.interp(t_in, tknots, ptsT[i])
+        return out.T
+
+    def calc_tangent(self, t_in, tknots = None):
+        if tknots is None:
+            tknots = self.tknots
+
+        lookup_segments = GenerateLookup(self.is_cyclic, self.pts.tolist())
+        return [lookup_segments.find_bucket(f) for f in t_in]
 
 class GenerateLookup():
 
@@ -259,40 +315,23 @@ class SvInterpolationNodeMK3(bpy.types.Node, SverchCustomTreeNode):
                 t_corr = np.array(t_in).clip(0, 1)
 
                 if self.mode == 'LIN':
-                    if self.is_cyclic:
-                        pts = np.array(v + [v[0]])
-                    else:
-                        pts = np.array(v)
-                    tknots = create_knots(pts, metric=self.knot_mode)
-                    out = eval_linear_spline(pts, tknots, t_corr)
+                    spline = LinearSpline(v, metric = self.knot_mode, is_cyclic = self.is_cyclic)
+                    out = spline.eval(t_corr)
                     verts_out.append(out.tolist())
 
                     if calc_tanget:
-                        lookup_segments = GenerateLookup(self.is_cyclic, v)
-                        tanget_out.append([lookup_segments.find_bucket(f) for f in t_corr])
+                        tanget_out.append(spline.calc_tangent(t_corr))
 
                 else:  # SPL
-                    if self.is_cyclic:
-
-                        pts = np.array(v[-4:] + v + v[:4])
-                        tknots = create_knots(pts, metric=self.knot_mode)
-                        scale = 1 / (tknots[-4] - tknots[4])
-                        base = tknots[4]
-                        tknots -= base
-                        tknots *= scale
-                    else:
-                        pts = np.array(v)
-                        tknots = create_knots(pts, metric=self.knot_mode)
-
-                    spl = cubic_spline(pts, tknots)
-                    out = eval_spline(spl, tknots, t_corr)
+                    spline = CubicSpline(v, metric = self.knot_mode, is_cyclic = self.is_cyclic)
+                    out = spline.eval(t_corr)
                     verts_out.append(out.tolist())
                     if calc_tanget:
-                        tanget = calc_spline_tanget(spl, tknots, t_corr, h)
+                        tangent = spline.calc_tangent(t_corr, h)
                         if norm_tanget:
-                            norm = np.linalg.norm(tanget, axis=1)
-                            norm_tanget_out.append((tanget / norm[:, np.newaxis]).tolist())
-                        tanget_out.append(tanget.tolist())
+                            norm = np.linalg.norm(tangent, axis=1)
+                            norm_tanget_out.append((tangent / norm[:, np.newaxis]).tolist())
+                        tanget_out.append(tangent.tolist())
 
             outputs = self.outputs
             if outputs['Vertices'].is_linked:

--- a/nodes/vector/interpolation_mk3.py
+++ b/nodes/vector/interpolation_mk3.py
@@ -17,235 +17,13 @@
 # ##### END GPL LICENSE BLOCK #####
 
 import numpy as np
-import math
 
 import bpy
 from bpy.props import EnumProperty, FloatProperty, BoolProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode, dataCorrect, repeat_last
-
-# spline function modifed from
-# from looptools 4.5.2 done by Bart Crouch
-
-class Spline(object):
-    @classmethod
-    def create_knots(cls, pts, metric="DISTANCE"):
-        if metric == "DISTANCE":
-            tmp = np.linalg.norm(pts[:-1] - pts[1:], axis=1)
-            tknots = np.insert(tmp, 0, 0).cumsum()
-            tknots = tknots / tknots[-1]
-        elif metric == "MANHATTAN":
-            tmp = np.sum(np.absolute(pts[:-1] - pts[1:]), 1)
-            tknots = np.insert(tmp, 0, 0).cumsum()
-            tknots = tknots / tknots[-1]
-        elif metric == "POINTS":
-            tknots = np.linspace(0, 1, len(pts))
-        elif metric == "CHEBYSHEV":
-            tknots = np.max(np.absolute(pts[1:] - pts[:-1]), 1)
-            tmp = np.insert(tmp, 0, 0).cumsum()
-            tknots = tknots / tknots[-1]
-
-        return tknots
-
-
-class CubicSpline(Spline):
-    def __init__(self, vertices, tknots = None, metric = None, is_cyclic = False):
-        """    locs is and np.array with shape (n,3) and tknots has shape (n-1,)
-        creates a cubic spline thorugh the locations given in locs
-
-        """
-
-        if is_cyclic:
-
-            locs = np.array(vertices[-4:] + vertices + vertices[:4])
-            if tknots is None:
-                if metric is None:
-                    raise Exception("CubicSpline: either tknots or metric must be specified")
-                tknots = Spline.create_knots(locs, metric)
-                scale = 1 / (tknots[-4] - tknots[4])
-                base = tknots[4]
-                tknots -= base
-                tknots *= scale
-        else:
-            locs = np.array(vertices)
-            if tknots is None:
-                if metric is None:
-                    raise Exception("CubicSpline: either tknots or metric must be specified")
-                tknots = Spline.create_knots(locs, metric)
-
-        self.tknots = tknots
-        self.is_cyclic = is_cyclic
-
-        n = len(locs)
-        if n < 2:
-            return
-
-        # a = locs
-        h = tknots[1:] - tknots[:-1]
-        h[h == 0] = 1e-8
-        q = np.zeros((n - 1, 3))
-        q[1:] = 3 / h[1:, np.newaxis] * (locs[2:] - locs[1:-1]) - 3 / \
-            h[:-1, np.newaxis] * (locs[1:-1] - locs[:-2])
-
-        l = np.zeros((n, 3))
-        l[0, :] = 1.0
-        u = np.zeros((n - 1, 3))
-        z = np.zeros((n, 3))
-
-        for i in range(1, n - 1):
-            l[i] = 2 * (tknots[i + 1] - tknots[i - 1]) - h[i - 1] * u[i - 1]
-            l[i, l[i] == 0] = 1e-8
-            u[i] = h[i] / l[i]
-            z[i] = (q[i] - h[i - 1] * z[i - 1]) / l[i]
-        l[-1, :] = 1.0
-        z[-1] = 0.0
-
-        b = np.zeros((n - 1, 3))
-        c = np.zeros((n, 3))
-
-        for i in range(n - 2, -1, -1):
-            c[i] = z[i] - u[i] * c[i + 1]
-        b = (locs[1:] - locs[:-1]) / h[:, np.newaxis] - h[:, np.newaxis] * (c[1:] + 2 * c[:-1]) / 3
-        d = (c[1:] - c[:-1]) / (3 * h[:, np.newaxis])
-
-        splines = np.zeros((n - 1, 5, 3))
-        splines[:, 0] = locs[:-1]
-        splines[:, 1] = b
-        splines[:, 2] = c[:-1]
-        splines[:, 3] = d
-        splines[:, 4] = tknots[:-1, np.newaxis]
-        
-        self.splines = splines
-
-    def eval(self, t_in, tknots = None):
-        """
-        Evaluate the spline at the points in t_in, which must be an array
-        with values in [0,1]
-        returns and np array with the corresponding points
-        """
-
-        if tknots is None:
-            tknots = self.tknots
-
-        index = tknots.searchsorted(t_in, side='left') - 1
-        index = index.clip(0, len(self.splines) - 1)
-        to_calc = self.splines[index]
-        ax, bx, cx, dx, tx = np.swapaxes(to_calc, 0, 1)
-        t_r = t_in[:, np.newaxis] - tx
-        out = ax + t_r * (bx + t_r * (cx + t_r * dx))
-        return out
-
-    def calc_tangent(self, t_in, h, tknots=None):
-        """
-        Calc numerical tangents for spline at t_in
-        """
-
-        if tknots is None:
-            tknots = self.tknots
-
-        t_ph = t_in + h
-        t_mh = t_in - h
-        t_less_than_0 = t_mh < 0.0
-        t_great_than_1 = t_ph > 1.0
-        t_mh[t_less_than_0] += h
-        t_ph[t_great_than_1] -= h
-        tanget_ph = self.eval(t_ph)
-        tanget_mh = self.eval(t_mh)
-        tanget = tanget_ph - tanget_mh
-        tanget[t_less_than_0 | t_great_than_1] *= 2
-        return tanget
-
-class LinearSpline(Spline):
-    def __init__(self, vertices, tknots = None, metric = None, is_cyclic = False):
-
-        if is_cyclic:
-            pts = np.array(vertices + [vertices[0]])
-        else:
-            pts = np.array(vertices)
-
-        if tknots is None:
-            if metric is None:
-                raise Exception("LinearSpline: either tknots or metric must be specified")
-            tknots = Spline.create_knots(pts, metric)
-
-        self.pts = pts
-        self.tknots = tknots
-        self.is_cyclic = is_cyclic
-
-    def eval(self, t_in, tknots = None):
-        """
-        Eval the liner spline f(t) = x,y,z through the points
-        in pts given the knots in tknots at the point in t_in
-        """
-
-        if tknots is None:
-            tknots = self.tknots
-            
-        ptsT = self.pts.T
-        out = np.zeros((3, len(t_in)))
-        for i in range(3):
-            out[i] = np.interp(t_in, tknots, ptsT[i])
-        return out.T
-
-    def calc_tangent(self, t_in, tknots = None):
-        if tknots is None:
-            tknots = self.tknots
-
-        lookup_segments = GenerateLookup(self.is_cyclic, self.pts.tolist())
-        return [lookup_segments.find_bucket(f) for f in t_in]
-
-class GenerateLookup():
-
-    def __init__(self, cyclic, vlist):
-        self.lookup = {}
-        self.summed_lengths = []
-        self.indiv_lengths = []
-        self.normals = []
-        self.buckets = []
-        if cyclic:
-            vlist = vlist + [vlist[0]]
-
-        self.get_seq_len(vlist)
-        self.acquire_lookup_table()
-        self.get_buckets()
-        # for idx, (k, v) in enumerate(sorted(self.lookup.items())):
-        #     print(k, v)
-
-    def find_bucket(self, factor):
-        for bucket_min, bucket_max in zip(self.buckets[:-1], self.buckets[1:]):
-            if bucket_min <= factor < bucket_max:
-                tval = self.lookup.get(bucket_min)  # , self.lookup.get(self.buckets[-1]))
-
-                return tval
-
-        # return last bucket just in case
-        return self.lookup.get(self.buckets[-1])
-
-    def get_buckets(self):
-        self.buckets = [(clen / self.total_length) for clen in self.summed_lengths]
-    
-    def acquire_lookup_table(self):
-        for current_length, segment_normal in zip(self.summed_lengths, self.normals):
-            self.lookup[current_length / self.total_length] = segment_normal
-        
-    def get_seq_len(self, vlist):
-        add_len = self.indiv_lengths.append
-        add_normal = self.normals.append
-        add_to_sumlist = self.summed_lengths.append
-        current_length = 0.0
-        for idx in range(len(vlist)-1):
-            v = vlist[idx][0]-vlist[idx+1][0], vlist[idx][1]-vlist[idx+1][1], vlist[idx][2]-vlist[idx+1][2]
-            length = math.sqrt((v[0]*v[0]) + (v[1]*v[1]) + (v[2]*v[2]))
-            add_normal(v)
-            add_len(length)
-            add_to_sumlist(current_length)
-            current_length += length
-
-        self.total_length = sum(self.indiv_lengths)
-            
-
-
+from sverchok.utils.geom import LinearSpline, CubicSpline
 
 class SvInterpolationNodeMK3(bpy.types.Node, SverchCustomTreeNode):
     '''Vector Interpolate'''
@@ -320,14 +98,14 @@ class SvInterpolationNodeMK3(bpy.types.Node, SverchCustomTreeNode):
                     verts_out.append(out.tolist())
 
                     if calc_tanget:
-                        tanget_out.append(spline.calc_tangent(t_corr))
+                        tanget_out.append(spline.tangent(t_corr))
 
                 else:  # SPL
                     spline = CubicSpline(v, metric = self.knot_mode, is_cyclic = self.is_cyclic)
                     out = spline.eval(t_corr)
                     verts_out.append(out.tolist())
                     if calc_tanget:
-                        tangent = spline.calc_tangent(t_corr, h)
+                        tangent = spline.tangent(t_corr, h)
                         if norm_tanget:
                             norm = np.linalg.norm(tangent, axis=1)
                             norm_tanget_out.append((tangent / norm[:, np.newaxis]).tolist())

--- a/nodes/vector/interpolation_mk3.py
+++ b/nodes/vector/interpolation_mk3.py
@@ -98,7 +98,7 @@ class SvInterpolationNodeMK3(bpy.types.Node, SverchCustomTreeNode):
                     verts_out.append(out.tolist())
 
                     if calc_tanget:
-                        tanget_out.append(spline.tangent(t_corr))
+                        tanget_out.append(spline.tangent(t_corr).tolist())
 
                 else:  # SPL
                     spline = CubicSpline(v, metric = self.knot_mode, is_cyclic = self.is_cyclic)

--- a/utils/geom.py
+++ b/utils/geom.py
@@ -622,7 +622,7 @@ class LinearSpline(Spline):
             tknots = self.tknots
 
         lookup_segments = GenerateLookup(self.is_cyclic, self.pts.tolist())
-        return [lookup_segments.find_bucket(f) for f in t_in]
+        return np.array([lookup_segments.find_bucket(f) for f in t_in])
 
 class GenerateLookup():
 

--- a/utils/geom.py
+++ b/utils/geom.py
@@ -434,30 +434,74 @@ rects = vectorize(rect)
 lines = vectorize(line)
 grids = vectorize(grid)
 
+################################################
+# Newer implementation of spline interpolation
+# by zeffii, ly29 and portnov
+# based on implementation from looptools 4.5.2 done by Bart Crouch
+# factored out from interpolation_mk3 node
+################################################
 
-# ---------- Spline
+class Spline(object):
+    """
+    Base abstract class for LinearSpline and CubicSpline.
+    """
+    @classmethod
+    def create_knots(cls, pts, metric="DISTANCE"):
+        if metric == "DISTANCE":
+            tmp = np.linalg.norm(pts[:-1] - pts[1:], axis=1)
+            tknots = np.insert(tmp, 0, 0).cumsum()
+            tknots = tknots / tknots[-1]
+        elif metric == "MANHATTAN":
+            tmp = np.sum(np.absolute(pts[:-1] - pts[1:]), 1)
+            tknots = np.insert(tmp, 0, 0).cumsum()
+            tknots = tknots / tknots[-1]
+        elif metric == "POINTS":
+            tknots = np.linspace(0, 1, len(pts))
+        elif metric == "CHEBYSHEV":
+            tknots = np.max(np.absolute(pts[1:] - pts[:-1]), 1)
+            tmp = np.insert(tmp, 0, 0).cumsum()
+            tknots = tknots / tknots[-1]
 
-# spline function modifed from
-# from looptools 4.5.2 done by Bart Crouch
+        return tknots
 
-
-# calculates natural cubic splines through all given knots
-
-class CubicSpline:
-    def __init__(self, locs, tknots=None, metric='DISTANCE'):
-        """    locs is and np.array with shape (n,3) and tknots has shape (n-1,)
-        creates a cubic spline thorugh the locations given in locs
-
+class CubicSpline(Spline):
+    def __init__(self, vertices, tknots = None, metric = None, is_cyclic = False):
         """
-        n = len(locs)
-        if n < 2:
-            return False
+        vertices: vertices in Sverchok's format (list of tuples)
+        tknots: np.array of shape (n-1,). If not provided - calculated automatically based on metric
+        metric: string, one of "DISTANCE", "MANHATTAN", "POINTS", "CHEBYSHEV". Mandatory if tknots
+                is not provided
+        is_cyclic: whether the spline is cyclic
 
-        if tknots is None:
-            tknots = create_knots(locs, metric)
+        creates a cubic spline thorugh the locations given in vertices
+        """
+
+        if is_cyclic:
+
+            locs = np.array(vertices[-4:] + vertices + vertices[:4])
+            if tknots is None:
+                if metric is None:
+                    raise Exception("CubicSpline: either tknots or metric must be specified")
+                tknots = Spline.create_knots(locs, metric)
+                scale = 1 / (tknots[-4] - tknots[4])
+                base = tknots[4]
+                tknots -= base
+                tknots *= scale
+        else:
+            locs = np.array(vertices)
+            if tknots is None:
+                if metric is None:
+                    raise Exception("CubicSpline: either tknots or metric must be specified")
+                tknots = Spline.create_knots(locs, metric)
 
         self.tknots = tknots
+        self.is_cyclic = is_cyclic
 
+        n = len(locs)
+        if n < 2:
+            return
+
+        # a = locs
         h = tknots[1:] - tknots[:-1]
         h[h == 0] = 1e-8
         q = np.zeros((n - 1, 3))
@@ -491,31 +535,35 @@ class CubicSpline:
         splines[:, 2] = c[:-1]
         splines[:, 3] = d
         splines[:, 4] = tknots[:-1, np.newaxis]
-
+        
         self.splines = splines
 
-
-    def eval(self, t_in):
+    def eval(self, t_in, tknots = None):
         """
         Evaluate the spline at the points in t_in, which must be an array
         with values in [0,1]
         returns and np array with the corresponding points
         """
-        splines = self.splines
-        tknots = self.tknots
+
+        if tknots is None:
+            tknots = self.tknots
+
         index = tknots.searchsorted(t_in, side='left') - 1
-        index = index.clip(0, len(splines) - 1)
-        to_calc = splines[index]
+        index = index.clip(0, len(self.splines) - 1)
+        to_calc = self.splines[index]
         ax, bx, cx, dx, tx = np.swapaxes(to_calc, 0, 1)
         t_r = t_in[:, np.newaxis] - tx
         out = ax + t_r * (bx + t_r * (cx + t_r * dx))
         return out
 
-
-    def tangent(self, t_in, h=0.001):
+    def tangent(self, t_in, h=0.001, tknots=None):
         """
         Calc numerical tangents for spline at t_in
         """
+
+        if tknots is None:
+            tknots = self.tknots
+
         t_ph = t_in + h
         t_mh = t_in - h
         t_less_than_0 = t_mh < 0.0
@@ -528,46 +576,103 @@ class CubicSpline:
         tanget[t_less_than_0 | t_great_than_1] *= 2
         return tanget
 
-def create_knots(pts, metric="DISTANCE"):
-    if metric == "DISTANCE":
-        tmp = np.linalg.norm(pts[:-1] - pts[1:], axis=1)
-        tknots = np.insert(tmp, 0, 0).cumsum()
-        tknots = tknots / tknots[-1]
-    elif metric == "MANHATTAN":
-        tmp = np.sum(np.absolute(pts[:-1] - pts[1:]), 1)
-        tknots = np.insert(tmp, 0, 0).cumsum()
-        tknots = tknots / tknots[-1]
-    elif metric == "POINTS":
-        tknots = np.linspace(0, 1, len(pts))
-    elif metric == "CHEBYSHEV":
-        tknots = np.max(np.absolute(pts[1:] - pts[:-1]), 1)
-        tmp = np.insert(tmp, 0, 0).cumsum()
-        tknots = tknots / tknots[-1]
+class LinearSpline(Spline):
+    def __init__(self, vertices, tknots = None, metric = None, is_cyclic = False):
+        """
+        vertices: vertices in Sverchok's format (list of tuples)
+        tknots: np.array of shape (n-1,). If not provided - calculated automatically based on metric
+        metric: string, one of "DISTANCE", "MANHATTAN", "POINTS", "CHEBYSHEV". Mandatory if tknots
+                is not provided
+        is_cyclic: whether the spline is cyclic
 
-    return tknots
+        creates a cubic spline thorugh the locations given in vertices
+        """
 
+        if is_cyclic:
+            pts = np.array(vertices + [vertices[0]])
+        else:
+            pts = np.array(vertices)
 
-class LinearSpline:
-    def __init__(self, pts, tknots=None, metric='DISTANCE'):
-        self.pts = np.array(pts).T
         if tknots is None:
-            tknots = create_knots(locs, metric)
+            if metric is None:
+                raise Exception("LinearSpline: either tknots or metric must be specified")
+            tknots = Spline.create_knots(pts, metric)
 
+        self.pts = pts
         self.tknots = tknots
+        self.is_cyclic = is_cyclic
 
-
-    def eval(self, t_in):
+    def eval(self, t_in, tknots = None):
         """
         Eval the liner spline f(t) = x,y,z through the points
         in pts given the knots in tknots at the point in t_in
         """
-        ptsT = self.pts
-        tknots = self.tknots
-        out = np.empty((3, len(t_in)))
+
+        if tknots is None:
+            tknots = self.tknots
+            
+        ptsT = self.pts.T
+        out = np.zeros((3, len(t_in)))
         for i in range(3):
             out[i] = np.interp(t_in, tknots, ptsT[i])
         return out.T
 
+    def tangent(self, t_in, tknots = None):
+        if tknots is None:
+            tknots = self.tknots
+
+        lookup_segments = GenerateLookup(self.is_cyclic, self.pts.tolist())
+        return [lookup_segments.find_bucket(f) for f in t_in]
+
+class GenerateLookup():
+
+    def __init__(self, cyclic, vlist):
+        self.lookup = {}
+        self.summed_lengths = []
+        self.indiv_lengths = []
+        self.normals = []
+        self.buckets = []
+        if cyclic:
+            vlist = vlist + [vlist[0]]
+
+        self.get_seq_len(vlist)
+        self.acquire_lookup_table()
+        self.get_buckets()
+        # for idx, (k, v) in enumerate(sorted(self.lookup.items())):
+        #     print(k, v)
+
+    def find_bucket(self, factor):
+        for bucket_min, bucket_max in zip(self.buckets[:-1], self.buckets[1:]):
+            if bucket_min <= factor < bucket_max:
+                tval = self.lookup.get(bucket_min)  # , self.lookup.get(self.buckets[-1]))
+
+                return tval
+
+        # return last bucket just in case
+        return self.lookup.get(self.buckets[-1])
+
+    def get_buckets(self):
+        self.buckets = [(clen / self.total_length) for clen in self.summed_lengths]
+    
+    def acquire_lookup_table(self):
+        for current_length, segment_normal in zip(self.summed_lengths, self.normals):
+            self.lookup[current_length / self.total_length] = segment_normal
+        
+    def get_seq_len(self, vlist):
+        add_len = self.indiv_lengths.append
+        add_normal = self.normals.append
+        add_to_sumlist = self.summed_lengths.append
+        current_length = 0.0
+        for idx in range(len(vlist)-1):
+            v = vlist[idx][0]-vlist[idx+1][0], vlist[idx][1]-vlist[idx+1][1], vlist[idx][2]-vlist[idx+1][2]
+            length = math.sqrt((v[0]*v[0]) + (v[1]*v[1]) + (v[2]*v[2]))
+            add_normal(v)
+            add_len(length)
+            add_to_sumlist(current_length)
+            current_length += length
+
+        self.total_length = sum(self.indiv_lengths)
+            
 
 def multiply_vectors(M, vlist):
     # (4*4 matrix)  X   (3*1 vector)

--- a/utils/sv_vector_utils.py
+++ b/utils/sv_vector_utils.py
@@ -18,11 +18,13 @@
 
 import bisect
 import numpy as np
+import math
 
 # spline function modifed from
 # from looptools 4.5.2 done by Bart Crouch
 
 
+# kept as it is used in older nodes
 # calculates natural cubic splines through all given knots
 def cubic_spline(locs, tknots):
     knots = list(range(len(locs)))
@@ -73,6 +75,7 @@ def cubic_spline(locs, tknots):
     return splines
 
 
+# kept as it is used in older nodes
 def eval_spline(splines, tknots, t_in):
     out = []
     for t in t_in:
@@ -89,7 +92,7 @@ def eval_spline(splines, tknots, t_in):
         out.append(pt)
     return out
 
-
+# not used currently
 def sv_interpolate(v, t_in, mode='SPL'):
     '''
     input
@@ -114,3 +117,4 @@ def sv_interpolate(v, t_in, mode='SPL'):
     else:  # SPL
         spl = cubic_spline(v, t)
         return eval_spline(spl, t, t_corr)
+


### PR DESCRIPTION
A story: I wanted to write some code that uses cubic spline interpolation similar to "Vector interpolation mk3", and... found out that we have 5 (five!) definitions of `cubic_spline` method in master. Which are all more or less copy-paste of

    # spline function modifed from
    # from looptools 4.5.2 done by Bart Crouch

(all implementations have this comment).

There is also yet another implementation, in form of two classes (more OOP-style) in geom.py by @ly29 , which is not used anywhere.

So when I started to write some new code, I was faced with an idea of writing 7th implementation... no way. So I couldn't stay from moving the implementation from "interpolation_mk3.py" (which seems to be the last) to geom.py, merging with ly29's code. So in this PR we have LinearSpline and CubicSpline classes, which are used in interpolation_mk3. I did not touch other copies for now.

Theoretically, end-user is not able to see any differences before and after this PR, as this is just a movement of the same code from one module to another.

@zeffii could you please review?