### PR TITLE
Profiling facility

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -88,7 +88,7 @@ utils_modules = [
     "voronoi", "sv_script", "sv_itertools", "script_importhelper", "sv_oldnodes_parser",
     "csg_core", "csg_geom", "geom", "sv_easing_functions",
     "snlite_utils", "snlite_importhelper", "context_managers",
-    "logging",
+    "profile", "logging", 
     # UI text editor ui
     "text_editor_submenu", "text_editor_plugins",
     # UI operators and tools

--- a/core/update_system.py
+++ b/core/update_system.py
@@ -25,6 +25,7 @@ from mathutils import Vector
 from sverchok import data_structure
 from sverchok.core.socket_data import SvNoDataError, reset_socket_cache
 from sverchok.utils.logging import debug, info, warning, error, exception
+from sverchok.utils.profile import profile
 import sverchok
 
 import traceback
@@ -303,6 +304,7 @@ def reset_error_nodes(ng):
         del ng["error nodes"]
 
 
+@profile(section="UPDATE")
 def do_update_general(node_list, nodes, procesed_nodes=set()):
     """
     General update function for node set

--- a/settings.py
+++ b/settings.py
@@ -73,6 +73,18 @@ class SverchokPreferences(AddonPreferences):
         size=3, min=0.0, max=1.0,
         default=(1, 1, 1), subtype='COLOR')
 
+    # Profiling settings
+    profiling_sections = [
+        ("NONE", "Disable", "Disable profiling", 0),
+        ("MANUAL", "Marked methods only", "Profile only methods that are marked with @profile decorator", 1),
+        ("UPDATE", "Node tree update", "Profile whole node tree update process", 2)
+    ]
+
+    profile_mode = EnumProperty(name = "Profiling mode",
+            items = profiling_sections,
+            default = "NONE",
+            description = "Performance profiling mode")
+
     #  theme settings
 
     sv_theme = EnumProperty(
@@ -213,6 +225,7 @@ class SverchokPreferences(AddonPreferences):
 
             col2box = col2.box()
             col2box.label(text="Debug:")
+            col2box.prop(self, "profile_mode")
             col2box.prop(self, "show_debug")
             col2box.prop(self, "heat_map")
 

--- a/ui/sv_panels.py
+++ b/ui/sv_panels.py
@@ -23,6 +23,7 @@ from bpy.props import StringProperty, BoolProperty, FloatProperty
 import sverchok
 from sverchok.utils.sv_update_utils import version_and_sha
 from sverchok.core.update_system import process_from_nodes
+from sverchok.utils import profile
 
 objects_nodes_set = {'ObjectsNode', 'ObjectsNodeMK2', 'SvObjectsNodeMK3'}
 
@@ -273,6 +274,16 @@ class SverchokToolsMenu(bpy.types.Panel):
         layout = self.layout
         # layout.scale_y=1.1
         layout.active = True
+
+        addon = context.user_preferences.addons.get(sverchok.__name__)
+        if addon.preferences.profile_mode != "NONE":
+            profile_row = layout.row(align=True)
+            if profile.is_currently_enabled:
+                profile_row.operator("node.sverchok_profile_toggle", text="Stop profiling")
+            else:
+                profile_row.operator("node.sverchok_profile_toggle", text="Start profiling")
+            profile_row.operator("node.sverchok_profile_dump", text="Dump data")
+
         row = layout.row(align=True)
         col = row.column(align=True)
         col.scale_y = 3.0

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -2,6 +2,7 @@
 import bpy
 
 import inspect
+import traceback
 import logging
 import logging.handlers
 
@@ -92,7 +93,7 @@ def try_initialize():
 
     with sv_preferences() as prefs:
         if not prefs:
-            logging.error("Can't obtain logging preferences, it's too early")
+            logging.error("Can't obtain logging preferences, it's too early. Stack:\n%s", "".join(traceback.format_stack()))
             return
 
         if not internal_buffer_initialized:

--- a/utils/profile.py
+++ b/utils/profile.py
@@ -52,6 +52,13 @@ def is_profiling_enabled(section):
     with sv_preferences() as prefs:
         return prefs.profile_mode == section
 
+def is_profiling_enabled_in_settings():
+    """
+    Check if profiling is not set to NONE in addon preferences.
+    """
+    with sv_preferences() as prefs:
+        return prefs.profile_mode != "NONE"
+
 def profile(function = None, section = "MANUAL"):
     """
     Decorator for profiling the specific methods.
@@ -70,10 +77,13 @@ def profile(function = None, section = "MANUAL"):
     The second form is equivalent to the first with section = "MANUAL".
     Profiling section is a named set of methods which should be profiled.
     Supported values of section are listed in SverchokPreferences.profiling_sections.
-    The @profile(section) decorator does profile the method only if
-    profiling for specified section is enabled in settings (profile_mode option),
-    and profiling is currently active.
+
+    The @profile(section) decorator does profile the method only if all following
+    conditions are met:
+    * profiling for specified section is enabled in settings (profile_mode option),
+    * profiling is currently active.
     """
+
     def profiling_decorator(func):
         def wrapper(*args, **kwargs):
             if is_profiling_enabled(section):

--- a/utils/profile.py
+++ b/utils/profile.py
@@ -105,6 +105,10 @@ def dump_stats():
     Dump profiling statistics to the log.
     """
     profile = get_global_profile()
+    if not profile.getstats():
+        info("There are no profiling results yet")
+        return
+
     stream = StringIO()
     stats = pstats.Stats(profile, stream=stream).sort_stats('tottime')
     stats.print_stats()

--- a/utils/profile.py
+++ b/utils/profile.py
@@ -1,0 +1,147 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import cProfile
+import pstats
+from io import StringIO
+
+import bpy
+
+from sverchok.utils.logging import info
+from sverchok.utils.context_managers import sv_preferences
+
+# Global cProfile.Profile singleton
+_global_profile = None
+# Nesting level for @profile decorator
+_profile_nesting = 0
+# Whether the profiling is enabled by "Start profiling" toggle
+is_currently_enabled = False
+
+def get_global_profile():
+    """
+    Get cProfile.Profile singleton object
+    """
+    global _global_profile
+    if _global_profile is None:
+        _global_profile = cProfile.Profile()
+    return _global_profile
+
+def is_profiling_enabled(section):
+    """
+    Check if profiling is enabled in general,
+    and if it is enabled for specified section.
+    """
+    global is_currently_enabled
+    if not is_currently_enabled:
+        return False
+    with sv_preferences() as prefs:
+        return prefs.profile_mode == section
+
+def profile(function = None, section = "MANUAL"):
+    """
+    Decorator for profiling the specific methods.
+    It can be used in two ways:
+
+    @profile
+    def method(...):
+        ...
+
+    or
+
+    @profile(section="SECTION"):
+    def method(...):
+        ...
+
+    The second form is equivalent to the first with section = "MANUAL".
+    Profiling section is a named set of methods which should be profiled.
+    Supported values of section are listed in SverchokPreferences.profiling_sections.
+    The @profile(section) decorator does profile the method only if
+    profiling for specified section is enabled in settings (profile_mode option),
+    and profiling is currently active.
+    """
+    def profiling_decorator(func):
+        def wrapper(*args, **kwargs):
+            if is_profiling_enabled(section):
+                global _profile_nesting
+
+                profile = get_global_profile()
+                _profile_nesting += 1
+                if _profile_nesting == 1:
+                    profile.enable()
+                result = func(*args, **kwargs)
+                _profile_nesting -= 1
+                if _profile_nesting == 0:
+                    profile.disable()
+                return result
+            else:
+                return func(*args, **kwargs)
+            
+        wrapper.__name__ = func.__name__
+        wrapper.__doc__ = func.__doc__
+        return wrapper
+
+    if callable(function):
+        return profiling_decorator(function)
+    else:
+        return profiling_decorator
+
+def dump_stats():
+    """
+    Dump profiling statistics to the log.
+    """
+    profile = get_global_profile()
+    stream = StringIO()
+    stats = pstats.Stats(profile, stream=stream).sort_stats('tottime')
+    stats.print_stats()
+    info("Profiling results:\n" + stream.getvalue())
+    info("---------------------------")
+
+class SvProfilingToggle(bpy.types.Operator):
+    """Toggle profiling on/off"""
+    bl_idname = "node.sverchok_profile_toggle"
+    bl_label = "Toggle profiling"
+    bl_options = {'INTERNAL'}
+
+    def execute(self, context):
+        global is_currently_enabled
+
+        is_currently_enabled = not is_currently_enabled
+        info("Profiling is set to %s", is_currently_enabled)
+
+        return {'FINISHED'}
+
+class SvProfileDump(bpy.types.Operator):
+    """Dump profiling statistics to log"""
+    bl_idname = "node.sverchok_profile_dump"
+    bl_label = "Dump profiling statistics"
+    bl_options = {'INTERNAL'}
+
+    def execute(self, context):
+        dump_stats()
+        return {'FINISHED'}
+
+classes = [SvProfilingToggle, SvProfileDump]
+
+def register():
+    for class_name in classes:
+        bpy.utils.register_class(class_name)
+
+def unregister():
+    for class_name in reversed(classes):
+        bpy.utils.unregister_class(class_name)
+


### PR DESCRIPTION
This adds some more advanced profiling facilities that we already have. I started to write this when wrote "bend along surface" node, to dig into details of it's performance.

In addon preferences, there is new option introduced, "Profiling mode", with following values:
* Disable - profiling is disabled (default)
* Only marked methods - only methods manually marked by developer with `@profile` (`sverchok.utils.profile.profile`) decorator are profiled. By default no methods are decorated in such way, so this option profiles nothing. These marks are supposed to be added either locally or in some debugging branches.
* Whole update process - the whole `do_update_general` method is profiled.

![screenshot_20171211_223651](https://user-images.githubusercontent.com/284644/33845000-d97ac41a-dec3-11e7-8913-61bca1379f10.png)

If profiling is not disabled in settings, there are two new buttons in nodetree N panel (near "Update all"):
* Start/stop profiling - start/stop gathering statistics. Statistics are not gathered by default.
* Dump stats - dump collected statistics to the log. Just writes a message if we do not have statistics to dump yet. In the popup window you can specify how to sort the data.

![screenshot_20171211_223841](https://user-images.githubusercontent.com/284644/33845086-18401ace-dec4-11e7-8680-a0e4705f8457.png)


So the usual workflow if you want to profile something is:
* If you want to profile the whole nodetree update process, set profiling mode = "Node tree update" in settings.
* Or if you want to profile the specific node or some set of methods:
  * Edit the source and mark interesting methods with `@profile` decorator
  * Set profiling mode = "Marked methods only" in settings.
* Click "Start profiling"
* Do something that calls your methods, for example press "Update All", one or several times
* Click "Stop profiling"
* Repeat if necessary
* Click "Dump statistics"
* Observe the log.

Under the hood, standard python's `cProfile` module is used.

To generalize a bit, there is concept of "profiling section" used. Profiling section is a named set of methods to be profiled. The `@profile` decorator can be provided with name of profiling section, by default section is "MANUAL". The decorator only actually profiles the method if provided name of section equals to `profile_mode` option in settings. For now, we have only two sections: MANUAL for manually marked methods and UPDATE for `do_update_general` method. Later we may want to add other sections.

Example output: https://gist.github.com/portnov/a394ac0b4793f639c58c8e0f18cf5d47

With my examples, i do not see any performance overhead of profiling, it is less than measurement error. But it is possible that there is some overhead in some cases.

@zeffii @DolphinDream @nortikin please review and test.