### PR TITLE
add notion to return new node from make_monad_unique function

### DIFF
--- a/core/monad.py
+++ b/core/monad.py
@@ -85,8 +85,10 @@ def monad_make_unique(node):
 
     # the new tree dict will contain information about 1 node only, and 
     # the node_group too (at the moment) but the node_group data can be ignored.
-    skip_set = {n for n in nodes if n != node}
-    layout_json = create_dict_of_tree(ng=node_tree, skip_set=skip_set)
+    layout_json = create_dict_of_tree(ng=node_tree, identified_node=node)
+
+    # do not restore links this way. wipe this entry and restore at a later stage.
+    layout_json['update_lists'] = []
 
     # massage content of node_items, to correspond with the new desired name.
     node_ref = layout_json['nodes'][node.name]

--- a/core/monad.py
+++ b/core/monad.py
@@ -99,14 +99,22 @@ def monad_make_unique(node):
     # place new empty version of the monad node
     import_tree(node_tree, nodes_json=layout_json)
 
-    # at this point record all incoming and outgoing connections
-    ...
+    """
+    notions..:
+    
+        if (original instance has no connections) then 
+            replace it outright.
+        else
+            if mode=='replace':
+                store connections
+                replace instance with new unique instance
+                reconnect old connections
+            elif mode=='dupe_translate':
+                generate unique instance
+                attache node to transform operator.
 
-    # remove the old node (this is probably a duplicate anyway)
-    ...
 
-    # reconnect old connections.
-    ...
+    """
 
     # return newly generated node?
 

--- a/core/monad.py
+++ b/core/monad.py
@@ -108,6 +108,8 @@ def monad_make_unique(node):
     # reconnect old connections.
     ...
 
+    # return newly generated node?
+
 
 def get_socket_data(socket):
     other = get_other_socket(socket)

--- a/ui/nodeview_rclick_menu.py
+++ b/ui/nodeview_rclick_menu.py
@@ -178,6 +178,8 @@ class SvNodeviewRClickMenu(bpy.types.Menu):
             col.prop(node, 'label_size', slider=True)
             col.prop(node, 'shrink')
 
+        if node and hasattr(node, 'monad'):
+            layout.operator("node.sv_monad_make_unique", icon="RNA_ADD")
 
 
 def register():

--- a/utils/sv_IO_panel_tools.py
+++ b/utils/sv_IO_panel_tools.py
@@ -245,7 +245,7 @@ def handle_enum_property(node, k, v, node_items, node_enums):
         node_items[k] = v
 
 
-def create_dict_of_tree(ng, skip_set={}, selected=False):
+def create_dict_of_tree(ng, skip_set={}, selected=False, identified_node=None):
     nodes = ng.nodes
     layout_dict = {}
     nodes_dict = {}
@@ -256,6 +256,10 @@ def create_dict_of_tree(ng, skip_set={}, selected=False):
 
     if selected:
         nodes = list(filter(lambda n: n.select, nodes))
+
+    if identified_node:
+        # this mode will import one node only.
+        nodes = [identified_node]
 
     # get nodes and params
     for node in nodes:


### PR DESCRIPTION
thinking about making various version of the operator. some of these modes/scenarios may overlap

- [ ] ensure fake user of new nodegroup

- [ ] mode 1
use an existing unattached instance of monad to make a unique duplicate, remove existing instance - replace with unique duplicate

- [ ] mode 2
if  existing instance is connected to other nodes, add a unique version and remove the existing instance
remap any previously existing connections

- [ ] mode 3
allow dup unique operator to drag from existing instance and create the unique duplicate with no attachments.