### PR TITLE
Add 3DProject node (WIP)

### DIFF
--- a/docs/nodes/transforms/3d_project.rst
+++ b/docs/nodes/transforms/3d_project.rst
@@ -1,0 +1,32 @@
+3D Project
+----------
+
+This node projects vertices in 3D space into 2D space.
+
+Modes
+=====
+
+The available **Modes** are: PLANE, SPHERE.
+
+
+Inputs
+======
+
+**Verts**
+
++---------------+---------+---------+-------------------------------------------------+
+| Param         | Type    | Default | Description                                     |
++===============+=========+=========+=================================================+
+| **Mode**      | Enum    | PLANE   | Projection mode                                 |
+|               |  PLANE  |         |  PLANE  : Perspective projection onto a plane   |
+|               |  SPHERE |         |  SPHERE : Perspective projection onto a sphere  |
++---------------+---------+---------+-------------------------------------------------+
+| **Distance**  | float   | 2.0     |  Distance between the projection point and the  |
+|               |         |         |  projection surface.                            |
++---------------+---------+---------+-------------------------------------------------+
+
+Outputs
+=======
+
+**Verts**
+

--- a/docs/nodes/transforms/transforms_index.rst
+++ b/docs/nodes/transforms/transforms_index.rst
@@ -23,3 +23,4 @@ Transforms
    randomize
    align_mesh_by_mesh
    transform_mesh
+   3d_project

--- a/index.md
+++ b/index.md
@@ -356,7 +356,9 @@
     SvRandomizeVerticesNode
     SvCastNode
     SvFormulaDeformMK2Node
-
+	---
+	Sv3DProjectNode
+	
 ## Modifier Change
     SvDeleteLooseNode
     SvMergeByDistanceNode

--- a/nodes/transforms/3d_project.py
+++ b/nodes/transforms/3d_project.py
@@ -105,34 +105,6 @@ def projection_spherical(verts3D, m, d):
     return vertList, focusList
 
 
