### PR TITLE
no errors when loading all nodes

### DIFF
--- a/nodes/analyzer/mesh_select.py
+++ b/nodes/analyzer/mesh_select.py
@@ -88,8 +88,8 @@ class SvMeshSelectNode(bpy.types.Node, SverchCustomTreeNode):
         c.use_prop = True
         c.prop = (0.0, 0.0, 0.0)
 
-        self.inputs.new('StringsSocket', 'Percent', 'Percent').prop_name = 'percent'
-        self.inputs.new('StringsSocket', 'Radius', 'Radius').prop_name = 'radius'
+        self.inputs.new('StringsSocket', 'Percent').prop_name = 'percent'
+        self.inputs.new('StringsSocket', 'Radius').prop_name = 'radius'
 
         self.outputs.new('StringsSocket', 'VerticesMask')
         self.outputs.new('StringsSocket', 'EdgesMask')

--- a/nodes/generator/script1_lite.py
+++ b/nodes/generator/script1_lite.py
@@ -45,9 +45,9 @@ snlite_template_path = os.path.join(sv_path, 'node_scripts', 'SNLite_templates')
 defaults = [0] * 32
 
 
-class SvScriptNodeLitePyMenu(bpy.types.Menu):
+class SV_MT_ScriptNodeLitePyMenu(bpy.types.Menu):
     bl_label = "SNLite templates"
-    bl_idname = "SvScriptNodeLitePyMenu"
+    bl_idname = "SV_MT_ScriptNodeLitePyMenu"
 
     def draw(self, context):
         if context.active_node:
@@ -454,7 +454,7 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode):
         row = layout.row()
         row.prop(self, 'selected_mode', expand=True)
         col = layout.column()
-        col.menu(SvScriptNodeLitePyMenu.bl_idname)
+        col.menu(SV_MT_ScriptNodeLitePyMenu.bl_idname)
 
 
     # ---- IO Json storage is handled in this node locally ----
@@ -520,7 +520,7 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode):
 classes = [
     SvScriptNodeLiteCustomCallBack,
     SvScriptNodeLiteTextImport,
-    SvScriptNodeLitePyMenu,
+    SV_MT_ScriptNodeLitePyMenu,
     SvScriptNodeLiteCallBack,
     SvScriptNodeLite
 ]

--- a/nodes/list_struct/shift_mk2.py
+++ b/nodes/list_struct/shift_mk2.py
@@ -47,9 +47,9 @@ class ShiftNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         layout.prop(self, "selected_mode", expand=True)
 
     def sv_init(self, context):
-        self.inputs.new('StringsSocket', "data", "data")
-        self.inputs.new('StringsSocket', "shift", "shift").prop_name = 'shift_c'
-        self.outputs.new('StringsSocket', 'data', 'data')
+        self.inputs.new('StringsSocket', "data")
+        self.inputs.new('StringsSocket', "shift").prop_name = 'shift_c'
+        self.outputs.new('StringsSocket', 'data')
 
     def update(self):
         if 'data' in self.inputs and self.inputs['data'].is_linked:

--- a/nodes/logic/switch.py
+++ b/nodes/logic/switch.py
@@ -31,7 +31,7 @@ class SvSwitchNode(bpy.types.Node, SverchCustomTreeNode):
 
     def draw_buttons(self, context, layout):
         row = layout.row()
-        split = row.split(0.6)
+        split = row.split(factor=0.6)
         split.row().prop(self, "selected_mode", expand=True)
         if self.selected_mode == 'single':
             layout.prop(self, "switch_count")

--- a/nodes/matrix/matrix_track_to.py
+++ b/nodes/matrix/matrix_track_to.py
@@ -85,7 +85,7 @@ class SvMatrixTrackToNode(bpy.types.Node, SverchCustomTreeNode):
             n2 = sum(ratios[n + 1:])  # size of all remaining columns
             p = n1 / (n1 + n2)  # percentage split of current vs remaning columns
             # print("n = ", n, " n1 = ", n1, " n2 = ", n2, " p = ", p)
