### PR TITLE
Smooth splines node

### DIFF
--- a/index.md
+++ b/index.md
@@ -42,6 +42,7 @@
     SvTorusKnotNode
     SvRingNode
     SvEllipseNode
+    SvSmoothLines
 
 ## Analyzers
     SvBBoxNode

--- a/nodes/generators_extended/smooth_lines.py
+++ b/nodes/generators_extended/smooth_lines.py
@@ -28,15 +28,22 @@ def spline_points(points, weights, index, params):
     divs = params.num_points
     a, b, c = points
 
-    if len(weights) == 3:
-        w1, w2, w3 = weights
+    if len(weights) == 2:
+        w1, w2 = weights
     else:
         w2 = weights[0]
 
+    # return early if no weight, then user wants no smooth/fillet
+    if -0.0001 < w2 < 0.0001:
+        return [b]
+
+    weight_to_use_1 = 1 - w2
+    weight_to_use_2 = 1 - w2
+
     # if params.clamping == 'HARD' and params.mode == 'ABSOLUTE':
-    # locate points  // # (1 - w) * p1 + w * p2
-    p1 = Vector(a).lerp(Vector(b), w2)[:] # locate_point(a, b, w2)
-    p2 = Vector(c).lerp(Vector(b), w2)[:] # locate_point(b, c, 1-w2)
+
+    p1 = Vector(a).lerp(Vector(b), weight_to_use_1)[:]
+    p2 = Vector(c).lerp(Vector(b), weight_to_use_2)[:]
 
     return [v[:] for v in bezlerp(p1, b, b, p2, divs)]
 
@@ -57,7 +64,7 @@ def func_xpline_2d(vlist, wlist, params):
         add_points([vlist[0]])
 
     for i in range(len(vlist)-2):
-        weights = wlist if len(wlist) == 1 else wlist[i:i+3]
+        weights = wlist if len(wlist) == 1 else wlist[i:i+2]
         add_points(spline_points(vlist[i:i+3], weights, index=i, params=params))
 
     if not params.loop:

--- a/nodes/generators_extended/smooth_lines.py
+++ b/nodes/generators_extended/smooth_lines.py
@@ -139,6 +139,7 @@ class SvSmoothLines(bpy.types.Node, SverchCustomTreeNode):
 
         if self.inputs["attributes"].is_linked:
             # gather own data, rather than socket data
+            # NOT IMPLEMENTED YET
             ...
 
         edges_socket = self.outputs['edges']

--- a/nodes/generators_extended/smooth_lines.py
+++ b/nodes/generators_extended/smooth_lines.py
@@ -1,0 +1,64 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import bpy
+# import mathutils
+# from mathutils import Vector
+from bpy.props import FloatProperty, EnumProperty
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode
+
+class SvSmoothLines(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: smooth lines fil 
+    Tooltip: accepts seq of verts and weights, returns smoothed lines
+    
+    This node should accept verts and weights and return the smoothed line representation.
+    """
+
+    bl_idname = 'SvSmoothLines'
+    bl_label = 'Smooth Lines'
+    bl_icon = 'GREASEPENCIL'
+
+    smooth_mode_options = [(k, k, '', i) for i, k in enumerate(["absolute", "relative"])]
+    smooth_selected_mode = EnumProperty(
+        items=smooth_mode_options, description="offers....",
+        default="absolute", update=updateNode)
+
+    close_mode_options = [(k, k, '', i) for i, k in enumerate(["cyclic", "open"])]
+    close_selected_mode = EnumProperty(
+        items=close_mode_options, description="offers....",
+        default="cyclic", update=updateNode)
+
+
+    weights = FloatProperty(default=0.0, name="weights", min=0)
+
+    def sv_init(self, context):
+        self.inputs.new("VerticesSocket", "vectors")
+        self.inputs.new("StringsSocket", "weights").prop_name = "weights"
+        self.inputs.new("StringsSocket", "attributes")
+
+    # def draw_buttons(self, context, layout):
+    #    ...
+
+    def process(self):
+        necessary_sockets = [self.inputs["vectors"], self.inputs["weights"]]
+        if not all(s.is_linked for s in necessary_sockets):
+            return
+
+        if self.inputs["attributes"].is_linked:
+            # gather own data, rather than socket data
+
+        
+
+
+def register():
+    bpy.utils.register_class(SvSmoothLines)
+
+
+def unregister():
+    bpy.utils.unregister_class(SvSmoothLines)

--- a/nodes/generators_extended/smooth_lines.py
+++ b/nodes/generators_extended/smooth_lines.py
@@ -6,11 +6,64 @@
 # License-Filename: LICENSE
 
 import bpy
-# import mathutils
-# from mathutils import Vector
-from bpy.props import FloatProperty, EnumProperty
+import mathutils
+from mathutils.geometry import interpolate_bezier as bezlerp
+from mathutils import Vector
+from bpy.props import FloatProperty, IntProperty, EnumProperty
+
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode
+
+
+def spline_points(points, weights, index, params):
+    """ 
+        b  .
+       .        .
+      .              .
+     .                    c
+    a
+
+    """
+    cyclic = params.loop
+    divs = params.num_points
+    a, b, c = points
+    w1, w2, w3 = weights
+
+    # if params.clamping == 'HARD' and params.mode == 'ABSOLUTE':
+    # locate points  // # (1 - w) * p1 + w * p2
+    p1 = Vector(a).lerp(Vector(b), w2)[:] # locate_point(a, b, w2)
+    p2 = Vector(c).lerp(Vector(b), w2)[:] # locate_point(b, c, 1-w2)
+
+    return bezlerp(p1, b, b, p2, divs)
+
+
+def func_xpline_2d(V_list, W_list, params):
+
+    # nonsense input, garbage in / out
+    if len(V_list) < 3:
+        return V_list
+
+    if params.loop:
+        V_list.append(V_list[0])
+        W_list.append(W_list[0])
+
+    final_points = []
+    add_points = final_points.append
+    for i, _ in enumerate(len(V_list)-3):
+        add_points(spline_points(V_list[i:i+3], W_list[i:i+3], index=i, params=params))
+
+    if params.loop:
+        for section in final_points:
+            section.pop()
+    else:
+        for index in range(len(final_points)-1):
+            final_points[index].pop()
+
+    return final_points
+
+
+
+
 
 class SvSmoothLines(bpy.types.Node, SverchCustomTreeNode):
     """
@@ -34,13 +87,15 @@ class SvSmoothLines(bpy.types.Node, SverchCustomTreeNode):
         items=close_mode_options, description="offers....",
         default="cyclic", update=updateNode)
 
