### PR TITLE
Fix the name for generator colors

### DIFF
--- a/ui/color_def.py
+++ b/ui/color_def.py
@@ -35,7 +35,7 @@ default_theme = {
     "Text": (0.5, 0.5, 1),
     "Scene": (0, 0.5, 0.2),
     "Layout": (0.674, 0.242, 0.363),
-    "Generators": (0, 0.5, 0.5),
+    "Generator": (0, 0.5, 0.5),
 }
 
 nipon_blossom = {
@@ -43,7 +43,7 @@ nipon_blossom = {
     "Text": (1.000000, 0.899344, 0.974251),
     "Scene": (0.904933, 1.000000, 0.883421),
     "Layout": (0.602957, 0.674000, 0.564277),
-    "Generators": (0.92, 0.92, 0.92),
+    "Generator": (0.92, 0.92, 0.92),
 }
 
 
@@ -57,7 +57,7 @@ def color_callback(self, context):
         ("Text", "color_tex"),
         ("Scene", "color_sce"),
         ("Layout", "color_lay"),
-        ("Generators", "color_gen"),
+        ("Generator", "color_gen"),
     ]
     # stop theme from auto updating and do one call instead of many
     auto_apply_theme = self.auto_apply_theme
@@ -79,7 +79,7 @@ def sv_colors_definition():
             "Text": prefs.color_tex,
             "Scene": prefs.color_sce,
             "Layout": prefs.color_lay,
-            "Generators": prefs.color_gen,
+            "Generator": prefs.color_gen,
             }
     else:
         sv_node_colors = default_theme


### PR DESCRIPTION
The generator category name was changed recently from Generators to Generator, which fix the indexing of the generator colors in the themes. This update fixes the indexing string to match the new "Generator" name.