### PR TITLE
Mesh eval node was trying to create unsupported node.

### DIFF
--- a/nodes/generators_extended/mesh_eval.py
+++ b/nodes/generators_extended/mesh_eval.py
@@ -104,7 +104,7 @@ def selected_masks_adding(node):
     links = tree.links
 
     mo = tree.nodes.new('MaskListNode')
-    mv = tree.nodes.new('VectorMoveNode')
+    mv = tree.nodes.new('SvMoveNodeMK2')
     rf = tree.nodes.new('SvGenFloatRange')
     vi = tree.nodes.new('GenVectorsNode')
     mi = tree.nodes.new('SvMaskJoinNode')


### PR DESCRIPTION
@nortikin It looks like you recreated some transformation nodes, but forgot to replace references to old ones everywhere :/

Also I'm going to make generation of additional nodes on creation of mesh_eval optional, but that will be another PR.