### PR TITLE
Io json cleanup alt

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -105,7 +105,7 @@ utils_modules = [
     # UI text editor ui
     "text_editor_submenu", "text_editor_plugins",
     # UI operators and tools
-    "sv_IO_monad_helpers", "sv_operator_utils",
+    "sv_IO_monad_helpers", "sv_operator_utils", "sv_IO_panel_properties", "sv_IO_panel_operators",
     "sv_panels_tools", "sv_gist_tools", "sv_IO_panel_tools", "sv_load_archived_blend",
     "monad", "sv_help", "sv_default_macros", "sv_macro_utils", "sv_extra_search", "sv_3dview_tools",
     #"loadscript",

--- a/utils/sv_IO_panel_operators.py
+++ b/utils/sv_IO_panel_operators.py
@@ -1,0 +1,303 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import zipfile
+import os
+from os.path import basename, dirname
+import json
+
+import bpy
+from bpy.utils import register_class, unregister_class
+from bpy.props import StringProperty, BoolProperty, PointerProperty, EnumProperty
+
+from sverchok.utils import sv_gist_tools
+from sverchok.utils.sv_IO_panel_tools import (
+     create_dict_of_tree, write_json, import_tree, load_json_from_gist, propose_archive_filepath)
+
+from sverchok.utils.logging import debug, info, warning, error, exception
+
+
+# pylint: disable=w0613
+
+class SvNodeTreeExporter(bpy.types.Operator):
+
+    '''Export will let you pick a .json file name'''
+
+    bl_idname = "node.tree_exporter"
+    bl_label = "sv NodeTree Export Operator"
+
+    filepath = StringProperty(
+        name="File Path",
+        description="Filepath used for exporting too",
+        maxlen=1024, default="", subtype='FILE_PATH')
+
+    filter_glob = StringProperty(
+        default="*.json",
+        options={'HIDDEN'})
+
+    id_tree = StringProperty()
+    compress = BoolProperty()
+
+    def execute(self, context):
+        ng = bpy.data.node_groups[self.id_tree]
+
+        destination_path = self.filepath
+        if not destination_path.lower().endswith('.json'):
+            destination_path += '.json'
+
+        # future: should check if filepath is a folder or ends in \
+
+        layout_dict = create_dict_of_tree(ng)
+        if not layout_dict:
+            msg = 'no update list found - didn\'t export'
+            self.report({"WARNING"}, msg)
+            warning(msg)
+            return {'CANCELLED'}
+
+        write_json(layout_dict, destination_path)
+        msg = 'exported to: ' + destination_path
+        self.report({"INFO"}, msg)
+        info(msg)
+
+        if self.compress:
+            comp_mode = zipfile.ZIP_DEFLATED
+
+            # destination path = /a../b../c../somename.json
+            base = basename(destination_path)  # somename.json
+            basedir = dirname(destination_path)  # /a../b../c../
+
+            # somename.zip
+            final_archivename = base.replace('.json', '') + '.zip'
+
+            # /a../b../c../somename.zip
+            fullpath = os.path.join(basedir, final_archivename)
+
+            with zipfile.ZipFile(fullpath, 'w', compression=comp_mode) as myzip:
+                myzip.write(destination_path, arcname=base)
+                info('wrote:', final_archivename)
+
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        wm = context.window_manager
+        wm.fileselect_add(self)
+        return {'RUNNING_MODAL'}
+
+
+class SvNodeTreeImporterSilent(bpy.types.Operator):
+
+    '''Importing operation just do it!'''
+
+    bl_idname = "node.tree_importer_silent"
+    bl_label = "sv NodeTree Import Silent"
+
+    filepath = StringProperty(
+        name="File Path",
+        description="Filepath used to import from",
+        maxlen=1024, default="", subtype='FILE_PATH')
+
+    id_tree = StringProperty()
+
+    def execute(self, context):
+
+        # print(self.id_tree, self.filepath)
+
+        # if triggered from a non-initialized tree, we first make a tree
+        if self.id_tree == '____make_new____':
+            ng_params = {
+                'name': basename(self.filepath),
+                'type': 'SverchCustomTreeType'}
+            ng = bpy.data.node_groups.new(**ng_params)
+
+            # pass this tree to the active nodeview
+            context.space_data.node_tree = ng
+
+        else:
+
+            ng = bpy.data.node_groups[self.id_tree]
+
+        # Deselect everything, so as a result only imported nodes
+        # will be selected
+        bpy.ops.node.select_all(action='DESELECT')
+        import_tree(ng, self.filepath)
+        context.space_data.node_tree = ng
+        return {'FINISHED'}
+
+
+class SvNodeTreeImporter(bpy.types.Operator):
+
+    '''Importing operation will let you pick a file to import from'''
+
+    bl_idname = "node.tree_importer"
+    bl_label = "sv NodeTree Import Operator"
+
+    filepath = StringProperty(
+        name="File Path",
+        description="Filepath used to import from",
+        maxlen=1024, default="", subtype='FILE_PATH')
+
+    filter_glob = StringProperty(
+        default="*.json",
+        options={'HIDDEN'})
+
+    id_tree = StringProperty()
+    new_nodetree_name = StringProperty()
+
+    def execute(self, context):
+        if not self.id_tree:
+            ng_name = self.new_nodetree_name
+            ng_params = {
+                'name': ng_name or 'unnamed_tree',
+                'type': 'SverchCustomTreeType'}
+            ng = bpy.data.node_groups.new(**ng_params)
+        else:
+            ng = bpy.data.node_groups[self.id_tree]
+        import_tree(ng, self.filepath)
+
+        # set new node tree to active
+        context.space_data.node_tree = ng
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        wm = context.window_manager
+        wm.fileselect_add(self)
+        return {'RUNNING_MODAL'}
+
+
+class SvNodeTreeImportFromGist(bpy.types.Operator):
+
+    bl_idname = "node.tree_import_from_gist"
+    bl_label = "sv NodeTree Gist Import Operator"
+
+    id_tree = StringProperty()
+    new_nodetree_name = StringProperty()
+    gist_id = StringProperty()
+
+    def execute(self, context):
+        if not self.id_tree:
+            ng_name = self.new_nodetree_name
+            ng_params = {
+                'name': ng_name or 'unnamed_tree',
+                'type': 'SverchCustomTreeType'}
+            ng = bpy.data.node_groups.new(**ng_params)
+        else:
+            ng = bpy.data.node_groups[self.id_tree]
+
+        if self.gist_id == 'clipboard':
+            self.gist_id = context.window_manager.clipboard
+
+        nodes_json = load_json_from_gist(self.gist_id.strip(), self)
+        if not nodes_json:
+            return {'CANCELLED'}
+
+        # import tree and set new node tree to active
+        import_tree(ng, nodes_json=nodes_json)
+        context.space_data.node_tree = ng
+        return {'FINISHED'}
+
+
+class SvNodeTreeExportToGist(bpy.types.Operator):
+    """Export to anonymous gist and copy id to clipboard"""
+    bl_idname = "node.tree_export_to_gist"
+    bl_label = "sv NodeTree Gist Export Operator"
+
+    selected_only = BoolProperty(name="Selected only", default=False)
+
+    def execute(self, context):
+        ng = context.space_data.node_tree
+        gist_filename = ng.name
+        gist_description = 'to do later? 2018'
+        layout_dict = create_dict_of_tree(ng, skip_set={}, selected=self.selected_only)
+
+        try:
+            gist_body = json.dumps(layout_dict, sort_keys=True, indent=2)
+        except Exception as err:
+            if 'not JSON serializable' in repr(err):
+                error(layout_dict)
+            else:
+                exception(err)
+            self.report({'WARNING'}, "See terminal/Command prompt for printout of error")
+            return {'CANCELLED'}
+
+        try:
+            gist_url = sv_gist_tools.main_upload_function(gist_filename, gist_description, gist_body, show_browser=False)
+            context.window_manager.clipboard = gist_url   # full destination url
+            info(gist_url)
+            self.report({'WARNING'}, "Copied gistURL to clipboad")
+
+            sv_gist_tools.write_or_append_datafiles(gist_url, gist_filename)
+            return {'FINISHED'}
+        except Exception as err:
+            info(err)
+            self.report({'ERROR'}, "Error uploading the gist, check your internet connection!")
+
+        return {'CANCELLED'}
+
+
+class SvBlendToArchive(bpy.types.Operator):
+    """ Archive this blend file as zip or gz """
+
+    bl_idname = "node.blend_to_archive"
+    bl_label = "Archive .blend"
+
+    archive_ext = bpy.props.StringProperty(default='zip')
+    
+
+    def complete_msg(self, blend_archive_path):
+        msg = 'saved current .blend as archive at ' + blend_archive_path
+        self.report({'INFO'}, msg)
+        info(msg)
+
+    def execute(self, context):
+
+        blendpath = bpy.data.filepath
+
+        if not blendpath:
+            msg = 'you must save the .blend first before we can compress it'
+            self.report({'INFO'}, msg)
+            return {'CANCELLED'}
+
+        blend_archive_path, blendname = propose_archive_filepath(blendpath, extension=self.archive_ext)
+        context.window_manager.clipboard = blend_archive_path
+
+        if self.archive_ext == 'zip':
+            with zipfile.ZipFile(blend_archive_path, 'w', zipfile.ZIP_DEFLATED) as myzip:
+                myzip.write(blendpath, blendname)
+            self.complete_msg(blend_archive_path)
+            return {'FINISHED'}
+
+        elif self.archive_ext == 'gz':
+
+            import gzip
+            import shutil
+
+            with open(blendpath, 'rb') as f_in:
+                with gzip.open(blend_archive_path, 'wb') as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+            self.complete_msg(blend_archive_path)
+            return {'FINISHED'}
+
+        return {'CANCELLED'}
+
+
+classes = [
+    SvNodeTreeExporter,
+    SvNodeTreeExportToGist,
+    SvNodeTreeImporter,
+    SvNodeTreeImporterSilent,
+    SvNodeTreeImportFromGist,
+    SvBlendToArchive
+]
+
+
+def register():
+    _ = [register_class(cls) for cls in classes]
+
+
+
+def unregister():
+    _ = [unregister_class(cls) for cls in classes[::-1]]

--- a/utils/sv_IO_panel_operators.py
+++ b/utils/sv_IO_panel_operators.py
@@ -302,6 +302,5 @@ def register():
     _ = [register_class(cls) for cls in classes]
 
 
-
 def unregister():
     _ = [unregister_class(cls) for cls in classes[::-1]]

--- a/utils/sv_IO_panel_operators.py
+++ b/utils/sv_IO_panel_operators.py
@@ -6,17 +6,21 @@
 # License-Filename: LICENSE
 
 import zipfile
+import json
 import os
 from os.path import basename, dirname
-import json
 
 import bpy
 from bpy.utils import register_class, unregister_class
-from bpy.props import StringProperty, BoolProperty, PointerProperty, EnumProperty
+from bpy.props import StringProperty, BoolProperty
 
 from sverchok.utils import sv_gist_tools
 from sverchok.utils.sv_IO_panel_tools import (
-     create_dict_of_tree, write_json, import_tree, load_json_from_gist, propose_archive_filepath)
+    propose_archive_filepath,
+    create_dict_of_tree,
+    load_json_from_gist,
+    import_tree,
+    write_json)
 
 from sverchok.utils.logging import debug, info, warning, error, exception
 

