### PR TITLE
B28 nodes fix

### DIFF
--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -108,7 +108,7 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
             groups = bpy.data.groups
             names = [obj.name for obj in groups[self.groupname].objects]
         else:
-            names = [obj.name for obj in bpy.data.objects if obj.select_get()]
+            names = [obj.name for obj in bpy.data.objects if (obj.select_get() and len(obj.users_scene) > 0 and len(obj.users_collection) > 0)]
 
         if self.sort:
             names.sort()

--- a/nodes/transforms/move_mk2.py
+++ b/nodes/transforms/move_mk2.py
@@ -57,7 +57,7 @@ class SvMoveNodeMK2(bpy.types.Node, SverchCustomTreeNode):
 
     def moving(self, v, c, m):
         #print('moving function test',v,c,m)
-        return [(Vector(v) + Vector(c) @ m)[:]]
+        return [(Vector(v) + Vector(c) * m)[:]]
 
 
 def register():

--- a/nodes/transforms/scale_mk2.py
+++ b/nodes/transforms/scale_mk2.py
@@ -60,7 +60,7 @@ class SvScaleNodeMK2(bpy.types.Node, SverchCustomTreeNode):
 
     def scaling(self, v, c, m):
         # print(c,v,m)
-        return [(Vector(c) + m @ (Vector(v) - Vector(c)))[:]]
+        return [(Vector(c) + m * (Vector(v) - Vector(c)))[:]]
 
 
 def register():


### PR DESCRIPTION
## Nodes fix

Fix 1, Scale mk2: fixed operation on vectors, my shortest commit. :)

Fix 2, Objects in mk3: fixed 'Get selected' button for a nasty case. When you've got an object in the viewport and delete it, it stays in bpy.data.objects and its attribute select_get() is still set to True and so when you select another object in the viewport and hit 'Get selected', this function sometimes gets a previously deleted object that we can't access in the UI anymore. I added a check on users_scene and the new users_collection.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [ ] Code documentation complete.
- [ ] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

