### PR TITLE
Random Num Gen Weighted Int and distributed Float 

### DIFF
--- a/docs/nodes/number/random_num_gen.rst
+++ b/docs/nodes/number/random_num_gen.rst
@@ -1,0 +1,80 @@
+Random
+======
+
+
+Functionality
+-------------
+
+Produces a list of pseudo-random numbers from a seed value.
+
+
+Inputs & Parameters
+-------------------
+
++----------------+------------------------------------------------------------------------+
+| Parameters     | Description                                                            |
++================+========================================================================+
+| Int/ Float     | Number type to be created                                              |
++----------------+------------------------------------------------------------------------+
+| Size           | Amount of numbers you want to create                                   |
++----------------+------------------------------------------------------------------------+
+| Seed           | Accepts float values, they are hashed into *Integers* internally.      |
++----------------+------------------------------------------------------------------------+
+| Int/Float Low  | Accepts float values, they are hashed into *Integers* internally.      |
++----------------+------------------------------------------------------------------------+
+| Int/Float High | Number of random numbers to spit out                                   |
++----------------+------------------------------------------------------------------------+
+| Weights        | On "Int" mode. Can be supplied to create a non-uniform distribution    |
++----------------+------------------------------------------------------------------------+
+| Distribution   | On "Float" mode many distribution functions can be selected.           |
+|                | Beta, Binomial, Chi_square, Exponential, F Distrib., Gamma, Geometric, | 
+|                | Gumbel, Laplace, Logistic, Log Normal, Log Series, Negative Binomial,  | 
+|                | Noncentred Chi-Square, Normal, Pareto, Poisson, Power, RayLeigh,       |
+|                | Standard Cauchy, Standard Gamma, Standard T, Triangular, Uniform,      |
+|                | Vonmises, Wald, Weibull, Zipf                                          |
++----------------+------------------------------------------------------------------------+
+| Alpha          | Distribution parameter. Alpha > 0*                                     |
++----------------+------------------------------------------------------------------------+
+| Beta           | Secondary distribution parameter. Beta > 0*                            |
++----------------+------------------------------------------------------------------------+
+|  t             | Normalized distribution parameter. 0 < t < 1                           |
++----------------+------------------------------------------------------------------------+
+
+What's a Seed? Read the `Python docs here <https://docs.python.org/3.4/library/random.html>`_
+Learn more about the distribution functions on the `SciPy random reference <https://docs.scipy.org/doc/numpy-1.14.0/reference/routines.random.html>`_
+
+Outputs
+-------
+
+A list, or nested lists.
+
+Notes
+-----
+
+Providing a float values as a Seed parameter may be unconventional, if you are uncomfortable with it you 
+could place a *FloatToInt* node before the Seed parameter.
+
+(*)On the "F Distribution" the minimum "Beta" is 0.025
+   On the "Pareto" distribution the minimum valid "Alpha" is 0.01
+   On the "Standard T" distribution the minimum valid "Alpha" is 0.017
+   On the "Triangular" distribution the "Alpha" parameter has to be greater than the "Float Low" and smaller than the  "Float High".
+   On the "Weibull the minimum valid "Alpha" is 0.0028. 
+   On the "Zipf" distribution the minimum valid "Alpha" has to be bigger than 1.0
+
+Examples
+--------
+With the "Weighted" distribution you can control the relative probability of each possilbe solution.
+
+.. image:: https://user-images.githubusercontent.com/10011941/46135042-9816dd00-c244-11e8-80e4-41195b3fbdcd.png
+  :alt: Weighted_Distribution1.PNG
+
+.. image:: https://user-images.githubusercontent.com/10011941/46135049-9baa6400-c244-11e8-8cc9-3903e05bcd02.png
+  :alt: Weighted_Distribution2.PNG
+
+The distribution functions can lead from the default Uniform to a more organic result (Laplace) or with a desired tendency (Triangular)
+
+.. image:: https://user-images.githubusercontent.com/10011941/46135062-9f3deb00-c244-11e8-9de4-b06c044d5520.png
+  :alt: Random_Distribution3.PNG
+  
+.. image:: https://user-images.githubusercontent.com/10011941/46135077-a82ebc80-c244-11e8-9616-6e8cb7218726.png
+  :alt: Random_Distribution4.PNG

