### PR TITLE
add runtest bat

### DIFF
--- a/run_tests.bat
+++ b/run_tests.bat
@@ -1,0 +1,7 @@
+echo off
+
+:: blender executable path
+set arg1=%1 
+
+shift
+%arg1% -b --addons sverchok --python utils/testing.py --python-exit-code 1 


### PR DESCRIPTION
adds a windows version of the test, just to see if there's a difference.

##### run_tests.bat

```bat
echo off

:: blender executable path
set arg1=%1 

shift
%arg1% -b --addons sverchok --python utils/testing.py --python-exit-code 1 
```

usage: 
```
PS C:\Users\zeffi\Desktop\GITHUB\sverchok> .\run_tests.bat C:\fullpathto\b279\blender.exe
```
and it will start