### PR TITLE
Fix render scale and location of easing and texture viewer nodes

### DIFF
--- a/nodes/text/stethoscope_mk2.py
+++ b/nodes/text/stethoscope_mk2.py
@@ -132,7 +132,7 @@ class SvStethoscopeNodeMK2(bpy.types.Node, SverchCustomTreeNode):
             try:
                 with sv_preferences() as prefs:
                     scale = prefs.stethoscope_view_scale
-                    location_theta = prefs.stethoscope_view_xy_multiplier
+                    location_theta = prefs.render_location_xy_multiplier
             except:
                 # print('did not find preferences - you need to save user preferences')
                 scale = 1.0
@@ -141,7 +141,6 @@ class SvStethoscopeNodeMK2(bpy.types.Node, SverchCustomTreeNode):
             # gather vertices from input
             data = inputs[0].sv_get(deepcopy=False)
             self.num_elements = len(data)
-
 
             if self.selected_mode == 'text-based':
                 props = lambda: None
@@ -190,7 +189,7 @@ class SvStethoscopeNodeMK2(bpy.types.Node, SverchCustomTreeNode):
             return
         try:
             if not self.inputs[0].other:
-                nvBGL.callback_disable(node_id(self))        
+                nvBGL.callback_disable(node_id(self))
         except:
             print('stethoscope update holdout (not a problem)')
 

--- a/nodes/viz/texture_viewer.py
+++ b/nodes/viz/texture_viewer.py
@@ -26,6 +26,7 @@ from bpy.props import (
     FloatProperty, EnumProperty, StringProperty, BoolProperty, IntProperty
 )
 
+from sverchok.utils.context_managers import sv_preferences
 from sverchok.data_structure import updateNode, node_id
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.ui import nodeview_bgl_viewer_draw_mk2 as nvBGL2
@@ -383,6 +384,18 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
             bgl.glGenTextures(1, name)
             self.texture[n_id] = name[0]
             init_texture(width, height, name[0], texture, gl_color_constant)
+
+            # adjust render location based on preference multiplier setting
+            try:
+                with sv_preferences() as prefs:
+                    multiplier = prefs.render_location_xy_multiplier
+                    scale = prefs.render_scale
+            except:
+                # print('did not find preferences - you need to save user preferences')
+                multiplier = 1.0
+                scale = 1.0
+            x, y = [x * multiplier, y * multiplier]
+            width, height =[width * scale, height * scale]
 
             draw_data = {
                 'tree_name': self.id_data.name[:],

--- a/settings.py
+++ b/settings.py
@@ -163,9 +163,13 @@ class SverchokPreferences(AddonPreferences):
     enable_live_objin = BoolProperty(
         description="Objects in edit mode will be updated in object-in Node")
 
+    render_scale = FloatProperty(
+        default=1.0, min=0.01, step=0.01, description='default render scale')
+
+    render_location_xy_multiplier = FloatProperty(
+        default=1.0, min=0.01, step=0.01, description='default render location xy multiplier')
+
     stethoscope_view_scale = FloatProperty(
-        default=1.0, min=0.01, step=0.01, description='default stethoscope scale')
-    stethoscope_view_xy_multiplier = FloatProperty(
         default=1.0, min=0.01, step=0.01, description='default stethoscope scale')
 
     index_viewer_scale = FloatProperty(
@@ -270,10 +274,12 @@ class SverchokPreferences(AddonPreferences):
             row_sub1 = col.row().split(0.5)
             box_sub1 = row_sub1.box()
             box_sub1_col = box_sub1.column(align=True)
-            box_sub1_col.label('stethoscope mk2 settings')
+            box_sub1_col.label('Render Scale & Location')
+            box_sub1_col.prop(self, 'render_location_xy_multiplier', text='xy multiplier')
+            box_sub1_col.prop(self, 'render_scale', text='scale')
+            box_sub1_col.label('Stethoscope MK2 settings')
             box_sub1_col.prop(self, 'stethoscope_view_scale', text='scale')
-            box_sub1_col.prop(self, 'stethoscope_view_xy_multiplier', text='xy multiplier')
-            box_sub1_col.label('index viewer settings')
+            box_sub1_col.label('Index Viewer settings')
             box_sub1_col.prop(self, 'index_viewer_scale', text='scale')
 
             col3 = row_sub1.split().column()


### PR DESCRIPTION
Easing and texture viewer nodes suffered form the same x2 resolution issue as the index viewer and stethoscope nodes due to resolution doubling on some machines (e.g. mac book with retina display). This PR fixes the issues by using the same render scale / xy multiplier used already by the stethoscope node to adjust the rendered location/scale.

- made scale and xy multiplier pref settings generic to be used by multiple nodes
- add scale/multiplier adjustments to the texture viewer and easing node and update stethoscope node to use the same scale/multiplier

Addressing issues discussed in #2309 and #2284

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

