### PR TITLE
"Bricks grid" node update

### DIFF
--- a/docs/nodes/generator/bricks.rst
+++ b/docs/nodes/generator/bricks.rst
@@ -1,13 +1,17 @@
 Bricks Grid
 ===========
 
-*destination after Beta: Generators*
-
 Functionality
 -------------
 
-This node generates bricks-like grid, i.e. a grid each row of which is shifted with relation to another. It is also possible to specify toothing, so it will be like engaged bricks.
-All parameters of bricks can be randomized with separate control over randomization of each parameter.
+This node generates bricks-like grid, i.e. a grid each row of which is shifted
+with relation to another. It is also possible to specify toothing, so it will
+be like engaged bricks.
+All parameters of bricks can be randomized with separate control over
+randomization of each parameter.
+
+Optionally the grid may be cyclic in one or two directions. This can be useful
+if you are going to map the grid onto some sort of cyclic or toroidal surface.
 
 
 Inputs & Parameters
@@ -19,6 +23,18 @@ All inputs are vectorized and they will accept single or multiple values.
 +-----------------+---------------+-------------+-------------------------------------------------------------+
 | Param           | Type          | Default     | Description                                                 |
 +=================+===============+=============+=============================================================+
+| **Cycle U**     | Boolean       | False       | Make the grid cyclic in U direction, i.e. the direction of  |
+|                 |               |             | brick rows. This makes sense only if you are going to map   |
+|                 |               |             | the grid on to some sort of cyclic surface (e.g. cylinder). |
+|                 |               |             | **Note**: after such mapping, you may want to use "Remove   |
+|                 |               |             | doubles" node.                                              |
++-----------------+---------------+-------------+-------------------------------------------------------------+
+| **Cycle V**     | Boolean       | False       | Make the grid cyclic in V direction, i.e. the direction of  |
+|                 |               |             | brick columns. This makes sense only if you are going to map|
+|                 |               |             | the grid on to some sort of cyclic surface (e.g. cylinder). |
+|                 |               |             | **Note**: after such mapping, you may want to use "Remove   |
+|                 |               |             | doubles" node.                                              |
++-----------------+---------------+-------------+-------------------------------------------------------------+
 | **Faces mode**  | Flat or       | Flat        | What kind of polygons to generate:                          |
 |                 |               |             |                                                             |
 |                 | Stitch or     |             | * Flat - generate one polygon (n-gon, in general) for each  |
@@ -26,7 +42,9 @@ All inputs are vectorized and they will accept single or multiple values.
 |                 | Center        |             | * Stitch - split each brick into several triangles, with    |
 |                 |               |             |   edges going across brick.                                 |
 |                 |               |             | * Center - split each brick into triangles by adding new    |
-|                 |               |             |   vertex in the center of the brick.                        |
+|                 |               |             |   vertex in the center of the brick. This mode is not       |
+|                 |               |             |   available if *any* of **Cycle U**, **Cycle V**            |
+|                 |               |             |   parameters is checked.                                    |
 +-----------------+---------------+-------------+-------------------------------------------------------------+
 | **Unit width**  | Float         | 2.0         | Width of one unit (brick).                                  |
 +-----------------+---------------+-------------+-------------------------------------------------------------+

--- a/nodes/generator/bricks.py
+++ b/nodes/generator/bricks.py
@@ -426,7 +426,12 @@ class SvBricksNode(bpy.types.Node, SverchCustomTreeNode):
             # With cycling, it may appear that we enumerated the same vertex index
             # in one face twice.
             if self.cycle_u or self.cycle_v:
-                faces = [list(collections.OrderedDict.fromkeys(face)) for face in faces]
+                filtered_faces = []
+                for face in faces:
+                    new_face = list(collections.OrderedDict.fromkeys(face))
+                    if len(new_face) > 2:
+                        filtered_faces.append(new_face)
+                faces = filtered_faces
 
             result_vertices.append(vertices)
             result_edges.append(edges)