--- a/docs/nodes/number/random_num_gen.rst
+++ b/docs/nodes/number/random_num_gen.rst
@@ -1,5 +1,5 @@
-Random
-======
+Random Num Gen
+==============
 
 
 Functionality
@@ -20,9 +20,9 @@ Inputs & Parameters
 +----------------+------------------------------------------------------------------------+
 | Seed           | Accepts float values, they are hashed into *Integers* internally.      |
 +----------------+------------------------------------------------------------------------+
-| Int/Float Low  | Accepts float values, they are hashed into *Integers* internally.      |
+| Int/Float Low  | Lower limit of values (included)*                                      |
 +----------------+------------------------------------------------------------------------+
-| Int/Float High | Number of random numbers to spit out                                   |
+| Int/Float High | Higher limit of values (included)*                                     |
 +----------------+------------------------------------------------------------------------+
 | Weights        | On "Int" mode. Can be supplied to create a non-uniform distribution    |
 +----------------+------------------------------------------------------------------------+
@@ -33,15 +33,16 @@ Inputs & Parameters
 |                | Standard Cauchy, Standard Gamma, Standard T, Triangular, Uniform,      |
 |                | Vonmises, Wald, Weibull, Zipf                                          |
 +----------------+------------------------------------------------------------------------+
-| Alpha          | Distribution parameter. Alpha > 0*                                     |
+| Alpha          | Distribution parameter. Alpha > 0**                                    |
 +----------------+------------------------------------------------------------------------+
-| Beta           | Secondary distribution parameter. Beta > 0*                            |
+| Beta           | Secondary distribution parameter. Beta > 0**                           |
 +----------------+------------------------------------------------------------------------+
 |  t             | Normalized distribution parameter. 0 < t < 1                           |
 +----------------+------------------------------------------------------------------------+
 
-What's a Seed? Read the `Python docs here <https://docs.python.org/3.4/library/random.html>`_
-Learn more about the distribution functions on the `SciPy random reference <https://docs.scipy.org/doc/numpy-1.14.0/reference/routines.random.html>`_
+What's a Seed? Read the `Python docs here <https://docs.python.org/3.4/library/random.html>`_.
+
+Learn more about the distribution functions on the `SciPy random reference <https://docs.scipy.org/doc/numpy-1.14.0/reference/routines.random.html>`_.
 
 Outputs
 -------
@@ -54,17 +55,19 @@ Notes
 Providing a float values as a Seed parameter may be unconventional, if you are uncomfortable with it you 
 could place a *FloatToInt* node before the Seed parameter.
 
-(*)Notes on Alpha and Beta values
-   On the "F Distribution" the minimum "Beta" is 0.025
-   On the "Pareto" distribution the minimum valid "Alpha" is 0.01
-   On the "Standard T" distribution the minimum valid "Alpha" is 0.017
-   On the "Triangular" distribution the "Alpha" parameter has to be greater than the "Float Low" and smaller than the  "Float High".
-   On the "Weibull the minimum valid "Alpha" is 0.0028. 
-   On the "Zipf" distribution the minimum valid "Alpha" has to be bigger than 1.0
+(*) Notes on Float Low and Float High
+ Except on some distributions (Uniform, Beta and Triangular) the output values are mapped to fit the desired range. Due this mapping there will be at least one value which matches the "Float High" and  another that matches the "Float Low"
+(**)Notes on Alpha and Beta values
+ - On the "F Distribution" the minimum "Beta" is 0.025 
+ - On the "Pareto" distribution the minimum valid "Alpha" is 0.01
+ - On the "Standard T" distribution the minimum valid "Alpha" is 0.017
+ - On the "Triangular" distribution the "Alpha" parameter has to be greater than the "Float Low" and smaller than the  "Float High".
+ - On the "Weibull the minimum valid "Alpha" is 0.0028. 
+ - On the "Zipf" distribution the minimum valid "Alpha" has to be bigger than 1.0
 
 Examples
 --------
-With the "Weighted" distribution you can control the relative probability of each possilbe solution.
+With the "Weighted" distribution you can control the relative probability of each possible solution.
 
 .. image:: https://user-images.githubusercontent.com/10011941/46135042-9816dd00-c244-11e8-80e4-41195b3fbdcd.png
   :alt: Weighted_Distribution1.PNG