--- a/utils/sv_IO_panel_properties.py
+++ b/utils/sv_IO_panel_properties.py
@@ -1,0 +1,53 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+
+import bpy
+from bpy.utils import register_class, unregister_class
+from bpy.props import StringProperty, BoolProperty, PointerProperty, EnumProperty
+
+
+class SvIOPanelProperties(bpy.types.PropertyGroup):
+
+    new_nodetree_name = StringProperty(
+        name='new_nodetree_name',
+        default="Imported_name",
+        description="The name to give the new NodeTree, defaults to: Imported")
+
+    compress_output = BoolProperty(
+        default=0,
+        name='compress_output',
+        description='option to also compress the json, will generate both')
+
+    gist_id = StringProperty(
+        name='new_gist_id',
+        default="Enter Gist ID here",
+        description="This gist ID will be used to obtain the RAW .json from github")
+
+    io_options_enum = EnumProperty(
+        items=[("Import", "Import", "", 0), ("Export", "Export", "", 1)],
+        description="display import or export",
+        default="Export")
+
+    export_selected_only = BoolProperty(
+        name="Selected Only",
+        description="Export selected nodes only",
+        default=False)
+
+
+def register():
+    register_class(SvIOPanelProperties)
+    bpy.types.NodeTree.io_panel_properties = PointerProperty(name="io_panel_properties", type=SvIOPanelProperties)
+
+
+def unregister():
+    del bpy.types.NodeTree.io_panel_properties
+    unregister_class(SvIOPanelProperties)
+
+
+# if __name__ == '__main__':
+#    register()

