### PR TITLE
adjusts location of bgl text depending on framed or not

### DIFF
--- a/nodes/text/stethoscope_mk2.py
+++ b/nodes/text/stethoscope_mk2.py
@@ -25,6 +25,7 @@ from bpy.props import BoolProperty, FloatVectorProperty, StringProperty, IntProp
 from mathutils import Vector
 
 from sverchok.utils.context_managers import sv_preferences
+from sverchok.utils.sv_node_utils import recursive_framed_location_finder
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import node_id, updateNode
 from sverchok.ui import nodeview_bgl_viewer_draw_mk2 as nvBGL
@@ -159,9 +160,14 @@ class SvStethoscopeNodeMK2(bpy.types.Node, SverchCustomTreeNode):
                 #                # implement another nvBGL parses for gfx
                 processed_data = data
 
-            # adjust the location of the printed bgl text, depending on hidden state
             node_width = (self.width_hidden + 30.0) if self.hide else self.width
-            _x, _y = (self.location + Vector((node_width + 20, 0)))
+
+            # adjust proposed text location in case node is framed.
+            # take into consideration the hidden state
+            _x, _y = recursive_framed_location_finder(self, self.location[:])
+            _x, _y = Vector((_x, _y)) + Vector((node_width + 20, 0))
+
+            # this alters location based on DPI/Scale settings.
             location = adjust_location(_x, _y, location_theta)
 
             draw_data = {


### PR DESCRIPTION
addresses bgl print location for stethoscopes that are inside a frame (or nested n deep inside n frames)