### PR TITLE
Updated docstrings that appear in the browser

### DIFF
--- a/nodes/analyzer/kd_tree_MK2.py
+++ b/nodes/analyzer/kd_tree_MK2.py
@@ -24,7 +24,7 @@ from sverchok.data_structure import (updateNode, match_long_repeat as mlr)
 
 
 class SvKDTreeNodeMK2(bpy.types.Node, SverchCustomTreeNode):
-    ''' KDT Closest Verts MK2 '''
+    '''Find nearest verts'''
     bl_idname = 'SvKDTreeNodeMK2'
     bl_label = 'KDT Closest Verts MK2'
     bl_icon = 'OUTLINER_OB_EMPTY'

--- a/nodes/analyzer/kd_tree_edges_mk2.py
+++ b/nodes/analyzer/kd_tree_edges_mk2.py
@@ -26,7 +26,7 @@ from sverchok.data_structure import updateNode
 
 # documentation/blender_python_api_2_70_release/mathutils.kdtree.html
 class SvKDTreeEdgesNodeMK2(bpy.types.Node, SverchCustomTreeNode):
-
+    '''Create Edges by distance'''
     bl_idname = 'SvKDTreeEdgesNodeMK2'
     bl_label = 'KDT Closest Edges MK2'
     bl_icon = 'OUTLINER_OB_EMPTY'

--- a/nodes/analyzer/proportional.py
+++ b/nodes/analyzer/proportional.py
@@ -46,6 +46,7 @@ def invsquare(x):
     return x*x
 
 class SvProportionalEditNode(bpy.types.Node, SverchCustomTreeNode):
+    ''' Curved mask coeffs.'''
     bl_idname = 'SvProportionalEditNode'
     bl_label = 'Proportional Edit Falloff'
     bl_icon = 'PROP_ON'

--- a/nodes/generator/basic_spline.py
+++ b/nodes/generator/basic_spline.py
@@ -37,7 +37,7 @@ def generate_bezier(verts=None, num_verts=20):
 
 
 class BasicSplineNode(bpy.types.Node, SverchCustomTreeNode):
-    ''' Line '''
+    ''' Bezier Curve '''
     bl_idname = 'BasicSplineNode'
     bl_label = '2pt Spline'
     bl_icon = 'CURVE_BEZCURVE'

--- a/nodes/generators_extended/mesh_eval.py
+++ b/nodes/generators_extended/mesh_eval.py
@@ -199,6 +199,7 @@ class SvJsonFromMesh(bpy.types.Operator):
         bpy.data.texts[text].write(values)
 
 class SvMeshEvalNode(bpy.types.Node, SverchCustomTreeNode):
+    '''Parametric mesh JSON'''
     bl_idname = 'SvMeshEvalNode'
     bl_label = 'Mesh Expression'
     bl_icon = 'OUTLINER_OB_EMPTY'

--- a/nodes/logic/logic_node.py
+++ b/nodes/logic/logic_node.py
@@ -29,7 +29,7 @@ from sverchok.utils.sv_itertools import (recurse_fx, recurse_fxy)
 
 
 class SvLogicNode(bpy.types.Node, SverchCustomTreeNode):
-    ''' LogicNode '''
+    '''And, Or, If, <, >..'''
     bl_idname = 'SvLogicNode'
     bl_label = 'Logic functions'
     bl_icon = 'LOGIC'

--- a/nodes/modifier_make/bisect.py
+++ b/nodes/modifier_make/bisect.py
@@ -81,6 +81,7 @@ def bisect(cut_me_vertices, cut_me_edges, pp, pno, outer, inner, fill):
 
 
 class SvBisectNode(bpy.types.Node, SverchCustomTreeNode):
+    ''' Matrix Cuts geometry'''
     bl_idname = 'SvBisectNode'
     bl_label = 'Bisect'
     bl_icon = 'OUTLINER_OB_EMPTY'

--- a/nodes/modifier_make/cross_section.py
+++ b/nodes/modifier_make/cross_section.py
@@ -162,6 +162,7 @@ def section(cut_me_vertices, cut_me_edges, mx, pp, pno, FILL=False, TRI=True):
 
 
 class CrossSectionNode(bpy.types.Node, SverchCustomTreeNode):
