### PR TITLE
use transform for monadclone unique

### DIFF
--- a/core/monad.py
+++ b/core/monad.py
@@ -98,6 +98,8 @@ def monad_make_unique(node):
     node_items['monad'] = new_monad_group.name
     node_items['cls_dict']['cls_bl_idname'] = new_cls_name
 
+    pre_nodes = set(nodes)
+
     # place new empty version of the monad node
     import_tree(node_tree, nodes_json=layout_json)
 
@@ -118,7 +120,9 @@ def monad_make_unique(node):
 
     """
 
-    # return newly generated node?
+    # return newly generated node!
+    return (set(node_tree.nodes) ^ pre_nodes).pop() 
+
 
 
 def get_socket_data(socket):

--- a/ui/nodeview_rclick_menu.py
+++ b/ui/nodeview_rclick_menu.py
@@ -179,7 +179,7 @@ class SvNodeviewRClickMenu(bpy.types.Menu):
             col.prop(node, 'shrink')
 
         if node and hasattr(node, 'monad'):
-            layout.operator("node.sv_monad_make_unique", icon="RNA_ADD")
+            layout.operator("node.sv_monad_make_unique", icon="RNA_ADD").use_transform=True
 
 
 def register():

--- a/utils/monad.py
+++ b/utils/monad.py
@@ -591,7 +591,7 @@ class SvMonadMakeUnique(Operator):
     use_transform = BoolProperty(
         name="Use Transform",
         description="Start transform operator after inserting the node",
-        default=False)
+        default=True)
 
     @staticmethod
     def store_mouse_cursor(context, event):

--- a/utils/monad.py
+++ b/utils/monad.py
@@ -586,6 +586,25 @@ class SvMonadMakeUnique(Operator):
     bl_idname = "node.sv_monad_make_unique"
     bl_label = "Make Unique (Monad)"
 
+    # partial copy of Blender's own NodeAddOperator
+
+    use_transform = BoolProperty(
+        name="Use Transform",
+        description="Start transform operator after inserting the node",
+        default=False)
+
+    @staticmethod
+    def store_mouse_cursor(context, event):
+        space = context.space_data
+        tree = space.edit_tree
+
+        # convert mouse position to the View2D for later node placement
+        if context.region.type == 'WINDOW':
+            # convert mouse position to the View2D for later node placement
+            space.cursor_location_from_region(event.mouse_region_x, event.mouse_region_y)
+        else:
+            space.cursor_location = tree.view_center
+
     @classmethod
     def poll(cls, context):
         space_data = context.space_data
@@ -606,15 +625,40 @@ class SvMonadMakeUnique(Operator):
         - replace the new node.monad with the copy
 
         """
-        
+        space = context.space_data
+        tree = space.edit_tree
+
         try:
-            monad_make_unique(context.active_node)
+            node = monad_make_unique(context.active_node)
+    
+            # select only the new node
+            for n in tree.nodes:
+                n.select = False
+    
+            node.select = True
+            tree.nodes.active = node
+            node.location = space.cursor_location                
+
+
         except Exception as err:
             sys.stderr.write('ERROR: %s\n' % str(err))
             print(sys.exc_info()[-1].tb_frame.f_code)
             print('Error on line {}'.format(sys.exc_info()[-1].tb_lineno))
+            return {'CANCELLED'}
         
         return {'FINISHED'}
+
+    # Default invoke stores the mouse position to place the node correctly
+    # and optionally invokes the transform operator
+    def invoke(self, context, event):
+        self.store_mouse_cursor(context, event)
+        result = self.execute(context)
+
+        if self.use_transform and ('FINISHED' in result):
+            # removes the node again if transform is canceled
+            bpy.ops.node.translate_attach_remove_on_cancel('INVOKE_DEFAULT')
+
+        return result
 
 
 classes = [


### PR DESCRIPTION
monad clone worked, but didn't behave as Blender's own AddNode operator (which attaches the new node to the mouse cursor/ relative to it)