### PR TITLE
Rename Templates menu to Examples.

### DIFF
--- a/ui/sv_templates_menu.py
+++ b/ui/sv_templates_menu.py
@@ -23,12 +23,12 @@ from sverchok.utils.sv_update_utils import sv_get_local_path
 
 sv_path = os.path.dirname(sv_get_local_path()[0])
 
-# Node Templates Menu
+# Node Examples Menu
 class SV_MT_layouts_templates(bpy.types.Menu):
     bl_idname = 'SV_MT_layouts_templates'
     bl_space_type = 'NODE_EDITOR'
-    bl_label = "Templates"
-    bl_description = "List of Sverchok Templates"
+    bl_label = "Examples"
+    bl_description = "List of Sverchok Examples"
 
 
     def avail_templates():


### PR DESCRIPTION
## Addressed problem description

Was discussed and agreed in #2132 .

## Solution description

Rename Templates menu to Examples.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