-def projection_planar2D(vert3D, m, d):
-    """
-    Project a 3D vector onto 2D space given the projection distance
-    """
-    ox, oy, oz = [m[0][3], m[1][3], m[2][3]]  # projection screen origin
-    nx, ny, nz = [m[0][2], m[1][2], m[2][2]]  # projection screen normal
-
-    x, y, z = vert3D
-
-    x = x - ox
-    y = y - oy
-    z = z - oz
-
-    an = x * nx + y * ny + z * nz  # v projection along the plane normal
-
-    s = d / (d + an)  # perspective factor
-
-    xa = s * (x - an * nx)
-    ya = s * (y - an * ny)
-    za = s * (z - an * nz)
-
-    px = ox + xa
-    py = oy + ya
-    pz = oz + za
-
-    return [px, py, pz]
-
-
 def projection_planar(verts3D, m, d):
     """
     Project the 3D verts onto 2D space given the projection distance
@@ -144,13 +116,6 @@ def projection_planar(verts3D, m, d):
     focusList = []
     for vert in verts3D:
         x, y, z = vert
-
-        # Focus location
-        # Xx Yx Zx Tx        0     Tx - d * Zx
-        # Xy Yy Zy Ty   *    0  =  Ty - d * Zy
-        # Xz Yz Zz Tz      - d     Tz - d * Zz
-        # 0  0  0  1         1     1
-
         dx = x - ox
         dy = y - oy
         dz = z - oz
@@ -169,29 +134,14 @@ def projection_planar(verts3D, m, d):
 
         vertList.append([px, py, pz])
 
-    focusList = [[ox - d*nx, oy - d*ny, oz - d * nz]]
-
-    return vertList, focusList
-
-
-def projection_planar2(verts3D, m, d):
-    """
-    Project the 3D verts onto 2D space given the projection distance
-    """
-    verts2D = [projection_planar2D(verts3D[i], m, d) for i in range(len(verts3D))]
-
     # Focus location
     # Xx Yx Zx Tx        0     Tx - d * Zx
     # Xy Yy Zy Ty   *    0  =  Ty - d * Zy
     # Xz Yz Zz Tz      - d     Tz - d * Zz
     # 0  0  0  1         1     1
+    focusList = [[ox - d*nx, oy - d*ny, oz - d * nz]]
 
-    ox, oy, oz = [m[0][3], m[1][3], m[2][3]]  # projection plane origin
-    nx, ny, nz = [m[0][2], m[1][2], m[2][2]]  # projection plane normal
-
-    focus = [[ox - d*nx, oy - d*ny, oz - d * nz]]
-
-    return verts2D, focus
+    return vertList, focusList
 
 
 class Sv3DProjectNode(bpy.types.Node, SverchCustomTreeNode):

--- a/nodes/transforms/3d_project.py
+++ b/nodes/transforms/3d_project.py
@@ -1,0 +1,148 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import bpy
+from bpy.props import IntProperty, FloatProperty, BoolProperty, EnumProperty, FloatVectorProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode, match_long_repeat
+
+modeItems = [
+    ("PLANE",  "PLANE",  "Project onto a plane", 0),
+    ("SPHERE", "SPHERE", "Project onto a sphere", 1),
+    ("CYLINDER", "CYLINDER", "Project onto a cylinder", 2)]
+
+
+projectionItems = [
+    ("PERSPECTIVE",  "PERSPECTIVE",  "Perspective projection", 0),
+    ("ORTHOGRAPHIC", "ORTHOGRAPHIC", "Orthographic projection", 1)]
+
+
+def project_2d(vert3D, d):
+    """
+    Project a 3D vector onto 2D space given the projection distance
+    """
+    cx, cy, cz = [0.0, 0.0, 0.0]  # center (projection origin)
+    x, y, z = vert3D
+    s = d / (d + z)
+    xx = x * s
+    yy = y * s
+    return [xx, yy, 0]
+
+
+def project_3d_verts(verts3D, d):
+    """
+    Project the 3D verts onto 2D space given the projection distance
+    """
+    verts2D = [project_2d(verts3D[i], d) for i in range(len(verts3D))]
+    return verts2D
+
+
+class Sv3DProjectNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: 3D Projection
+    Tooltips: Perspective projection from 3D space to 2D space
+    """
+    bl_idname = 'Sv3DProjectNode'
+    bl_label = '3D Project'
+
+    def update_mode(self, context):
+        # if self.mode == self.last_mode:
+        #     return
+
+        # self.last_mode = self.mode
+        # self.update_sockets(context)
+        updateNode(self, context)
+
+    mode = EnumProperty(
+        name="Mode", items=modeItems, default="PLANE", update=update_mode)
+
+    distance = FloatProperty(
+        name="Distance", description="Projection Distance",
+        default=2.0, min=0.0,
+        update=updateNode)
+
+    def sv_init(self, context):
+        self.inputs.new('VerticesSocket', "Verts")
+        self.inputs.new('StringsSocket', "Edges")
+        self.inputs.new('StringsSocket', "Polys")
+        # projection screen location
+        self.inputs.new('MatrixSocket', "Matrix")
+
+        self.inputs.new('StringsSocket', "D").prop_name = 'distance'
+
+        self.outputs.new('VerticesSocket', "Verts")
+        self.outputs.new('StringsSocket', "Edges")
+        self.outputs.new('StringsSocket', "Polys")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "mode")
+
+    def process(self):
+        # return if no outputs are connected
+        outputs = self.outputs
+        if not any(s.is_linked for s in outputs):
+            return
+
+        inputs = self.inputs
+
+        if inputs["Verts"].is_linked:
+            input_v = inputs["Verts"].sv_get()
+        else:
+            return
+
+        if inputs["Edges"].is_linked:
+            input_e = inputs["Edges"].sv_get()
+        else:
+            input_e = [[]]
+
+        if inputs["Polys"].is_linked:
+            input_p = inputs["Polys"].sv_get()
+        else:
+            input_p = [[]]
+
+        input_d = inputs["D"].sv_get()[0]
+
+        # sanitize inputs
+        input_d = list(map(lambda d: max(0, d), input_d))
+
+        params = match_long_repeat([input_v, input_e, input_p, input_d])
+
+        vertList = []
+        edgeList = []
+        polyList = []
+        for v, e, p, d in zip(*params):
+            verts = project_3d_verts(v, d)
+            vertList.append(verts)
+            edgeList.append(e)
+            polyList.append(p)
+
+        if outputs["Verts"].is_linked:
+            outputs["Verts"].sv_set(vertList)
+        if outputs["Edges"].is_linked:
+            outputs["Edges"].sv_set(edgeList)
+        if outputs["Polys"].is_linked:
+            outputs["Polys"].sv_set(polyList)
+
+
+def register():
+    bpy.utils.register_class(Sv3DProjectNode)
+
+
+def unregister():
+    bpy.utils.unregister_class(Sv3DProjectNode)

