### PR TITLE
Request drop 2

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -101,7 +101,7 @@ utils_modules = [
     "voronoi", "sv_script", "sv_itertools", "script_importhelper", "sv_oldnodes_parser",
     "csg_core", "csg_geom", "geom", "sv_easing_functions", "sv_text_io_common",
     "snlite_utils", "snlite_importhelper", "context_managers", "sv_node_utils",
-    "profile", "logging", "testing", "sv_prefs",
+    "profile", "logging", "testing", "sv_prefs", "sv_requests",
     # UI text editor ui
     "text_editor_submenu", "text_editor_plugins",
     # UI operators and tools

--- a/utils/sv_requests.py
+++ b/utils/sv_requests.py
@@ -1,0 +1,16 @@
+import json
+import urllib
+import urllib.request
+
+def get(url):
+
+    def get_json():
+        json_to_parse = urllib.urlopen(url)
+        found_json = json_to_parse.read().decode()
+        wfile = json.JSONDecoder()
+        return wfile.decode(found_json)        
+
+    processed = lambda: None
+    processed.json = get_json()
+    return processed
+

--- a/utils/sv_requests.py
+++ b/utils/sv_requests.py
@@ -23,6 +23,6 @@ def get(url):
         return wfile.decode(found_json)        
 
     processed = lambda: None
-    processed.json = get_json()
+    processed.json = get_json
     return processed
 

--- a/utils/sv_requests.py
+++ b/utils/sv_requests.py
@@ -1,11 +1,23 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+
 import json
-import urllib
-import urllib.request
+import urllib.request as rq
+
+
+# we dont use requests for anything significant other than getting 
+# a json, this is a dummy module with one feature implemented (.get )
+
 
 def get(url):
 
     def get_json():
-        json_to_parse = urllib.urlopen(url)
+        json_to_parse = rq.urlopen(url)
         found_json = json_to_parse.read().decode()
         wfile = json.JSONDecoder()
         return wfile.decode(found_json)        

--- a/utils/sv_update_utils.py
+++ b/utils/sv_update_utils.py
@@ -16,7 +16,6 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
-import requests
 import os
 import urllib
 import urllib.request
@@ -24,6 +23,7 @@ from zipfile import ZipFile
 
 import bpy
 import sverchok
+from sverchok.utils import sv_requests as requests
 
 # pylint: disable=w0141
 


### PR DESCRIPTION
requests module is no longer used anywhere in Sverchok. Reliance on the `requests` module has now generated 7 orso separate issues. I'm losing count, and losing confidence that the module can be relied on. So.. henceforth i suggest we don't use the module for trivial stuff like here.