--- a/docs/nodes/number/random_num_gen.rst
+++ b/docs/nodes/number/random_num_gen.rst
@@ -54,7 +54,8 @@ Notes
 Providing a float values as a Seed parameter may be unconventional, if you are uncomfortable with it you 
 could place a *FloatToInt* node before the Seed parameter.
 
-(*)On the "F Distribution" the minimum "Beta" is 0.025
+(*)Notes on Alpha and Beta values
+   On the "F Distribution" the minimum "Beta" is 0.025
    On the "Pareto" distribution the minimum valid "Alpha" is 0.01
    On the "Standard T" distribution the minimum valid "Alpha" is 0.017
    On the "Triangular" distribution the "Alpha" parameter has to be greater than the "Float Low" and smaller than the  "Float High".

--- a/nodes/number/random_num_gen.py
+++ b/nodes/number/random_num_gen.py
@@ -32,7 +32,6 @@ class SvRndNumGen(bpy.types.Node, SverchCustomTreeNode):
     Triggers: Random thru a range
     Tooltip: Generate a random number (int of float) thru a given range (inclusive) .
     """
-    ''' '''
     bl_idname = 'SvRndNumGen'
     bl_label = 'Random Num Gen'
     bl_icon = 'OUTLINER_OB_EMPTY'
@@ -96,7 +95,7 @@ class SvRndNumGen(bpy.types.Node, SverchCustomTreeNode):
         "F_DIST":        (5, np.random.f,                     [1, 2, 0],    True,  "F Distrib.",            (1e-06, 0.025)),
         "GAMMA":         (6, np.random.gamma,                 [1, 6, 0],    True,  "Gamma",                 (1e-06, 1e-06)),
         "GEOMETRIC":     (7, np.random.geometric,             [3, 0],       True,  "Geometric",             (1e-06, 1e-06)),
-        "GUMBEL":        (8, np.random.gumbel,                [6, 6, 0],   True,  "Gumbel",                (1e-06, 1e-06)),
+        "GUMBEL":        (8, np.random.gumbel,                [6, 6, 0],    True,  "Gumbel",                (1e-06, 1e-06)),
         "LAPLACE":       (9,  np.random.laplace,              [6, 6, 0],    True,  "Laplace",               (1e-06, 1e-06)),
         "LOGISTIC":      (10, np.random.logistic,             [6, 6, 0],    True,  "Logistic",              (1e-06, 1e-06)),
         "LOG_NORMAL":    (11, np.random.lognormal,            [6, 1, 0],    True,  "Log Normal",            (1e-06, 1e-06)),
@@ -272,7 +271,6 @@ class SvRndNumGen(bpy.types.Node, SverchCustomTreeNode):
         return result
 
     def produce_range(self, *params):
-
         if self.type_selected_mode == 'Int':
             result = self.int_random_range(*params)
         else:
@@ -284,7 +282,6 @@ class SvRndNumGen(bpy.types.Node, SverchCustomTreeNode):
         return result
 
     def process(self):
-        print(len(self.inputs))
         inputs = self.inputs
         outputs = self.outputs
         m = self.type_selected_mode

--- a/nodes/number/random_num_gen.py
+++ b/nodes/number/random_num_gen.py
@@ -17,7 +17,8 @@
 # ##### END GPL LICENSE BLOCK #####
 
 import numpy as np
-from math import isclose
+
+from math import isclose, ceil, floor
 
 import bpy
 from bpy.props import BoolProperty, FloatProperty, IntProperty
@@ -54,57 +55,127 @@ class SvRndNumGen(bpy.types.Node, SverchCustomTreeNode):
 
     size = IntProperty(
         name='Size', description='number of values to output (count.. or size)',
-        default=10,
+        default=10, min=1,
         options={'ANIMATABLE'}, update=updateNode)
 
     seed = IntProperty(
         name='Seed', description='seed, grow',
-        default=0,
+        default=0, min=0,
         options={'ANIMATABLE'}, update=updateNode)
+
+    alpha = FloatProperty(
+        name='Alpha', description='seed, grow',
+        default=2.0, min=(1e-06),
+        options={'ANIMATABLE'}, update=updateNode)
+
+    beta = FloatProperty(
+        name='Beta', description='seed, grow',
+        default=2.0, min=(1e-06),
+        options={'ANIMATABLE'}, update=updateNode)
+
+    t_in = FloatProperty(
+         name="t",
+         default=.5, min=1e-06, max=1.0-1e-06, precision=6,
+         options={'ANIMATABLE'}, update=updateNode)
 
     as_list = BoolProperty(
         name='As List', description='on means output list, off means output np.array 1d',
-        default=True, 
+        default=True,
         update=updateNode)
 
-    mode_options = [
-        ("Simple", "Simple", "", 0),
-        ("Advanced", "Advanced", "", 1)
-    ]
-    
-    selected_mode = bpy.props.EnumProperty(
-        items=mode_options,
-        description="offers....",
-        default="Simple", update=updateNode
-    )
+    func_dict = {
+        "UNIFORM":       (0, np.random.ranf,                  [0],          False, "Uniform",               (1e-06, 1e-06)),
+        "BETA":          (1, np.random.beta,                  [1, 2, 0],    False, "Beta",                  (1e-06, 1e-06)),
+        "BINOMIAL":      (2, np.random.binomial,              [1, 3, 0],    True,  "Binomial",              (1e-06, 1e-06)),
+        "CHI_SQUARE":    (3, np.random.chisquare,             [1, 0],       True,  "Chi_square",            (1e-06, 1e-06)),
+        "EXPONENTIAL":   (4, np.random.exponential,           [6, 0],       True,  "Exponential",           (1e-06, 1e-06)),
+        "F_DIST":        (5, np.random.f,                     [1, 2, 0],    True,  "F Distrib.",            (1e-06, 0.025)),
+        "GAMMA":         (6, np.random.gamma,                 [1, 6, 0],    True,  "Gamma",                 (1e-06, 1e-06)),
+        "GEOMETRIC":     (7, np.random.geometric,             [3, 0],       True,  "Geometric",             (1e-06, 1e-06)),
+        "GUMBEL":        (8, np.random.gumbel,                [6, 6, 0],   True,  "Gumbel",                (1e-06, 1e-06)),
+        "LAPLACE":       (9,  np.random.laplace,              [6, 6, 0],    True,  "Laplace",               (1e-06, 1e-06)),
+        "LOGISTIC":      (10, np.random.logistic,             [6, 6, 0],    True,  "Logistic",              (1e-06, 1e-06)),
+        "LOG_NORMAL":    (11, np.random.lognormal,            [6, 1, 0],    True,  "Log Normal",            (1e-06, 1e-06)),
+        "LOG_SERIES":    (12, np.random.logseries,            [3, 0],       True,  "Log Series",            (1e-06, 1e-06)),
+        "NEG_BINOMIAL":  (13, np.random.negative_binomial,    [1, 3, 0],    True,  "Negative Binomial",     (1e-06, 1e-06)),
+        "NONCEN_CHI_SQ": (14, np.random.noncentral_chisquare, [1, 2, 0],    True,  "Noncentred Chi-Square", (1e-06, 1e-06)),
+        "NORMAL":        (15, np.random.normal,               [6, 6, 0],    True,  "Normal",                (1e-06, 1e-06)),
+        "PARETO":        (16, np.random.pareto,               [1, 0],       True,  "Pareto",                (0.01,  1e-06)),
+        "POISSON":       (17, np.random.poisson,              [6, 0],       True,  "Poisson",               (1e-06, 1e-06)),
+        "POWER":         (18, np.random.power,                [1, 0],       True,  "Power",                 (1e-06, 1e-06)),
+        "RAYLEIGH":      (19, np.random.rayleigh,             [6, 0],       True,  "RayLeigh",              (1e-06, 1e-06)),
+        "STD_CAUCHY":    (20, np.random.standard_cauchy,      [0],          True,  "Standard Cauchy",       (1e-06, 1e-06)),
+        "STD_GAMMA":     (22, np.random.standard_gamma,       [6, 0],       True,  "Standard Gamma",        (1e-06, 1e-06)),
+        "STD_T":         (24, np.random.standard_t,           [1, 0],       True,  "Standard T",            (0.017, 1e-06)),
+        "TRIANGULAR":    (25, np.random.triangular,           [4, 1, 5, 0], False, "Triangular",            (1e-06, 1e-06)),
+        "VONMISES":      (26, np.random.vonmises,             [1, 2, 0],    True,  "Vonmises",              (1e-06, 1e-06)),
+        "WALD":          (27, np.random.wald,                 [1, 2, 0],    True,  "Wald",                  (1e-06, 1e-06)),
+        "WEIBULL":       (28, np.random.weibull,              [1, 0],       True,  "Weibull",               (0.0028, 1e-06)),
+        "ZIPF":          (29, np.random.zipf,                 [1, 0],       True,  "Zipf",                  (1+1e-05, 1e-06)),
+    }
 
+    distribute_options = [(key, value[4], "", value[0]) for key, value in sorted(func_dict.items())]
+
+    soket_opt = [
+        ('Alpha', 'alpha', 1),
+        ('Beta', 'beta', 2),
+        ('t', 't_in', 3)]
 
     def adjust_inputs(self, context):
         m = self.type_selected_mode
         si = self.inputs
+        ssk = self.soket_opt
+        if m == 'Int':
+            if si[2].prop_name[-1] == 'f':
+                si[2].prop_name = 'low_i'
+                si[3].prop_name = 'high_i'
 
-        if m == 'Int' and si[2].prop_name[-1] == 'f':
-            si[2].prop_name = 'low_i'
-            si[3].prop_name = 'high_i'
-        
-        elif m == 'Float' and si[2].prop_name[-1] == 'i':
-            si[2].prop_name = 'low_f'
-            si[3].prop_name = 'high_f'
+            if self.weighted and 'Weights' not in si:
+                self.inputs.new('StringsSocket', 'Weights', 'Weights')
+            elif not self.weighted and 'Weights' in si:
+                self.inputs.remove(self.inputs['Weights'])
+            for i in range(0, 3):
+                if ssk[i][0] in si:
+                    self.inputs.remove(self.inputs[ssk[i][0]])
+
+        elif m == 'Float':
+            dsm = self.distribute_mode
+            func = self.func_dict[dsm]
+            if si[2].prop_name[-1] == 'i':
+                si[2].prop_name = 'low_f'
+                si[3].prop_name = 'high_f'
+            if 'Weights' in si:
+                self.inputs.remove(self.inputs['Weights'])
+            for i in range(1, 4):
+                if i in func[2] and ssk[i-1][0] not in si:
+                    self.inputs.new('StringsSocket', ssk[i-1][0], ssk[i-1][0]).prop_name = ssk[i-1][1]
+                elif i not in func[2] and ssk[i-1][0] in si:
+                    self.inputs.remove(self.inputs[ssk[i-1][0]])
 
         updateNode(self, context)
-
 
     type_mode_options = [
         ("Int", "Int", "", 0),
         ("Float", "Float", "", 1)
     ]
-    
+
     type_selected_mode = bpy.props.EnumProperty(
         items=type_mode_options,
         description="offers....",
         default="Int", update=adjust_inputs
     )
 
+    weighted = BoolProperty(
+        name='Weighted', description='on means output list, off means output np.array 1d',
+        default=False,
+        update=adjust_inputs)
+
+    distribute_mode = bpy.props.EnumProperty(
+        name="Distribution",
+        items=distribute_options,
+        description="offers....",
+        default="UNIFORM", update=adjust_inputs
+    )
 
     def sv_init(self, context):
         si = self.inputs
@@ -115,46 +186,111 @@ class SvRndNumGen(bpy.types.Node, SverchCustomTreeNode):
         so = self.outputs
         so.new('StringsSocket', "Value")
 
-
-    def draw_buttons(self, _, layout):
+    def buttons(self, layout):
         row = layout.row()
         row.prop(self, 'type_selected_mode', expand=True)
+        if self.type_selected_mode == "Int":
+            layout.prop(self, "weighted")
+        else:
+            layout.prop(self, "distribute_mode")
+
+    def draw_buttons(self, context, layout):
+        self.buttons(layout)
+
+    def draw_buttons_ext(self, context, layout):
+        self.buttons(layout)
         layout.prop(self, "as_list")
-    
 
-    def produce_range(self, *params):
-        size, seed, low, high = params
-
+    def int_random_range(self, *params):
+        if len(params) < 5:
+            size, seed, low, high = params
+            weights = []
+        else:
+            size, seed, low, high, weights = params
         size = max(size, 1)
         seed = max(seed, 0)
+        np.random.seed(seed)
+        low, high = sorted([low, high])
+        if self.weighted and len(weights) > 0:
+            population, weights = match_long_repeat([range(low, high+1), weights])
+            total_weight = sum(weights)
+            weights = [w/total_weight for w in weights]
+            result = np.random.choice(population, size, p=weights)
+        else:
+            result = np.random.random_integers(low, high, size)
+
+        return result
+
+    def float_random_range(self, *params):
+        func = self.func_dict[self.distribute_mode]
+        alpha = 0.5
+        beta = 1
+        t_in = 1
+        if len(params) < 5:
+            size, seed, low, high = params
+        elif len(params) == 6:
+            if 2 in func[2]:
+                size, seed, low, high, alpha, beta = params
+            elif 3 in func[2]:
+                size, seed, low, high, alpha, t_in = params
+
+        elif len(params) == 5:
+            if 1 in func[2]:
+                size, seed, low, high, alpha = params
+            elif 3 in func[2]:
+                size, seed, low, high, t_in = params
+        alpha = max(alpha, func[5][0])
+        beta = max(beta, func[5][1])
+        size = max(size, 1)
+        seed = max(seed, 0)
+        t_in = min(max(t_in, 1e-06), 1-1e-06)
+
+        args = [size, alpha, beta, t_in, low, high, 1]
+        args = [args[i] for i in func[2]]
 
         np.random.seed(seed)
+        result = func[1](*args)
+
+        if func[3]:
+            min_v = (np.ndarray.min(result))
+            max_v = (np.ndarray.max(result))
+        else:
+            min_v = 0.0
+            max_v = 1.0
+
+        epsilon_relative = 1e-06
+        if isclose(low, min_v, rel_tol=epsilon_relative) and isclose(high, max_v, rel_tol=epsilon_relative):
+            pass
+        else:
+            my_func = lambda inval: np.interp(inval, [min_v, max_v], [low, high])
+            result = np.apply_along_axis(my_func, 0, result)
+        return result
+
+    def produce_range(self, *params):
 
         if self.type_selected_mode == 'Int':
-            low, high = sorted([low, high])
-            result = np.random.random_integers(low, high, size)
+            result = self.int_random_range(*params)
         else:
-            result = np.random.ranf(size)
-            epsilon_relative = 1e-06
-            if isclose(low, 0.0, rel_tol=epsilon_relative) and isclose(high, 1.0, rel_tol=epsilon_relative):
-                pass
-            else:
-                my_func = lambda inval: np.interp(inval, [0.0, 1.0], [low, high])
-                result = np.apply_along_axis(my_func, 0, result)
+            result = self.float_random_range(*params)
 
         if self.as_list:
             result = result.tolist()
 
         return result
 
-
     def process(self):
         outputs = self.outputs
-
+        m = self.type_selected_mode
         if outputs['Value'].is_linked:
-            params = [self.inputs[i].sv_get()[0] for i in range(4)]
+            if m == 'Int':
+                params = [self.inputs[i].sv_get()[0] for i in range(4)]
+                if len(self.inputs) == 5 and self.inputs[4].is_linked:
+                    params.append(self.inputs[4].sv_get())
+            elif m == 'Float':
+                params = [self.inputs[i].sv_get()[0] for i in range(len(self.inputs))]
             out = [self.produce_range(*args) for args in zip(*match_long_repeat(params))]
             outputs['Value'].sv_set(out)
+
 
 def register():
     bpy.utils.register_class(SvRndNumGen)


### PR DESCRIPTION
## Addressed problem description
"Random Num Gen" offers uniform distributions, but it could be expanded (using numpy) it to create Weighted distribution of Integers and non-uniform distribution of floats


## Solution description

I added most of the methods described in de numpy.random reference https://docs.scipy.org/doc/numpy-1.14.0/reference/routines.random.html

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