-            split = col2.split(percentage=p, align=aligns[n])
+            split = col2.split(factor=p, align=aligns[n])
             col1 = split.column(align=True)
             col2 = split.column(align=True)
             cols.append(col1)

--- a/nodes/modifier_change/edges_intersect_mk2.py
+++ b/nodes/modifier_change/edges_intersect_mk2.py
@@ -282,7 +282,7 @@ class SvIntersectEdgesNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     def draw_buttons(self, context, layout):
         layout.prop(self, "mode", expand=True)
         r = layout.row(align=True)
-        r1 = r.split(0.32)
+        r1 = r.split(factor=0.32)
         r1.prop(self, 'rm_switch', text='doubles', toggle=True)
         r2 = r1.split()
         r2.enabled = self.rm_switch

--- a/nodes/modifier_change/flip_normals.py
+++ b/nodes/modifier_change/flip_normals.py
@@ -87,7 +87,7 @@ class SvFlipNormalsNode(bpy.types.Node, SverchCustomTreeNode):
 
     def draw_buttons(self, context, layout):
         r = layout.row(align=True)
-        r1 = r.split(0.35)        
+        r1 = r.split(factor=0.35)        
         r1.prop(self, 'reverse', text='reverse', toggle=True)
         r2 = r1.split().row()
         r2.prop(self, "selected_mode", expand=True)

--- a/nodes/modifier_change/limited_dissolve_mk2.py
+++ b/nodes/modifier_change/limited_dissolve_mk2.py
@@ -33,6 +33,7 @@ class SvLimitedDissolveMK2(bpy.types.Node, SverchCustomTreeNode):
 
     angle: FloatProperty(default=5.0, min=0.0, update=updateNode)
     use_dissolve_boundaries: BoolProperty(update=updateNode)
+    delimit: IntProperty(update=updateNode)
 
     def sv_init(self, context):
         self.inputs.new('StringsSocket', 'bmesh_list')

--- a/nodes/modifier_change/vertices_mask.py
+++ b/nodes/modifier_change/vertices_mask.py
@@ -32,11 +32,11 @@ class SvVertMaskNode(bpy.types.Node, SverchCustomTreeNode):
 
     def sv_init(self, context):
         self.inputs.new('StringsSocket', 'Mask')
-        self.inputs.new('VerticesSocket', 'Vertices', 'Vertices')
-        self.inputs.new('StringsSocket', 'Poly Egde', 'Poly Egde')
+        self.inputs.new('VerticesSocket', 'Vertices')
+        self.inputs.new('StringsSocket', 'Poly Egde')
 
-        self.outputs.new('VerticesSocket', 'Vertices', 'Vertices')
-        self.outputs.new('StringsSocket', 'Poly Egde', 'Poly Egde')
+        self.outputs.new('VerticesSocket', 'Vertices')
+        self.outputs.new('StringsSocket', 'Poly Egde')
 
     def process(self):
         if not any(s.is_linked for s in self.outputs):

--- a/nodes/modifier_make/wafel.py
+++ b/nodes/modifier_make/wafel.py
@@ -110,7 +110,7 @@ class SvWafelNode(bpy.types.Node, SverchCustomTreeNode):
 
         self.outputs.new('VerticesSocket', 'vert')
         self.outputs.new('StringsSocket', 'edge')
-        self.outputs.new('VerticesSocket', 'centers', 'centers')
+        self.outputs.new('VerticesSocket', 'centers')
 
     def draw_main_ui_elements(self, context, layout):
         col = layout.column(align=True)

--- a/nodes/scene/3dview_props.py
+++ b/nodes/scene/3dview_props.py
@@ -36,20 +36,21 @@ class Sv3DviewPropsNode(bpy.types.Node, SverchCustomTreeNode):
             for area in window.screen.areas:
                 if area.type == 'VIEW_3D':
                     idx += 1
-                    n_panel = area.spaces[0]
+                    n_panel = area.spaces[0].overlay
+                    # context.space_data.overlay.show_overlays = False
 
                     row = layout.row(align=True)
                     row.label(text='3dview {idx}:'.format(idx=idx))
 
                     col = row.column()
