### PR TITLE
Added search for limits to vector sort

### DIFF
--- a/docs/nodes/vector/vertices_sort.rst
+++ b/docs/nodes/vector/vertices_sort.rst
@@ -15,19 +15,19 @@ and optional inputs(Vector, matrix and user data)
 Parameters
 ----------
 
-+--------------+---------------+-------------+----------------------------------------------------+
-| Param        | Type          | Default     | Description                                        |
-+==============+===============+=============+====================================================+
-| **Vertices** | Vector        |             | vertices from nodes generators or lists (in, out)  |
-+--------------+---------------+-------------+----------------------------------------------------+
-| **PolyEdge** | Int           |             | index of polgons or edges     (in, out)            |
-+--------------+---------------+-------------+----------------------------------------------------+
-| **Sortmode** | XYZ, Dist,    | XYZ         | will sort the index according to different criteria|
-|              | Axis, Connect,|             |                                                    |
-|              | User          |             |                                                    |
-+--------------+---------------+-------------+----------------------------------------------------+
-| **Item order** | Int         |             | output the index sequence                          |
-+--------------+---------------+-------------+----------------------------------------------------+
++----------------+---------------+-------------+----------------------------------------------------+
+| Param          | Type          | Default     | Description                                        |
++================+===============+=============+====================================================+
+| **Vertices**   | Vector        |             | vertices from nodes generators or lists (in, out)  |
++----------------+---------------+-------------+----------------------------------------------------+
+| **PolyEdge**   | Int           |             | index of polgons or edges     (in, out)            |
++----------------+---------------+-------------+----------------------------------------------------+
+| **Sortmode**   | XYZ, Dist,    | XYZ         | will sort the index according to different criteria|
+|                | Axis, Connect,|             |                                                    |
+|                | User          |             |                                                    |
++----------------+---------------+-------------+----------------------------------------------------+
+| **Item order** | Int           |             | output the index sequence                          |
++----------------+---------------+-------------+----------------------------------------------------+
 
 Outputs
 -------
@@ -43,6 +43,8 @@ Example with an Hilbert 3d node and polyline viewer with Vector sort set to Dist
 .. image:: https://cloud.githubusercontent.com/assets/1275858/24357298/7c3e0f6a-12fd-11e7-9852-0d800ec51742.png
 
 The *Connect* mode it is meant to work with paths. Sorting the vertices along the edges.
+The "Search fot limits" option will handle discontinities in the path.
+
 Example used to sort the vertices after the *Mesh Filter* node
 
 .. image:: https://user-images.githubusercontent.com/10011941/35187803-3f88191c-fe2a-11e7-874b-da8cb4ec3751.png


### PR DESCRIPTION
## Addressed problem description

When sorting by  connections the start of the paths (if there where any) was not taken into account

## Solution description

I added a "Search for limits" option to search first for this particular cases and use the as starting points.
![vector_sort_by_connexion1](https://user-images.githubusercontent.com/10011941/45375757-33c60d80-b5f6-11e8-9e4e-8ef6b9529cb6.png)


## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

