### PR TITLE
List Math warp output

### DIFF
--- a/nodes/list_main/func.py
+++ b/nodes/list_main/func.py
@@ -31,7 +31,7 @@ class ListFuncNode(bpy.types.Node, SverchCustomTreeNode):
     '''
     Triggers: List functions
     Tooltip: Operations with list, sum, average, min, max
-    '''    '''  '''
+    '''
     bl_idname = 'ListFuncNode'
     bl_label = 'List Math'
     bl_icon = 'OUTLINER_OB_EMPTY'

--- a/nodes/list_main/func.py
+++ b/nodes/list_main/func.py
@@ -19,7 +19,7 @@
 from itertools import accumulate
 
 import bpy
-from bpy.props import EnumProperty, IntProperty
+from bpy.props import EnumProperty, IntProperty, BoolProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode
@@ -49,12 +49,17 @@ class ListFuncNode(bpy.types.Node, SverchCustomTreeNode):
     level = IntProperty(name='level_to_count',
                         default=1, min=0,
                         update=updateNode)
+    wrap = BoolProperty(name='wrap', description='extra level add', 
+                        default=False,update=updateNode)
 #    typ = bpy.props.StringProperty(name='typ', default='')
 #    newsock = bpy.props.BoolProperty(name='newsock', default=False)
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "level", text="level")
         layout.prop(self, "func_", "Functions:")
+
+    def draw_buttons_ext(self, context, layout):
+        layout.prop(self, "wrap", text="wrap")
 
     def sv_init(self, context):
         self.inputs.new('StringsSocket', "Data", "Data")
@@ -77,7 +82,7 @@ class ListFuncNode(bpy.types.Node, SverchCustomTreeNode):
                 else:
                     out = self.count(data, self.level, func)
 
-                self.outputs['Function'].sv_set([out])
+                self.outputs['Function'].sv_set([out] if self.wrap else out)
 
     def count(self, data, level, func):
         out = []

--- a/nodes/list_main/func.py
+++ b/nodes/list_main/func.py
@@ -28,7 +28,10 @@ def acc(l):
     return list(accumulate(l))
 
 class ListFuncNode(bpy.types.Node, SverchCustomTreeNode):
-    ''' List function '''
+    '''
+    Triggers: List functions
+    Tooltip: Operations with list, sum, average, min, max
+    '''    '''  '''
     bl_idname = 'ListFuncNode'
     bl_label = 'List Math'
     bl_icon = 'OUTLINER_OB_EMPTY'

--- a/nodes/list_main/func.py
+++ b/nodes/list_main/func.py
@@ -74,7 +74,7 @@ class ListFuncNode(bpy.types.Node, SverchCustomTreeNode):
                 else:
                     out = self.count(data, self.level, func)
 
-                self.outputs['Function'].sv_set(out)
+                self.outputs['Function'].sv_set([out])
 
     def count(self, data, level, func):
         out = []


### PR DESCRIPTION
## Addressed problem description
The "List Math" output has a missing level.

During years it was necessary  to use a ·"list join warp" to input in a node with the output of "list math".
The "List Math" Output was [1] in stead of [[1]]
## Solution description

Added the missing brackets

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x ] Code changes complete.
- [x ] Code documentation complete.
- [ x] Documentation for users complete (or not required, if user never sees these changes).
- [ x] Manual testing done. 
- [x ] Unit-tests implemented.
- [ x] Ready for merge.