-                    col.prop(n_panel, 'show_only_render', text='render')
+                    col.prop(n_panel, 'show_overlays', text='render')
 
                     col = row.column()
-                    col.active = not n_panel.show_only_render
+                    col.active = not n_panel.show_overlays
                     col.prop(n_panel, 'show_floor', text='grid')
 
                     row = layout.row(align=True)
-                    row.active = not n_panel.show_only_render
+                    row.active = not n_panel.show_overlays
                     row.prop(n_panel, "show_axis_x", text="X", toggle=True)
                     row.prop(n_panel, "show_axis_y", text="Y", toggle=True)
                     row.prop(n_panel, "show_axis_z", text="Z", toggle=True)
@@ -75,7 +76,7 @@ class Sv3DviewPropsNode(bpy.types.Node, SverchCustomTreeNode):
             boxrow.prop(gradients, 'gradient', text='')
 
         row = layout.row(align=True)
-        row.prop(world, 'horizon_color', text='horizon')
+        # row.prop(world, '   color', text='horizon')
 
         row = layout.row(align=True)
         row.prop(prefs.inputs, 'view_rotate_method', text='orbit', expand=True)

--- a/nodes/scene/dupli_instances_mk4.py
+++ b/nodes/scene/dupli_instances_mk4.py
@@ -78,7 +78,7 @@ class SvDupliInstancesMK4(bpy.types.Node, SverchCustomTreeNode):
     def draw_buttons(self, context, layout):
         layout.prop(self, "mode", expand=True)
         col = layout.column(align=True)
-        col.prop(self, 'name_node_generated_parent', text='', icon='LOOPSEL')
+        col.prop(self, 'name_node_generated_parent', text='', icon='EDITMODE_HLT')
         #col.prop_search(self, 'name_child', bpy.data, 'objects', text='')
         col.prop(self, 'scale', text='Scale children', toggle=True)
         col.prop(self, 'auto_release', text='One Object only', toggle=True)

--- a/nodes/scene/instancer.py
+++ b/nodes/scene/instancer.py
@@ -147,7 +147,7 @@ class SvInstancerNode(bpy.types.Node, SverchCustomTreeNode):
             col2.scale_x = 0.3
             col2.operator(cfg, text="reset").obj_name = "__SV_INSTANCE_RESET__"
 
-        layout.label("Object base name", icon='OUTLINER_OB_MESH')
+        layout.label(text="Object base name", icon='OUTLINER_OB_MESH')
         col = layout.column(align=True)
         row = col.row(align=True)
         row.prop(self, "basemesh_name", text="")

--- a/nodes/viz/lamp_out.py
+++ b/nodes/viz/lamp_out.py
@@ -37,7 +37,7 @@ class SvLampOutNode(bpy.types.Node, SverchCustomTreeNode):
 
     bl_idname = "SvLampOutNode"
     bl_label = "Lamp"
