### PR TITLE
Self fixing vcol mk3

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -53,10 +53,9 @@ bl_info = {
     "description": "Parametric node-based geometry programming",
     "warning": "",
     "wiki_url": "http://nikitron.cc.ua/sverch/html/main.html",
-    "tracker_url": (
-        "http://www.blenderartists.org/forum/showthread.php?272679"
-        "-Addon-WIP-Sverchok-parametric-tool-for-architects"),
-    "category": "Node"}
+    "tracker_url": "http://www.blenderartists.org/forum/showthread.php?272679",
+    "category": "Node"
+}
 
 
 import sys

--- a/core/socket_conversions.py
+++ b/core/socket_conversions.py
@@ -187,7 +187,7 @@ class DefaultImplicitConversionPolicy(NoImplicitConversionPolicy):
         Return collection of bl_idnames of socket classes
         that are allowed to consume arbitrary data type.
         """
-        return ['StringsSocket', 'SvObjectSocket']
+        return ['StringsSocket', 'SvObjectSocket', 'SvColorSocket']
 
     @classmethod
     def vectors_to_matrices(cls, socket, source_data):

--- a/menu.py
+++ b/menu.py
@@ -95,6 +95,9 @@ def juggle_and_join(node_cats):
         node_refs = node_cats.pop(ltype)
         node_cats["List Main"].extend(node_refs)
 
+    objects_cat = node_cats.pop('Objects')
+    node_cats['BPY Data'].extend(objects_cat)
+
     # add extended gens to Gens menu
     gen_ext = node_cats.pop("Generators Extended")
     node_cats["Generator"].extend(gen_ext)

--- a/nodes/object_nodes/vertex_colors_mk2.py
+++ b/nodes/object_nodes/vertex_colors_mk2.py
@@ -30,7 +30,7 @@ from sverchok.data_structure import (updateNode, repeat_last, fullList)
 class SvVertexColorNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     ''' Vertex Colors '''
     bl_idname = 'SvVertexColorNodeMK2'
-    bl_label = 'Vertex color new'
+    bl_label = 'Vertex color MK2'
     bl_icon = 'OUTLINER_OB_EMPTY'
 
     vertex_color = StringProperty(default='SvCol', update=updateNode)

--- a/nodes/object_nodes/vertex_colors_mk2.py
+++ b/nodes/object_nodes/vertex_colors_mk2.py
@@ -31,7 +31,7 @@ class SvVertexColorNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     ''' Vertex Colors '''
     bl_idname = 'SvVertexColorNodeMK2'
     bl_label = 'Vertex color MK2'
-    bl_icon = 'OUTLINER_OB_EMPTY'
+    bl_icon = 'COLOR'
 
     vertex_color = StringProperty(default='SvCol', update=updateNode)
     clear = BoolProperty(name='clear c', default=True, update=updateNode)

--- a/nodes/object_nodes/vertex_colors_mk3.py
+++ b/nodes/object_nodes/vertex_colors_mk3.py
@@ -122,9 +122,10 @@ class SvVertexColorNodeMK3(bpy.types.Node, SverchCustomTreeNode):
         inew = self.inputs.new
         inew('SvObjectSocket', 'Object')
         inew('StringsSocket', "Index")
-        color_socket = inew('StringsSocket', "Color")
-        color_socket.prop_name = 'unit_color'
-        color_socket.nodule_color = (0.899, 0.8052, 0.0, 1.0)
+        inew('SvColorSocket', "Color")
+        # color_socket = inew('StringsSocket', "Color")
+        # color_socket.prop_name = 'unit_color'
+        # color_socket.nodule_color = (0.899, 0.8052, 0.0, 1.0)
 
     def get_vertex_color_layer(self, obj):
         vcols = obj.data.vertex_colors
@@ -135,13 +136,19 @@ class SvVertexColorNodeMK3(bpy.types.Node, SverchCustomTreeNode):
         return vertex_color or vcols.new(name=self.vertex_color)
 
     def process(self):
-        objects = self.inputs["Object"].sv_get()
+
         color_socket = self.inputs["Color"]
         index_socket = self.inputs["Index"]
+
+        # self upgrade, shall only be called once if encountered.
+        if color_socket.bl_idname == 'StringsSocket':
+            color_socket.replace_socket('SvColorSocket')
+
+        objects = self.inputs["Object"].sv_get()
         color_data = color_socket.sv_get(deepcopy=False, default=[None])
         index_data = index_socket.sv_get(deepcopy=False, default=[None])
-        for obj, input_colors, indices in zip(objects, repeat_last(color_data), repeat_last(index_data)):
 
+        for obj, input_colors, indices in zip(objects, repeat_last(color_data), repeat_last(index_data)):
             if not input_colors:
                 continue
 

--- a/nodes/object_nodes/vertex_colors_mk3.py
+++ b/nodes/object_nodes/vertex_colors_mk3.py
@@ -84,7 +84,7 @@ class SvVertexColorNodeMK3(bpy.types.Node, SverchCustomTreeNode):
     ''' Vertex Colors '''
     bl_idname = 'SvVertexColorNodeMK3'
     bl_label = 'Vertex color mk3'
-    bl_icon = 'OUTLINER_OB_EMPTY'
+    bl_icon = 'COLOR'
 
     modes = [
         ("vertices", "Vert", "Vcol - color per vertex", 1),
@@ -122,10 +122,9 @@ class SvVertexColorNodeMK3(bpy.types.Node, SverchCustomTreeNode):
         inew = self.inputs.new
         inew('SvObjectSocket', 'Object')
         inew('StringsSocket', "Index")
-        inew('SvColorSocket', "Color")
-        # color_socket = inew('StringsSocket', "Color")
-        # color_socket.prop_name = 'unit_color'
-        # color_socket.nodule_color = (0.899, 0.8052, 0.0, 1.0)
+        color_socket = inew('SvColorSocket', "Color")
+        color_socket.prop_name = 'unit_color'
+
 
     def get_vertex_color_layer(self, obj):
         vcols = obj.data.vertex_colors

--- a/nodes/vector/color_out_mk1.py
+++ b/nodes/vector/color_out_mk1.py
@@ -21,7 +21,7 @@ import bpy
 from bpy.props import FloatProperty, BoolProperty, FloatVectorProperty
 from mathutils import Color
 
-from sverchok.node_tree import SverchCustomTreeNode, StringsSocket
+from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode, fullList, dataCorrect
 from sverchok.utils.sv_itertools import sv_zip_longest
 


### PR DESCRIPTION
## Addressed problem description

- [x] implicit conversion ( I C ) warning for * -> SvColorSocket
- [x] vertex col mk3 using StringSocket still.
- [x] vertex col New is an uninformative name.
- [x] vcol nodes appear in regular menu, but not in shift+A..

## Solution description

- add SvColorSocket to `get_lenient_socket_types`
- add self replacing SvColorSocket socket to vcol mk3 (does require a f8 / recalc nodetree ..but whatever..)
- rename `vertex color new` -> `vertex color MK2`.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

