### PR TITLE
Text In mk2: sort output sockets, if order is not defined.

### DIFF
--- a/nodes/text/text_in_mk2.py
+++ b/nodes/text/text_in_mk2.py
@@ -448,7 +448,7 @@ class SvTextInNodeMK2(bpy.types.Node, SverchCustomTreeNode, CommonTextMixinIO):
 
             socket_iterator = iterate_socket_order()
         else:
-            socket_iterator = json_data.items()
+            socket_iterator = sorted(json_data.items())
 
         for named_socket, data in socket_iterator:
             if len(data) == 2 and data[0] in {'v', 's', 'm'}:


### PR DESCRIPTION
## Addressed problem description

#2126 

## Solution description

Order outputs by using sorted(), if "sockets_order" is not defined.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