--- a/utils/sv_IO_panel_tools.py
+++ b/utils/sv_IO_panel_tools.py
@@ -16,27 +16,23 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
-import json
-import sys
 import os
-import re
-import zipfile
-import traceback
+from os.path import basename, dirname
 from time import gmtime, strftime
+import zipfile
+import json
+import re
 import urllib
 from urllib.request import urlopen
-
-from os.path import basename, dirname
 from itertools import chain
 
 import bpy
-from bpy.props import StringProperty, BoolProperty, PointerProperty
-from bpy.utils import register_class, unregister_class
 
 from sverchok import old_nodes
-from sverchok.utils import sv_gist_tools
 from sverchok.utils.sv_IO_monad_helpers import pack_monad, unpack_monad
 from sverchok.utils.logging import debug, info, warning, error, exception
+
+# pylint: disable=w0621
 
 
 SCRIPTED_NODES = {'SvScriptNode', 'SvScriptNodeMK2', 'SvScriptNodeLite'}
@@ -44,19 +40,19 @@ PROFILE_NODES = {'SvProfileNode', 'SvProfileNodeMK2'}
 
 _EXPORTER_REVISION_ = '0.072'
 
-'''
+IO_REVISION_HISTORY = r"""
 0.072 new route for node.storage_get/set_data. no change to json format
 0.07  add initial support for socket properties.
 0.065 general refactoring to get the monad pack/unpack into one file
 0.064 prop_types as a property is now tracked for scalarmath and logic node, this uses boolvec.
-0.063 add support for obj_in_lite obj serialization \o/ .
+0.063 add support for obj_in_lite obj serialization.
 0.062 (no revision change) - fixes import of sn texts that are present already in .blend
 0.062 (no revision change) - looks in multiple places for textmode param.
 0.062 monad export properly
 
 revisions below this are your own problem.
 
-'''
+"""
 
 
 def get_file_obj_from_zip(fullpath):
@@ -249,7 +245,6 @@ def create_dict_of_tree(ng, skip_set={}, selected=False):
     layout_dict = {}
     nodes_dict = {}
     groups_dict = {}
-    texts = bpy.data.texts
 
     if not skip_set:
         skip_set = {'Sv3DviewPropsNode'}
@@ -677,7 +672,7 @@ def import_tree(ng, fullpath='', nodes_json=None, create_texts=True):
             debug('==== loading monad ====')
         info(('#' * 12) + nodes_json['export_version'])
 
-        ''' create all nodes and groups '''
+        # ''' create all nodes and groups '''
 
         update_lists = nodes_json['update_lists']
         nodes_to_import = nodes_json['nodes']
@@ -686,23 +681,23 @@ def import_tree(ng, fullpath='', nodes_json=None, create_texts=True):
         add_groups(groups_to_import)  # this return is not used yet
         name_remap = add_nodes(ng, nodes_to_import, nodes, create_texts)
 
-        ''' now connect them '''
+        # ''' now connect them '''
 
         # prevent unnecessary updates
         ng.freeze(hard=True)
         make_links(update_lists, name_remap)
 
-        ''' set frame parents '''
+        # ''' set frame parents '''
 
         place_frames(ng, nodes_json, name_remap)
 
-        ''' clean up '''
+        # ''' clean up '''
 
         old_nodes.scan_for_old(ng)
         ng.unfreeze(hard=True)
         ng.update()
 
-    ''' ---- read files (.json or .zip) or straight json data----- '''
+    # ''' ---- read files (.json or .zip) or straight json data----- '''
 
     if fullpath.endswith('.zip'):
         nodes_json = get_file_obj_from_zip(fullpath)
@@ -716,150 +711,6 @@ def import_tree(ng, fullpath='', nodes_json=None, create_texts=True):
     elif nodes_json:
         generate_layout('', nodes_json)
 
-
-class SvNodeTreeExporter(bpy.types.Operator):
-
-    '''Export will let you pick a .json file name'''
-
-    bl_idname = "node.tree_exporter"
-    bl_label = "sv NodeTree Export Operator"
-
-    filepath = StringProperty(
-        name="File Path",
-        description="Filepath used for exporting too",
-        maxlen=1024, default="", subtype='FILE_PATH')
-
-    filter_glob = StringProperty(
-        default="*.json",
-        options={'HIDDEN'})
-
-    id_tree = StringProperty()
-    compress = BoolProperty()
-
-    def execute(self, context):
-        ng = bpy.data.node_groups[self.id_tree]
-
-        destination_path = self.filepath
-        if not destination_path.lower().endswith('.json'):
-            destination_path += '.json'
-
-        # future: should check if filepath is a folder or ends in \
-
-        layout_dict = create_dict_of_tree(ng)
-        if not layout_dict:
-            msg = 'no update list found - didn\'t export'
-            self.report({"WARNING"}, msg)
-            warning(msg)
-            return {'CANCELLED'}
-
-        write_json(layout_dict, destination_path)
-        msg = 'exported to: ' + destination_path
-        self.report({"INFO"}, msg)
-        info(msg)
-
-        if self.compress:
-            comp_mode = zipfile.ZIP_DEFLATED
-
-            # destination path = /a../b../c../somename.json
-            base = basename(destination_path)  # somename.json
-            basedir = dirname(destination_path)  # /a../b../c../
-
-            # somename.zip
-            final_archivename = base.replace('.json', '') + '.zip'
-
-            # /a../b../c../somename.zip
-            fullpath = os.path.join(basedir, final_archivename)
-
-            with zipfile.ZipFile(fullpath, 'w', compression=comp_mode) as myzip:
-                myzip.write(destination_path, arcname=base)
-                info('wrote:', final_archivename)
-
-        return {'FINISHED'}
-
-    def invoke(self, context, event):
-        wm = context.window_manager
-        wm.fileselect_add(self)
-        return {'RUNNING_MODAL'}
-
-
-class SvNodeTreeImporterSilent(bpy.types.Operator):
-
-    '''Importing operation just do it!'''
-
-    bl_idname = "node.tree_importer_silent"
-    bl_label = "sv NodeTree Import Silent"
-
-    filepath = StringProperty(
-        name="File Path",
-        description="Filepath used to import from",
-        maxlen=1024, default="", subtype='FILE_PATH')
-
-    id_tree = StringProperty()
-
-    def execute(self, context):
-
-        # print(self.id_tree, self.filepath)
-
-        # if triggered from a non-initialized tree, we first make a tree
-        if self.id_tree == '____make_new____':
-            ng_params = {
-                'name': basename(self.filepath),
-                'type': 'SverchCustomTreeType'}
-            ng = bpy.data.node_groups.new(**ng_params)
-
-            # pass this tree to the active nodeview
-            context.space_data.node_tree = ng
-
-        else:
-
-            ng = bpy.data.node_groups[self.id_tree]
-
-        # Deselect everything, so as a result only imported nodes
-        # will be selected
-        bpy.ops.node.select_all(action='DESELECT')
-        import_tree(ng, self.filepath)
-        context.space_data.node_tree = ng
-        return {'FINISHED'}
-
-
-class SvNodeTreeImporter(bpy.types.Operator):
-
-    '''Importing operation will let you pick a file to import from'''
-
-    bl_idname = "node.tree_importer"
-    bl_label = "sv NodeTree Import Operator"
-
-    filepath = StringProperty(
-        name="File Path",
-        description="Filepath used to import from",
-        maxlen=1024, default="", subtype='FILE_PATH')
-
-    filter_glob = StringProperty(
-        default="*.json",
-        options={'HIDDEN'})
-
-    id_tree = StringProperty()
-    new_nodetree_name = StringProperty()
-
-    def execute(self, context):
-        if not self.id_tree:
-            ng_name = self.new_nodetree_name
-            ng_params = {
-                'name': ng_name or 'unnamed_tree',
-                'type': 'SverchCustomTreeType'}
-            ng = bpy.data.node_groups.new(**ng_params)
-        else:
-            ng = bpy.data.node_groups[self.id_tree]
-        import_tree(ng, self.filepath)
-
-        # set new node tree to active
-        context.space_data.node_tree = ng
-        return {'FINISHED'}
-
-    def invoke(self, context, event):
-        wm = context.window_manager
-        wm.fileselect_add(self)
-        return {'RUNNING_MODAL'}
 
 def load_json_from_gist(gist_id, operator=None):
     """