--- a/nodes/generator/bricks.py
+++ b/nodes/generator/bricks.py
@@ -223,17 +223,22 @@ class SvBricksNode(bpy.types.Node, SverchCustomTreeNode):
             ("centers", "Centers", "Connect each edge with face center", 2)
         ]
 
+    def available_face_modes(self, context):
+        result = self.faces_modes[:]
+        if self.cycle_u or self.cycle_v:
+            del result[-1]
+        return result
+
     faces_mode = EnumProperty(name="Faces",
             description="Faces triangularization mode",
-            items=faces_modes,
-            default="flat",
+            items = available_face_modes,
             update=updateNode)
 
     def draw_buttons(self, context, layout):
-        layout.prop(self, "faces_mode", expand=True)
         row = layout.row(align=True)
         row.prop(self, "cycle_u", toggle=True)
         row.prop(self, "cycle_v", toggle=True)
+        layout.prop(self, "faces_mode")
 
     def sv_init(self, context):
         self.inputs.new('StringsSocket', "DU").prop_name = 'du_'

--- a/nodes/generator/bricks.py
+++ b/nodes/generator/bricks.py
@@ -17,6 +17,7 @@
 # ##### END GPL LICENSE BLOCK #####
 
 import random
+import itertools
 
 import bpy
 from bpy.props import BoolProperty, IntProperty, FloatProperty, EnumProperty
@@ -25,25 +26,73 @@ from mathutils import Vector
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import (fullList, match_long_repeat, updateNode)
 
+"""
+The grid is represented by following structure:
+ 
+ V axis
+
+ ^
+ |
+ |  ----------o-------------------o----------------o----------  <-- ULine
+ |            |                   |                |
+ |          VEdge              VEdge            VEdge   
+ |            |                   |                |
+ |  ----o-----o---------o---------o------o---------o------o---  <-- ULine
+ |      |               |                |                |
+ |    VEdge          VEdge            VEdge             VEdge
+ |      |               |                |                |
+ |  ----o---------------o----------------o----------------o---  <-- ULine
+ |
+ O---------------------------------------------------------------------------> U axis
+"""
+
 class Vertex(object):
+    """
+    Object representing a vertex of the grid in U-V coordinate plane.
+    """
     def __init__(self, u, v):
-        self.index = None
+        self._index = None
+        self.replacement = None
         self.u = u
         self.v = v
 
+    def set_index(self, index):
+        self._index = index
+
+    def get_index(self):
+        if self.replacement is not None:
+            return self.replacement.index
+        else:
+            return self._index
+
+    index = property(get_index, set_index)
+
     def __str__(self):
-        if self.index:
+        if self.index is not None:
             return "<" + str(self.index) + ">"
         else:
-            return "<>"
+            return "<{:.4}, {:.4}>".format(self.u, self.v)
+
+    def __repr__(self):
+        return str(self)
     
     def __lt__(self, other):
         return self.u < other.u
+
+# #     def __eq__(self, other):
+#         return self.u == other.u and self.v == other.v
+# 
+#     def __hash__(self):
+#         return hash(self.u) + hash(self.v)
     
 # #     def vector(self):
 #         return Vector((self.u, self.v, 0.0))
 
 class VEdge(object):
+    """
+    Class representing a vertical edge between two bricks.
+    The edge connects two vertices.
+    """
     def __init__(self, v1, v2):
         self.v1 = v1
         self.v2 = v2
@@ -52,6 +101,10 @@ class VEdge(object):
         return str(self.v1) + " - " + str(self.v2)
 
 class ULine(object):
+    """
+    Class representing horiszontal line between rows of bricks.
+    Such line goes through the set of vertices.
+    """
     def __init__(self, lst):
         self.list = sorted(lst, key=lambda v: v.u)
         self.coords = [v.u for v in self.list]