+    '''Plane Intersection'''
     bl_idname = 'CrossSectionNode'
     bl_label = 'Cross Section'
     bl_icon = 'OUTLINER_OB_EMPTY'

--- a/nodes/modifier_make/lathe.py
+++ b/nodes/modifier_make/lathe.py
@@ -45,7 +45,7 @@ def get_lathed_geometry(node, verts, edges, cent, axis, dvec, angle, steps):
 
 
 class SvLatheNode(bpy.types.Node, SverchCustomTreeNode):
-
+    '''Spin, Screw, Revol.'''
     bl_idname = 'SvLatheNode'
     bl_label = 'Lathe'
     bl_icon = 'MOD_SCREW'

--- a/nodes/modifier_make/solidify.py
+++ b/nodes/modifier_make/solidify.py
@@ -60,7 +60,7 @@ def solidify(vertices, faces, t):
 
 
 class SvSolidifyNode(bpy.types.Node, SverchCustomTreeNode):
-    '''Soldifies geometry'''
+    '''Extrude along normal'''
     bl_idname = 'SvSolidifyNode'
     bl_label = 'Solidify'
     bl_icon = 'MOD_SOLIDIFY'

--- a/nodes/modifier_make/voronoi_2d.py
+++ b/nodes/modifier_make/voronoi_2d.py
@@ -25,7 +25,7 @@ from sverchok.utils.voronoi import Site, computeVoronoiDiagram, computeDelaunayT
 
 
 class Voronoi2DNode(bpy.types.Node, SverchCustomTreeNode):
-    ''' Voronoi 2d line '''
+    ''' vr Voronoi 2d line '''
     bl_idname = 'Voronoi2DNode'
     bl_label = 'Voronoi 2D'
     bl_icon = 'OUTLINER_OB_EMPTY'
@@ -109,7 +109,7 @@ class Voronoi2DNode(bpy.types.Node, SverchCustomTreeNode):
 
 # computeDelaunayTriangulation
 class DelaunayTriangulation2DNode(bpy.types.Node, SverchCustomTreeNode):
-    ''' DelaunayTriangulation '''
+    '''dea Verts. Triangulation '''
     bl_idname = 'DelaunayTriangulation2DNode'
     bl_label = 'Delaunay 2D'
     bl_icon = 'OUTLINER_OB_EMPTY'

--- a/nodes/modifier_make/wireframe.py
+++ b/nodes/modifier_make/wireframe.py
@@ -45,7 +45,7 @@ def wireframe(vertices, faces, t, self):
 
 
 class SvWireframeNode(bpy.types.Node, SverchCustomTreeNode):
-    '''Wireframe'''
+    '''wf Wireframe Modif.'''
     bl_idname = 'SvWireframeNode'
     bl_label = 'Wireframe'
     bl_icon = 'MOD_WIREFRAME'

--- a/nodes/number/easing.py
+++ b/nodes/number/easing.py
@@ -105,6 +105,7 @@ def simple_grid_xy(x, y, args):
 
 
 class SvEasingNode(bpy.types.Node, SverchCustomTreeNode):
+    '''Curved interpolation'''
     bl_idname = 'SvEasingNode'
     bl_label = 'Easing 0..1'
 