@@ -912,74 +763,6 @@ def load_json_from_gist(gist_id, operator=None):
     nodes_str = wjson['files'][file_name]['content']
     return json.loads(nodes_str)
 
-class SvNodeTreeImportFromGist(bpy.types.Operator):
-
-    bl_idname = "node.tree_import_from_gist"
-    bl_label = "sv NodeTree Gist Import Operator"
-
-    id_tree = StringProperty()
-    new_nodetree_name = StringProperty()
-    gist_id = StringProperty()
-
-    def execute(self, context):
-        if not self.id_tree:
-            ng_name = self.new_nodetree_name
-            ng_params = {
-                'name': ng_name or 'unnamed_tree',
-                'type': 'SverchCustomTreeType'}
-            ng = bpy.data.node_groups.new(**ng_params)
-        else:
-            ng = bpy.data.node_groups[self.id_tree]
-
-        if self.gist_id == 'clipboard':
-            self.gist_id = context.window_manager.clipboard
-
-        nodes_json = load_json_from_gist(self.gist_id.strip(), self)
-        if not nodes_json:
-            return {'CANCELLED'}
-
-        # import tree and set new node tree to active
-        import_tree(ng, nodes_json=nodes_json)
-        context.space_data.node_tree = ng
-        return {'FINISHED'}
-
-
-class SvNodeTreeExportToGist(bpy.types.Operator):
-    """Export to anonymous gist and copy id to clipboard"""
-    bl_idname = "node.tree_export_to_gist"
-    bl_label = "sv NodeTree Gist Export Operator"
-
-    selected_only = BoolProperty(name = "Selected only", default=False)
-
-    def execute(self, context):
-        ng = context.space_data.node_tree
-        gist_filename = ng.name
-        gist_description = 'to do later?'
-        layout_dict = create_dict_of_tree(ng, skip_set={}, selected=self.selected_only)
-
-        try:
-            gist_body = json.dumps(layout_dict, sort_keys=True, indent=2)
-        except Exception as err:
-            if 'not JSON serializable' in repr(err):
-                error(layout_dict)
-            else:
-                exception(err)
-            self.report({'WARNING'}, "See terminal/Command prompt for printout of error")
-            return {'CANCELLED'}
-
-        try:
-            gist_url = sv_gist_tools.main_upload_function(gist_filename, gist_description, gist_body, show_browser=False)
-            context.window_manager.clipboard = gist_url   # full destination url
-            info(gist_url)
-            self.report({'WARNING'}, "Copied gistURL to clipboad")
-
-            sv_gist_tools.write_or_append_datafiles(gist_url, gist_filename)
-
-        except:
-            self.report({'ERROR'}, "Error uploading the gist, check your internet connection!")
-        finally:
-            return {'FINISHED'}
-
 
 def propose_archive_filepath(blendpath, extension='zip'):
     """ disect existing filepath, add timestamp """