--- a/nodes/transforms/3d_project.py
+++ b/nodes/transforms/3d_project.py
@@ -40,6 +40,7 @@ idMat = [[tuple(v) for v in Matrix()]]  # identity matrix
 
 EPSILON = 1e-10
 
+
 @profile
 def projection_cylindrical(verts3D, m, d):
     """
@@ -134,11 +135,11 @@ def projection_planar(verts3D, m, d):
 
         vertList.append([px, py, pz])
 
-    # Focus location
-    # Xx Yx Zx Tx        0     Tx - d * Zx
-    # Xy Yy Zy Ty   *    0  =  Ty - d * Zy
-    # Xz Yz Zz Tz      - d     Tz - d * Zz
-    # 0  0  0  1         1     1
+    # Focus location m * D:
+    #  Xx Yx Zx Tx        0     Tx - d * Zx
+    #  Xy Yy Zy Ty   *    0  =  Ty - d * Zy
+    #  Xz Yz Zz Tz      - d     Tz - d * Zz
+    #  0  0  0  1         1     1
     focusList = [[ox - d*nx, oy - d*ny, oz - d * nz]]
 
     return vertList, focusList

--- a/nodes/transforms/3d_project.py
+++ b/nodes/transforms/3d_project.py
@@ -48,23 +48,23 @@ def projection_planar(verts3D, m, d, perspective):
            m : transformation matrix of the projection plane (location & rotation)
            d : distance between the projection point (focus) and the projection plane
     """
-    ox, oy, oz = [m[0][3], m[1][3], m[2][3]]  # projection screen origin
-    nx, ny, nz = [m[0][2], m[1][2], m[2][2]]  # projection screen normal
+    ox, oy, oz = [m[0][3], m[1][3], m[2][3]]  # projection plane origin
+    nx, ny, nz = [m[0][2], m[1][2], m[2][2]]  # projection plane normal
 
-    d = d if perspective else 1e10
+    # d = d if perspective else 1e10
 
     vertList = []
-    focusList = []
     for vert in verts3D:
         x, y, z = vert
+        # vector relative to the plane origin (V-O)
         dx = x - ox
         dy = y - oy
         dz = z - oz
-
-        an = dx * nx + dy * ny + dz * nz  # v projection along the plane normal
-
-        s = d / (d + an)  # perspective factor
-
+        # magnitude of the vector projected parallel to the plane normal
+        an = dx * nx + dy * ny + dz * nz
+        # factor to scale the vector to touch the plane
+        s = d / (d + an)
+        # extended vector touching the plane
         px = ox + s * (dx - an * nx)
         py = oy + s * (dy - an * ny)
         pz = oz + s * (dz - an * nz)
@@ -76,9 +76,9 @@ def projection_planar(verts3D, m, d, perspective):
     #  Xy Yy Zy Ty   *    0  =  Ty - d * Zy
     #  Xz Yz Zz Tz      - d     Tz - d * Zz
     #  0  0  0  1         1     1
-    focusList = [[ox - d * nx, oy - d * ny, oz - d * nz]]
+    focus = [[ox - d * nx, oy - d * ny, oz - d * nz]]
 
-    return vertList, focusList
+    return vertList, focus
 
 
 def projection_cylindrical(verts3D, m, d, perspective):
@@ -93,10 +93,9 @@ def projection_cylindrical(verts3D, m, d, perspective):
     nx, ny, nz = [m[0][2], m[1][2], m[2][2]]  # projection cylinder axis
 
     vertList = []
-    focusList = []
     for vert in verts3D:
         x, y, z = vert
-        # vector relative to the center of the cylinder (V-O)
+        # vector relative to the cylinder origin (V-O)
         dx = x - ox
         dy = y - oy
         dz = z - oz
@@ -117,9 +116,9 @@ def projection_cylindrical(verts3D, m, d, perspective):
 
         vertList.append([xx, yy, zz])
 
-    focusList = [[ox, oy, oz]]
+    focus = [[ox, oy, oz]]
 
-    return vertList, focusList
+    return vertList, focus
 
 
 def projection_spherical(verts3D, m, d, perspective):
@@ -132,9 +131,9 @@ def projection_spherical(verts3D, m, d, perspective):
     ox, oy, oz = [m[0][3], m[1][3], m[2][3]]  # projection sphere origin
 
     vertList = []
-    focusList = []
     for vert in verts3D:
         x, y, z = vert
+        # vector relative to the sphere origin (V-O)
         dx = x - ox
         dy = y - oy
         dz = z - oz
@@ -147,9 +146,9 @@ def projection_spherical(verts3D, m, d, perspective):
 
         vertList.append([xx, yy, zz])
 
