### PR TITLE
moves old class to old node where it belongs

### DIFF
--- a/node_tree.py
+++ b/node_tree.py
@@ -81,18 +81,6 @@ def process_from_socket(self, context):
     self.node.process_node(context)
 
 
-# this property group is only used by the old viewer draw
-
-
-class SvColors(bpy.types.PropertyGroup):
-    """ Class for colors CollectionProperty """
-    color = FloatVectorProperty(
-        name="svcolor", description="sverchok color",
-        default=(0.055, 0.312, 0.5), min=0, max=1,
-        step=1, precision=3, subtype='COLOR_GAMMA', size=3,
-        update=updateNode)
-
-
 class SvSocketCommon:
     """ Base class for all Sockets """
     use_prop = BoolProperty(default=False)
@@ -799,7 +787,7 @@ class SverchCustomTreeNode:
             pass
 
 classes = [
-    SvColors, SverchCustomTree,
+    SverchCustomTree,
     VerticesSocket, MatrixSocket, StringsSocket,
     SvColorSocket, SvQuaternionSocket, SvDummySocket,
     SvLinkNewNodeInput,

--- a/old_nodes/viewer.py
+++ b/old_nodes/viewer.py
@@ -17,7 +17,7 @@
 # ##### END GPL LICENSE BLOCK #####
 
 import bpy
-from bpy.props import BoolProperty, StringProperty
+from bpy.props import BoolProperty, StringProperty, FloatVectorProperty
 from mathutils import Matrix
 
 from sverchok.node_tree import (

--- a/old_nodes/viewer.py
+++ b/old_nodes/viewer.py
@@ -20,12 +20,22 @@ import bpy
 from bpy.props import BoolProperty, StringProperty
 from mathutils import Matrix
 
-from sverchok.node_tree import (SverchCustomTreeNode, SvColors,
-                       StringsSocket, VerticesSocket, MatrixSocket)
-from sverchok.data_structure import (dataCorrect, node_id,
-                            Vector_generate, Matrix_generate,
-                            updateNode, SvGetSocketAnyType)
+from sverchok.node_tree import (
+    SverchCustomTreeNode, StringsSocket, VerticesSocket, MatrixSocket)
+
+from sverchok.data_structure import (
+    dataCorrect, node_id, Vector_generate, Matrix_generate, updateNode, SvGetSocketAnyType)
+
 from sverchok.ui.viewer_draw import callback_disable, callback_enable
+
+
+class SvColors(bpy.types.PropertyGroup):
+    """ Class for colors CollectionProperty """
+    color = FloatVectorProperty(
+        name="svcolor", description="sverchok color",
+        default=(0.055, 0.312, 0.5), min=0, max=1,
+        step=1, precision=3, subtype='COLOR_GAMMA', size=3,
+        update=updateNode)
 
 
 class SvObjBake(bpy.types.Operator):
@@ -261,6 +271,7 @@ class ViewerNode(bpy.types.Node, SverchCustomTreeNode):
             bake(idname=self.name, idtree=self.id_data.name)
 
 def register():
+    bpy.utils.register_class(SvColors)
     bpy.utils.register_class(ViewerNode)
     bpy.utils.register_class(SvObjBake)
 
@@ -268,6 +279,7 @@ def register():
 def unregister():
     bpy.utils.unregister_class(SvObjBake)
     bpy.utils.unregister_class(ViewerNode)
+    bpy.utils.unregister_class(SvColors)
 
-if __name__ == '__main__':
-    register()
+# if __name__ == '__main__':
+#     register()


### PR DESCRIPTION
## Addressed problem description

orphan class takes up brainspace in nodetree.py - no longer.

## Solution description

moved to the viewer.py in old_nodes, where this class is used exclusively.

