### PR TITLE
Allow SvObjectSocket to consume arbitrary data.

### DIFF
--- a/core/socket_conversions.py
+++ b/core/socket_conversions.py
@@ -176,10 +176,18 @@ class DefaultImplicitConversionPolicy(NoImplicitConversionPolicy):
             return cls.quaternions_to_matrices(socket, source_data)
         elif is_matrix_to_quaternion(socket):
             return cls.matrices_to_quaternions(socket, source_data)
-        elif socket.bl_idname == 'StringsSocket':
+        elif socket.bl_idname in cls.get_lenient_socket_types():
             return source_data
         else:
             super().convert(socket, source_data)
+
+    @classmethod
+    def get_lenient_socket_types(cls):
+        """
+        Return collection of bl_idnames of socket classes
+        that are allowed to consume arbitrary data type.
+        """
+        return ['StringsSocket', 'SvObjectSocket']
 
     @classmethod
     def vectors_to_matrices(cls, socket, source_data):

--- a/tests/socket_conversion_tests.py
+++ b/tests/socket_conversion_tests.py
@@ -84,7 +84,8 @@ class SocketConversionTests(EmptyTreeTestCase):
                 'ListSortNodeMK2': ['data'],
                 'SvListSplitNode': ['Data'],
                 'ListFLNode': ['Data'],
-                'Formula2Node': ["X", "n[0]"]
+                'Formula2Node': ["X", "n[0]"],
+                'SvSetDataObjectNodeMK2': ["Objects"]
             }
         for bl_idname in tested_nodes.keys():
             with self.subTest(bl_idname = bl_idname):


### PR DESCRIPTION
## Addressed problem description

Was discussed in #2058.

## Solution description

* In `DefaultImplicitConversionPolicy`, introduced classmethod `get_lenient_socket_types`
* Default implementation returns StringsSocket and SvObjectSocket. Child classes can override this.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [x] Unit-tests implemented.
- [x] Ready for merge.

