### PR TITLE
Added back Edges intersect Tolerance

### DIFF
--- a/nodes/modifier_make/contour2D.py
+++ b/nodes/modifier_make/contour2D.py
@@ -609,7 +609,7 @@ class SvContourNode(bpy.types.Node, SverchCustomTreeNode):
 
     def mask_edges_by_mid_points(self, verts_out, edges_out, parameters, v_len, edges_in):
         mid_points = calculate_mid_points(verts_out, edges_out)
-        mask_edg = mask_by_distance(mid_points, parameters, v_len, edges_in, abs(self.mask_t))
+        mask_edg = mask_by_distance(mid_points, parameters, v_len, edges_in, self.mask_t)
         return mask_edges(edges_out, mask_edg)
 
     def get_perimeter_and_radius(self, params):
@@ -657,7 +657,7 @@ class SvContourNode(bpy.types.Node, SverchCustomTreeNode):
 
             verts_out, _, edges_out = mesh_join(points, [], edg)
 
-            verts_out, edges_out = intersect_edges_2d(verts_out, edges_out, self.mask_t)
+            verts_out, edges_out = intersect_edges_2d(verts_out, edges_out, abs(self.mask_t))
 
             edges_out = self.mask_edges_by_mid_points(verts_out, edges_out, parameters, v_len, edges_in)
 


### PR DESCRIPTION
After using the Intersect Edges node (2D)  I observed tolerance was needed to avoid the creation of doubled vertices. 
So I added back intersection tolerance to intersect Edges 2d as it was suggested by @zeffi in the pull request https://github.com/nortikin/sverchok/pull/2001

I updated that change in  the Contour2D node as it was depending on it.

## Preflight checklist


- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [x] Unit-tests implemented. Could you point me where to check what this is?
- [x] Ready for merge.