@@ -990,103 +773,3 @@ def propose_archive_filepath(blendpath, extension='zip'):
     archivename = blendbasename + '_' + raw_time_stamp + '.' + extension
 
     return os.path.join(blenddir, archivename), blendname
-
-
-class SvBlendToArchive(bpy.types.Operator):
-    """ Archive this blend file as zip or gz """
-
-    bl_idname = "node.blend_to_archive"
-    bl_label = "Archive .blend"
-
-    archive_ext = bpy.props.StringProperty(default='zip')
-    
-
-    def complete_msg(self, blend_archive_path):
-        msg = 'saved current .blend as archive at ' + blend_archive_path
-        self.report({'INFO'}, msg)
-        info(msg)
-
-    def execute(self, context):
-
-        blendpath = bpy.data.filepath
-
-        if not blendpath:
-            msg = 'you must save the .blend first before we can compress it'
-            self.report({'INFO'}, msg)
-            return {'CANCELLED'}
-
-        blend_archive_path, blendname = propose_archive_filepath(blendpath, extension=self.archive_ext)
-        context.window_manager.clipboard = blend_archive_path
-
-        if self.archive_ext == 'zip':
-            with zipfile.ZipFile(blend_archive_path, 'w', zipfile.ZIP_DEFLATED) as myzip:
-                myzip.write(blendpath, blendname)
-            self.complete_msg(blend_archive_path)
-            return {'FINISHED'}
-
-        elif self.archive_ext == 'gz':
-
-            import gzip
-            import shutil
-
-            with open(blendpath, 'rb') as f_in:
-                with gzip.open(blend_archive_path, 'wb') as f_out:
-                    shutil.copyfileobj(f_in, f_out)
-            self.complete_msg(blend_archive_path)
-            return {'FINISHED'}
-
-        return {'CANCELLED'}
-
-
-class SvIOPanelProperties(bpy.types.PropertyGroup):
-
-    new_nodetree_name = StringProperty(
-        name='new_nodetree_name',
-        default="Imported_name",
-        description="The name to give the new NodeTree, defaults to: Imported")
-
-    compress_output = BoolProperty(
-        default=0,
-        name='compress_output',
-        description='option to also compress the json, will generate both')
-
-    gist_id = StringProperty(
-        name='new_gist_id',
-        default="Enter Gist ID here",
-        description="This gist ID will be used to obtain the RAW .json from github")
-
-    io_options_enum = bpy.props.EnumProperty(
-        items=[("Import", "Import", "", 0), ("Export", "Export", "", 1)],
-        description="display import or export",
-        default="Export"
-    )
-
-    export_selected_only = BoolProperty(
-        name = "Selected Only",
-        description = "Export selected nodes only",
-        default = False
-    )
-
-classes = [
-    SvIOPanelProperties,
-    SvNodeTreeExporter,
-    SvNodeTreeExportToGist,
-    SvNodeTreeImporter,
-    SvNodeTreeImporterSilent,
-    SvNodeTreeImportFromGist,
-    SvBlendToArchive
-]
-
-
-def register():
-    _ = [register_class(cls) for cls in classes]
-    bpy.types.NodeTree.io_panel_properties = PointerProperty(name="io_panel_properties", type=SvIOPanelProperties)
-
-
-def unregister():
-    del bpy.types.NodeTree.io_panel_properties
-    _ = [unregister_class(cls) for cls in classes[::-1]]
-
-
-# if __name__ == '__main__':
-#    register()

