### PR TITLE
Node-defined right-click menu and nodes replacement

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -102,7 +102,7 @@ utils_modules = [
 ui_modules = [
     "color_def", "sv_IO_panel", "sv_templates_menu",
     "sv_panels", "nodeview_rclick_menu", "nodeview_space_menu", "nodeview_keymaps",
-    "monad", "sv_icons", "presets",
+    "monad", "sv_icons", "presets", "nodes_replacement",
     # bgl modules
     "viewer_draw", "viewer_draw_mk2", "nodeview_bgl_viewer_draw", "nodeview_bgl_viewer_draw_mk2",
     "index_viewer_draw", "bgl_callback_3dview",

--- a/node_tree.py
+++ b/node_tree.py
@@ -63,6 +63,7 @@ from sverchok.utils import get_node_class_reference
 from sverchok.utils.context_managers import sv_preferences
 from sverchok.utils.docstring import SvDocstring
 from sverchok.ui import color_def
+from sverchok.ui.nodes_replacement import set_inputs_mapping, set_outputs_mapping
 import sverchok.utils.logging
 from sverchok.utils.logging import debug
 
@@ -779,124 +780,11 @@ class SverchCustomTreeNode:
         else:
             pass
 
-class SvSocketReplacement(bpy.types.PropertyGroup):
-    """
-    Utility class for mapping old socket name to new socket name.
-    """
-    old_name = bpy.props.StringProperty(name="Name of socket in the old node")
-    new_name = bpy.props.StringProperty(name="Name of socket in the new node")
-
-def set_inputs_mapping(operator, mapping):
-    operator.inputs_mapping.clear()
-    if mapping:
-        for old, new in mapping.items():
-            item = operator.inputs_mapping.add()
-            item.old_name = old
-            item.new_name = new
-
-def set_outputs_mapping(operator, mapping):
-    operator.outputs_mapping.clear()
-    if mapping:
-        for old, new in mapping.items():
-            item = operator.outputs_mapping.add()
-            item.old_name = old
-            item.new_name = new
-
-class SvReplaceNode(bpy.types.Operator):
-    """
-    Replace selected node with another node.
-
-    This operator removes old node and creates a new node.
-    It tries to preserve all links and properties that old
-    node had. For cases when new node has other names of 
-    inputs and/or outputs, it is possible to define mapping.
-    In the end, this operator calls `migrate_from' method
-    of the new node, so the new node can copy it's settings
-    from correct places of old node.
-    """
-    bl_idname = "node.sv_replace_node"
-    bl_label = "Replace selected node with another"
-    bl_options = {'INTERNAL'}
-
-    old_node_name = bpy.props.StringProperty(name="Old node name")
-    new_bl_idname = bpy.props.StringProperty(name="New node bl_idname")
-    inputs_mapping = bpy.props.CollectionProperty(name="Input sockets names mapping",
-            type = SvSocketReplacement)
-    outputs_mapping = bpy.props.CollectionProperty(name="Output sockets names mapping",
-            type = SvSocketReplacement)
-
-    def get_new_input_name(self, old_name):
-        for item in self.inputs_mapping:
-            if item.old_name == old_name:
-                return item.new_name
-        return old_name
-
-    def get_new_output_name(self, old_name):
-        for item in self.outputs_mapping:
-            if item.old_name == old_name:
-                return item.new_name
-        return old_name
-
-    def execute(self, context):
-        if not self.old_node_name:
-            self.report({'ERROR'}, "Old node name is not provided")
-            return {'CANCELLED'}
-
-        if not self.new_bl_idname:
-            self.report({'ERROR'}, "New node bl_idname is not provided")
-            return {'CANCELLED'}
-
-        tree = context.space_data.edit_tree
-
-        old_node = tree.nodes[self.old_node_name]
-        new_node = tree.nodes.new(self.new_bl_idname)
-        # Copy UI properties
-        ui_props = ['location', 'height', 'width', 'label', 'hide']
-        for prop_name in ui_props:
-            setattr(new_node, prop_name, getattr(old_node, prop_name))
-        # Copy ID properties
-        for prop_name, prop_value in old_node.items():
-            new_node[prop_name] = old_node[prop_name]
-
-        # Copy incoming / outgoing links
-        old_in_links = [link for link in tree.links if link.to_node == old_node]
-        old_out_links = [link for link in tree.links if link.from_node == old_node]
-
-        for old_link in old_in_links:
-            new_target_socket_name = self.get_new_input_name(old_link.to_socket.name)
-            if new_target_socket_name in new_node.inputs:
-                new_target_socket = new_node.inputs[new_target_socket_name]
-                new_link = tree.links.new(old_link.from_socket, new_target_socket)
-            else:
-                debug("New node %s has no input named %s, skipping", new_node.name, new_target_socket_name)
-            tree.links.remove(old_link)
-
-        for old_link in old_out_links:
-            new_source_socket_name = self.get_new_output_name(old_link.from_socket.name)
-            # We have to remove old link before creating new one
-            # Blender would not allow two links pointing to the same target socket
-            old_target_socket = old_link.to_socket
-            tree.links.remove(old_link)
-            if new_source_socket_name in new_node.outputs:
-                new_source_socket = new_node.outputs[new_source_socket_name]
-                new_link = tree.links.new(new_source_socket, old_target_socket)
-            else:
-                debug("New node %s has no output named %s, skipping", new_node.name, new_source_socket_name)
-
-        if hasattr(new_node, "migrate_from"):
-            # Allow new node to copy what generic code could not.
-            new_node.migrate_from(old_node)
-
-        tree.nodes.remove(old_node)
-
-        return {'FINISHED'}
-
 classes = [
     SvColors, SverchCustomTree,
     VerticesSocket, MatrixSocket, StringsSocket,
     SvColorSocket, SvQuaternionSocket, SvDummySocket,
     SvLinkNewNodeInput,
-    SvSocketReplacement, SvReplaceNode,
 ]
 
 

--- a/node_tree.py
+++ b/node_tree.py
@@ -801,6 +801,9 @@ class SverchCustomTreeNode:
     def rclick_menu(self, context, layout):
         self.node_replacement_menu(context, layout)
 
+    def migrate_from(self, old_node):
+        pass
+
     def sv_init(self, context):
         self.create_sockets()
 
@@ -936,6 +939,9 @@ class SvReplaceNode(bpy.types.Operator):
                 new_link = tree.links.new(new_source_socket, old_target_socket)
             else:
                 debug("New node %s has no output named %s, skipping", new_node.name, new_source_socket_name)
+
+        if hasattr(new_node, "migrate_from"):
+            new_node.migrate_from(old_node)
 
         tree.nodes.remove(old_node)
 

--- a/node_tree.py
+++ b/node_tree.py
@@ -60,6 +60,7 @@ from sverchok.core.socket_conversions import (
 
 from sverchok.core.node_defaults import set_defaults_if_defined
 
+from sverchok.utils import get_node_class_reference
 from sverchok.utils.context_managers import sv_preferences
 from sverchok.ui import color_def
 import sverchok.utils.logging
@@ -786,6 +787,20 @@ class SverchCustomTreeNode:
 
         return cls.get_docstring().get_shorthand()
 
+    def node_replacement_menu(self, context, layout):
+        if hasattr(self, "replacement_nodes"):
+            for bl_idname, inputs_mapping, outputs_mapping in self.replacement_nodes:
+                node_class = get_node_class_reference(bl_idname)
+                text = "Replace with {}".format(node_class.bl_label)
+                op = layout.operator("node.sv_replace_node", text=text)
+                op.old_node_name = self.name
+                op.new_bl_idname = bl_idname
+                set_inputs_mapping(op, inputs_mapping)
+                set_outputs_mapping(op, outputs_mapping)
+
+    def rclick_menu(self, context, layout):
+        self.node_replacement_menu(context, layout)
+
     def sv_init(self, context):
         self.create_sockets()
 
@@ -835,11 +850,103 @@ class SverchCustomTreeNode:
         else:
             pass
 
+class SvSocketReplacement(bpy.types.PropertyGroup):
+    old_name = bpy.props.StringProperty(name="Name of socket in the old node")
+    new_name = bpy.props.StringProperty(name="Name of socket in the new node")
+
+def set_inputs_mapping(self, mapping):
+    self.inputs_mapping.clear()
+    if mapping:
+        for old, new in mapping.items():
+            item = self.inputs_mapping.add()
+            item.old_name = old
+            item.new_name = new
+
+def set_outputs_mapping(self, mapping):
+    self.outputs_mapping.clear()
+    if mapping:
+        for old, new in mapping.items():
+            item = self.outputs_mapping.add()
+            item.old_name = old
+            item.new_name = new
+
+class SvReplaceNode(bpy.types.Operator):
+    bl_idname = "node.sv_replace_node"
+    bl_label = "Replace selected node with another"
+    bl_options = {'INTERNAL'}
+
+    old_node_name = bpy.props.StringProperty(name="Old node name")
+    new_bl_idname = bpy.props.StringProperty(name="New node bl_idname")
+    inputs_mapping = bpy.props.CollectionProperty(name="Input sockets names mapping",
+            type = SvSocketReplacement)
+    outputs_mapping = bpy.props.CollectionProperty(name="Output sockets names mapping",
+            type = SvSocketReplacement)
+
+    def get_new_input_name(self, old_name):
+        for item in self.inputs_mapping:
+            if item.old_name == old_name:
+                return item.new_name
+        return old_name
+
+    def get_new_output_name(self, old_name):
+        for item in self.outputs_mapping:
+            if item.old_name == old_name:
+                return item.new_name
+        return old_name
+
+    def execute(self, context):
+        if not self.old_node_name:
+            self.report({'ERROR'}, "Old node name is not provided")
+            return {'CANCELLED'}
+
+        if not self.new_bl_idname:
+            self.report({'ERROR'}, "New node bl_idname is not provided")
+            return {'CANCELLED'}
+
+        tree = context.space_data.edit_tree
+
+        old_node = tree.nodes[self.old_node_name]
+        new_node = tree.nodes.new(self.new_bl_idname)
+        ui_props = ['location', 'height', 'width', 'label', 'hide']
+        for prop_name in ui_props:
+            setattr(new_node, prop_name, getattr(old_node, prop_name))
+        for prop_name, prop_value in old_node.items():
+            new_node[prop_name] = old_node[prop_name]
+
+        old_in_links = [link for link in tree.links if link.to_node == old_node]
+        old_out_links = [link for link in tree.links if link.from_node == old_node]
+
+        for old_link in old_in_links:
+            new_target_socket_name = self.get_new_input_name(old_link.to_socket.name)
+            if new_target_socket_name in new_node.inputs:
+                new_target_socket = new_node.inputs[new_target_socket_name]
+                new_link = tree.links.new(old_link.from_socket, new_target_socket)
+            else:
+                debug("New node %s has no input named %s, skipping", new_node.name, new_target_socket_name)
+            tree.links.remove(old_link)
+
+        for old_link in old_out_links:
+            new_source_socket_name = self.get_new_output_name(old_link.from_socket.name)
+            # We have to remove old link before creating new one
+            # Blender would not allow two links pointing to the same target socket
+            old_target_socket = old_link.to_socket
+            tree.links.remove(old_link)
+            if new_source_socket_name in new_node.outputs:
+                new_source_socket = new_node.outputs[new_source_socket_name]
+                new_link = tree.links.new(new_source_socket, old_target_socket)
+            else:
+                debug("New node %s has no output named %s, skipping", new_node.name, new_source_socket_name)
+
+        tree.nodes.remove(old_node)
+
+        return {'FINISHED'}
+
 classes = [
     SvColors, SverchCustomTree,
     VerticesSocket, MatrixSocket, StringsSocket,
     SvColorSocket, SvQuaternionSocket, SvDummySocket,
     SvLinkNewNodeInput,
+    SvSocketReplacement, SvReplaceNode,
 ]
 
 

--- a/nodes/matrix/matrix_in_mk2.py
+++ b/nodes/matrix/matrix_in_mk2.py
@@ -53,6 +53,12 @@ class SvMatrixGenNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         s = self.inputs.new('StringsSocket', "Angle")
         s.prop_name = 'a_'
         self.outputs.new('MatrixSocket', "Matrix")
+    
+    def migrate_from(self, old_node):
+        if old_node.bl_idname == 'MatrixGenNode':
+            self.l_ = old_node.inputs['Location'].prop
+            self.s_ = old_node.inputs['Scale'].prop
+            self.r_ = old_node.inputs['Rotation'].prop
 
     def process(self):
         L,S,R,A = self.inputs

--- a/nodes/modifier_change/extrude_separate.py
+++ b/nodes/modifier_change/extrude_separate.py
@@ -44,6 +44,11 @@ class SvExtrudeSeparateNode(bpy.types.Node, SverchCustomTreeNode):
         name="Scale", description="Extruded faces scale",
         default=1.0, min=0.0, update=updateNode)
 
+    replacement_nodes = [
+            ('SvInsetSpecial',
+                dict(Vertices='vertices', Polygons='polygons'),
+                dict(Vertices='vertices', Polygons='polygons'))]
+
     def sv_init(self, context):
         inew = self.inputs.new
         onew = self.outputs.new

--- a/old_nodes/matrix_in.py
+++ b/old_nodes/matrix_in.py
@@ -28,6 +28,8 @@ class MatrixGenNode(bpy.types.Node, SverchCustomTreeNode):
     bl_label = 'Matrix in'
     bl_icon = 'OUTLINER_OB_EMPTY'
 
+    replacement_nodes = [('SvMatrixGenNodeMK2', None, None)]
+
     def sv_init(self, context):
         s = self.inputs.new('VerticesSocket', "Location")
         s.use_prop = True

--- a/ui/nodes_replacement.py
+++ b/ui/nodes_replacement.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import bpy
+
+class SvSocketReplacement(bpy.types.PropertyGroup):
+    """
+    Utility class for mapping old socket name to new socket name.
+    """
+    old_name = bpy.props.StringProperty(name="Name of socket in the old node")
+    new_name = bpy.props.StringProperty(name="Name of socket in the new node")
+
+def set_inputs_mapping(operator, mapping):
+    operator.inputs_mapping.clear()
+    if mapping:
+        for old, new in mapping.items():
+            item = operator.inputs_mapping.add()
+            item.old_name = old
+            item.new_name = new
+
+def set_outputs_mapping(operator, mapping):
+    operator.outputs_mapping.clear()
+    if mapping:
+        for old, new in mapping.items():
+            item = operator.outputs_mapping.add()
+            item.old_name = old
+            item.new_name = new
+
+class SvReplaceNode(bpy.types.Operator):
+    """
+    Replace selected node with another node.
+
+    This operator removes old node and creates a new node.
+    It tries to preserve all links and properties that old
+    node had. For cases when new node has other names of 
+    inputs and/or outputs, it is possible to define mapping.
+    In the end, this operator calls `migrate_from' method
+    of the new node, so the new node can copy it's settings
+    from correct places of old node.
+    """
+    bl_idname = "node.sv_replace_node"
+    bl_label = "Replace selected node with another"
+    bl_options = {'INTERNAL'}
+
+    old_node_name = bpy.props.StringProperty(name="Old node name")
+    new_bl_idname = bpy.props.StringProperty(name="New node bl_idname")
+    inputs_mapping = bpy.props.CollectionProperty(name="Input sockets names mapping",
+            type = SvSocketReplacement)
+    outputs_mapping = bpy.props.CollectionProperty(name="Output sockets names mapping",
+            type = SvSocketReplacement)
+
+    def get_new_input_name(self, old_name):
+        for item in self.inputs_mapping:
+            if item.old_name == old_name:
+                return item.new_name
+        return old_name
+
+    def get_new_output_name(self, old_name):
+        for item in self.outputs_mapping:
+            if item.old_name == old_name:
+                return item.new_name
+        return old_name
+
+    def execute(self, context):
+        if not self.old_node_name:
+            self.report({'ERROR'}, "Old node name is not provided")
+            return {'CANCELLED'}
+
+        if not self.new_bl_idname:
+            self.report({'ERROR'}, "New node bl_idname is not provided")
+            return {'CANCELLED'}
+
+        tree = context.space_data.edit_tree
+
+        old_node = tree.nodes[self.old_node_name]
+        new_node = tree.nodes.new(self.new_bl_idname)
+        # Copy UI properties
+        ui_props = ['location', 'height', 'width', 'label', 'hide']
+        for prop_name in ui_props:
+            setattr(new_node, prop_name, getattr(old_node, prop_name))
+        # Copy ID properties
+        for prop_name, prop_value in old_node.items():
+            new_node[prop_name] = old_node[prop_name]
+
+        # Copy incoming / outgoing links
+        old_in_links = [link for link in tree.links if link.to_node == old_node]
+        old_out_links = [link for link in tree.links if link.from_node == old_node]
+
+        for old_link in old_in_links:
+            new_target_socket_name = self.get_new_input_name(old_link.to_socket.name)
+            if new_target_socket_name in new_node.inputs:
+                new_target_socket = new_node.inputs[new_target_socket_name]
+                new_link = tree.links.new(old_link.from_socket, new_target_socket)
+            else:
+                debug("New node %s has no input named %s, skipping", new_node.name, new_target_socket_name)
+            tree.links.remove(old_link)
+
+        for old_link in old_out_links:
+            new_source_socket_name = self.get_new_output_name(old_link.from_socket.name)
+            # We have to remove old link before creating new one
+            # Blender would not allow two links pointing to the same target socket
+            old_target_socket = old_link.to_socket
+            tree.links.remove(old_link)
+            if new_source_socket_name in new_node.outputs:
+                new_source_socket = new_node.outputs[new_source_socket_name]
+                new_link = tree.links.new(new_source_socket, old_target_socket)
+            else:
+                debug("New node %s has no output named %s, skipping", new_node.name, new_source_socket_name)
+
+        if hasattr(new_node, "migrate_from"):
+            # Allow new node to copy what generic code could not.
+            new_node.migrate_from(old_node)
+
+        tree.nodes.remove(old_node)
+
+        return {'FINISHED'}
+
+classes = [
+        SvSocketReplacement,
+        SvReplaceNode,
+    ]
+
+def register():
+    for cls in classes:
+        bpy.utils.register_class(cls)
+
+
+def unregister():
+    for cls in classes:
+        bpy.utils.unregister_class(cls)
+

--- a/ui/nodes_replacement.py
+++ b/ui/nodes_replacement.py
@@ -19,6 +19,8 @@
 
 import bpy
 
+from sverchok.utils.logging import debug, info
+
 class SvSocketReplacement(bpy.types.PropertyGroup):
     """
     Utility class for mapping old socket name to new socket name.
@@ -126,6 +128,12 @@ class SvReplaceNode(bpy.types.Operator):
         if hasattr(new_node, "migrate_from"):
             # Allow new node to copy what generic code could not.
             new_node.migrate_from(old_node)
+
+        msg = "Node `{}' ({}) has been replaced with new node `{}' ({})".format(
+                old_node.name, old_node.bl_idname,
+                new_node.name, new_node.bl_idname)
+        info(msg)
+        self.report({'INFO'}, msg)
 
         tree.nodes.remove(old_node)
 

--- a/ui/nodeview_rclick_menu.py
+++ b/ui/nodeview_rclick_menu.py
@@ -125,9 +125,6 @@ class SvGenericDeligationOperator(bpy.types.Operator):
 
         return {'FINISHED'}
 
-
-
-
 class SvNodeviewRClickMenu(bpy.types.Menu):
     bl_label = "Right click menu for Sverchok"
     bl_idname = "NODEVIEW_MT_sv_rclick_menu"
@@ -143,12 +140,16 @@ class SvNodeviewRClickMenu(bpy.types.Menu):
         nodes = tree.nodes
         node = valid_active_node(nodes)
 
-        if node and node.bl_idname in {'ViewerNode2', 'SvBmeshViewerNodeMK2'}:
-            layout.operator("node.sv_deligate_operator", text="Connect IDXViewer").fn = "+idxv"
+        if node:
+            if node.bl_idname in {'ViewerNode2', 'SvBmeshViewerNodeMK2'}:
+                layout.operator("node.sv_deligate_operator", text="Connect IDXViewer").fn = "+idxv"
+            else:
+                if hasattr(node, "rclick_menu"):
+                    node.rclick_menu(context, layout)
 
-        elif has_outputs(node):
-            layout.operator("node.sv_deligate_operator", text="Connect ViewerDraw").fn = "vdmk2"
-            # layout.operator("node.sv_deligate_operator", text="Connect ViewerDraw + IDX").fn="vdmk2 + idxv"
+                if has_outputs(node):
+                    layout.operator("node.sv_deligate_operator", text="Connect ViewerDraw").fn = "vdmk2"
+                    # layout.operator("node.sv_deligate_operator", text="Connect ViewerDraw + IDX").fn="vdmk2 + idxv"
         
         else:
             layout.menu("NODEVIEW_MT_Dynamic_Menu", text='node menu')
@@ -166,3 +167,4 @@ def register():
 def unregister():
     bpy.utils.unregister_class(SvNodeviewRClickMenu)
     bpy.utils.unregister_class(SvGenericDeligationOperator)
+

--- a/utils/docstring.py
+++ b/utils/docstring.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import sys
+import time
+import math
+import email
+
+class SvDocstring(object):
+    """
+    A class that incapsulates parsing of Sverchok's nodes docstrings.
+    As a standard, RFC822-style syntax is to be used. The docstring should
+    start with headers:
+
+            Triggers: This should be very short (two or three words, not much more) to be used in Ctrl-Space search menu.
+            Tooltip: Longer description to be present as a tooltip in UI.
+
+            More detailed description with technical information or historical notes goes after empty line.
+            This is not shown anywhere in the UI.
+
+    Other headers can possibly be introduced later. Unknown headers are just ignored.
+    For compatibility reasons, the old docstring syntax is also supported:
+
+            Triggers description /// Longer description
+
+    If we can't parse Triggers and Tooltip from docstring, then:
+    * The whole docstring will be used as tooltip
+    * The node will not have shorthand for search.
+    """
+
+    def __init__(self, docstring):
+        self.docstring = docstring
+        if docstring:
+            self.message = email.message_from_string(SvDocstring.trim(docstring))
+        else:
+            self.message = {}
+
+    @staticmethod
+    def trim(docstring):
+        """
+        Trim docstring indentation and extra spaces.
+        This is just copy-pasted from PEP-0257.
+        """
+
+        if not docstring:
+            return ''
+        # Convert tabs to spaces (following the normal Python rules)
+        # and split into a list of lines:
+        lines = docstring.expandtabs().splitlines()
+        # Determine minimum indentation (first line doesn't count):
+        indent = sys.maxsize
+        for line in lines[1:]:
+            stripped = line.lstrip()
+            if stripped:
+                indent = min(indent, len(line) - len(stripped))
+        # Remove indentation (first line is special):
+        trimmed = [lines[0].strip()]
+        if indent < sys.maxsize:
+            for line in lines[1:]:
+                trimmed.append(line[indent:].rstrip())
+        # Strip off trailing and leading blank lines:
+        while trimmed and not trimmed[-1]:
+            trimmed.pop()
+        while trimmed and not trimmed[0]:
+            trimmed.pop(0)
+        # Return a single string:
+        return '\n'.join(trimmed)
+
+    def get(self, header, default=None):
+        """Obtain any header from docstring."""
+        return self.message.get(header, default)
+
+    def __getitem__(self, header):
+        return self.message[header]
+
+    def get_shorthand(self, fallback=True):
+        """
+        Get shorthand to be used in search menu.
+        If fallback == True, then whole docstring
+        will be returned for case when we can't
+        find valid shorthand specification.
+        """
+
+        if 'Triggers' in self.message:
+            return self.message['Triggers']
+        elif not self.docstring:
+            return ""
+        elif '///' in self.docstring:
+            return self.docstring.strip().split('///')[0]
+        elif fallback:
+            return self.docstring
+        else:
+            return None
+
+    def has_shorthand(self):
+        return self.get_shorthand() is not None
+
+    def get_tooltip(self):
+        """Get tooltip"""
+
+        if 'Tooltip' in self.message:
+            return self.message['Tooltip'].strip()
+        elif not self.docstring:
+            return ""
+        elif '///' in self.docstring:
+            return self.docstring.strip().split('///')[1].strip()
+        else:
+            return self.docstring.strip()
+

--- a/utils/docstring.py
+++ b/utils/docstring.py
@@ -18,8 +18,6 @@
 # ##### END GPL LICENSE BLOCK #####
 
 import sys
-import time
-import math
 import email
 
 class SvDocstring(object):

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -25,6 +25,7 @@ import sverchok
 from sverchok.menu import make_node_cats
 from sverchok.node_tree import SvDocstring
 from sverchok.utils import get_node_class_reference
+from sverchok.utils.docstring import SvDocstring
 from sverchok.ui.sv_icons import custom_icon
 from sverchok.utils.sv_default_macros import macros, DefaultMacros
 from nodeitems_utils import _node_categories

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -23,7 +23,6 @@ import nodeitems_utils
 
 import sverchok
 from sverchok.menu import make_node_cats
-from sverchok.node_tree import SvDocstring
 from sverchok.utils import get_node_class_reference
 from sverchok.utils.docstring import SvDocstring
 from sverchok.ui.sv_icons import custom_icon


### PR DESCRIPTION
This is partly a continuation of  #1959.

What this adds is:
* Possibility for node class to define what to put to node's right-click menu.
* By default, items are added allowing to replace this node with new one. This is primarily intended to allow to easily replace deprecated node with new one. But it can be also used to replace one node to other, which has similar functionality.
* bl_idnames of nodes which this node can be replaced with, along with remapping of input/output socket names, is defined declaratively via `replacement_nodes` class property.
* New node class can override `migrate_from` method to correctly copy all settings from old node.
* Two simple examples are added: replacement of old MatrixIn node with new one, and replacement of Extrude Separate node with Inset Special.

Please review and test.