### PR TITLE
Add first iteration of mk2 - untested

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -86,7 +86,7 @@ utils_modules = [
     # non UI tools
     "cad_module", "cad_module_class", "sv_bmesh_utils", "sv_viewer_utils", "sv_curve_utils",
     "voronoi", "sv_script", "sv_itertools", "script_importhelper", "sv_oldnodes_parser",
-    "csg_core", "csg_geom", "geom", "sv_easing_functions",
+    "csg_core", "csg_geom", "geom", "sv_easing_functions", "sv_text_io_common",
     "snlite_utils", "snlite_importhelper", "context_managers",
     "profile", "logging", 
     # UI text editor ui

--- a/index.md
+++ b/index.md
@@ -225,8 +225,8 @@
 
 ## Text
     ViewerNodeTextMK2
-    SvTextInNode
-    SvTextOutNode
+    SvTextInNodeMK2
+    SvTextOutNodeMK2
     NoteNode
     SvDataShapeNode
     GTextNode

--- a/nodes/text/text_in_mk2.py
+++ b/nodes/text/text_in_mk2.py
@@ -60,7 +60,11 @@ def pop_all_data(node, n_id):
 
 
 class SvTextInNodeMK2(bpy.types.Node, SverchCustomTreeNode):
-    ''' Text Input '''
+    """
+    Triggers: Text in from datablock
+    Tooltip: Quickly load text from datablock into NodeView
+    """
+
     bl_idname = 'SvTextInNodeMK2'
     bl_label = 'Text in+'
     bl_icon = 'PASTEDOWN'

--- a/nodes/text/text_in_mk2.py
+++ b/nodes/text/text_in_mk2.py
@@ -121,7 +121,7 @@ class SvTextInNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     csv_custom_decimalmark = StringProperty(default=',', name="Custom")
 
     # Sverchok list options
-    # choose which socket to interpretate data as
+    # choose which socket to interpret data as
     socket_type = EnumProperty(items=socket_types, default='s')
 
     #interesting but dangerous, TODO
@@ -140,7 +140,7 @@ class SvTextInNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         over_sized_buttons = addon.preferences.over_sized_buttons
 
         col = layout.column(align=True)
-        col.prop(self, 'autoreload', toggle=True)# reload() not work properly somehow 2016.10.07
+        col.prop(self, 'autoreload', toggle=True)  # reload() not work properly somehow 2016.10.07 | really? 2017.12.21
         if self.current_text:
             col.label(text="File: {0} loaded".format(self.current_text))
             row = col.row(align=True)

--- a/nodes/text/text_in_mk2.py
+++ b/nodes/text/text_in_mk2.py
@@ -73,7 +73,7 @@ class SvTextInNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     n_id = StringProperty(default='')
     force_input = BoolProperty()
 
-    textmode = EnumProperty(items=text_modes, default='CSV', update=updateNode, )
+    textmode = EnumProperty(items=text_modes, default='CSV', update=updateNode, name='textmode')
 
     # name of loaded text, to support reloading
     text = StringProperty(default="")
@@ -154,8 +154,8 @@ class SvTextInNodeMK2(bpy.types.Node, SverchCustomTreeNode):
             col.prop_search(self, 'text', bpy.data, 'texts', text="Read")
 
             row = col.row(align=True)
-            row.prop(self, 'textmode', 'textmode', expand=True)
-            col.prop(self, 'one_sock', 'one_sock')
+            row.prop(self, 'textmode', expand=True)
+            col.prop(self, 'one_sock')
             if self.textmode == 'CSV':
                 col.prop(self, 'csv_header')
                 col.prop(self, 'csv_dialect')
@@ -182,11 +182,18 @@ class SvTextInNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     def copy(self, node):
         self.n_id = ''
 
-    # free potentially lots of data
     def free(self):
+        # free potentially lots of data
         n_id = node_id(self)
         pop_all_data(self, n_id)
 
+    def reset(self):
+        n_id = node_id(self)
+        self.outputs.clear()
+        self.current_text = ''
+        pop_all_data(self, n_id)
+
+    
     def reload(self):
         # reload should ONLY be called from operator on ui change
         if self.textmode == 'CSV':
@@ -199,14 +206,8 @@ class SvTextInNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         # if we turn on reload on update we need a safety check for this to work.
         updateNode(self, None)
 
-    def process(self):  # dispatch based on mode
 
-        # startup safety net
-        try:
-            l = bpy.data.node_groups[self.id_data.name]
-        except Exception as e:
-            print(self.name, "cannot run during startup, press update.")
-            return
+    def process(self):  # dispatch based on mode
 
         if not self.current_text:
             return
@@ -218,11 +219,6 @@ class SvTextInNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         elif self.textmode == 'JSON':
             self.update_json()
 
-    def reset(self):
-        n_id = node_id(self)
-        self.outputs.clear()
-        self.current_text = ''
-        pop_all_data(self, n_id)
 
     def load(self):
         if self.textmode == 'CSV':

--- a/nodes/text/text_in_mk2.py
+++ b/nodes/text/text_in_mk2.py
@@ -63,7 +63,7 @@ class SvTextInNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     ''' Text Input '''
     bl_idname = 'SvTextInNodeMK2'
     bl_label = 'Text in+'
-    bl_icon = 'OUTLINER_OB_EMPTY'
+    bl_icon = 'PASTEDOWN'
 
     csv_data = {}
     list_data = {}
@@ -128,7 +128,7 @@ class SvTextInNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     autoreload = BoolProperty(default=False, description="Reload text file on every update", name='auto reload')
 
     # to have one socket output
-    one_sock = BoolProperty(name='one_sock', default=False)
+    one_sock = BoolProperty(name='one socket', default=False)
 
     def draw_buttons_ext(self, context, layout):
         if self.textmode == 'CSV':

--- a/nodes/text/text_in_mk2.py
+++ b/nodes/text/text_in_mk2.py
@@ -151,7 +151,7 @@ class SvTextInNodeMK2(bpy.types.Node, SverchCustomTreeNode):
             col.operator(TEXT_IO_CALLBACK, text='R E S E T').fn_name = 'reset'
 
         else:
-            col.prop_search(self, 'text', bpy.data, 'texts', text="read from")
+            col.prop_search(self, 'text', bpy.data, 'texts', text="Read")
 
             row = col.row(align=True)
             row.prop(self, 'textmode', 'textmode', expand=True)

--- a/nodes/text/text_out_mk2.py
+++ b/nodes/text/text_out_mk2.py
@@ -74,16 +74,16 @@ class SvTextOutNodeMK2(bpy.types.Node, SverchCustomTreeNode):
 
     text = StringProperty()
 
-    text_mode = EnumProperty(items=text_modes, default='CSV', update=change_mode)
-    csv_dialect = EnumProperty(items=csv_dialects, default='excel')
-    sv_mode = EnumProperty(items=sv_modes, default='compact')
-    json_mode = EnumProperty(items=json_modes, default='pretty')
+    text_mode = EnumProperty(items=text_modes, default='CSV', update=change_mode, name="Text format")
+    csv_dialect = EnumProperty(items=csv_dialects, default='excel', name="Dialect")
+    sv_mode = EnumProperty(items=sv_modes, default='compact', name="Format")
+    json_mode = EnumProperty(items=json_modes, default='pretty', name="Format")
 
     append = BoolProperty(default=False, description="Append to output file")
     base_name = StringProperty(name='base_name', default='Col ')
     multi_socket_type = StringProperty(name='multi_socket_type', default='StringsSocket')
 
-    autodump = BoolProperty(default=False, description="autodump")
+    autodump = BoolProperty(default=False, description="autodump", name="auto dump")
 
     def sv_init(self, context):
         self.inputs.new('StringsSocket', 'Col 0', 'Col 0')
@@ -94,24 +94,24 @@ class SvTextOutNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         over_sized_buttons = addon.preferences.over_sized_buttons
 
         col = layout.column(align=True)
-        col.prop(self, 'autodump', "auto dump", toggle=True)
+        col.prop(self, 'autodump', toggle=True)
         row = col.row(align=True)
         row.prop_search(self, 'text', bpy.data, 'texts', text="Output to")
 
         row = col.row(align=True)
-        row.prop(self, 'text_mode', "Text format", expand=True)
+        row.prop(self, 'text_mode', expand=True)
 
         row = col.row(align=True)
         if self.text_mode == 'CSV':
-            row.prop(self, 'csv_dialect', "Dialect")
+            row.prop(self, 'csv_dialect')
         elif self.text_mode == 'SV':
-            row.prop(self, 'sv_mode', "Format", expand=True)
+            row.prop(self, 'sv_mode', expand=True)
         elif self.text_mode == 'JSON':
-            row.prop(self, 'json_mode', "Format", expand=True)
+            row.prop(self, 'json_mode', expand=True)
 
-        col2 = col.column(align=True)
-        row = col2.row(align=True)
         if not self.autodump:
+            col2 = col.column(align=True)
+            row = col2.row(align=True)
             row.scale_y = 4.0 if over_sized_buttons else 1
             row.operator(TEXT_IO_CALLBACK, text='D U M P').fn_name = 'dump'
             col2.prop(self, 'append', "Append")

--- a/nodes/text/text_out_mk2.py
+++ b/nodes/text/text_out_mk2.py
@@ -97,7 +97,10 @@ def get_sv_data(node):
 
 
 class SvTextOutNodeMK2(bpy.types.Node, SverchCustomTreeNode):
-    ''' Text Output Node '''
+    """
+    Triggers: Text Out to datablock
+    Tooltip: Quickly write data from NodeView to text datablock
+    """
     bl_idname = 'SvTextOutNodeMK2'
     bl_label = 'Text out+'
     bl_icon = 'COPYDOWN'

--- a/nodes/text/text_out_mk2.py
+++ b/nodes/text/text_out_mk2.py
@@ -1,0 +1,198 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+# made by: Linus Yng, haxed by zeffii to mk2
+# pylint: disable=c0326
+
+import io
+import csv
+import json
+import itertools
+import pprint
+import sverchok
+
+import bpy
+from bpy.props import BoolProperty, EnumProperty, StringProperty
+
+from sverchok.node_tree import SverchCustomTreeNode, StringsSocket
+from sverchok.data_structure import node_id, multi_socket, updateNode
+
+from sverchok.utils.sv_text_io_common import (
+    FAIL_COLOR, READY_COLOR, TEXT_IO_CALLBACK,
+    get_socket_type,
+    new_output_socket,
+    name_dict,
+    text_modes
+)
+
+
+class SvTextOutNodeMK2(bpy.types.Node, SverchCustomTreeNode):
+    ''' Text Output Node '''
+    bl_idname = 'SvTextOutNodeMK2'
+    bl_label = 'Text out+'
+    bl_icon = 'OUTLINER_OB_EMPTY'
+
+    sv_modes = [
+        ('compact',     'Compact',      'Using str()',        1),
+        ('pretty',      'Pretty',       'Using pretty print', 2)]
+
+    json_modes = [
+        ('compact',     'Compact',      'Minimal',            1),
+        ('pretty',      'Pretty',       'Indent and order',   2)]
+
+    csv_dialects = [
+        ('excel',       'Excel',        'Standard excel',     1),
+        ('excel-tab',   'Excel tabs',   'Excel tab format',   2),
+        ('unix',        'Unix',         'Unix standard',      3)]
+
+    def change_mode(self, context):
+        self.inputs.clear()
+
+        if self.text_mode == 'CSV':
+            self.inputs.new('StringsSocket', 'Col 0')
+            self.base_name = 'Col '
+        elif self.text_mode == 'JSON':
+            self.inputs.new('StringsSocket', 'Data 0')
+            self.base_name = 'Data '
+        elif self.text_mode == 'SV':
+            self.inputs.new('StringsSocket', 'Data')
+
+    text = StringProperty()
+
+    text_mode = EnumProperty(items=text_modes, default='CSV', update=change_mode)
+    csv_dialect = EnumProperty(items=csv_dialects, default='excel')
+    sv_mode = EnumProperty(items=sv_modes, default='compact')
+    json_mode = EnumProperty(items=json_modes, default='pretty')
+
+    append = BoolProperty(default=False, description="Append to output file")
+    base_name = StringProperty(name='base_name', default='Col ')
+    multi_socket_type = StringProperty(name='multi_socket_type', default='StringsSocket')
+
+    autodump = BoolProperty(default=False, description="autodump")
+
+    def sv_init(self, context):
+        self.inputs.new('StringsSocket', 'Col 0', 'Col 0')
+
+    def draw_buttons(self, context, layout):
+
+        addon = context.user_preferences.addons.get(sverchok.__name__)
+        over_sized_buttons = addon.preferences.over_sized_buttons
+
+        col = layout.column(align=True)
+        col.prop(self, 'autodump', "auto dump", toggle=True)
+        row = col.row(align=True)
+        row.prop_search(self, 'text', bpy.data, 'texts', text="Output to")
+
+        row = col.row(align=True)
+        row.prop(self, 'text_mode', "Text format", expand=True)
+
+        row = col.row(align=True)
+        if self.text_mode == 'CSV':
+            row.prop(self, 'csv_dialect', "Dialect")
+        elif self.text_mode == 'SV':
+            row.prop(self, 'sv_mode', "Format", expand=True)
+        elif self.text_mode == 'JSON':
+            row.prop(self, 'json_mode', "Format", expand=True)
+
+        col2 = col.column(align=True)
+        row = col2.row(align=True)
+        if not self.autodump:
+            row.scale_y = 4.0 if over_sized_buttons else 1
+            row.operator(TEXT_IO_CALLBACK, text='D U M P').fn_name = 'dump'
+            col2.prop(self, 'append', "Append")
+
+    def update_socket(self, context):
+        self.update()
+
+    def process(self):
+        if self.text_mode in {'CSV', 'JSON'}:
+            multi_socket(self, min=1)
+
+        if self.autodump:
+            self.append = False
+            self.dump()
+
+    # build a string with data from sockets
+    def dump(self):
+        out = self.get_data()
+        if len(out) == 0:
+            return False
+
+        if not self.append:
+            bpy.data.texts[self.text].clear()
+        bpy.data.texts[self.text].write(out)
+        self.color = READY_COLOR
+
+        return True
+
+    def get_data(self):
+        out = ""
+        if self.text_mode == 'CSV':
+            data_out = []
+            for socket in self.inputs:
+                if socket.is_linked:
+
+                    tmp = socket.sv_get(deepcopy=False)
+                    if tmp:
+                        # flatten list
+                        data_out.extend(list(itertools.chain.from_iterable([tmp])))
+
+            csv_str = io.StringIO()
+            writer = csv.writer(csv_str, dialect=self.csv_dialect)
+            for row in zip(*data_out):
+                writer.writerow(row)
+
+            out = csv_str.getvalue()
+
+        elif self.text_mode == 'JSON':
+            data_out = {}
+
+            for socket in self.inputs:
+                if socket.is_linked:
+                    tmp = socket.sv_get(deepcopy=False)
+                    if tmp:
+                        tmp_name = socket.links[0].from_node.name+':'+socket.links[0].from_socket.name
+                        name = tmp_name
+                        j = 1
+                        while name in data_out:
+                            name = tmp_name+str(j)
+                            j += 1
+
+                        data_out[name] = (get_socket_type(self, socket.name), tmp)
+
+            if self.json_mode == 'pretty':
+                out = json.dumps(data_out, indent=4)
+            else:
+                out = json.dumps(data_out, separators=(',', ':'))
+
+        elif self.text_mode == 'SV':
+            if self.inputs['Data'].links:
+                data = self.inputs['Data'].sv_get(deepcopy=False)
+                if self.sv_mode == 'pretty':
+                    out = pprint.pformat(data)
+                else:  # compact
+                    out = str(data)
+        return out
+
+
+def register():
+    bpy.utils.register_class(SvTextOutNodeMK2)
+
+
+def unregister():
+    bpy.utils.unregister_class(SvTextOutNodeMK2)

--- a/nodes/text/text_out_mk2.py
+++ b/nodes/text/text_out_mk2.py
@@ -96,7 +96,8 @@ class SvTextOutNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         col = layout.column(align=True)
         col.prop(self, 'autodump', toggle=True)
         row = col.row(align=True)
-        row.prop_search(self, 'text', bpy.data, 'texts', text="Output to")
+        row.prop_search(self, 'text', bpy.data, 'texts', text="Write")
+        row.operator("text.new", icon="ZOOMIN", text='')
 
         row = col.row(align=True)
         row.prop(self, 'text_mode', expand=True)

--- a/utils/sv_text_io_common.py
+++ b/utils/sv_text_io_common.py
@@ -45,7 +45,7 @@ def new_output_socket(node, name, _type):
 
 
 class SvTextIOMK2Op(bpy.types.Operator):
-    """ Load text data """
+    """ generic callback for TEXT IO nodes """
     bl_idname = "node.sverchok_textio_mk2_callback"
     bl_label = "text IO operator cb"
     bl_options = {'REGISTER', 'UNDO'}

--- a/utils/sv_text_io_common.py
+++ b/utils/sv_text_io_common.py
@@ -1,0 +1,76 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+# pylint: disable=c0326
+
+import bpy
+
+# status colors
+FAIL_COLOR = (0.85, 0.85, 0.8)
+READY_COLOR = (0.5, 0.7, 1)
+
+text_modes = [
+    ("CSV",         "Csv",          "Csv data",           1),
+    ("SV",          "Sverchok",     "Python data",        2),
+    ("JSON",        "JSON",         "Sverchok JSON",      3)]
+
+name_dict = {'m': 'Matrix', 's': 'Data', 'v': 'Vertices'}
+
+map_to_short = {'VerticesSocket': 'v', 'StringsSocket': 's', 'MatrixSocket': 'm'}
+map_from_short = {'v': 'VerticesSocket', 's': 'StringsSocket', 'm': 'MatrixSocket'}
+
+
+def get_socket_type(node, inputsocketname):
+    socket_type = node.inputs[inputsocketname].links[0].from_socket.bl_idname
+    return map_to_short.get(socket_type, 's')
+
+def new_output_socket(node, name, _type):
+    bl_idname = map_from_short.get(_type, 'StringsSocket')
+    node.outputs.new(bl_idname, name)
+
+
+class SvTextIOMK2Op(bpy.types.Operator):
+    """ Load text data """
+    bl_idname = "node.sverchok_textio_mk2_callback"
+    bl_label = "text IO operator cb"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    fn_name = bpy.props.StringProperty(name='tree name')
+
+    def execute(self, context):
+        n = context.node
+        fn_name = self.fn_name
+
+        f = getattr(n, fn_name, None)
+        if not f:
+            msg = "{0} has no function named '{1}'".format(n.name, fn_name)
+            self.report({"WARNING"}, msg)
+            return {'CANCELLED'}
+        f()
+
+        return {'FINISHED'}
+
+TEXT_IO_CALLBACK = SvTextIOMK2Op.bl_idname
+
+
+def register():
+    bpy.utils.register_class(SvTextIOMK2Op)
+
+
+def unregister():
+    bpy.utils.unregister_class(SvTextIOMK2Op)


### PR DESCRIPTION
- fix parenthesized output / input read
- create MK2 of TextIn and TextOut
- UI backend streamline
- reorder imports
- introduce common util for TextIO nodes (including operator: `utils/sv_text_io_common`)
- place Text Nodes within Text Category.
- move over to text=Stringproperty and obtain textblock using prop_search on `bpy.data.texts`.
- some logic shortcutting.