-    focusList = [[ox, oy, oz]]
+    focus = [[ox, oy, oz]]
 
-    return vertList, focusList
+    return vertList, focus
 
 
 class Sv3DProjectNode(bpy.types.Node, SverchCustomTreeNode):
@@ -170,7 +169,7 @@ class Sv3DProjectNode(bpy.types.Node, SverchCustomTreeNode):
         name="Distance", description="Projection Distance", default=2.0, update=updateNode)
 
     def sv_init(self, context):
-        self.width = 160
+        self.width = 180
         self.inputs.new('VerticesSocket', "Verts")
         self.inputs.new('StringsSocket', "Edges")
         self.inputs.new('StringsSocket', "Polys")

--- a/nodes/transforms/3d_project.py
+++ b/nodes/transforms/3d_project.py
@@ -36,32 +36,32 @@ projection_type_items = [
     ("PERSPECTIVE",  "Perspective",  "Perspective projection", 0),
     ("ORTHOGRAPHIC", "Orthographic", "Orthographic projection", 1)]
 
-idMat = [[tuple(v) for v in Matrix()]]  # identity matrix
+id_mat = [[tuple(v) for v in Matrix()]]  # identity matrix
 
 EPSILON = 1e-10
 
 
-def projection_planar(verts3D, m, d, perspective):
+def projection_planar(verts_3D, m, d, perspective):
     """
-    Project the 3D verts onto a plane.
-     verts3D : vertices to project (perspective or ortographic)
-           m : transformation matrix of the projection plane (location & rotation)
-           d : distance between the projection point (focus) and the projection plane
+    Project the 3D verts onto a planar screen
+     verts_3D : vertices to project (perspective or ortographic)
+            m : transformation matrix of the projection plane (location & rotation)
+            d : distance between the projection point (focus) and the projection plane
     """
     ox, oy, oz = [m[0][3], m[1][3], m[2][3]]  # projection plane origin
     nx, ny, nz = [m[0][2], m[1][2], m[2][2]]  # projection plane normal
 
     # d = d if perspective else 1e10
 
-    vertList = []
-    for vert in verts3D:
+    vert_list = []
+    for vert in verts_3D:
         x, y, z = vert
         # vector relative to the plane origin (V-O)
         dx = x - ox
         dy = y - oy
         dz = z - oz
         # magnitude of the vector projected parallel to the plane normal
-        an = dx * nx + dy * ny + dz * nz
+        an = dx * nx + dy * ny + dz * nz + EPSILON
         # factor to scale the vector to touch the plane
         s = d / (d + an)
         # extended vector touching the plane
@@ -69,7 +69,7 @@ def projection_planar(verts3D, m, d, perspective):
         py = oy + s * (dy - an * ny)
         pz = oz + s * (dz - an * nz)
 
-        vertList.append([px, py, pz])
+        vert_list.append([px, py, pz])
 
     # Focus location m * D:
     #  Xx Yx Zx Tx        0     Tx - d * Zx
@@ -78,22 +78,22 @@ def projection_planar(verts3D, m, d, perspective):
     #  0  0  0  1         1     1
     focus = [[ox - d * nx, oy - d * ny, oz - d * nz]]
 
-    return vertList, focus
+    return vert_list, focus
 
 
-def projection_cylindrical(verts3D, m, d, perspective):
+def projection_cylindrical(verts_3D, m, d, perspective):
     """
-    Project the 3D verts onto a cylinder.
-     verts3D : vertices to project (perspective)
-           m : transformation matrix of the projection cylinder (location & rotation)
-           d : distance between the projection point (focus) and the projection cylinder (cylinder radius)
+    Project the 3D verts onto a cylinderical screen
+     verts_3D : vertices to project (perspective)
+            m : transformation matrix of the projection cylinder (location & rotation)
+            d : distance between the projection point (focus) and the projection cylinder (cylinder radius)
 
     """
     ox, oy, oz = [m[0][3], m[1][3], m[2][3]]  # projection cylinder origin
     nx, ny, nz = [m[0][2], m[1][2], m[2][2]]  # projection cylinder axis
 
-    vertList = []
-    for vert in verts3D:
+    vert_list = []
+    for vert in verts_3D:
         x, y, z = vert
         # vector relative to the cylinder origin (V-O)
         dx = x - ox
@@ -114,24 +114,24 @@ def projection_cylindrical(verts3D, m, d, perspective):
         yy = oy + dy * s
         zz = oz + dz * s
 
