### PR TITLE
Bend surface ungroup

### DIFF
--- a/docs/nodes/modifier_change/bend_along_surface.rst
+++ b/docs/nodes/modifier_change/bend_along_surface.rst
@@ -24,7 +24,8 @@ Inputs
 
 This node has the following inputs:
 
-- **Vertices**. Vertices of object to be bent.
+- **Vertices**. Vertices of object to be bent. This node can consume either
+  list of vertices, or list of lists of vertices.
 - **Surface**. Vertices of the surface along which the object should be bent.
   Please note that this input expects a list of lists of vertices for each
   object (sort of grid). Each list of vertices should describe a curve along
@@ -51,6 +52,10 @@ This node has the following parameters:
   is false.
 - **Cycle V**. Whether the surface is cyclic in the V direction. Default value
   is false.
+- **Grouped**. If checked, then the node expects list of lists of vertices at
+  **Vertices** input. If not checked, then node expects list of vertices at
+  **Vertices** input. Nesting level of output is always corresponding to input.
+  Default is checked.
 - **Flip surface**. If checked, then the surface normal will be flipped, so the
   object will be flipped upside down with relation to the surface. Unchecked by
   default. This parameter is available only in the N panel.

--- a/nodes/modifier_change/bend_along_surface.py
+++ b/nodes/modifier_change/bend_along_surface.py
@@ -83,6 +83,11 @@ class SvBendAlongSurfaceNode(bpy.types.Node, SverchCustomTreeNode):
         default=False,
         update=updateNode)
 
+    grouped = BoolProperty(name = "Grouped",
+        description = "If enabled, then the node expects list of lists of vertices, instead of list of vertices. Output has corresponding shape.",
+        default = True,
+        update=updateNode)
+
     is_cycle_u = BoolProperty(name="Cycle U",
         description = "Whether the spline is cyclic in U direction",
         default = False,
@@ -118,6 +123,7 @@ class SvBendAlongSurfaceNode(bpy.types.Node, SverchCustomTreeNode):
         row = col.row(align=True)
         row.prop(self, "is_cycle_u", toggle=True)
         row.prop(self, "is_cycle_v", toggle=True)
+        col.prop(self, "grouped", toggle=True)
 
     def draw_buttons_ext(self, context, layout):
         self.draw_buttons(context, layout)
@@ -194,7 +200,7 @@ class SvBendAlongSurfaceNode(bpy.types.Node, SverchCustomTreeNode):
                 surface = transpose_list(surface)
             #print("Surface: {} of {} of {}".format(type(surface), type(surface[0]), type(surface[0][0])))
             spline = self.build_spline(surface)
-            # uv_coords will be list of lists of 2-tuples of floats
+            # uv_coords will be list[m] of lists[n] of 2-tuples of floats
             # number of "rows" and "columns" in uv_coords will match so of vertices.
             src_size_u, src_size_v, uv_coords = self.get_uv(vertices)
             if self.autoscale:
@@ -222,6 +228,8 @@ class SvBendAlongSurfaceNode(bpy.types.Node, SverchCustomTreeNode):
                 new_vertices.append(new_row)
             result_vertices.append(new_vertices)
 
+        if not self.grouped:
+            result_vertices = result_vertices[0]
         self.outputs['Vertices'].sv_set(result_vertices)
 
 def register():


### PR DESCRIPTION
Added new option "Grouped". If checked, then the node expects list of     lists of vertices (level 4) instead of list of vertices (level 3).    Output always has corresponding nesting level.
    
Default value Grouped = true corresponds to old behaivour.

So, basically, instead of passing output via "List Del Levels", you can now just uncheck the "Grouped" option.