-
-    weights = FloatProperty(default=0.0, name="weights", min=0)
+    n_verts = IntProperty(default=5, name="n_verts", min=0) 
+    weights = FloatProperty(default=0.0, name="weights", min=0.0)
 
     def sv_init(self, context):
         self.inputs.new("VerticesSocket", "vectors")
         self.inputs.new("StringsSocket", "weights").prop_name = "weights"
         self.inputs.new("StringsSocket", "attributes")
+        self.outputs.new("VerticesSocket", "verts")
+        self.outputs.new("StringsSocket", "edges")
 
     # def draw_buttons(self, context, layout):
     #    ...
@@ -52,8 +107,20 @@ class SvSmoothLines(bpy.types.Node, SverchCustomTreeNode):
 
         if self.inputs["attributes"].is_linked:
             # gather own data, rather than socket data
+            ...
 
-        
+        verts_out = []
+        for vlist, wlist in zip(V_list, W_list):
+            params = lambda: None
+            params.num_points = 10
+            params.loop = False
+            params.remove_doubles = False
+            verts_out.append(func_xpline_2d(V_list, W_list, params))
+
+        edges_out = []
+
+        self.outputs['verts'].sv_set(verts_out)
+        self.outputs['edges'].sv_set(edges_out)
 
 
 def register():

--- a/nodes/generators_extended/smooth_lines.py
+++ b/nodes/generators_extended/smooth_lines.py
@@ -54,7 +54,8 @@ def func_xpline_2d(vlist, wlist, params):
     final_points = []
     add_points = final_points.append
     for i in range(len(vlist)-3):
-        add_points(spline_points(vlist[i:i+3], wlist[i:i+3], index=i, params=params))
+        weights = wlist if len(wlist) == 1 else wlist[i:i+3]
+        add_points(spline_points(vlist[i:i+3], weights, index=i, params=params))
 
     if params.loop:
         for section in final_points:
@@ -89,7 +90,7 @@ class SvSmoothLines(bpy.types.Node, SverchCustomTreeNode):
         default="cyclic", update=updateNode)
 
     n_verts = IntProperty(default=5, name="n_verts", min=0) 
-    weights = FloatProperty(default=0.0, name="weights", min=0.0)
+    weights = FloatProperty(default=0.0, name="weights", min=0.0, update=updateNode)
 
     def sv_init(self, context):
         self.inputs.new("VerticesSocket", "vectors")

--- a/nodes/generators_extended/smooth_lines.py
+++ b/nodes/generators_extended/smooth_lines.py
@@ -40,10 +40,18 @@ def spline_points(points, weights, index, params):
     weight_to_use_1 = 1 - w2
     weight_to_use_2 = 1 - w2
 