-        vertList.append([xx, yy, zz])
+        vert_list.append([xx, yy, zz])
 
     focus = [[ox, oy, oz]]
 
-    return vertList, focus
+    return vert_list, focus
 
 
-def projection_spherical(verts3D, m, d, perspective):
+def projection_spherical(verts_3D, m, d, perspective):
     """
-    Project the 3D verts onto a sphere.
-     verts3D : vertices to project (perspective)
-           m : transformation matrix of the projection sphere (location & rotation)
-           d : distance between the projection point (focus and the projection sphere (sphere radius)
+    Project the 3D verts onto a spherical screen
+     verts_3D : vertices to project (perspective)
+            m : transformation matrix of the projection sphere (location & rotation)
+            d : distance between the projection point (focus and the projection sphere (sphere radius)
     """
     ox, oy, oz = [m[0][3], m[1][3], m[2][3]]  # projection sphere origin
 
-    vertList = []
-    for vert in verts3D:
+    vert_list = []
+    for vert in verts_3D:
         x, y, z = vert
         # vector relative to the sphere origin (V-O)
         dx = x - ox
@@ -144,11 +144,11 @@ def projection_spherical(verts3D, m, d, perspective):
         yy = oy + dy * d/r
         zz = oz + dz * d/r
 
-        vertList.append([xx, yy, zz])
+        vert_list.append([xx, yy, zz])
 
     focus = [[ox, oy, oz]]
 
-    return vertList, focus
+    return vert_list, focus
 
 
 class Sv3DProjectNode(bpy.types.Node, SverchCustomTreeNode):
@@ -159,29 +159,29 @@ class Sv3DProjectNode(bpy.types.Node, SverchCustomTreeNode):
     bl_idname = 'Sv3DProjectNode'
     bl_label = '3D Projection'
 
