### PR TITLE
Line mk2 nestiness fix

### DIFF
--- a/nodes/generator/line_mk2.py
+++ b/nodes/generator/line_mk2.py
@@ -19,7 +19,7 @@
 import bpy
 from bpy.props import IntProperty, FloatProperty, BoolProperty, EnumProperty
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import updateNode, fullList, match_long_repeat, second_as_first_cycle as safc
+from sverchok.data_structure import updateNode, fullList, match_long_repeat
 
 directionItems = [("X", "X", ""), ("Y", "Y", ""), ("Z", "Z", "")]
 
@@ -102,7 +102,6 @@ class SvLineNodeMK2(bpy.types.Node, SverchCustomTreeNode):
                 num = max(2,num)
                 s = s[:(num - 1)]  # shorten if needed
                 fullList(s, num - 1)  # extend if needed
-            # s = safc(n, s)
                 stepList.append([S * self.size / sum(s) for S in s] if self.normalize else s)
             for s in stepList:
                 r1,r2 = make_line(s, c, d)

--- a/nodes/generator/line_mk2.py
+++ b/nodes/generator/line_mk2.py
@@ -18,9 +18,8 @@
 
 import bpy
 from bpy.props import IntProperty, FloatProperty, BoolProperty, EnumProperty
-
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import updateNode, fullList, match_long_repeat
+from sverchok.data_structure import updateNode, fullList, match_long_repeat, second_as_first_cycle as safc
 
 directionItems = [("X", "X", ""), ("Y", "Y", ""), ("Z", "Z", "")]
 
@@ -33,16 +32,13 @@ def make_line(steps, center, direction):
     elif direction == "Z":
         v = lambda l: (0.0, 0.0, l)
 
-    c = - sum(steps) / 2 if center else 0
     verts = []
     addVert = verts.append
-    x = c
+    x = -sum(steps) / 2 if center else 0
     for s in [0.0] + steps:
         x = x + s
         addVert(v(x))
-
     edges = [[i, i + 1] for i in range(len(steps))]
-
     return verts, edges
 
 
@@ -79,7 +75,6 @@ class SvLineNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     def sv_init(self, context):
         self.inputs.new('StringsSocket', "Num").prop_name = 'num'
         self.inputs.new('StringsSocket', "Step").prop_name = 'step'
-
         self.outputs.new('VerticesSocket', "Vertices", "Vertices")
         self.outputs.new('StringsSocket', "Edges", "Edges")
 
@@ -95,35 +90,28 @@ class SvLineNodeMK2(bpy.types.Node, SverchCustomTreeNode):
             row.prop(self, "size")
 
     def process(self):
-        # return if no outputs are connected
         if not any(s.is_linked for s in self.outputs):
             return
-
         input_num = self.inputs["Num"].sv_get()
         input_step = self.inputs["Step"].sv_get()
-
-        params = match_long_repeat([input_num, input_step])
-
-        stepList = []
-        for n, s in zip(*params):
-            num = max(2, n[0])  # sanitize the input
-            # adjust the step list based on number of verts and steps
-            steps = s[:(num - 1)]  # shorten if needed
-            fullList(steps, num - 1)  # extend if needed
-            if self.normalize:
-                size = self.size / sum(steps)
-                steps = [s * size for s in steps]
-            stepList.append(steps)
-
         c, d = self.center, self.direction
-        verts, edges = [ve for ve in zip(*[make_line(s, c, d) for s in stepList])]
-
-        # outputs
+        stepList = []
+        res1,res2 = [],[]
+        for n, s in zip(*match_long_repeat([input_num, input_step])):
+            for num in n:
+                num = max(2,num)
+                s = s[:(num - 1)]  # shorten if needed
+                fullList(s, num - 1)  # extend if needed
+            # s = safc(n, s)
+                stepList.append([S * self.size / sum(s) for S in s] if self.normalize else s)
+            for s in stepList:
+                r1,r2 = make_line(s, c, d)
+                res1.append(r1)
+                res2.append(r2)
         if self.outputs['Vertices'].is_linked:
-            self.outputs['Vertices'].sv_set(verts)
-
+            self.outputs['Vertices'].sv_set(res1)
         if self.outputs['Edges'].is_linked:
-            self.outputs['Edges'].sv_set(edges)
+            self.outputs['Edges'].sv_set(res2)
 
 
 def register():

--- a/nodes/generator/line_mk2.py
+++ b/nodes/generator/line_mk2.py
@@ -103,10 +103,10 @@ class SvLineNodeMK2(bpy.types.Node, SverchCustomTreeNode):
                 s = s[:(num - 1)]  # shorten if needed
                 fullList(s, num - 1)  # extend if needed
                 stepList.append([S * self.size / sum(s) for S in s] if self.normalize else s)
-            for s in stepList:
-                r1,r2 = make_line(s, c, d)
-                res1.append(r1)
-                res2.append(r2)
+        for s in stepList:
+            r1,r2 = make_line(s, c, d)
+            res1.append(r1)
+            res2.append(r2)
         if self.outputs['Vertices'].is_linked:
             self.outputs['Vertices'].sv_set(res1)
         if self.outputs['Edges'].is_linked:


### PR DESCRIPTION
It's been placing Edges output container list inside of additional tuple layer all this time. And many Sverchok nodes does not throws errors. But some of them do, so better lets fix it.