--- a/utils/sv_IO_panel_tools.py
+++ b/utils/sv_IO_panel_tools.py
@@ -663,7 +663,6 @@ def import_tree(ng, fullpath='', nodes_json=None, create_texts=True):
             debug('no failed connections! awesome.')
 
     def generate_layout(fullpath, nodes_json):
-        '''cummulative function '''
 
         # it may be necessary to store monads as dicts instead of string/json
         # this will handle both scenarios
@@ -672,8 +671,7 @@ def import_tree(ng, fullpath='', nodes_json=None, create_texts=True):
             debug('==== loading monad ====')
         info(('#' * 12) + nodes_json['export_version'])
 
-        # ''' create all nodes and groups '''
-
+        # create all nodes and groups '''
         update_lists = nodes_json['update_lists']
         nodes_to_import = nodes_json['nodes']
         groups_to_import = nodes_json.get('groups', {})
@@ -681,23 +679,19 @@ def import_tree(ng, fullpath='', nodes_json=None, create_texts=True):
         add_groups(groups_to_import)  # this return is not used yet
         name_remap = add_nodes(ng, nodes_to_import, nodes, create_texts)
 
-        # ''' now connect them '''
-
-        # prevent unnecessary updates
+        # now connect them / prevent unnecessary updates
         ng.freeze(hard=True)
         make_links(update_lists, name_remap)
 
-        # ''' set frame parents '''
-
+        # set frame parents '''
         place_frames(ng, nodes_json, name_remap)
 
-        # ''' clean up '''
-
+        # clean up
         old_nodes.scan_for_old(ng)
         ng.unfreeze(hard=True)
         ng.update()
 
-    # ''' ---- read files (.json or .zip) or straight json data----- '''
+    # ---- read files (.json or .zip) or straight json data -----
 
     if fullpath.endswith('.zip'):
         nodes_json = get_file_obj_from_zip(fullpath)


### PR DESCRIPTION
stealthy non user facing file fixes.

`sv_io_panel_tools.py` is too damn big. Many functions inside rarely need any serious modification anymore, and it might be time to fully modularize (but I resist turning this into a class-system )

I'm electing to move many functions into their own (or existing, sensible location) and reduce the import if possible, i'd like `sv_io_panel_tools.py` to be no longer than 500 lines orso.