### PR TITLE
Formula node mk3

### DIFF
--- a/docs/nodes/number/formula3.rst
+++ b/docs/nodes/number/formula3.rst
@@ -1,0 +1,88 @@
+Formula Node Mk3
+================
+
+Functionality
+-------------
+
+This node allows one to evaluate (almost) arbitrary Python expressions, using inputs as variables.
+It is possible to calculate numeric values, construct lists, tuples, vertices and matrices.
+
+The node allows to evaluate up to 4 formulas for each set of input values.
+
+Expression syntax
+-----------------
+
+Syntax being used for formulas is standard Python's syntax for expressions. 
+For exact syntax definition, please refer to https://docs.python.org/3/reference/expressions.html.
+
+In short, you can use usual mathematical operations (`+`, `-`, `*`, `/`, `**` for power), numbers, variables, parenthesis, and function call, such as `sin(x)`.
+
+One difference with Python's syntax is that you can call only restricted number of Python's functions. Allowed are:
+
+- Functions from math module:
+  - acos, acosh, asin, asinh, atan, atan2,
+        atanh, ceil, copysign, cos, cosh, degrees,
+        erf, erfc, exp, expm1, fabs, factorial, floor,
+        fmod, frexp, fsum, gamma, hypot, isfinite, isinf,
+        isnan, ldexp, lgamma, log, log10, log1p, log2, modf,
+        pow, radians, sin, sinh, sqrt, tan, tanh, trunc;
+- Constants from math module: pi, e;
+- Additional functions: abs, sign;
+- From mathutlis module: Vector, Matrix;
+- Python type conversions: tuple, list.
+
+This restriction is for security reasons. However, Python's ecosystem does not guarantee that noone can call some unsafe operations by using some sort of language-level hacks. So, please be warned that usage of this node with JSON definition obtained from unknown or untrusted source can potentially harm your system or data.
+
+Examples of valid expressions are:
+
+* 1.0
+* x
+* x+1
+* 0.75*X + 0.25*Y
+* R * sin(phi)
+
+Inputs
+------
+
+Set of inputs for this node depends on used formulas. Each variable used in formula becomes one input. If there are no variables used in formula, then this node will have no inputs.
+
+Parameters
+----------
+
+This node has the following parameters:
+
+- **Dimensions**. This parameter is available in the N panel only. It defines how many formulas the node will allow to specify and evaluate. Default value is 1. Maximum value is 4.
+- **Formula 1** to **Formula 4** input boxes. Formulas theirselve. If no formula is specified, then nothing will be calculated for this dimension. Number of formula input boxes is defined by **Dimensions** parameter.
+- **Separate**. If the flag is set, then for each combination of input values, list of values calculated by formula is enclosed in separate list. Usually you will want to uncheck this if you are using only one formula. Usually you will want to check this if you are using more than one formula. Other combinations can be of use in specific cases. Unchecked by default.
+- **Wrap**. If checked, then the whole output of the node will be enclosed in additional brackets. Checked by default.
+
+For example, let's consider the following setup:
+
+.. image:: https://user-images.githubusercontent.com/284644/53962080-00c78700-410c-11e9-9563-855fca16537a.png
+
+Then the following combinations of flags are possible:
+
++-----------+-----------+--------------------+
+| Separate  | Wrap      | Result             |
++===========+===========+====================+
+| Checked   | Checked   | [[[1, 3], [2, 4]]] |
++-----------+-----------+--------------------+
+| Checked   | Unchecked | [[1, 3], [2, 4]]   |
++-----------+-----------+--------------------+
+| Unchecked | Checked   | [[1, 3, 2, 4]]     |
++-----------+-----------+--------------------+
+| Unchecked | Unchecked | [1, 3, 2, 4]       |
++-----------+-----------+--------------------+
+
+Outputs
+-------
+
+**Result** - what we got as result.  
+
+Usage examples
+--------------
+
+.. image:: https://user-images.githubusercontent.com/284644/53965898-dbd71200-4113-11e9-83c7-cb3c7ced8c1e.png
+
+.. image:: https://user-images.githubusercontent.com/284644/53967764-9f0d1a00-4117-11e9-92e3-a047dbd2981b.png
+

