### PR TITLE
3pt update

### DIFF
--- a/node_tree.py
+++ b/node_tree.py
@@ -89,6 +89,8 @@ class SvSocketCommon:
     use_quicklink = BoolProperty(default=True)
     expanded = BoolProperty(default=False)
 
+    quicklink_func_name = StringProperty(default="", name="quicklink_func_name")    
+
     @property
     def other(self):
         return get_other_socket(self)
@@ -218,9 +220,9 @@ class SvSocketCommon:
             elif self.use_prop:  # no property but use default prop
                 self.draw_expander_template(context, layout, prop_origin=self)
 
-            elif hasattr(node, "quicklink_func_name"):
+            elif self.quicklink_func_name:
                 try:
-                    getattr(node, node.quicklink_func_name)(self, context, layout, node)
+                    getattr(node, self.quicklink_func_name)(self, context, layout, node)
                 except Exception as e:
                     self.draw_quick_link(context, layout, node)
                 layout.label(text)

--- a/node_tree.py
+++ b/node_tree.py
@@ -218,6 +218,13 @@ class SvSocketCommon:
             elif self.use_prop:  # no property but use default prop
                 self.draw_expander_template(context, layout, prop_origin=self)
 
+            elif hasattr(node, "quicklink_func_name"):
+                try:
+                    getattr(node, node.quicklink_func_name)(self, context, layout, node)
+                except Exception as e:
+                    self.draw_quick_link(context, layout, node)
+                layout.label(text)
+
             else:  # no property and not use default prop
                 self.draw_quick_link(context, layout, node)
                 layout.label(text)

--- a/nodes/generator/basic_3pt_arc.py
+++ b/nodes/generator/basic_3pt_arc.py
@@ -115,12 +115,25 @@ class svBasicArcNode(bpy.types.Node, SverchCustomTreeNode):
         update=updateNode,
         size=3)
 
-    def sv_init(self, context):
-        self.inputs.new('StringsSocket', "num_verts").prop_name = 'num_verts'
-        self.inputs.new('VerticesSocket', "arc_pts").prop_name = 'arc_pts'
+    # def sv_init(self, context):
+    #     self.inputs.new('StringsSocket', "num_verts").prop_name = 'num_verts'
+    #     self.inputs.new('VerticesSocket', "arc_pts").prop_name = 'arc_pts'
 
-        self.outputs.new('VerticesSocket', "Verts", "Verts")
-        self.outputs.new('StringsSocket', "Edges", "Edges")
+    #     self.outputs.new('VerticesSocket', "Verts", "Verts")
+    #     self.outputs.new('StringsSocket', "Edges", "Edges")
+
+    def sv_init(self, context):
+
+        # inputs
+        self.inputs.new('StringsSocket', "num_verts").prop_name = 'num_verts'
+        vector_prop = self.inputs.new('VerticesSocket', "arc_pts")
+        vector_prop.prop_name = 'arc_pts'
+        vector_prop.use_expander = False
+        vector_prop.use_quicklink = True
+
+        # outputs
+        self.outputs.new('VerticesSocket', "Verts")
+        self.outputs.new('StringsSocket', "Edges")
 
     def draw_buttons(self, context, layout):
         pass

--- a/nodes/generator/basic_3pt_arc.py
+++ b/nodes/generator/basic_3pt_arc.py
@@ -20,7 +20,7 @@ import math
 
 import bpy
 import mathutils
-from bpy.props import IntProperty, FloatProperty, FloatVectorProperty, StringProperty
+from bpy.props import IntProperty, FloatProperty, FloatVectorProperty
 from mathutils import Vector, Euler, geometry
 
 from sverchok.node_tree import SverchCustomTreeNode, VerticesSocket, StringsSocket
@@ -117,11 +117,16 @@ class svBasicArcNode(bpy.types.Node, SverchCustomTreeNode):
 
     @staticmethod
     def draw_basic_arc_qlink(socket, context, layout, node):
+        """
+        here's an example of an "bound-to-node quicklink socket ui descriptor"
+        - this lets you define the ui of that quicklink, in this case it replicates
+          the standard quicklink.
+        """
 
         if socket.use_quicklink:
             new_node_idname = "GenVectorsNode"
 
-            op = layout.operator('node.sv_quicklink_new_node_input', text="", icon="NODETREE")
+            op = layout.operator('node.sv_quicklink_new_node_input', text="", icon="PLUGIN")
             op.socket_index = socket.index
             op.origin = node.name
             op.new_node_idname = new_node_idname