@@ -65,11 +118,36 @@ class ULine(object):
     def __getitem__(self, i):
         return self.list[i]
 
-    def select(self, v1, v2):
-        return [v.index for v in self.list if v.u > v1.u and v.u < v2.u]
+    def __str__(self):
+        return str(self.list)
+
+    def __repr__(self):
+        return str(self.list)
+
+    def is_empty(self):
+        return len(self.list) == 0
+
+    def remove_by_index(self, idx):
+        del self.list[idx]
+        del self.coords[idx]
+
+    def get_by_u(self, u):
+        for vertex in self.list:
+            if vertex.u == u:
+                return vertex
+        return None
+
+    def select_index(self, v1, v2):
+        if v2 < v1:
+            return list(reversed([v.index for v in self.list if v.u < v2.u or v.u > v1.u]))
+        else:
+            return [v.index for v in self.list if v.u > v1.u and v.u < v2.u]
 
     def select_v(self, v1, v2):
-        return [v for v in self.list if v.u > v1.u and v.u < v2.u]
+        if v2 < v1:
+            return list(reversed([v for v in self.list if v.u < v2.u or v.u > v1.u]))
+        else:
+            return [v for v in self.list if v.u > v1.u and v.u < v2.u]
 
 
 def get_center(vertices):
@@ -78,14 +156,17 @@ def get_center(vertices):
     cv = sum([v.v for v in vertices]) / n
     return Vertex(cu, cv)
 
-def select(line, v1, v2):
+def select_index(line, v1, v2):
     return [v.index for v in line if v.u > v1.u and v.u < v2.u]
 
 def select_v(line, v1, v2):
     return [v for v in line if v.u > v1.u and v.u < v2.u]
 
 class SvBricksNode(bpy.types.Node, SverchCustomTreeNode):
-    ''' Bricks '''
+    """
+    Triggers: Bricks
+    Tooltip: Create a brick wall or honeycomb-like structure.
+    """
     bl_idname = 'SvBricksNode'
     bl_label = 'Bricks grid'
     bl_icon = 'OUTLINER_OB_EMPTY'
@@ -126,6 +207,16 @@ class SvBricksNode(bpy.types.Node, SverchCustomTreeNode):
             default=0,
             update=updateNode)
 
