### PR TITLE
Metaball out vectorized (WIP)

### DIFF
--- a/nodes/matrix/matrix_in_mk2.py
+++ b/nodes/matrix/matrix_in_mk2.py
@@ -62,6 +62,7 @@ class SvMatrixGenNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         loc = Vector_generate(L.sv_get())
         scale = Vector_generate(S.sv_get())
         rot = Vector_generate(R.sv_get())
+        self.debug("Rot: %s", rot)
         rotA, angle = [[]], [[0.0]]
         # ability to add vector & vector difference instead of only rotation values
         if A.is_linked:

--- a/utils/sv_obj_helper.py
+++ b/utils/sv_obj_helper.py
@@ -300,20 +300,26 @@ class SvObjHelper():
         for object_name in obj_names:
             kinds.remove(kinds[object_name])        
 
+    def create_object(self, object_name, obj_index, data):
+        """
+        Create a new object and link it into scene.
+        """
+        obj = bpy.data.objects.new(object_name, data)
+        obj['basedata_name'] = self.basedata_name
+        obj['madeby'] = self.name
+        obj['idx'] = obj_index
+        bpy.context.scene.objects.link(obj)
+        return obj
+
     def get_or_create_object(self, object_name, obj_index, data):
         """
         Return existing Object or create new one.
         """
         objects = bpy.data.objects
-        scene = bpy.context.scene
         # if object reference exists, pick it up else make a new one
         obj = objects.get(object_name)
         if not obj:
-            obj = objects.new(object_name, data)
-            obj['basedata_name'] = self.basedata_name
-            obj['madeby'] = self.name
-            obj['idx'] = obj_index
-            scene.objects.link(obj)
+            obj = self.create_object(object_name, obj_index, data)
         return obj
 
     def get_obj_curve(self, obj_index):


### PR DESCRIPTION
The goal is to be able to create several META objects. For that, the Metaball Out node should be able to consume a list of lists of matrices: one list of matrices per Meta object. Or it in consume just a list of matrices (compatibility mode) and produce single object.