--- a/nodes/generator/basic_3pt_arc.py
+++ b/nodes/generator/basic_3pt_arc.py
@@ -115,10 +115,6 @@ class svBasicArcNode(bpy.types.Node, SverchCustomTreeNode):
         update=updateNode,
         size=3)
 
-    quicklink_func_name = StringProperty(
-        default="draw_basic_arc_qlink",
-        name="quicklink_func_name")
-
     @staticmethod
     def draw_basic_arc_qlink(socket, context, layout, node):
 
@@ -139,6 +135,7 @@ class svBasicArcNode(bpy.types.Node, SverchCustomTreeNode):
         vector_prop = self.inputs.new('VerticesSocket', "arc_pts")
         vector_prop.use_expander = False
         vector_prop.use_quicklink = True
+        vector_prop.quicklink_func_name = 'draw_basic_arc_qlink'
 
         # outputs
         self.outputs.new('VerticesSocket', "Verts")

--- a/nodes/generator/basic_3pt_arc.py
+++ b/nodes/generator/basic_3pt_arc.py
@@ -115,19 +115,11 @@ class svBasicArcNode(bpy.types.Node, SverchCustomTreeNode):
         update=updateNode,
         size=3)
 
-    # def sv_init(self, context):
-    #     self.inputs.new('StringsSocket', "num_verts").prop_name = 'num_verts'
-    #     self.inputs.new('VerticesSocket', "arc_pts").prop_name = 'arc_pts'
-
-    #     self.outputs.new('VerticesSocket', "Verts", "Verts")
-    #     self.outputs.new('StringsSocket', "Edges", "Edges")
-
     def sv_init(self, context):
 
         # inputs
         self.inputs.new('StringsSocket', "num_verts").prop_name = 'num_verts'
         vector_prop = self.inputs.new('VerticesSocket', "arc_pts")
-        vector_prop.prop_name = 'arc_pts'
         vector_prop.use_expander = False
         vector_prop.use_quicklink = True
 

--- a/nodes/generator/basic_3pt_arc.py
+++ b/nodes/generator/basic_3pt_arc.py
@@ -20,7 +20,7 @@ import math
 
 import bpy
 import mathutils
-from bpy.props import IntProperty, FloatProperty, FloatVectorProperty
+from bpy.props import IntProperty, FloatProperty, FloatVectorProperty, StringProperty
 from mathutils import Vector, Euler, geometry
 
 from sverchok.node_tree import SverchCustomTreeNode, VerticesSocket, StringsSocket
@@ -114,6 +114,23 @@ class svBasicArcNode(bpy.types.Node, SverchCustomTreeNode):
         description="3 points, Start-Through-End",
         update=updateNode,
         size=3)
+
+    quicklink_func_name = StringProperty(
+        default="draw_basic_arc_qlink",
+        name="quicklink_func_name")
+
+    @staticmethod
+    def draw_basic_arc_qlink(socket, context, layout, node):
+
+        if socket.use_quicklink:
+            new_node_idname = "GenVectorsNode"
+
+            op = layout.operator('node.sv_quicklink_new_node_input', text="", icon="NODETREE")
+            op.socket_index = socket.index
+            op.origin = node.name
+            op.new_node_idname = new_node_idname
+            op.new_node_offsetx = -200 - 40 * socket.index
+            op.new_node_offsety = -30 * socket.index
 
     def sv_init(self, context):
 


### PR DESCRIPTION
the default UI for this node doesn't make a whole lot of sense, we can use the quicklink mechanism to inject a vector node into the 3pt input socket. It might be interesting and beneficial for other nodes to also offer a way for nodes to override the exact kind of  quicklink behaviour.

The initial intent of the quicklink handler was to allow specific behaviour that makes sense to individual nodes. A quicklink for the Rotation node isn't the same behaviour you might want for the 3pt_node, proof is the [issue posted](https://github.com/nortikin/sverchok/issues/2244) by @Durman .

This pr updates the 3pt node  and now will offer a custom function (defined in the node) to set up your own quicklink behaviour.

 - new general `socket property` called "custom_quicklink_function_name", it will (obviously?) store the name of the function (located on the node) that will be used to draw the `socket ui row`.
- when the above property is not "", then the function will be called in a try/except by the quicklink pathway in `node_tree.py` -  

```python
     def draw_quick_link(self, context, layout, node):
         ...
```
- if there are errors in the UI draw call, then the default quicklink for that sockettype will be drawn.

no ETA.