### PR TITLE
Add default font scale to index viewer node settable via preferences

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -30,7 +30,7 @@ class SverchokPreferences(AddonPreferences):
             color_def.apply_theme()
 
     tab_modes = [(k, k, '', i) for i, k in enumerate(["General", "Node Defaults", "Theme"])]
-    
+
     selected_tab = bpy.props.EnumProperty(
         items=tab_modes,
         description="pick viewing mode",
@@ -168,6 +168,9 @@ class SverchokPreferences(AddonPreferences):
     stethoscope_view_xy_multiplier = FloatProperty(
         default=1.0, min=0.01, step=0.01, description='default stethoscope scale')
 
+    index_viewer_scale = FloatProperty(
+        default=1.0, min=0.01, step=0.01, description='default index viewer scale')
+
     datafiles = os.path.join(bpy.utils.user_resource('DATAFILES', path='sverchok', create=True))
     defaults_location = StringProperty(default=datafiles, description='usually ..data_files\\sverchok\\defaults\\nodes.json')
     external_editor = StringProperty(description='which external app to invoke to view sources')
@@ -178,7 +181,7 @@ class SverchokPreferences(AddonPreferences):
     def update_log_level(self, context):
         logging.info("Setting log level to %s", self.log_level)
         logging.setLevel(self.log_level)
-    
+
     log_levels = [
             ("DEBUG", "Debug", "Debug output", 0),
             ("INFO", "Information", "Informational output", 1),
@@ -270,6 +273,8 @@ class SverchokPreferences(AddonPreferences):
             box_sub1_col.label('stethoscope mk2 settings')
             box_sub1_col.prop(self, 'stethoscope_view_scale', text='scale')
             box_sub1_col.prop(self, 'stethoscope_view_xy_multiplier', text='xy multiplier')
+            box_sub1_col.label('index viewer settings')
+            box_sub1_col.prop(self, 'index_viewer_scale', text='scale')
 
             col3 = row_sub1.split().column()
             col3.label('Location of custom defaults')

--- a/ui/index_viewer_draw.py
+++ b/ui/index_viewer_draw.py
@@ -24,6 +24,7 @@ import blf
 import bgl
 from mathutils import Vector
 
+from sverchok.utils.context_managers import sv_preferences
 from sverchok.data_structure import Vector_generate, Matrix_generate
 
 SpaceView3D = bpy.types.SpaceView3D
@@ -154,8 +155,15 @@ def draw_callback_px(n_id, draw_verts, draw_edges, draw_faces, draw_matrix, draw
     display_edge_index = settings['display_edge_index']
     display_face_index = settings['display_face_index']
 
+    try:
+        with sv_preferences() as prefs:
+            scale = prefs.index_viewer_scale
+    except:
+        # print('did not find preferences - you need to save user preferences')
+        scale = 1.0
+
     font_id = 0
-    text_height = 13
+    text_height = int(13.0 * scale)
     blf.size(font_id, text_height, 72)  # should check prefs.dpi
 
     region_mid_width = region.width / 2.0
@@ -222,7 +230,7 @@ def draw_callback_px(n_id, draw_verts, draw_edges, draw_faces, draw_matrix, draw
 
         if data_edges and display_edge_index:
             for edge_index, (idx1, idx2) in enumerate(data_edges[obj_index]):
-                
+
                 v1 = Vector(final_verts[idx1])
                 v2 = Vector(final_verts[idx2])
                 loc = v1 + ((v2 - v1) / 2)


### PR DESCRIPTION
For some screen resolutions (e.g. mac book pro with retina display / double pixel resolution) the index viewer node's font size was too small to read and needed a scale factor of 2x. With this new setting the user can define the desired font scale in the SV preference settings. The default font scale is 1.0.

This addresses discussion in #2284

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

 
![indexviwer-scale1](https://user-images.githubusercontent.com/2083719/48426595-b705fb80-e72c-11e8-9d17-933d9347d988.jpg)
![indexviwer-scale2](https://user-images.githubusercontent.com/2083719/48426596-b705fb80-e72c-11e8-8ca9-9b030fd4d2e1.jpg)

