### PR TITLE
Introduce a proper logging facility

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -158,8 +158,17 @@ if reload_event:
 import bpy
 from sverchok.utils import ascii_print, auto_gather_node_classes, node_classes
 from sverchok.core import node_defaults
+from sverchok.ui.development import get_branch, get_hash
 
-
+def get_version_string():
+    version = ".".join(map(str, bl_info['version']))
+    branch = get_branch()
+    if branch:
+        version += ", branch " + branch
+        hash = get_hash()
+        if hash:
+            version += ", commit " + hash
+    return version
 
 def register():
     for m in imported_modules + node_list:
@@ -170,7 +179,7 @@ def register():
     # this is used to access preferences, should/could be hidden
     # in an interface
     data_structure.SVERCHOK_NAME = __name__
-    print("** version: ", bl_info['version']," **")
+    print("** version: ", get_version_string()," **")
     print("** Have a nice day with sverchok  **\n")
     ascii_print.logo()
     node_defaults.register_defaults()

--- a/__init__.py
+++ b/__init__.py
@@ -158,17 +158,7 @@ if reload_event:
 import bpy
 from sverchok.utils import ascii_print, auto_gather_node_classes, node_classes
 from sverchok.core import node_defaults
-from sverchok.ui.development import get_branch, get_hash
-
-def get_version_string():
-    version = ".".join(map(str, bl_info['version']))
-    branch = get_branch()
-    if branch:
-        version += ", branch " + branch
-        hash = get_hash()
-        if hash:
-            version += ", commit " + hash
-    return version
+from sverchok.ui.development import get_version_string
 
 def register():
     for m in imported_modules + node_list:

