### PR TITLE
Add issue template and a PR template.

### DIFF
--- a/docs/issue_template.rst
+++ b/docs/issue_template.rst
@@ -1,0 +1,22 @@
+## Problem statement
+
+Please describe your problem here.
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Expected result
+
+What did you expect to see as a result of those steps?
+
+## Actual result
+
+What did you actually get?
+
+## Sverchok version
+
+This is especially important for installation-related issues. Please specify how do you install Sverchok: from sverchok-master.zip from github, or from release zip file, or from cloned git repo.
+

--- a/docs/pull_request_template.rst
+++ b/docs/pull_request_template.rst
@@ -1,0 +1,19 @@
+## Addressed problem description
+
+Please describe what problem does this PR solve. If it was already was disussed in an issue, it is enough to give a link as #number.
+
+## Solution description
+
+Please describe how do you intend to solve the problem: change some method, or introduce new class, or whatever.
+
+## Preflight checklist
+
+Put an x letter in each brackets when you're done this item:
+
+- [ ] Code changes complete.
+- [ ] Code documentation complete.
+- [ ] Documentation for users complete (or not required, if user never sees these changes).
+- [ ] Manual testing done. 
+- [ ] Unit-tests implemented.
+- [ ] Ready for merge.
+

--- a/docs/pull_request_template.rst
+++ b/docs/pull_request_template.rst
@@ -1,6 +1,7 @@
 ## Addressed problem description
 
-Please describe what problem does this PR solve. If it was already was disussed in an issue, it is enough to give a link as #number.
+Please describe what problem does this PR solve. If it was already was discussed in an issue, it is enough to give a link as #number.
+If this adds a new feature (a new node, for example), please state why (for what cases) do you think it is needed.
 
 ## Solution description
 


### PR DESCRIPTION
This adds templates for Github issues and PRs. Obviously seasoned contributers can totally ignore them and write good issues/PRs without them, but for novices I think this is a good starting point.

@zeffii  Maybe some ideas?