--- a/nodes/number/formula2.py
+++ b/nodes/number/formula2.py
@@ -37,7 +37,7 @@ from sverchok.data_structure import (
 
 
 class Formula2Node(bpy.types.Node, SverchCustomTreeNode):
-    ''' Formula2 '''
+    ''' Custom formula '''
     bl_idname = 'Formula2Node'
     bl_label = 'Formula'
     bl_icon = 'OUTLINER_OB_EMPTY'

--- a/nodes/number/numbers.py
+++ b/nodes/number/numbers.py
@@ -43,7 +43,7 @@ def uset(self, value, origin):
 
 
 class SvNumberNode(bpy.types.Node, SverchCustomTreeNode):
-    ''' Float '''
+    ''' Integer  / Float '''
     bl_idname = 'SvNumberNode'
     bl_label = 'A Number'
     bl_icon = 'OUTLINER_OB_EMPTY'

--- a/nodes/number/scalar_mk2.py
+++ b/nodes/number/scalar_mk2.py
@@ -109,7 +109,7 @@ def property_change(node, context, origin):
 
 
 class SvScalarMathNodeMK2(bpy.types.Node, SverchCustomTreeNode):
-    ''' SvScalarMathNodeMK2 '''
+    '''Scalar: Add, Sine... '''
     bl_idname = 'SvScalarMathNodeMK2'
     bl_label = 'Math MK2'
     sv_icon = 'SV_FUNCTION'

--- a/nodes/scene/blenddata_to_svdata2.py
+++ b/nodes/scene/blenddata_to_svdata2.py
@@ -24,6 +24,7 @@ from sverchok.data_structure import (updateNode)
 
 
 class SvObjectToMeshNodeMK2(bpy.types.Node, SverchCustomTreeNode):
+    '''Get Object Data'''
     bl_idname = 'SvObjectToMeshNodeMK2'
     bl_label = 'Object ID Out MK2'
     bl_icon = 'OUTLINER_OB_EMPTY'

--- a/nodes/scene/dupli_instances_mk4.py
+++ b/nodes/scene/dupli_instances_mk4.py
@@ -37,6 +37,7 @@ def wipe_object(ob):
 
 
 class SvDupliInstancesMK4(bpy.types.Node, SverchCustomTreeNode):
+    '''Copy by Dupli Faces'''
     bl_idname = 'SvDupliInstancesMK4'
     bl_label = 'Dupli instancer mk4'
     bl_icon = 'OUTLINER_OB_EMPTY'

--- a/nodes/scene/instancer.py
+++ b/nodes/scene/instancer.py
@@ -85,7 +85,7 @@ class SvInstancerOp(bpy.types.Operator):
 
 
 class SvInstancerNode(bpy.types.Node, SverchCustomTreeNode):
-
+    '''Copy by mesh data'''
     bl_idname = 'SvInstancerNode'
     bl_label = 'Mesh instancer'
     bl_icon = 'OUTLINER_OB_EMPTY'

--- a/nodes/script/multi_exec.py
+++ b/nodes/script/multi_exec.py
@@ -64,7 +64,7 @@ class SvExecNodeModCallback(bpy.types.Operator):
 
 
 class SvExecNodeMod(bpy.types.Node, SverchCustomTreeNode):
-    ''' Exec Node Mod'''
+    '''Execute small script'''
     bl_idname = 'SvExecNodeMod'
     bl_label = 'Exec Node Mod'
     bl_icon = 'CONSOLE'

--- a/nodes/transforms/deform.py
+++ b/nodes/transforms/deform.py
@@ -45,7 +45,7 @@ def map_linear(src_min, src_max, new_min, new_max, value):
     return new_min + scale * (value - src_min)
 
 class SvSimpleDeformNode(bpy.types.Node, SverchCustomTreeNode):
-    ''' Simple deformation node'''
+    ''' Twist, Bend, Taper'''
     bl_idname = 'SvSimpleDeformNode'
     bl_label = 'Simple deformation'
     bl_icon = 'MOD_SIMPLEDEFORM'

--- a/nodes/transforms/mirror.py
+++ b/nodes/transforms/mirror.py
@@ -69,7 +69,7 @@ def mirrorPlane(vertex, matrix):
 
 
 class SvMirrorNode(bpy.types.Node, SverchCustomTreeNode):
-    ''' Mirroring  '''
+    ''' Mirroring, Symmetry'''
     bl_idname = 'SvMirrorNode'
     bl_label = 'Mirror'
     bl_icon = 'MOD_MIRROR'

--- a/nodes/vector/interpolation.py
+++ b/nodes/vector/interpolation.py
@@ -97,7 +97,7 @@ def eval_spline(splines, tknots, t_in):
 
 
 class SvInterpolationNode(bpy.types.Node, SverchCustomTreeNode):
-    '''Vector Interpolate'''
+    '''Basic Vect. Interpolation'''
     bl_idname = 'SvInterpolationNode'
     bl_label = 'Vector Interpolation'
     bl_icon = 'OUTLINER_OB_EMPTY'

--- a/nodes/vector/interpolation_mk2.py
+++ b/nodes/vector/interpolation_mk2.py
@@ -96,7 +96,7 @@ def eval_spline(splines, tknots, t_in):
 
 
 class SvInterpolationNodeMK2(bpy.types.Node, SverchCustomTreeNode):
-    '''Vector Interpolate'''
+    '''Bi-dimensional interp. '''
     bl_idname = 'SvInterpolationNodeMK2'
     bl_label = 'Vector Interpolation mk2'
     bl_icon = 'OUTLINER_OB_EMPTY'

--- a/nodes/vector/interpolation_mk3.py
+++ b/nodes/vector/interpolation_mk3.py
@@ -26,7 +26,7 @@ from sverchok.data_structure import updateNode, dataCorrect, repeat_last
 from sverchok.utils.geom import LinearSpline, CubicSpline
 
 class SvInterpolationNodeMK3(bpy.types.Node, SverchCustomTreeNode):
-    '''Vector Interpolate'''
+    '''Advanced Vect. Interpolation'''
     bl_idname = 'SvInterpolationNodeMK3'
     bl_label = 'Vector Interpolation mk3'
     bl_icon = 'OUTLINER_OB_EMPTY'

--- a/nodes/vector/math_mk2.py
+++ b/nodes/vector/math_mk2.py
@@ -90,7 +90,7 @@ def recurse_fxy(l1, l2, f, level):
 
 
 class SvVectorMathNodeMK2(bpy.types.Node, SverchCustomTreeNode):
-    ''' VectorMath Node MK2'''
+    '''Vector: Add, Dot P..'''
     bl_idname = 'SvVectorMathNodeMK2'
     bl_label = 'Vector Math'
     bl_icon = 'OUTLINER_OB_EMPTY'

--- a/nodes/viz/viewer_curves.py
+++ b/nodes/viz/viewer_curves.py
@@ -238,7 +238,7 @@ class SvCurveViewOp(bpy.types.Operator):
 
 # should inherit from bmeshviewer, many of these methods are largely identical.
 class SvCurveViewerNode(bpy.types.Node, SverchCustomTreeNode):
-
+    '''cv Create 3D Curve'''
     bl_idname = 'SvCurveViewerNode'
     bl_label = 'Curve Viewer'
     bl_icon = 'MOD_CURVE'

--- a/nodes/viz/viewer_curves_2d.py
+++ b/nodes/viz/viewer_curves_2d.py
@@ -251,7 +251,7 @@ class SvCurveViewOp2D(bpy.types.Operator):
 
 # should inherit from bmeshviewer, many of these methods are largely identical.
 class SvCurveViewerNode2D(bpy.types.Node, SverchCustomTreeNode):
-
+    '''cv Create 2D Curve'''
     bl_idname = 'SvCurveViewerNodeAlt'
     bl_label = 'Curve Viewer 2D'
     bl_icon = 'MOD_CURVE'

--- a/nodes/viz/viewer_polyline_mk1.py
+++ b/nodes/viz/viewer_polyline_mk1.py
@@ -177,7 +177,7 @@ class SvPolylineViewOpMK1(bpy.types.Operator):
 
 # should inherit from bmeshviewer, many of these methods are largely identical.
 class SvPolylineViewerNodeMK1(bpy.types.Node, SverchCustomTreeNode):
-
+    '''cv 2D/3D Polyline'''
     bl_idname = 'SvPolylineViewerNodeMK1'
     bl_label = 'Polyline Viewer MK1'
     bl_icon = 'MOD_CURVE'

--- a/nodes/viz/viewer_typography.py
+++ b/nodes/viz/viewer_typography.py
@@ -162,7 +162,7 @@ class SvTypeViewOp2(bpy.types.Operator):
 
 
 class SvTypeViewerNode(bpy.types.Node, SverchCustomTreeNode):
-
+    '''Create Text Obj'''
     bl_idname = 'SvTypeViewerNode'
     bl_label = 'Typography Viewer'
     bl_icon = 'OUTLINER_OB_EMPTY'


### PR DESCRIPTION

The docstrings that appear in the search menu are sometimes missing, sometime useless due repeating the node name

I reviewed the menu and added some of them.
I tried to be as clear as possible
In some cases i added a shortcut as suggested  in https://github.com/nortikin/sverchok/issues/1663 
I tried to use different words to cover a bigger scope in the search.

I didnt change all the nodes, but i think 30 files is enough for this commit

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [ x] Code changes complete.
- [x ] Code documentation complete.
- [x ] Documentation for users complete (or not required, if user never sees these changes).
- [x ] Manual testing done. 
- [ x] Unit-tests implemented.??
- [x ] Ready for merge.

