### PR TITLE
Deformula index per object (and fixed imports in Exec Node)

### DIFF
--- a/docs/nodes/beta_nodes/deform_by_formula.rst
+++ b/docs/nodes/beta_nodes/deform_by_formula.rst
@@ -5,7 +5,9 @@ Functionality
 -------------
 
 available variables: **x**, **y**, **z** for access to initial (xyz) coordinates.
-And **i** for access to index of current vertex to be evaluated.
+And **i** for access to index of current vertex to be evaluated. It is also possible
+to get index of current object list evaluated as "I" variable.
+So "i" for index of vertex, and "I" for index of object.
 Internally imported everything from Python **math** module.
 Blender Py API also accessible (like **bpy.context.scene.frame_current**)
 

--- a/docs/nodes/beta_nodes/deform_by_formula.rst
+++ b/docs/nodes/beta_nodes/deform_by_formula.rst
@@ -6,8 +6,8 @@ Functionality
 
 available variables: **x**, **y**, **z** for access to initial (xyz) coordinates.
 And **i** for access to index of current vertex to be evaluated. It is also possible
-to get index of current object list evaluated as "I" variable.
-So "i" for index of vertex, and "I" for index of object.
+to get index of current object list evaluated as **I** variable.
+So **i** for index of vertex, and **I** for index of object.
 Internally imported everything from Python **math** module.
 Blender Py API also accessible (like **bpy.context.scene.frame_current**)
 

--- a/nodes/script/multi_exec.py
+++ b/nodes/script/multi_exec.py
@@ -197,7 +197,7 @@ class SvExecNodeMod(bpy.types.Node, SverchCustomTreeNode):
         append = out.append
 
         # locals() is needed for generic module imports.
-        exec('\n'.join([j.line for j in self.dynamic_strings]), globals().update(locals()))
+        exec('\n'.join([j.line for j in self.dynamic_strings]), globals(), locals())
 
         self.outputs[0].sv_set(out)
 

--- a/nodes/script/multi_exec.py
+++ b/nodes/script/multi_exec.py
@@ -197,7 +197,7 @@ class SvExecNodeMod(bpy.types.Node, SverchCustomTreeNode):
         append = out.append
 
         # locals() is needed for generic module imports.
-        exec('\n'.join([j.line for j in self.dynamic_strings]), locals())
+        exec('\n'.join([j.line for j in self.dynamic_strings]), globals().update(locals()))
 
         self.outputs[0].sv_set(out)
 

--- a/nodes/vector/formula_deform.py
+++ b/nodes/vector/formula_deform.py
@@ -48,13 +48,9 @@ class SvFormulaDeformNode(bpy.types.Node, SverchCustomTreeNode):
         Io = self.inputs[0]
         Oo = self.outputs[0]
         if Oo.is_linked:
-            out = []
             V = Io.sv_get()
             IndObj = range(len(V))
-            Value = "[("+self.ModeX+","+self.ModeY+","+self.ModeZ+") for (x, y, z),i in zip(L,range(len(L)))]"
-            for L,I in zip(V,IndObj):
-                out.append(eval(Value, globals().update(locals())))
-            Oo.sv_set(out)
+            exec("Oo.sv_set([[("+self.ModeX+","+self.ModeY+","+self.ModeZ+") for (x, y, z),i in zip(L,range(len(L)))] for L,I in zip(V,IndObj)])")
 
     def update_socket(self, context):
         self.update()

--- a/nodes/vector/formula_deform.py
+++ b/nodes/vector/formula_deform.py
@@ -49,8 +49,8 @@ class SvFormulaDeformNode(bpy.types.Node, SverchCustomTreeNode):
         Oo = self.outputs[0]
         if Oo.is_linked:
             V = Io.sv_get()
-            IndObj = range(len(V))
-            exec("Oo.sv_set([[("+self.ModeX+","+self.ModeY+","+self.ModeZ+") for (x, y, z),i in zip(L,range(len(L)))] for L,I in zip(V,IndObj)])")
+            exec_string = "Oo.sv_set([[({n.ModeX},{n.ModeY},{n.ModeZ}) for i, (x, y, z) in enumerate(L)] for I, L in enumerate(V)])"
+            exec(exec_string.format(n=self))
 
     def update_socket(self, context):
         self.update()

--- a/nodes/vector/formula_deform.py
+++ b/nodes/vector/formula_deform.py
@@ -53,7 +53,7 @@ class SvFormulaDeformNode(bpy.types.Node, SverchCustomTreeNode):
             IndObj = range(len(V))
             Value = "[("+self.ModeX+","+self.ModeY+","+self.ModeZ+") for (x, y, z),i in zip(L,range(len(L)))]"
             for L,I in zip(V,IndObj):
-                out.append(eval(Value,locals()))
+                out.append(eval(Value, globals().update(locals())))
             Oo.sv_set(out)
 
     def update_socket(self, context):

--- a/nodes/vector/formula_deform.py
+++ b/nodes/vector/formula_deform.py
@@ -50,10 +50,10 @@ class SvFormulaDeformNode(bpy.types.Node, SverchCustomTreeNode):
         if Oo.is_linked:
             out = []
             V = Io.sv_get()
-            Value = "[("+self.ModeX+","+self.ModeY+","+self.ModeZ+") for (x, y, z),i in zip(L, I)]"
-            for L in V:
-                I = range(len(L))
-                out.append(eval(Value))
+            IndObj = range(len(V))
+            Value = "[("+self.ModeX+","+self.ModeY+","+self.ModeZ+") for (x, y, z),i in zip(L,range(len(L)))]"
+            for L,I in zip(V,IndObj):
+                out.append(eval(Value,locals()))
             Oo.sv_set(out)
 
     def update_socket(self, context):


### PR DESCRIPTION
Now it is also possible to get index of current object list evaluated as "I" variable.

So "i" for index of vertex, and "I" for index of object.