### PR TITLE
add new text io route

### DIFF
--- a/nodes/text/text_in_mk2.py
+++ b/nodes/text/text_in_mk2.py
@@ -437,13 +437,32 @@ class SvTextInNodeMK2(bpy.types.Node, SverchCustomTreeNode):
             self.current_text = ''
             return
 
-        for item, data in json_data.items():
-            if len(data) == 2 and data[0] in {'v', 's', 'm'}:
-                new_output_socket(self, item, data[0])
-            else:
-                self.use_custom_color = True
-                self.color = FAIL_COLOR
-                return
+        # if you can still read this I have been out of time to refactor.
+
+        socket_order = json_data.get('socket_order')
+        if socket_order:
+            # this is necessary to avoid arbitrary socket assignment upon import
+            # not all gists/iojsons will have this key, hence the test. but it is
+            # important, and will let you define the order manually by editing the file
+            # if you have to.
+            for named_socket in socket_order:
+                data = json_data.get(named_socket)
+                if len(data) == 2 and data[0] in {'v', 's', 'm'}:
+                    new_output_socket(self, named_socket, data[0])
+                else:
+                    self.use_custom_color = True
+                    self.color = FAIL_COLOR
+                    return
+        else:
+            for named_socket, data in json_data.items():
+                if len(data) == 2 and data[0] in {'v', 's', 'm'}:
+                    new_output_socket(self, named_socket, data[0])
+                else:
+                    self.use_custom_color = True
+                    self.color = FAIL_COLOR
+                    return
+
+
 
     def reload_json(self):
         n_id = node_id(self)

--- a/nodes/text/text_in_mk2.py
+++ b/nodes/text/text_in_mk2.py
@@ -437,31 +437,25 @@ class SvTextInNodeMK2(bpy.types.Node, SverchCustomTreeNode):
             self.current_text = ''
             return
 
-        # if you can still read this I have been out of time to refactor.
-
         socket_order = json_data.get('socket_order')
         if socket_order:
-            # this is necessary to avoid arbitrary socket assignment upon import
-            # not all gists/iojsons will have this key, hence the test. but it is
-            # important, and will let you define the order manually by editing the file
-            # if you have to.
-            for named_socket in socket_order:
-                data = json_data.get(named_socket)
-                if len(data) == 2 and data[0] in {'v', 's', 'm'}:
-                    new_output_socket(self, named_socket, data[0])
-                else:
-                    self.use_custom_color = True
-                    self.color = FAIL_COLOR
-                    return
-        else:
-            for named_socket, data in json_data.items():
-                if len(data) == 2 and data[0] in {'v', 's', 'm'}:
-                    new_output_socket(self, named_socket, data[0])
-                else:
-                    self.use_custom_color = True
-                    self.color = FAIL_COLOR
-                    return
+            # avoid arbitrary socket assignment order
+            def iterate_socket_order():
+                for named_socket in socket_order:
+                    data = json_data.get(named_socket)
+                    yield named_socket, data
 
+            socket_iterator = iterate_socket_order()
+        else:
+            socket_iterator = json_data.items()
+
+        for named_socket, data in socket_iterator:
+            if len(data) == 2 and data[0] in {'v', 's', 'm'}:
+                new_output_socket(self, named_socket, data[0])
+            else:
+                self.use_custom_color = True
+                self.color = FAIL_COLOR
+                return
 
 
     def reload_json(self):

--- a/nodes/text/text_out_mk2.py
+++ b/nodes/text/text_out_mk2.py
@@ -62,6 +62,7 @@ def get_csv_data(node):
 def get_json_data(node):
     data_out = {}
 
+    socket_order = []
     for socket in node.inputs:
         if socket.is_linked:
             tmp = socket.sv_get(deepcopy=False)
@@ -75,6 +76,9 @@ def get_json_data(node):
                     j += 1
 
                 data_out[name] = (get_socket_type(node, socket.name), tmp)
+                socket_order.append(name)
+
+    data_out['socket_order'] = socket_order
 
     if node.json_mode == 'pretty':
         out = json.dumps(data_out, indent=4)

--- a/utils/sv_IO_panel_tools.py
+++ b/utils/sv_IO_panel_tools.py
@@ -213,8 +213,10 @@ def create_dict_of_tree(ng, skip_set={}, selected=False):
         ProfileParamNode = (node.bl_idname == 'SvProfileNode')
         IsGroupNode = (node.bl_idname == 'SvGroupNode')
         IsMonadInstanceNode = (node.bl_idname.startswith('SvGroupNodeMonad'))
-        TextInput = (node.bl_idname == 'SvTextInNode')
+        
         SvExecNodeMod = (node.bl_idname == 'SvExecNodeMod')
+        TextInput = (node.bl_idname == 'SvTextInNode')
+        # TextIO_MK2
 
         for k, v in node.items():
 

--- a/utils/sv_IO_panel_tools.py
+++ b/utils/sv_IO_panel_tools.py
@@ -215,8 +215,7 @@ def create_dict_of_tree(ng, skip_set={}, selected=False):
         IsMonadInstanceNode = (node.bl_idname.startswith('SvGroupNodeMonad'))
         
         SvExecNodeMod = (node.bl_idname == 'SvExecNodeMod')
-        TextInput = (node.bl_idname == 'SvTextInNode')
-        # TextIO_MK2
+        TextInput = (node.bl_idname in {'SvTextInNode', 'SvTextInNodeMK2'})
 
         for k, v in node.items():
 
@@ -540,7 +539,7 @@ def add_texts(node, node_ref):
     elif node.bl_idname == 'SvProfileNode':
         perform_profile_node_inject(node, node_ref)
 
-    elif node.bl_idname == 'SvTextInNode':
+    elif (node.bl_idname in {'SvTextInNode', 'SvTextInNodeMK2'}):
         perform_svtextin_node_object(node, node_ref)
 
 
@@ -548,7 +547,7 @@ def apply_post_processing(node, node_ref):
     '''
     Nodes that require post processing to work properly
     '''
-    if node.bl_idname in {'SvGroupInputsNode', 'SvGroupOutputsNode', 'SvTextInNode'}:
+    if node.bl_idname in {'SvGroupInputsNode', 'SvGroupOutputsNode', 'SvTextInNode', 'SvTextInNodeMK2'}:
         node.load()
     elif node.bl_idname in {'SvGroupNode'}:
         node.load()


### PR DESCRIPTION
- [x] add support for IO json
     - [x] (json mode) store the output file used by TextInMk2
     - [x] (json mode) load works
     - [x] (json mode) restore sockets with the same order as existed during export (currently not the case, because json reading as dataform picks sub structures in an arbitrary order) 
- [ ] explore handling TextIn and TextOut bl_idname for old nodes [the 2 nodes per file issue described here](https://github.com/nortikin/sverchok/pull/1961#issuecomment-353583357)