-    # if params.clamping == 'HARD' and params.mode == 'ABSOLUTE':
+    # if params.clamping == 'HARD' 
+    if params.mode == 'absolute':
+        len_ab = (Vector(a)-Vector(b)).length
+        len_cb = (Vector(c)-Vector(b)).length
+        weight_to_use_1 = w2 / len_ab
+        weight_to_use_2 = w2 / len_cb
+        p1 = Vector(b).lerp(Vector(a), weight_to_use_1)[:]
+        p2 = Vector(b).lerp(Vector(c), weight_to_use_2)[:]
+    else:
 
-    p1 = Vector(a).lerp(Vector(b), weight_to_use_1)[:]
-    p2 = Vector(c).lerp(Vector(b), weight_to_use_2)[:]
+        p1 = Vector(a).lerp(Vector(b), weight_to_use_1)[:]
+        p2 = Vector(c).lerp(Vector(b), weight_to_use_2)[:]
 
     return [v[:] for v in bezlerp(p1, b, b, p2, divs)]
 
@@ -150,12 +158,14 @@ class SvSmoothLines(bpy.types.Node, SverchCustomTreeNode):
 
         for vlist, wlist in zip(V_list, W_list):
             
-            # setup this sequence
+            # setup this sequence, 
             params = lambda: None
-            params.num_points = self.n_verts # or from attributes
+            params.num_points = self.n_verts
             params.loop = False if not self.type_selected_mode == 'cyclic' else True
             params.remove_doubles = False
             params.weight = self.weights
+            params.mode = self.smooth_selected_mode
+            # params = self.get_params_from_attribute_socket()
 
             new_verts = func_xpline_2d(vlist, wlist, params)
             verts_out.append(new_verts)

--- a/nodes/generators_extended/smooth_lines.py
+++ b/nodes/generators_extended/smooth_lines.py
@@ -48,21 +48,14 @@ def func_xpline_2d(vlist, wlist, params):
         return vlist
 
     if params.loop:
-        vlist.append(vlist[0])
-        wlist.append(wlist[0])
+        vlist.extend(vlist[:2])
+        wlist.extend(wlist[:2])
 
     final_points = []
     add_points = final_points.append
     for i in range(len(vlist)-2):
         weights = wlist if len(wlist) == 1 else wlist[i:i+3]
         add_points(spline_points(vlist[i:i+3], weights, index=i, params=params))
-
-    if params.loop:
-        for section in final_points:
-            section.pop()
-    else:
-        for index in range(len(final_points)-1):
-            final_points[index].pop()
 
     return final_points
 
@@ -87,7 +80,7 @@ class SvSmoothLines(bpy.types.Node, SverchCustomTreeNode):
     type_mode_options = [(k, k, '', i) for i, k in enumerate(["cyclic", "open"])]
     type_selected_mode = EnumProperty(
         items=type_mode_options, description="offers....",
-        default="cyclic", update=updateNode)
+        default="open", update=updateNode)
 
     n_verts = IntProperty(default=5, name="n_verts", min=0, update=updateNode) 
     weights = FloatProperty(default=0.0, name="weights", min=0.0, update=updateNode)
@@ -103,7 +96,7 @@ class SvSmoothLines(bpy.types.Node, SverchCustomTreeNode):
 
         # with attrs socket connected all params must be passed via this socket, to override node variables
         attr_socket = self.inputs.get('attributes')
-        if not attr_socket or not attr_socket.is_linked:
+        if attr_socket and attr_socket.is_linked:
             return
 
         col = layout.column()


### PR DESCRIPTION
## adds a "filleted polyline" Node. I call it smoothed line


```
        b  .                                     ..y..
       .        .                          .        . 
      .              .            .                  .
     .                    c                           .
    a                                                ..z..
```
in individual weight mode you pass a `location` and `weight` for all points ( when weights is connected )
in homogeneous weight mode all weights are the value of the slider. (currently not smart)


progress
- [x] relative mode ( weight is relative to the distance between the `a-b b-c`
- [x] absolute mode ( weight is real world value dependant)
- [x] clamping, automatically constrict values that are not possible in absolute mode
- [x] cyclic open / closed
- [x] generate edges
- [ ] drop consecutive doubles (optional, and with epsilon) 
- [ ] forgetting other modes...

![image](https://user-images.githubusercontent.com/619340/47047195-3ab4e280-d197-11e8-8e9f-ed7285575157.png)

![image](https://user-images.githubusercontent.com/619340/47047374-b1ea7680-d197-11e8-9ef1-fd5ca13188d0.png)