-    projection_screen = EnumProperty(
+    projection_screen: EnumProperty(
         name="Screen", items=projection_screen_items, default="PLANAR", update=updateNode)
 
-    projection_type = EnumProperty(
+    projection_type: EnumProperty(
         name="Type", items=projection_type_items, default="PERSPECTIVE", update=updateNode)
 
-    distance = FloatProperty(
+    distance: FloatProperty(
         name="Distance", description="Projection Distance", default=2.0, update=updateNode)
 
     def sv_init(self, context):
         self.width = 180
-        self.inputs.new('VerticesSocket', "Verts")
-        self.inputs.new('StringsSocket', "Edges")
-        self.inputs.new('StringsSocket', "Polys")
+        self.inputs.new('SvVerticesSocket', "Verts")
+        self.inputs.new('SvStringsSocket', "Edges")
+        self.inputs.new('SvStringsSocket', "Polys")
         # projection screen location and orientation
-        self.inputs.new('MatrixSocket', "Matrix")
+        self.inputs.new('SvMatrixSocket', "Matrix")
         # distance from the projection point to the projection screen
-        self.inputs.new('StringsSocket', "D").prop_name = 'distance'
+        self.inputs.new('SvStringsSocket', "D").prop_name = 'distance'
 
-        self.outputs.new('VerticesSocket', "Verts")
-        self.outputs.new('StringsSocket', "Edges")
-        self.outputs.new('StringsSocket', "Polys")
-        self.outputs.new('VerticesSocket', "Focus")
+        self.outputs.new('SvVerticesSocket', "Verts")
+        self.outputs.new('SvStringsSocket', "Edges")
+        self.outputs.new('SvStringsSocket', "Polys")
+        self.outputs.new('SvVerticesSocket', "Focus")
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "projection_screen", text="")
@@ -213,7 +213,7 @@ class Sv3DProjectNode(bpy.types.Node, SverchCustomTreeNode):
         else:
             input_p = [[]]
 
-        input_m = inputs["Matrix"].sv_get(default=idMat)
+        input_m = inputs["Matrix"].sv_get(default=id_mat)
 
         input_d = inputs["D"].sv_get()[0]
 
@@ -228,25 +228,25 @@ class Sv3DProjectNode(bpy.types.Node, SverchCustomTreeNode):
 
         perspective = self.projection_type == "PERSPECTIVE"
 
-        vertList = []
-        edgeList = []
-        polyList = []
-        focusList = []
+        vert_list = []
+        edge_list = []
+        poly_list = []
+        focus_list = []
         for v, e, p, m, d in zip(*params):
             verts, focus = projector(v, m, d, perspective)
-            vertList.append(verts)
-            edgeList.append(e)
-            polyList.append(p)
-            focusList.append(focus)
+            vert_list.append(verts)
+            edge_list.append(e)
+            poly_list.append(p)
+            focus_list.append(focus)
 
         if outputs["Verts"].is_linked:
-            outputs["Verts"].sv_set(vertList)
+            outputs["Verts"].sv_set(vert_list)
         if outputs["Edges"].is_linked:
-            outputs["Edges"].sv_set(edgeList)
+            outputs["Edges"].sv_set(edge_list)
         if outputs["Polys"].is_linked:
-            outputs["Polys"].sv_set(polyList)
+            outputs["Polys"].sv_set(poly_list)
         if outputs["Focus"].is_linked:
-            outputs["Focus"].sv_set(focusList)
+            outputs["Focus"].sv_set(focus_list)
 
 
 def register():

--- a/nodes/transforms/3d_project.py
+++ b/nodes/transforms/3d_project.py
@@ -43,13 +43,13 @@ EPSILON = 1e-10
 
 def projection_cylindrical(verts_3D, m, d, perspective):
     """
-    Project the 3D verts onto a CYLINDRICAL screen
+    Project the 3D verts onto a CYLINDRICAL surface
      verts_3D : vertices to project (perspective)
             m : transformation matrix of the projection cylinder (location & rotation)
             d : distance between the projection point (focus) and the projection cylinder (cylinder radius)
     """
     ox, oy, oz = [m[0][3], m[1][3], m[2][3]]  # projection cylinder origin
-    nx, ny, nz = [m[0][2], m[1][2], m[2][2]]  # projection cylinder axis
+    nx, ny, nz = [m[0][2], m[1][2], m[2][2]]  # projection cylinder axis (Z)
 
     vert_list = []
     focus_list = []
@@ -83,10 +83,10 @@ def projection_cylindrical(verts_3D, m, d, perspective):
 
 def projection_spherical(verts_3D, m, d, perspective):
     """
-    Project the 3D verts onto a SPHERICAL screen
+    Project the 3D verts onto a SPHERICAL surface
      verts_3D : vertices to project (perspective)
             m : transformation matrix of the projection sphere (location & rotation)
-            d : distance between the projection point (focus and the projection sphere (sphere radius)
+            d : distance between the projection point (focus) and the projection sphere (sphere radius)
     """
     ox, oy, oz = [m[0][3], m[1][3], m[2][3]]  # projection sphere origin
 
@@ -120,6 +120,12 @@ def projection_planar(verts_3D, m, d, perspective):
      verts_3D : vertices to project (perspective or ortographic)
             m : transformation matrix of the projection plane (location & rotation)
             d : distance between the projector point (focus) and the plane plane
+
+    Projection point (focus) location is given by m * D:
+        Xx Yx Zx Tx        0     Tx - d * Zx
+        Xy Yy Zy Ty   *    0  =  Ty - d * Zy
+        Xz Yz Zz Tz      - d     Tz - d * Zz
+        0  0  0  1         1     1
     """
     ox, oy, oz = [m[0][3], m[1][3], m[2][3]]  # projection plane origin
     nx, ny, nz = [m[0][2], m[1][2], m[2][2]]  # projection plane normal
@@ -145,12 +151,7 @@ def projection_planar(verts_3D, m, d, perspective):
 
         vert_list.append([px, py, pz])
 
-    # Focus location m * D:
-    #  Xx Yx Zx Tx        0     Tx - d * Zx
-    #  Xy Yy Zy Ty   *    0  =  Ty - d * Zy
-    #  Xz Yz Zz Tz      - d     Tz - d * Zz
-    #  0  0  0  1         1     1
-    focus_list = [[ox - d * nx, oy - d * ny, oz - d * nz]]
+    focus_list = [[ox - d * nx, o   y - d * ny, oz - d * nz]]
 
     return vert_list, focus_list
 

--- a/nodes/transforms/3d_project.py
+++ b/nodes/transforms/3d_project.py
@@ -147,6 +147,7 @@ class Sv3DProjectNode(bpy.types.Node, SverchCustomTreeNode):
     """
     bl_idname = 'Sv3DProjectNode'
     bl_label = '3D Projection'
+    bl_icon = 'EMPTY_DATA'
 
     projection_screen: EnumProperty(
         name="Screen", items=projection_screen_items, default="PLANAR", update=updateNode)

--- a/nodes/transforms/3d_project.py
+++ b/nodes/transforms/3d_project.py
@@ -43,7 +43,7 @@ EPSILON = 1e-10
 
 def projection_planar(verts_3D, m, d, perspective):
     """
-    Project the 3D verts onto a planar screen
+    Project the 3D verts onto a PLANAR screen
      verts_3D : vertices to project (perspective or ortographic)
             m : transformation matrix of the projection plane (location & rotation)
             d : distance between the projection point (focus) and the projection plane
@@ -54,6 +54,7 @@ def projection_planar(verts_3D, m, d, perspective):
     # d = d if perspective else 1e10
 
     vert_list = []
+    focus_list = []
     for vert in verts_3D:
         x, y, z = vert
         # vector relative to the plane origin (V-O)
@@ -76,23 +77,23 @@ def projection_planar(verts_3D, m, d, perspective):
     #  Xy Yy Zy Ty   *    0  =  Ty - d * Zy
     #  Xz Yz Zz Tz      - d     Tz - d * Zz
     #  0  0  0  1         1     1
-    focus = [[ox - d * nx, oy - d * ny, oz - d * nz]]
+    focus_list = [[ox - d * nx, oy - d * ny, oz - d * nz]]
 
-    return vert_list, focus
+    return vert_list, focus_list
 
 
 def projection_cylindrical(verts_3D, m, d, perspective):
     """
-    Project the 3D verts onto a cylinderical screen
+    Project the 3D verts onto a CYLINDRICAL screen
      verts_3D : vertices to project (perspective)
             m : transformation matrix of the projection cylinder (location & rotation)
             d : distance between the projection point (focus) and the projection cylinder (cylinder radius)
-
     """
     ox, oy, oz = [m[0][3], m[1][3], m[2][3]]  # projection cylinder origin
     nx, ny, nz = [m[0][2], m[1][2], m[2][2]]  # projection cylinder axis
 
     vert_list = []
+    focus_list = []
     for vert in verts_3D:
         x, y, z = vert
         # vector relative to the cylinder origin (V-O)
@@ -116,14 +117,14 @@ def projection_cylindrical(verts_3D, m, d, perspective):
 
         vert_list.append([xx, yy, zz])
 
-    focus = [[ox, oy, oz]]
+    focus_list = [[ox, oy, oz]]
 
-    return vert_list, focus
+    return vert_list, focus_list
 
 
 def projection_spherical(verts_3D, m, d, perspective):
     """
-    Project the 3D verts onto a spherical screen
+    Project the 3D verts onto a SPHERICAL screen
      verts_3D : vertices to project (perspective)
             m : transformation matrix of the projection sphere (location & rotation)
             d : distance between the projection point (focus and the projection sphere (sphere radius)
@@ -131,6 +132,7 @@ def projection_spherical(verts_3D, m, d, perspective):
     ox, oy, oz = [m[0][3], m[1][3], m[2][3]]  # projection sphere origin
 
     vert_list = []
+    focus_list = []
     for vert in verts_3D:
         x, y, z = vert
         # vector relative to the sphere origin (V-O)
@@ -146,9 +148,9 @@ def projection_spherical(verts_3D, m, d, perspective):
 
         vert_list.append([xx, yy, zz])
 
-    focus = [[ox, oy, oz]]
+    focus_list = [[ox, oy, oz]]
 
-    return vert_list, focus
+    return vert_list, focus_list
 
 
 class Sv3DProjectNode(bpy.types.Node, SverchCustomTreeNode):

--- a/nodes/transforms/3d_project.py
+++ b/nodes/transforms/3d_project.py
@@ -143,15 +143,15 @@ def projection_planar(verts_3D, m, d, perspective):
         # magnitude of the OV vector projected PARALLEL to the plane normal (OV * N)
         l = dx * nx + dy * ny + dz * nz + EPSILON
         # factor to scale the OV vector to touch the plane
-        s = d / (d + l)
+        s = d / l
         # extended vector touching the plane
-        px = ox - dx + l * nx
-        py = oy - dy + l * ny
-        pz = oz - dz + l * nz
+        px = ox + dx * s
+        py = oy + dy * s
+        pz = oz + dz * s
 
         vert_list.append([px, py, pz])
 
-    focus_list = [[ox - d * nx, oy - d * ny, oz - d * nz]]
+    focus_list = [[ox, oy, oz]]
 
     return vert_list, focus_list
 

--- a/nodes/transforms/3d_project.py
+++ b/nodes/transforms/3d_project.py
@@ -41,47 +41,6 @@ id_mat = [[tuple(v) for v in Matrix()]]  # identity matrix
 EPSILON = 1e-10
 
 
-def projection_planar(verts_3D, m, d, perspective):
-    """
-    Project the 3D verts onto a PLANAR surface
-     verts_3D : vertices to project (perspective or ortographic)
-            m : transformation matrix of the projection plane (location & rotation)
-            d : distance between the projector point (focus) and the plane plane
-    """
-    ox, oy, oz = [m[0][3], m[1][3], m[2][3]]  # projection plane origin
-    nx, ny, nz = [m[0][2], m[1][2], m[2][2]]  # projection plane normal
-
-    # d = d if perspective else 1e10
-
-    vert_list = []
-    focus_list = []
-    for vert in verts_3D:
-        x, y, z = vert
-        # vertex vector relative to the projection point (OV = V - O)
-        dx = x - ox
-        dy = y - oy
-        dz = z - oz
-        # magnitude of the OV vector projected PARALLEL to the plane normal
-        l = dx * nx + dy * ny + dz * nz + EPSILON
-        # factor to scale the OV vector to touch the plane
-        s = d / (d + l)
-        # extended vector touching the plane
-        px = ox + s * (dx - l * nx)
-        py = oy + s * (dy - l * ny)
-        pz = oz + s * (dz - l * nz)
-
-        vert_list.append([px, py, pz])
-
-    # Focus location m * D:
-    #  Xx Yx Zx Tx        0     Tx - d * Zx
-    #  Xy Yy Zy Ty   *    0  =  Ty - d * Zy
-    #  Xz Yz Zz Tz      - d     Tz - d * Zz
-    #  0  0  0  1         1     1
-    focus_list = [[ox - d * nx, oy - d * ny, oz - d * nz]]
-
-    return vert_list, focus_list
-
-
 def projection_cylindrical(verts_3D, m, d, perspective):
     """
     Project the 3D verts onto a CYLINDRICAL screen
@@ -151,6 +110,47 @@ def projection_spherical(verts_3D, m, d, perspective):
         vert_list.append([xx, yy, zz])
 
     focus_list = [[ox, oy, oz]]
+
+    return vert_list, focus_list
+
+
+def projection_planar(verts_3D, m, d, perspective):
+    """
+    Project the 3D verts onto a PLANAR surface
+     verts_3D : vertices to project (perspective or ortographic)
+            m : transformation matrix of the projection plane (location & rotation)
+            d : distance between the projector point (focus) and the plane plane
+    """
+    ox, oy, oz = [m[0][3], m[1][3], m[2][3]]  # projection plane origin
+    nx, ny, nz = [m[0][2], m[1][2], m[2][2]]  # projection plane normal
+
+    # d = d if perspective else 1e10
+
+    vert_list = []
+    focus_list = []
+    for vert in verts_3D:
+        x, y, z = vert
+        # vertex vector relative to the projection point (OV = V - O)
+        dx = x - ox
+        dy = y - oy
+        dz = z - oz
+        # magnitude of the OV vector projected PARALLEL to the plane normal
+        l = dx * nx + dy * ny + dz * nz + EPSILON
+        # factor to scale the OV vector to touch the plane
+        s = d / (d + l)
+        # extended vector touching the plane
+        px = ox + s * (dx - l * nx)
+        py = oy + s * (dy - l * ny)
+        pz = oz + s * (dz - l * nz)
+
+        vert_list.append([px, py, pz])
+
+    # Focus location m * D:
+    #  Xx Yx Zx Tx        0     Tx - d * Zx
+    #  Xy Yy Zy Ty   *    0  =  Ty - d * Zy
+    #  Xz Yz Zz Tz      - d     Tz - d * Zz
+    #  0  0  0  1         1     1
+    focus_list = [[ox - d * nx, oy - d * ny, oz - d * nz]]
 
     return vert_list, focus_list
 


### PR DESCRIPTION
The node projects a mesh from 3D space onto a 2D space.

For start, the node does a perspective projection onto a plane.
Further development will add cylindrical and spherical projection as well and other features.

- [ ] Code changes complete.
- [ ] Code documentation complete.
- [ ] Documentation for users complete (or not required, if user never sees these changes).
- [ ] Manual testing done. 
- [ ] Unit-tests implemented.
- [ ] Ready for merge.

![sv-3dprojectnode-ui](https://user-images.githubusercontent.com/2083719/53611077-3c59d280-3b9b-11e9-8d84-fcdf57b5fe3e.jpg)

<img width="1270" alt="sv-3dprojectnode-example1" src="https://user-images.githubusercontent.com/2083719/53611078-3c59d280-3b9b-11e9-9546-3598c9da8468.png">