-    bl_icon = 'NONE' #"OUTLINER_OB_LAMP"
+    bl_icon = 'LIGHT' #"OUTLINER_OB_LAMP"
 
     activate: BoolProperty(
         name="Activate", default=True,
@@ -161,7 +161,7 @@ class SvLampOutNode(bpy.types.Node, SverchCustomTreeNode):
         self.outputs.new('SvObjectSocket', 'Objects')
 
     def draw_buttons(self, context, layout):
-        view_icon = 'OUTLINER_OB_LAMP' if self.activate else 'ERROR'
+        view_icon = 'LIGHT' if self.activate else 'ERROR'
         layout.prop(self, "activate", text="UPD", toggle=True, icon=view_icon)
         layout.prop(self, 'lamp_name')
         layout.prop(self, 'type')

--- a/nodes/viz/vd_draw_experimental.py
+++ b/nodes/viz/vd_draw_experimental.py
@@ -61,12 +61,12 @@ class SvObjBakeMK3(bpy.types.Operator):
     bl_label = "Sverchok mesh baker mk3"
     bl_options = {'REGISTER', 'UNDO'}
 
-    idname = StringProperty(
+    idname: StringProperty(
         name='idname',
         description='name of parent node',
         default='')
 
-    idtree = StringProperty(
+    idtree: StringProperty(
         name='idtree',
         description='name of parent tree',
         default='')

--- a/sockets.py
+++ b/sockets.py
@@ -206,7 +206,7 @@ class SvSocketCommon:
                     getattr(node, self.quicklink_func_name)(self, context, layout, node)
                 except Exception as e:
                     self.draw_quick_link(context, layout, node)
-                layout.label(text)
+                layout.label(text=text)
 
             else:  # no property and not use default prop
                 self.draw_quick_link(context, layout, node)

--- a/ui/monad.py
+++ b/ui/monad.py
@@ -36,8 +36,8 @@ def set_multiple_attrs(cls_ref, **kwargs):
         setattr(cls_ref, arg_name, value)
 
 
-class SvCustomGroupInterface(Panel):
-    bl_idname = "SvCustomGroupInterface"
+class SV_PT_CustomGroupInterface(Panel):
+    bl_idname = "SV_PT_CustomGroupInterface"
     bl_label = "Sv Custom Group Interface"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -130,9 +130,9 @@ class SvCustomGroupInterface(Panel):
 
 def register():
     bpy.types.NODE_HT_header.prepend(sv_back_to_parent)
-    bpy.utils.register_class(SvCustomGroupInterface)
+    bpy.utils.register_class(SV_PT_CustomGroupInterface)
 
 
 def unregister():
-    bpy.utils.unregister_class(SvCustomGroupInterface)
+    bpy.utils.unregister_class(SV_PT_CustomGroupInterface)
     bpy.types.NODE_HT_header.remove(sv_back_to_parent)

--- a/ui/presets.py
+++ b/ui/presets.py
@@ -553,8 +553,8 @@ def draw_presets_ops(layout, id_tree=None, presets=None, context=None):
     for preset in presets:
         preset.draw_operator(layout, id_tree)
 
-class SvUserPresetsPanel(bpy.types.Panel):
-    bl_idname = "SvUserPresetsPanel"
+class SV_PT_UserPresetsPanel(bpy.types.Panel):
+    bl_idname = "SV_PT_UserPresetsPanel"
     bl_label = "Presets"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'TOOLS'
@@ -633,7 +633,7 @@ classes = [
     SvDeletePreset,
     SvPresetToGist,
     SvPresetToFile,
-    SvUserPresetsPanel
+    SV_PT_UserPresetsPanel
 ]
 
 def register():

--- a/ui/sv_IO_panel.py
+++ b/ui/sv_IO_panel.py
@@ -31,8 +31,8 @@ from sverchok.utils.sv_IO_panel_tools import (
     create_dict_of_tree, import_tree)
 
 
-class SverchokIOLayoutsMenu(bpy.types.Panel):
-    bl_idname = "Sverchok_iolayouts_menu"
+class SV_PT_IOLayoutsMenu(bpy.types.Panel):
+    bl_idname = "SV_PT_IOLayoutsMenu"
     bl_label = "SV import/export"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -113,11 +113,11 @@ class SverchokIOLayoutsMenu(bpy.types.Panel):
 
 
 def register():
-    bpy.utils.register_class(SverchokIOLayoutsMenu)
+    bpy.utils.register_class(SV_PT_IOLayoutsMenu)
 
 
 def unregister():
-    bpy.utils.unregister_class(SverchokIOLayoutsMenu)
+    bpy.utils.unregister_class(SV_PT_IOLayoutsMenu)
 
 
 if __name__ == '__main__':

--- a/ui/sv_panel_display_nodes.py
+++ b/ui/sv_panel_display_nodes.py
@@ -348,8 +348,8 @@ class SvDisplayNodePanelProperties(bpy.types.PropertyGroup):
         default=20, update=arrange_nodes)
 
 
-class SvDisplayNodesPanel(bpy.types.Panel):
-    bl_idname = "sv_display_nodes_panel"
+class SV_PT_DisplayNodesPanel(bpy.types.Panel):
+    bl_idname = "SV_PT_DisplayNodesPanel"
     bl_label = "SV Display Nodes"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -391,7 +391,7 @@ class SvDisplayNodesPanel(bpy.types.Panel):
 
 def register():
     bpy.utils.register_class(SvNavigateCategory)
-    bpy.utils.register_class(SvDisplayNodesPanel)
+    bpy.utils.register_class(SV_PT_DisplayNodesPanel)
     bpy.utils.register_class(SvDisplayNodePanelProperties)
     bpy.types.NodeTree.displayNodesProps = PointerProperty(
         name="displayNodesProps", type=SvDisplayNodePanelProperties)
@@ -400,6 +400,6 @@ def register():
 
 def unregister():
     del bpy.types.NodeTree.displayNodesProps
-    bpy.utils.unregister_class(SvDisplayNodesPanel)
+    bpy.utils.unregister_class(SV_PT_DisplayNodesPanel)
     bpy.utils.unregister_class(SvDisplayNodePanelProperties)
     bpy.utils.unregister_class(SvNavigateCategory)

--- a/ui/sv_panel_display_nodes.py
+++ b/ui/sv_panel_display_nodes.py
@@ -372,7 +372,7 @@ class SvDisplayNodesPanel(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         displayProps = context.space_data.node_tree.displayNodesProps
-        split = layout.split(percentage=0.7, align=True)
+        split = layout.split(factor=0.7, align=True)
         c1 = split.column(align=True)
         c2 = split.column(align=True)
         c1.prop(displayProps, "category", text="")

--- a/ui/sv_panels.py
+++ b/ui/sv_panels.py
@@ -109,7 +109,7 @@ class Sv3DViewObjInUpdater(bpy.types.Operator, object):
         wm.event_timer_remove(self._timer)
 
 
-class Sv3DPanel(bpy.types.Panel):
+class SV_PT_3DPanel(bpy.types.Panel):
     ''' Panel to manipuplate parameters in Sverchok layouts '''
 
     bl_space_type = 'VIEW_3D'
@@ -259,8 +259,8 @@ class Sv3DPanel(bpy.types.Panel):
 
 
 
-class SverchokToolsMenu(bpy.types.Panel):
-    bl_idname = "Sverchok_tools_menu"
+class SV_PT_ToolsMenu(bpy.types.Panel):
+    bl_idname = "SV_PT_ToolsMenu"
     bl_label = "SV " + version_and_sha
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -420,8 +420,8 @@ class SverchokToolsMenu(bpy.types.Panel):
 
 sv_tools_classes = [
     Sv3DViewObjInUpdater,
-    SverchokToolsMenu,
-    Sv3DPanel,
+    SV_PT_ToolsMenu,
+    SV_PT_3DPanel,
     SvRemoveStaleDrawCallbacks
 ]
 

--- a/utils/testing.py
+++ b/utils/testing.py
@@ -727,8 +727,8 @@ class SvListOldNodes(bpy.types.Operator):
         self.report({'INFO'}, "See logs")
         return {'FINISHED'}
 
-class SvTestingPanel(bpy.types.Panel):
-    bl_idname = "SvTestingPanel"
+class SV_PT_TestingPanel(bpy.types.Panel):
+    bl_idname = "SV_PT_TestingPanel"
     bl_label = "SV Testing"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -751,7 +751,7 @@ class SvTestingPanel(bpy.types.Panel):
         layout.operator("node.sv_testing_list_old_nodes")
         layout.operator("node.sv_testing_dump_node_def")
 
-classes = [SvRunTests, SvDumpNodeDef, SvListOldNodes, SvTestingPanel]
+classes = [SvRunTests, SvDumpNodeDef, SvListOldNodes, SV_PT_TestingPanel]
 
 def register():
     for clazz in classes:


### PR DESCRIPTION
I fixed all the errors that the console was printing when loading all nodes.
Mainly errors with icon names, and other layout minorities

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