--- a/index.md
+++ b/index.md
@@ -174,6 +174,7 @@
     ScalarMathNode
     SvScalarMathNodeMK2
     Formula2Node
+    SvFormulaNodeMk3
     SvExecNodeMod
     ---
     GenListRangeIntNode

--- a/nodes/number/formula2.py
+++ b/nodes/number/formula2.py
@@ -49,6 +49,8 @@ class Formula2Node(bpy.types.Node, SverchCustomTreeNode):
     base_name = 'n'
     multi_socket_type = 'StringsSocket'
 
+    replacement_nodes = [('SvFormulaNodeMk3', None, None)]
+
     def draw_buttons(self, context, layout):
         layout.prop(self, "formula", text="")
 

--- a/nodes/number/formula3.py
+++ b/nodes/number/formula3.py
@@ -78,7 +78,7 @@ class VariableCollector(ast.NodeVisitor):
     only "lst" should be considered as a free variable, "g" should be not,
     as it is bound by list comprehension scope.
 
-    This implementation is not exactly complete (at list, dictionary comprehensions
+    This implementation is not exactly complete (at least, dictionary comprehensions
     are not supported yet). But it works for most cases.
 
     Please refer to ast.NodeVisitor class documentation for general reference.

--- a/nodes/number/formula3.py
+++ b/nodes/number/formula3.py
@@ -101,8 +101,8 @@ class VariableCollector(ast.NodeVisitor):
         Check if name is local variable
         """
 
-        for item in self.local_vars:
-            if name in item:
+        for stack_frame in self.local_vars:
+            if name in stack_frame:
                 return True
         return False
 
@@ -142,8 +142,10 @@ class VariableCollector(ast.NodeVisitor):
 
         self.generic_visit(node)
 
-    
 def get_variables(string):
+    """
+    Get set of free variables used by formula
+    """
     string = string.strip()
     if not len(string):
         return set()
@@ -155,6 +157,10 @@ def get_variables(string):
 
 # It could be safer...
 def safe_eval(string, variables):
+    """
+    Evaluate expression, allowing only functions known to be "safe"
+    to be used.
+    """
     try:
         env = dict()
         env.update(safe_names)

--- a/nodes/number/formula3.py
+++ b/nodes/number/formula3.py
@@ -1,0 +1,177 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import ast
+from math import *
+
+import bpy
+from bpy.props import BoolProperty, StringProperty, EnumProperty, FloatVectorProperty, IntProperty
+from mathutils import Vector, Matrix
+import json
+import io
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import fullList, updateNode, dataCorrect, match_long_repeat
+
+def make_functions_dict(*functions):
+    return dict([(function.__name__, function) for function in functions])
+
+# Standard functions which for some reasons are not in the math module
+def sign(x):
+    if x < 0:
+        return -1
+    elif x > 0:
+        return 1
+    else:
+        return 0
+
+# Functions
+safe_names = make_functions_dict(
+        # From math module
+        acos, acosh, asin, asinh, atan, atan2,
+        atanh, ceil, copysign, cos, cosh, degrees,
+        erf, erfc, exp, expm1, fabs, factorial, floor,
+        fmod, frexp, fsum, gamma, hypot, isfinite, isinf,
+        isnan, ldexp, lgamma, log, log10, log1p, log2, modf,
+        pow, radians, sin, sinh, sqrt, tan, tanh, trunc,
+        # Additional functions
+        abs, sign,
+        # From mathutlis module
+        Vector, Matrix,
+        # Python type conversions
+        tuple, list
+    )
+# Constants
+safe_names['e'] = e
+safe_names['pi'] = pi
+
+    
+def get_variables(string):
+    root = ast.parse(string, mode='eval')
+    result = {node.id for node in ast.walk(root) if isinstance(node, ast.Name)}
+    return result.difference(safe_names.keys())
+
+# It could be safer...
+def safe_eval(string, variables):
+    env = dict()
+    env.update(safe_names)
+    env.update(variables)
+    env["__builtins__"] = {}
+    root = ast.parse(string, mode='eval')
+    return eval(compile(root, "<expression>", 'eval'), env)
+
+class SvFormulaNodeMk3(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: Formula
+    Tooltip: Calculate by custom formula.
+    """
+    bl_idname = 'SvFormulaNodeMk3'
+    bl_label = 'Formula Mk3'
+    bl_icon = 'OUTLINER_OB_EMPTY'
+
+    def on_update(self, context):
+        self.adjust_sockets()
+        updateNode(self, context)
+
+    formula = StringProperty(default = "x+y", update=on_update)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "formula", text="")
+
+    def sv_init(self, context):
+        self.inputs.new('StringsSocket', "x")
+
+        self.outputs.new('StringsSocket', "Result")
+
+    def get_variables(self):
+        variables = set()
+        if not self.formula:
+            return variables
+
+        vs = get_variables(self.formula)
+        variables.update(vs)
+
+        return list(sorted(list(variables)))
+    
+    def adjust_sockets(self):
+        variables = self.get_variables()
+        #self.debug("adjust_sockets:" + str(variables))
+        #self.debug("inputs:" + str(self.inputs.keys()))
+        for key in self.inputs.keys():
+            if key not in variables:
+                self.debug("Input {} not in variables {}, remove it".format(key, str(variables)))
+                self.inputs.remove(self.inputs[key])
+        for v in variables:
+            if v not in self.inputs:
+                self.debug("Variable {} not in inputs {}, add it".format(v, str(self.inputs.keys())))
+                self.inputs.new('StringsSocket', v)
+
+
+    def update(self):
+        '''
+        update analyzes the state of the node and returns if the criteria to start processing
+        are not met.
+        '''
+
+        # keeping the file internal for now.
+        if not self.formula:
+            return
+
+        self.adjust_sockets()
+
+    def get_input(self):
+        variables = self.get_variables()
+        result = {}
+
+        for var in variables:
+            if var in self.inputs and self.inputs[var].is_linked:
+                result[var] = self.inputs[var].sv_get()[0]
+                #self.debug("get_input: {} => {}".format(var, result[var]))
+        return result
+
+    def process(self):
+
+        if not self.outputs[0].is_linked:
+            return
+
+        var_names = self.get_variables()
+        inputs = self.get_input()
+
+        results = []
+
+        if var_names:
+            input_values = [inputs.get(name, []) for name in var_names]
+            parameters = match_long_repeat(input_values)
+        else:
+            parameters = [[[]]]
+        for values in zip(*parameters):
+            variables = dict(zip(var_names, values))
+
+            value = safe_eval(self.formula, variables)
+            results.append(value)
+
+        self.outputs['Result'].sv_set([results])
+
+
+def register():
+    bpy.utils.register_class(SvFormulaNodeMk3)
+
+
+def unregister():
+    bpy.utils.unregister_class(SvFormulaNodeMk3)
+


### PR DESCRIPTION
## Addressed problem description
Our current "Formula" node has a couple of problems:

* Inconvenient syntax with only variables being available "X" and "n[0]" .. "n[150]"
* weird code with Lenin and some other strange people being involved for some reason >_<

It is also not very convenient to use it to produce curves or surfaces, because you have to write something like "[sin(n[0]), cos(n[0]), 0]".

## Solution description

Re-implement Formula node:

* Allow to write arbitrary Python expressions with arbitrary variable names, so that you can just write `R*sin(phi)`. Use the same technique as in "mesh evaluate" node to manage input sockets.
* Add possibility to write not only single formula, but up to 4. So to generate an ellipse, you have to write `A*cos(t)` in one input box, `B*sin(t)` in another, and that's it, no brackets and so on. By default, show only one input box to save screen space for most cases.
* Support a flag to enclose each vector produced by several formulas into separate sub-list. It is usually required when you have more than one formula; it is usually not required if you have only one formula; but there may be other options.
* Support a flag to enclose the whole output into additional pair of brackets, which other nodes may want to see.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Migration from old node supported.
- [ ] Ready for merge.

