### PR TITLE
add nodetree switcher to importsilent

### DIFF
--- a/utils/sv_IO_panel_tools.py
+++ b/utils/sv_IO_panel_tools.py
@@ -798,13 +798,20 @@ class SvNodeTreeImporterSilent(bpy.types.Operator):
 
     def execute(self, context):
 
+        # print(self.id_tree, self.filepath)
+
         # if triggered from a non-initialized tree, we first make a tree
         if self.id_tree == '____make_new____':
             ng_params = {
                 'name': basename(self.filepath),
                 'type': 'SverchCustomTreeType'}
             ng = bpy.data.node_groups.new(**ng_params)
+
+            # pass this tree to the active nodeview
+            context.space_data.node_tree = ng
+
         else:
+
             ng = bpy.data.node_groups[self.id_tree]
 
         # Deselect everything, so as a result only imported nodes


### PR DESCRIPTION
**addresses this issue:** https://github.com/nortikin/sverchok/issues/2082
**problem:** unable to load templates when no active nodetree is set
**solution:** give SilentImport operator the facility to set the node_tree to the new ng, when triggered with `self.id_tree == '____make_new____'` .