+    cycle_u = BoolProperty(name = "Cycle U",
+            description = "Cycle edges and faces in U direction",
+            default = False,
+            update=updateNode)
+    cycle_v = BoolProperty(name = "Cycle v",
+            description = "Cycle edges and faces in V direction",
+            default = False,
+            update=updateNode)
+
+
     faces_modes = [
             ("flat", "Flat", "Flat polygons", 0),
             ("stitch", "Stitch", "Stitch with triangles", 1),
@@ -140,6 +231,9 @@ class SvBricksNode(bpy.types.Node, SverchCustomTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "faces_mode", expand=True)
+        row = layout.row(align=True)
+        row.prop(self, "cycle_u", toggle=True)
+        row.prop(self, "cycle_v", toggle=True)
 
     def sv_init(self, context):
         self.inputs.new('StringsSocket', "DU").prop_name = 'du_'
@@ -212,15 +306,51 @@ class SvBricksNode(bpy.types.Node, SverchCustomTreeNode):
                     u += random.uniform(-rdu, rdu)
                     j += 1
 
+            if self.cycle_v:
+                # Merge lists of vertices in first and last ULine
+                def update(uline1, uline2):
+                    for vertex in uline1:
+                        other_vertex = None
+                        for o in uline2:
+                            if o.u == vertex.u and o.v != vertex.v:
+                                other_vertex = o
+
+                        if other_vertex is not None:
+                            if vertex.replacement is None:
+                                uline2.remove(other_vertex)
+                                other_vertex.replacement = vertex
+                        else:
+                            uline2.add(vertex)
+
+                update(ulines[0], ulines[-1])
+                update(ulines[-1], ulines[0])
+                if len(ulines[0]) == 0:
+                    del ulines[0]
+                if len(ulines[-1]) == 0:
+                    del ulines[-1]
+
             ulines = [(ULine(line)) for line in ulines]
 
+            if self.cycle_u:
+                # Make each ULine cyclic
+                for uline in ulines:
+                    last = uline[-1]
+                    last.replacement = uline[0]
+                    uline.remove_by_index(-1)
+
+            # Assign indicies to vertices
             vertex_idx = 0
             vertices = []
             for line in ulines:
                 for vt in line:
+                    if vt.replacement is not None:
+                        continue
+                    new_vertex = (vt.u, vt.v, 0.0)
+                    if new_vertex in vertices:
+                        continue
                     vt.index = vertex_idx
                     vertex_idx += 1
-                    vertices.append((vt.u, vt.v, 0.0))
+                    vertices.append(new_vertex)
 
             edges = []
             for line in ulines:
@@ -235,8 +365,11 @@ class SvBricksNode(bpy.types.Node, SverchCustomTreeNode):
             centers = []
             for i, lst in enumerate(vedges):
                 line1 = ulines[i]
-                line2 = ulines[i+1]
-                for e1,e2 in zip(lst, lst[1:]):
+                line2 = ulines[(i+1) % len(ulines)]
+                v_edge_pairs = list(zip(lst, lst[1:]))
+                if self.cycle_u:
+                    v_edge_pairs.append((lst[-1], lst[0]))
+                for e1,e2 in v_edge_pairs:
                     face_vertices = [e1.v2, e1.v1]
                     face_vertices.extend(line1.select_v(e1.v1, e2.v1))
                     face_vertices.extend([e2.v1, e2.v2])
@@ -248,8 +381,8 @@ class SvBricksNode(bpy.types.Node, SverchCustomTreeNode):
                         face = [v.index for v in face_vertices]
                         faces.append(face)
                     elif self.faces_mode == "stitch":
-                        vs1 = line1.select(e1.v1, e2.v1) + [e2.v1.index]
-                        vs2 = [e1.v2.index] + line2.select(e1.v2, e2.v2) + [e2.v2.index]
+                        vs1 = line1.select_index(e1.v1, e2.v1) + [e2.v1.index]
+                        vs2 = [e1.v2.index] + line2.select_index(e1.v2, e2.v2) + [e2.v2.index]
                         prev = e1.v1.index
                         alt = e1.v2.index
                         i = 0

--- a/nodes/generator/bricks.py
+++ b/nodes/generator/bricks.py
@@ -17,7 +17,7 @@
 # ##### END GPL LICENSE BLOCK #####
 
 import random
-import itertools
+import collections
 
 import bpy
 from bpy.props import BoolProperty, IntProperty, FloatProperty, EnumProperty
@@ -422,6 +422,11 @@ class SvBricksNode(bpy.types.Node, SverchCustomTreeNode):
                             faces.append(face)
                         face = [face_vertices[-1].index, face_vertices[0].index, center.index]
                         faces.append(face)
+
+            # With cycling, it may appear that we enumerated the same vertex index
+            # in one face twice.
+            if self.cycle_u or self.cycle_v:
+                faces = [list(collections.OrderedDict.fromkeys(face)) for face in faces]
 
             result_vertices.append(vertices)
             result_edges.append(edges)


### PR DESCRIPTION
Add possibility to make grid cyclic in U and/or V directions. This makes sense only if one is going to map the grid onto some sort of cylindrical or toroidal surface.
New modes are disabled by default, so existing scenes will not be broken.

![screenshot_20171211_222913](https://user-images.githubusercontent.com/284644/33844741-0f643940-dec3-11e7-9dc5-e1a3c254d992.png)


![loft-hex-metal-1](https://user-images.githubusercontent.com/284644/33844735-0845fc3e-dec3-11e7-9591-e862df976453.png)