--- a/__init__.py
+++ b/__init__.py
@@ -88,6 +88,7 @@ utils_modules = [
     "voronoi", "sv_script", "sv_itertools", "script_importhelper", "sv_oldnodes_parser",
     "csg_core", "csg_geom", "geom", "sv_easing_functions",
     "snlite_utils", "snlite_importhelper", "context_managers",
+    "logging",
     # UI text editor ui
     "text_editor_submenu", "text_editor_plugins",
     # UI operators and tools

--- a/core/socket_data.py
+++ b/core/socket_data.py
@@ -17,6 +17,7 @@
 # ##### END GPL LICENSE BLOCK #####
 
 from sverchok import data_structure
+from sverchok.utils.logging import warning
 
 #####################################
 # socket data cache                 #
@@ -71,9 +72,9 @@ def SvSetSocket(socket, out):
     global socket_data_cache
     if data_structure.DEBUG_MODE:
         if not socket.is_output:
-            print("Warning, {} setting input socket: {}".format(socket.node.name, socket.name))
+            warning("{} setting input socket: {}".format(socket.node.name, socket.name))
         if not socket.is_linked:
-            print("Warning: {} setting unconncted socket: {}".format(socket.node.name, socket.name))
+            warning("{} setting unconncted socket: {}".format(socket.node.name, socket.name))
     s_id = socket.socket_id
     s_ng = socket.id_data.name
     if s_ng not in socket_data_cache:
@@ -102,7 +103,8 @@ def SvGetSocket(socket, deepcopy=True):
                 return out
         else:
             if data_structure.DEBUG_MODE:
-                print("cache miss:", socket.node.name, "->", socket.name, "from:", other.node.name, "->", other.name)
+                debug("cache miss: %s -> %s from: %s -> %s",
+                        socket.node.name, socket.name, other.node.name, other.name)
             raise SvNoDataError(socket)
     # not linked
     raise SvNoDataError(socket)

--- a/core/update_system.py
+++ b/core/update_system.py
@@ -24,7 +24,7 @@ from mathutils import Vector
 
 from sverchok import data_structure
 from sverchok.core.socket_data import SvNoDataError, reset_socket_cache
-from sverchok.utils.logging import getLogger
+from sverchok.utils.logging import debug, info, warning, error, exception
 import sverchok
 
 import traceback
@@ -83,7 +83,7 @@ def make_dep_dict(node_tree, down=False):
     for name, var_name in wifi_out_nodes:
         other = wifi_dict.get(var_name)
         if not other:
-            getLogger().warning("Unsatisifed Wifi dependency: node, %s var,%s", name, var_name)
+            warning("Unsatisifed Wifi dependency: node, %s var,%s", name, var_name)
             return collections.defaultdict(set)
         if down:
             deps[other].add(name)
@@ -131,7 +131,7 @@ def make_update_list(node_tree, node_set=None, dependencies=None):
                 node_dependencies = False
                 break
         if len(tree_stack) > node_count:
-            getLogger().error("Invalid node tree!")
+            error("Invalid node tree!")
             return []
         # if all dependencies are in out
         if node_dependencies:
@@ -198,7 +198,7 @@ def make_tree_from_nodes(node_names, tree, down=True):
     ng = tree
     nodes = ng.nodes
     if not node_names:
-        getLogger().warning("No nodes!")
+        warning("No nodes!")
         return make_update_list(ng)
 
     out_set = set(node_names)
@@ -263,7 +263,7 @@ def do_update_heat_map(node_list, nodes):
         cold = Vector(addon.preferences.heat_map_cold)
         hot = addon.preferences.heat_map_hot
     else:
-        getLogger().error("Cannot find preferences")
+        error("Cannot find preferences")
         cold = Vector((1, 1, 1))
         hot = (.8, 0, 0)
     for name, t in zip(node_list, times):
@@ -324,7 +324,7 @@ def do_update_general(node_list, nodes, procesed_nodes=set()):
             delta = time.perf_counter() - start
             total_time += delta
             if data_structure.DEBUG_MODE:
-                getLogger().debug("Processed  %s in: %.4f", node_name, delta)
+                debug("Processed  %s in: %.4f", node_name, delta)
             timings.append(delta)
             graph.append({"name" : node_name,
                            "bl_idname": node.bl_idname,
@@ -335,11 +335,11 @@ def do_update_general(node_list, nodes, procesed_nodes=set()):
             ng = nodes.id_data
             update_error_nodes(ng, node_name, err)
             #traceback.print_tb(err.__traceback__)
-            getLogger().exception("Node %s had exception: %s", node_name, err)
+            exception("Node %s had exception: %s", node_name, err)
             return None
     graphs.append(graph)
     if data_structure.DEBUG_MODE:
-        getLogger().debug("Node set updated in: %.4f seconds", total_time)
+        debug("Node set updated in: %.4f seconds", total_time)
     return timings
 
 

--- a/core/update_system.py
+++ b/core/update_system.py
@@ -24,7 +24,7 @@ from mathutils import Vector
 
 from sverchok import data_structure
 from sverchok.core.socket_data import SvNoDataError, reset_socket_cache
-from sverchok.utils import logging
+from sverchok.utils.logging import getLogger
 import sverchok
 
 import traceback
@@ -34,8 +34,6 @@ graphs = []
 
 no_data_color = (1, 0.3, 0)
 exception_color = (0.8, 0.0, 0)
-
-logger = logging.getLogger()
 
 def update_error_colors(self, context):
     global no_data_color
@@ -85,7 +83,7 @@ def make_dep_dict(node_tree, down=False):
     for name, var_name in wifi_out_nodes:
         other = wifi_dict.get(var_name)
         if not other:
-            logger.warning("Unsatisifed Wifi dependency: node, %s var,%s", name, var_name)
+            getLogger().warning("Unsatisifed Wifi dependency: node, %s var,%s", name, var_name)
             return collections.defaultdict(set)
         if down:
             deps[other].add(name)
@@ -133,7 +131,7 @@ def make_update_list(node_tree, node_set=None, dependencies=None):
                 node_dependencies = False
                 break
         if len(tree_stack) > node_count:
-            logger.error("Invalid node tree!")
+            getLogger().error("Invalid node tree!")
             return []
         # if all dependencies are in out
         if node_dependencies:
@@ -200,7 +198,7 @@ def make_tree_from_nodes(node_names, tree, down=True):
     ng = tree
     nodes = ng.nodes
     if not node_names:
-        logger.warning("No nodes!")
+        getLogger().warning("No nodes!")
         return make_update_list(ng)
 
     out_set = set(node_names)
@@ -265,7 +263,7 @@ def do_update_heat_map(node_list, nodes):
         cold = Vector(addon.preferences.heat_map_cold)
         hot = addon.preferences.heat_map_hot
     else:
-        logger.error("Cannot find preferences")
+        getLogger().error("Cannot find preferences")
         cold = Vector((1, 1, 1))
         hot = (.8, 0, 0)
     for name, t in zip(node_list, times):
@@ -326,7 +324,7 @@ def do_update_general(node_list, nodes, procesed_nodes=set()):
             delta = time.perf_counter() - start
             total_time += delta
             if data_structure.DEBUG_MODE:
-                logger.debug("Processed  %s in: %.4f", node_name, delta)
+                getLogger().debug("Processed  %s in: %.4f", node_name, delta)
             timings.append(delta)
             graph.append({"name" : node_name,
                            "bl_idname": node.bl_idname,
@@ -337,11 +335,11 @@ def do_update_general(node_list, nodes, procesed_nodes=set()):
             ng = nodes.id_data
             update_error_nodes(ng, node_name, err)
             #traceback.print_tb(err.__traceback__)
-            logger.exception("Node %s had exception: %s", node_name, err)
+            getLogger().exception("Node %s had exception: %s", node_name, err)
             return None
     graphs.append(graph)
     if data_structure.DEBUG_MODE:
-        logger.debug("Node set updated in: %.4f seconds", total_time)
+        getLogger().debug("Node set updated in: %.4f seconds", total_time)
     return timings
 
 

--- a/core/update_system.py
+++ b/core/update_system.py
@@ -24,6 +24,7 @@ from mathutils import Vector
 
 from sverchok import data_structure
 from sverchok.core.socket_data import SvNoDataError, reset_socket_cache
+from sverchok.utils import logging
 import sverchok
 
 import traceback
@@ -33,6 +34,8 @@ graphs = []
 
 no_data_color = (1, 0.3, 0)
 exception_color = (0.8, 0.0, 0)
+
+logger = logging.getLogger()
 
 def update_error_colors(self, context):
     global no_data_color
@@ -82,7 +85,7 @@ def make_dep_dict(node_tree, down=False):
     for name, var_name in wifi_out_nodes:
         other = wifi_dict.get(var_name)
         if not other:
-            print("Unsatisifed Wifi dependency: node, {0} var,{1}".format(name, var_name))
+            logger.warning("Unsatisifed Wifi dependency: node, %s var,%s", name, var_name)
             return collections.defaultdict(set)
         if down:
             deps[other].add(name)
@@ -130,7 +133,7 @@ def make_update_list(node_tree, node_set=None, dependencies=None):
                 node_dependencies = False
                 break
         if len(tree_stack) > node_count:
-            print("Invalid node tree!")
+            logger.error("Invalid node tree!")
             return []
         # if all dependencies are in out
         if node_dependencies:
@@ -197,7 +200,7 @@ def make_tree_from_nodes(node_names, tree, down=True):
     ng = tree
     nodes = ng.nodes
     if not node_names:
-        print("No nodes!")
+        logger.warning("No nodes!")
         return make_update_list(ng)
 
     out_set = set(node_names)
@@ -262,7 +265,7 @@ def do_update_heat_map(node_list, nodes):
         cold = Vector(addon.preferences.heat_map_cold)
         hot = addon.preferences.heat_map_hot
     else:
-        print("Cannot find preferences")
+        logger.error("Cannot find preferences")
         cold = Vector((1, 1, 1))
         hot = (.8, 0, 0)
     for name, t in zip(node_list, times):
@@ -323,7 +326,7 @@ def do_update_general(node_list, nodes, procesed_nodes=set()):
             delta = time.perf_counter() - start
             total_time += delta
             if data_structure.DEBUG_MODE:
-                print("Processed  {} in: {:.4f}".format(node_name, delta))
+                logger.debug("Processed  %s in: %.4f", node_name, delta)
             timings.append(delta)
             graph.append({"name" : node_name,
                            "bl_idname": node.bl_idname,
@@ -333,12 +336,12 @@ def do_update_general(node_list, nodes, procesed_nodes=set()):
         except Exception as err:
             ng = nodes.id_data
             update_error_nodes(ng, node_name, err)
-            traceback.print_tb(err.__traceback__)
-            print("Node {0} had exception: {1}".format(node_name, err))
+            #traceback.print_tb(err.__traceback__)
+            logger.exception("Node %s had exception: %s", node_name, err)
             return None
     graphs.append(graph)
     if data_structure.DEBUG_MODE:
-        print("Node set updated in: {:.4f} seconds".format(total_time))
+        logger.debug("Node set updated in: %.4f seconds", total_time)
     return timings
 
 

--- a/node_tree.py
+++ b/node_tree.py
@@ -546,20 +546,23 @@ class SverchCustomTreeNode:
         ng = self.id_data
         update_error_nodes(ng, self.name, err)
 
-    def get_logger(self):
+    def getLogger(self):
         return sverchok.utils.logging.getLogger(self.__class__.__name__)
 
     def debug(self, msg, *args, **kwargs):
-        self.get_logger().debug(msg, *args, **kwargs)
+        self.getLogger().debug(msg, *args, **kwargs)
 
     def info(self, msg, *args, **kwargs):
-        self.get_logger().info(msg, *args, **kwargs)
+        self.getLogger().info(msg, *args, **kwargs)
 
     def warning(self, msg, *args, **kwargs):
-        self.get_logger().warning(msg, *args, **kwargs)
+        self.getLogger().warning(msg, *args, **kwargs)
 
     def error(self, msg, *args, **kwargs):
-        self.get_logger().error(msg, *args, **kwargs)
+        self.getLogger().error(msg, *args, **kwargs)
+
+    def exception(self, msg, *args, **kwargs):
+        self.getLogger().exception(msg, *args, **kwargs)
 
     def set_color(self):
         color = color_def.get_color(self.bl_idname)

--- a/node_tree.py
+++ b/node_tree.py
@@ -55,6 +55,7 @@ from sverchok.core.socket_conversions import (
 from sverchok.core.node_defaults import set_defaults_if_defined
 
 from sverchok.ui import color_def
+import sverchok.utils.logging
 
 
 def process_from_socket(self, context):
@@ -544,6 +545,21 @@ class SverchCustomTreeNode:
         """
         ng = self.id_data
         update_error_nodes(ng, self.name, err)
+
+    def get_logger(self):
+        return sverchok.utils.logging.getLogger(self.__class__.__name__)
+
+    def debug(self, msg, *args, **kwargs):
+        self.get_logger().debug(msg, *args, **kwargs)
+
+    def info(self, msg, *args, **kwargs):
+        self.get_logger().info(msg, *args, **kwargs)
+
+    def warning(self, msg, *args, **kwargs):
+        self.get_logger().warning(msg, *args, **kwargs)
+
+    def error(self, msg, *args, **kwargs):
+        self.get_logger().error(msg, *args, **kwargs)
 
     def set_color(self):
         color = color_def.get_color(self.bl_idname)

--- a/node_tree.py
+++ b/node_tree.py
@@ -547,7 +547,15 @@ class SverchCustomTreeNode:
         update_error_nodes(ng, self.name, err)
 
     def getLogger(self):
-        return sverchok.utils.logging.getLogger(self.__class__.__name__)
+        if hasattr(self, "draw_label"):
+            name = self.draw_label()
+        else:
+            name = self.label
+        if not name:
+            name = self.bl_label
+        if not name:
+            name = self.__class__.__name__
+        return sverchok.utils.logging.getLogger(name)
 
     def debug(self, msg, *args, **kwargs):
         self.getLogger().debug(msg, *args, **kwargs)

--- a/nodes/generator/box.py
+++ b/nodes/generator/box.py
@@ -140,6 +140,8 @@ class SvBoxNode(bpy.types.Node, SverchCustomTreeNode):
         outputs['Edgs'].sv_set(out[1])
         outputs['Pols'].sv_set(out[2])
 
+        self.debug("hello from the box")
+
 
 def register():
     bpy.utils.register_class(SvBoxNode)

--- a/nodes/generators_extended/mesh_eval.py
+++ b/nodes/generators_extended/mesh_eval.py
@@ -85,9 +85,9 @@ def evaluate(json, variables):
             if isinstance(c, str):
                 try:
                     val = safe_eval(c, variables)
-                    #print("EVAL: {} with {} => {}".format(c, variables, val))
+                    #self.debug("EVAL: {} with {} => {}".format(c, variables, val))
                 except NameError as e:
-                    print(e)
+                    self.exception(e)
                     val = 0.0
             else:
                 val = c
@@ -144,7 +144,7 @@ class SvJsonFromMesh(bpy.types.Operator):
     def execute(self, context):
         node = bpy.data.node_groups[self.treename].nodes[self.nodename]
         if not bpy.context.selected_objects[0].type == 'MESH':
-            print("JSON from mesh: selected object is not mesh")
+            self.info("JSON from mesh: selected object is not mesh")
             self.report({'INFO'}, 'It is not a mesh selected')
             return
 
@@ -297,15 +297,15 @@ class SvMeshEvalNode(bpy.types.Node, SverchCustomTreeNode):
 
     def adjust_sockets(self):
         variables = self.get_variables()
-        #print("adjust_sockets:" + str(variables))
-        #print("inputs:" + str(self.inputs.keys()))
+        #self.debug("adjust_sockets:" + str(variables))
+        #self.debug("inputs:" + str(self.inputs.keys()))
         for key in self.inputs.keys():
             if key not in variables:
-                print("Input {} not in variables {}, remove it".format(key, str(variables)))
+                self.debug("Input {} not in variables {}, remove it".format(key, str(variables)))
                 self.inputs.remove(self.inputs[key])
         for v in variables:
             if v not in self.inputs:
-                print("Variable {} not in inputs {}, add it".format(v, str(self.inputs.keys())))
+                self.debug("Variable {} not in inputs {}, add it".format(v, str(self.inputs.keys())))
                 self.inputs.new('StringsSocket', v)
 
         groups = self.get_group_names()
@@ -313,11 +313,11 @@ class SvMeshEvalNode(bpy.types.Node, SverchCustomTreeNode):
             if key in ['Vertices', 'Edges', 'Faces']:
                 continue
             if key not in groups:
-                print("Output {} not in groups {}, remove it".format(key, str(groups)))
+                self.debug("Output {} not in groups {}, remove it".format(key, str(groups)))
                 self.outputs.remove(self.outputs[key])
         for name in sorted(groups):
             if name not in self.outputs:
-                print("Group {} not in outputs {}, add it".format(name, str(self.outputs.keys())))
+                self.debug("Group {} not in outputs {}, add it".format(name, str(self.outputs.keys())))
                 self.outputs.new('StringsSocket', name)
 
 
@@ -351,11 +351,11 @@ class SvMeshEvalNode(bpy.types.Node, SverchCustomTreeNode):
             else:
                 value = defaults.get(var, 1.0)
                 if isinstance(value, str):
-                    #print("Eval: {} = {}, {}".format(var, value, default_results))
+                    #self.debug("Eval: {} = {}, {}".format(var, value, default_results))
                     value = safe_eval(value, default_results)
                     default_results[var] = value
                 result[var] = [value]
-            #print("get_input: {} => {}".format(var, result[var]))
+            #self.debug("get_input: {} => {}".format(var, result[var]))
         return result
 
     def groups_to_masks(self, groups, size):
@@ -420,7 +420,7 @@ class SvMeshEvalNode(bpy.types.Node, SverchCustomTreeNode):
             text = bpy.data.texts[self.filename].as_string()
             storage['geom'] = text
         else:
-            print("Unknown filename: {}".format(self.filename))
+            self.warning("Unknown filename: {}".format(self.filename))
 
 
 def register():

--- a/nodes/text/debug_print.py
+++ b/nodes/text/debug_print.py
@@ -61,7 +61,7 @@ class SvDebugPrintNode(bpy.types.Node, SverchCustomTreeNode):
             return
         for i, socket in enumerate(self.inputs):
             if socket.is_linked and self.print_socket[i]:
-                print(socket.sv_get(deepcopy=False))
+                self.debug(socket.sv_get(deepcopy=False))
 
 def register():
     bpy.utils.register_class(SvDebugPrintNode)

--- a/nodes/text/debug_print.py
+++ b/nodes/text/debug_print.py
@@ -61,7 +61,7 @@ class SvDebugPrintNode(bpy.types.Node, SverchCustomTreeNode):
             return
         for i, socket in enumerate(self.inputs):
             if socket.is_linked and self.print_socket[i]:
-                self.debug(socket.sv_get(deepcopy=False))
+                self.info(socket.sv_get(deepcopy=False))
 
 def register():
     bpy.utils.register_class(SvDebugPrintNode)

--- a/nodes/viz/metaball_out.py
+++ b/nodes/viz/metaball_out.py
@@ -229,7 +229,7 @@ class SvMetaballOutNode(bpy.types.Node, SverchCustomTreeNode):
         metaball_object = self.find_metaball()
         if not metaball_object:
             metaball_object = self.create_metaball()
-            print("Created new metaball")
+            self.debug("Created new metaball")
 
         self.update_material()
 
@@ -267,12 +267,12 @@ class SvMetaballOutNode(bpy.types.Node, SverchCustomTreeNode):
             element.use_negative = bool(negate)
 
         if len(items) == len(metaball_object.data.elements):
-            #print('Updating existing metaball data')
+            #self.debug('Updating existing metaball data')
 
             for (item, element) in zip(items, metaball_object.data.elements):
                 setup_element(element, item)
         else:
-            #print('Recreating metaball data')
+            #self.debug('Recreating metaball data')
             metaball_object.data.elements.clear()
 
             for item in items:

--- a/settings.py
+++ b/settings.py
@@ -7,7 +7,7 @@ from bpy.props import BoolProperty, FloatVectorProperty, EnumProperty, IntProper
 from sverchok import data_structure
 from sverchok.core import handlers
 from sverchok.core import update_system
-from sverchok.utils import sv_panels_tools
+from sverchok.utils import sv_panels_tools, logging
 from sverchok.ui import color_def
 
 
@@ -157,6 +157,37 @@ class SverchokPreferences(AddonPreferences):
     external_editor = StringProperty(description='which external app to invoke to view sources')
     real_sverchok_path = StringProperty(description='use with symlinked to get correct src->dst')
 
+    # Logging settings
+
+    def update_log_level(self, context):
+        logging.info("Setting log level to %s", self.log_level)
+        logging.setLevel(self.log_level)
+    
+    log_levels = [
+            ("DEBUG", "Debug", "Debug output", 0),
+            ("INFO", "Information", "Informational output", 1),
+            ("WARNING", "Warnings", "Show only warnings and errors", 2),
+            ("ERROR", "Errors", "Show errors only", 3)
+        ]
+
+    log_level = EnumProperty(name = "Logging level",
+            description = "Minimum events severity level to output. All more severe messages will be logged as well.",
+            items = log_levels,
+            update = update_log_level,
+            default = "INFO")
+
+    log_to_buffer = BoolProperty(name = "Log to text buffer",
+            description = "Enable log output to internal Blender's text buffer",
+            default = True)
+    log_to_buffer_clean = BoolProperty(name = "Clear buffer at startup",
+            description = "Clear text buffer at each Blender startup",
+            default = False)
+    log_to_file = BoolProperty(name = "Log to file",
+            description = "Enable log output to external file",
+            default = False)
+
+    log_buffer_name = StringProperty(name = "Buffer name", default = "sverchok.log")
+    log_file_name = StringProperty(name = "File path", default = "sverchok.log")
 
     def draw(self, context):
 
@@ -184,6 +215,21 @@ class SverchokPreferences(AddonPreferences):
             col2box.label(text="Debug:")
             col2box.prop(self, "show_debug")
             col2box.prop(self, "heat_map")
+
+            log_box = col2.box()
+            log_box.label(text="Logging:")
+            log_box.prop(self, "log_level")
+
+            buff_row = log_box.row()
+            buff_row.prop(self, "log_to_buffer")
+            if self.log_to_buffer:
+                buff_row.prop(self, "log_buffer_name")
+                log_box.prop(self, "log_to_buffer_clean")
+
+            file_row = log_box.row()
+            file_row.prop(self, "log_to_file")
+            if self.log_to_file:
+                file_row.prop(self, "log_file_name")
 
         if self.selected_tab == "Node Defaults":
 

--- a/settings.py
+++ b/settings.py
@@ -187,7 +187,7 @@ class SverchokPreferences(AddonPreferences):
             default = False)
 
     log_buffer_name = StringProperty(name = "Buffer name", default = "sverchok.log")
-    log_file_name = StringProperty(name = "File path", default = "sverchok.log")
+    log_file_name = StringProperty(name = "File path", default = os.path.join(datafiles, "sverchok.log"))
 
     def draw(self, context):
 

--- a/ui/color_def.py
+++ b/ui/color_def.py
@@ -21,6 +21,7 @@ import bpy
 from bpy.props import StringProperty
 
 from sverchok.menu import make_node_cats
+from sverchok.utils.logging import getLogger
 import sverchok
 
 colors_cache = {}
@@ -70,7 +71,7 @@ def color_callback(self, context):
 def sv_colors_definition():
     addon_name = sverchok.__name__
     addon = bpy.context.user_preferences.addons.get(addon_name)
-    print("got addon")
+    getLogger().debug("got addon")
     if addon:
         prefs = addon.preferences
         sv_node_colors = {
@@ -101,7 +102,7 @@ def get_color(bl_id):
     Get color for bl_id
     """
     if not colors_cache:
-        print("building color cache")
+        getLogger().debug("building color cache")
         rebuild_color_cache()
     return colors_cache.get(bl_id)
 

--- a/ui/color_def.py
+++ b/ui/color_def.py
@@ -21,7 +21,7 @@ import bpy
 from bpy.props import StringProperty
 
 from sverchok.menu import make_node_cats
-from sverchok.utils.logging import getLogger
+from sverchok.utils.logging import debug
 import sverchok
 
 colors_cache = {}
@@ -71,7 +71,7 @@ def color_callback(self, context):
 def sv_colors_definition():
     addon_name = sverchok.__name__
     addon = bpy.context.user_preferences.addons.get(addon_name)
-    getLogger().debug("got addon")
+    debug("got addon")
     if addon:
         prefs = addon.preferences
         sv_node_colors = {
@@ -102,7 +102,7 @@ def get_color(bl_id):
     Get color for bl_id
     """
     if not colors_cache:
-        getLogger().debug("building color cache")
+        debug("building color cache")
         rebuild_color_cache()
     return colors_cache.get(bl_id)
 

--- a/ui/development.py
+++ b/ui/development.py
@@ -62,6 +62,20 @@ def get_branch():
     except:
         BRANCH = ""
 
+    return BRANCH
+
+def get_hash():
+    get_branch()
+    if BRANCH:
+        path = os.path.join(os.path.dirname(sverchok.__file__), '.git', 'refs', 'heads', BRANCH)
+        if os.path.exists(path):
+            with open(path) as hashfile:
+                return hashfile.readlines()[0].strip()[:8]
+        else:
+            return None
+    else:
+        return None
+
 def displaying_sverchok_nodes(context):
     return context.space_data.tree_type in {'SverchCustomTreeType', 'SverchGroupTreeType'}
 

--- a/ui/development.py
+++ b/ui/development.py
@@ -76,6 +76,16 @@ def get_hash():
     else:
         return None
 
+def get_version_string():
+    version = ".".join(map(str, sverchok.bl_info['version']))
+    branch = get_branch()
+    if branch:
+        version += ", branch " + branch
+        hash = get_hash()
+        if hash:
+            version += ", commit " + hash
+    return version
+
 def displaying_sverchok_nodes(context):
     return context.space_data.tree_type in {'SverchCustomTreeType', 'SverchGroupTreeType'}
 

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -1,0 +1,47 @@
+
+import bpy
+
+import logging
+
+from sverchok import bl_info
+
+log_buffer_name = "sverchok.log"
+log_format = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+
+internal_buffer_initialized = False
+initialized = False
+
+def get_log_buffer():
+    try:
+        if log_buffer_name in bpy.data.texts:
+            return bpy.data.texts[log_buffer_name]
+        else:
+            return bpy.data.texts.new(name=log_buffer_name)
+    except AttributeError as e:
+        raise Exception("Can't initialize logging to internal buffer: get_log_buffer is called too early: {}".format(e))
+
+def ensure_initialized():
+    global internal_buffer_initialized
+    global initialized
+
+    if not internal_buffer_initialized:
+        handler = logging.StreamHandler(get_log_buffer())
+        handler.setFormatter(logging.Formatter(log_format))
+        logging.getLogger().addHandler(handler)
+        internal_buffer_initialized = True
+
+    if not initialized:
+        logging.info("Initializing Sverchok logging. Blender version %s, Sverchok version %s", bpy.app.version_string, bl_info['version'])
+        initialized = True
+
+
+def getLogger(name=None):
+    ensure_initialized()
+    return logging.getLogger(name)
+
+def register():
+    logging.basicConfig(level=logging.DEBUG, format=log_format)
+
+def unregister():
+    logging.shutdown()
+

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -102,6 +102,7 @@ def setLevel(level):
 
 def register():
     logging.basicConfig(level=logging.DEBUG, format=log_format)
+    logging.captureWarnings(True)
 
 def unregister():
     logging.shutdown()

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -5,7 +5,7 @@ import inspect
 import logging
 import logging.handlers
 
-from sverchok import bl_info
+from sverchok.ui.development import get_version_string
 from sverchok.utils.context_managers import sv_preferences
 
 log_format = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
@@ -56,7 +56,7 @@ def ensure_initialized():
 
             setLevel(prefs.log_level)
 
-            logging.info("Initializing Sverchok logging. Blender version %s, Sverchok version %s", bpy.app.version_string, bl_info['version'])
+            logging.info("Initializing Sverchok logging. Blender version %s, Sverchok version %s", bpy.app.version_string, get_version_string())
             logging.debug("Current log level: %s, log to text buffer: %s, log to file: %s",
                     prefs.log_level,
                     ("no" if not prefs.log_to_buffer else prefs.log_buffer_name),

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -2,42 +2,81 @@
 import bpy
 
 import logging
+import logging.handlers
 
 from sverchok import bl_info
+from sverchok.utils.context_managers import sv_preferences
 
-log_buffer_name = "sverchok.log"
 log_format = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
 
 internal_buffer_initialized = False
 initialized = False
 
-def get_log_buffer():
+def get_log_buffer(log_buffer_name):
     try:
         if log_buffer_name in bpy.data.texts:
             return bpy.data.texts[log_buffer_name]
         else:
             return bpy.data.texts.new(name=log_buffer_name)
     except AttributeError as e:
-        raise Exception("Can't initialize logging to internal buffer: get_log_buffer is called too early: {}".format(e))
+        logging.debug("Can't initialize logging to internal buffer: get_log_buffer is called too early: {}".format(e))
+        return None
 
 def ensure_initialized():
     global internal_buffer_initialized
     global initialized
 
     if not internal_buffer_initialized:
-        handler = logging.StreamHandler(get_log_buffer())
-        handler.setFormatter(logging.Formatter(log_format))
-        logging.getLogger().addHandler(handler)
-        internal_buffer_initialized = True
+        with sv_preferences() as prefs:
+            if prefs.log_to_buffer:
+                buffer = get_log_buffer(prefs.log_buffer_name)
+                if buffer is not None:
+                    if prefs.log_to_buffer_clean:
+                        buffer.clear()
+                        logging.debug("Internal text buffer cleared")
+                    handler = logging.StreamHandler(buffer)
+                    handler.setFormatter(logging.Formatter(log_format))
+                    logging.getLogger().addHandler(handler)
+                    internal_buffer_initialized = True
+            else:
+                internal_buffer_initialized = True
 
     if not initialized:
+        with sv_preferences() as prefs:
+            if prefs.log_to_file:
+                handler = logging.handlers.RotatingFileHandler(prefs.log_file_name, 
+                            maxBytes = 10*1024*1024,
+                            backupCount = 3)
+                handler.setFormatter(logging.Formatter(log_format))
+                logging.getLogger().addHandler(handler)
+
+            setLevel(prefs.log_level)
+
         logging.info("Initializing Sverchok logging. Blender version %s, Sverchok version %s", bpy.app.version_string, bl_info['version'])
+        logging.debug("Current log level: %s, log to text buffer: %s, log to file: %s",
+                prefs.log_level,
+                ("no" if not prefs.log_to_buffer else prefs.log_buffer_name),
+                ("no" if not prefs.log_to_file else prefs.log_file_name) )
         initialized = True
 
+# Convinience functions
+
+debug = logging.debug
+info = logging.info
+warning = logging.warning
+error = logging.error
+exception = logging.exception
 
 def getLogger(name=None):
     ensure_initialized()
     return logging.getLogger(name)
+
+def setLevel(level):
+    if type(level) != int:
+        level = getattr(logging, level)
+
+    for handler in logging.getLogger().handlers:
+        handler.setLevel(level)
 
 def register():
     logging.basicConfig(level=logging.DEBUG, format=log_format)

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -65,11 +65,25 @@ def ensure_initialized():
 
 # Convinience functions
 
-debug = logging.debug
-info = logging.info
-warning = logging.warning
-error = logging.error
-exception = logging.exception
+def with_module_logger(method_name):
+    def wrapper(*args, **kwargs):
+        frame = inspect.stack()[1]
+        module = inspect.getmodule(frame[0])
+        name = module.__name__
+        ensure_initialized()
+        logger = logging.getLogger(name)
+        method = getattr(logger, method_name)
+        return method(*args, **kwargs)
+
+    wrapper.__name__ = method_name
+
+    return wrapper
+
+debug = with_module_logger("debug")
+info = with_module_logger("info")
+warning = with_module_logger("warning")
+error = with_module_logger("error")
+exception = with_module_logger("exception")
 
 def getLogger(name=None):
     if name is None:

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -1,6 +1,7 @@
 
 import bpy
 
+import inspect
 import logging
 import logging.handlers
 
@@ -71,11 +72,12 @@ error = logging.error
 exception = logging.exception
 
 def getLogger(name=None):
-    if name is not None:
-        ensure_initialized()
-        return logging.getLogger(name)
-    else:
-        return logging.getLogger()
+    if name is None:
+        frame = inspect.stack()[1]
+        module = inspect.getmodule(frame[0])
+        name = module.__name__
+    ensure_initialized()
+    return logging.getLogger(name)
 
 def setLevel(level):
     if type(level) != int:


### PR DESCRIPTION
I hope, this movement will enhance usability a lot. But, for now only core support of logging was implemented; it is to be supported across the whole codebase yet, see details below.

## For users

Sverchok is going to write all it's messages not only to console window, but also:
* to text buffer within Blender's scene (optional)
* to external file somewhere on disk (optional)

It is also possible to specify minimum severity level of messages that you want to see in the log.

![screenshot_20171207_230748](https://user-images.githubusercontent.com/284644/33731077-ccb0718a-dba3-11e7-9b35-724e910ad21c.png)

So, when/if this (and possibly following PRs) is merged, the recommendation for users to have console window opened while working with Sverchok is going to be replaced with recommendation to have blender's text editor frame opened, which is much friendlier I think.

## For developers

The facility is implemented by means of standard python's `logging` module. All glue code lies in `sverchok.utils.logging`. 

The implementation is more or less straightforward; exceptions are:

* Due to "interesting" order of importing and initializing different things (bpy objects, addon preferences, ...) in blender's python environment, it is not possible to do just `logger = logging.getLogger(__name__)` in the beginning of each module, as many practices say; this is going to lead to exceptions. We have to obtain a logger at each event. To simplify things, a "standard" method family `sverchok.utils.logging.debug`, `info`, `warning`, `error`, `exception` is introduced (these methods use caller module name as logger name by default):

      from sverchok.utils.logging import debug

      def something():
          ...
          debug("got addon")
          ...

* It is possible also to use  `logging.debug` and siblings if you do not want to bother with logger name, and just write to root logger.
* For base node class, a family of logging methods is provided. So within any node class, you can just replace `print(xxx)` with `self.debug(xxx)`.
* It appears to be not possible to initialize output to blender's text buffer during `register()`. So, it is registered at the first call of `sverchok.utils.logging.getLogger()`, i.e. basically at first logged event.
* Due to mentioned initialization order things, there going to be some problems if one wants to replace different prints that are done during initialization with logging calls. I think it is simpler to do not touch these initialization printouts for now.

## Example of log output

      2017-12-07 23:34:00,558 [INFO] root: Initializing Sverchok logging. Blender version 2.79 (sub 0), Sverchok version (0, 5, 9, 6)
      2017-12-07 23:34:00,558 [DEBUG] root: Current log level: DEBUG, log to text buffer: sverchok.log, log to file: sverchok.log
      2017-12-07 23:34:00,558 [DEBUG] SvBoxNode: hello from the box
      2017-12-07 23:34:09,571 [DEBUG] SvBoxNode: hello from the box
      2017-12-07 23:34:09,683 [ERROR] sverchok.core.update_system: Node Rotation had exception: No data passed into socket `Vertices'
      Traceback (most recent call last):
        File "/home/portnov/.config/blender/2.79/scripts/addons/sverchok-master/core/update_system.py", line 323, in do_update_general
          node.process()
        File "/home/portnov/.config/blender/2.79/scripts/addons/sverchok-master/nodes/transforms/rotation.py", line 139, in process
          Vertices = self.inputs['Vertices'].sv_get()
        File "/home/portnov/.config/blender/2.79/scripts/addons/sverchok-master/node_tree.py", line 297, in sv_get
          raise SvNoDataError(self)
      sverchok.core.socket_data.SvNoDataError: No data passed into socket `Vertices'

## What next

As I said in the beginning, this adds only core support of logging. We have a lot of `print`-s across the whole codebase. I do not think that it worth the effort to go and replace all of them right now. Instead, I'd propose to update some most used / most verbose parts of code now (either within this PR or in separate, to be discussed). All other code can be updated gradually: just when you are fixing a regular bug in some node, replace all prints in it, it is not going to take much time.

@nortikin @zeffii @DolphinDream  please review and test.