### PR TITLE
Diameter node

### DIFF
--- a/docs/nodes/analyzers/analyzers_index.rst
+++ b/docs/nodes/analyzers/analyzers_index.rst
@@ -7,6 +7,7 @@ Analyzers
 
    area
    bbox
+   diameter
    distance_pp
    distance_point_line
    distance_point_plane

--- a/docs/nodes/analyzers/diameter.rst
+++ b/docs/nodes/analyzers/diameter.rst
@@ -1,0 +1,42 @@
+Diameter
+========
+
+Functionality
+-------------
+
+This node calculates the diameter of input set of vertices.
+
+It can calculate diameter in two ways:
+
+* General diameter, i.e. maximum distance between any two vertices from input set.
+* Diameter along specified direction (axis), i.e. the length of the projection
+  of whole input vertices set to specified direction.
+
+Inputs
+------
+
+This node has the following inputs:
+
+* **Vertices** - vertices to calculate diameter of. This input is mandatory for the node to function.
+* **Direction** - direction, along which diameter should be calculated. If this
+  input is not connected, then the node will calculate "general diameter" of
+  input vertices set.
+
+Outputs
+-------
+
+This node has one output: **Diameter** - calculated diameter of vertices set.
+
+Examples of usage
+-----------------
+
+Suzanne has "general diameter" of 2.73:
+
+.. image:: https://user-images.githubusercontent.com/284644/58649984-03aad000-8327-11e9-90b8-0c39f328402a.png
+
+Diameter of Suzanne along some diagonal direction is 2.44. Here the direction
+is drawn as green line, and the projection of Suzanne to that direction is
+marked with red dots:
+
+.. image:: https://user-images.githubusercontent.com/284644/58649983-03aad000-8327-11e9-852a-a75d8eb4aad4.png
+

--- a/index.md
+++ b/index.md
@@ -49,6 +49,7 @@
 
 ## Analyzers
     SvBBoxNode
+    SvDiameterNode
     SvVolumeNode
     AreaNode
     DistancePPNode

--- a/nodes/analyzer/diameter.py
+++ b/nodes/analyzer/diameter.py
@@ -1,0 +1,72 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+from itertools import product
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode, match_long_repeat
+from sverchok.utils.geom import diameter
+
+class SvDiameterNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: Diameter
+    Tooltip: Calculate diameter of input object
+    """
+
+    bl_idname = 'SvDiameterNode'
+    bl_label = "Diameter"
+    bl_icon = 'ARROW_LEFTRIGHT'
+
+    def sv_init(self, context):
+        self.inputs.new('VerticesSocket', 'Vertices')
+        self.inputs.new('VerticesSocket', 'Direction')
+        self.outputs.new('StringsSocket', 'Diameter')
+
+    def process(self):
+        if not self.inputs['Vertices'].is_linked:
+            return
+        if not any(s.is_linked for s in self.outputs):
+            return
+        
+        any_direction = not self.inputs['Direction'].is_linked
+
+        out_results = []
+
+        vertices_s = self.inputs['Vertices'].sv_get(default=[[]])
+        directions_s = self.inputs['Direction'].sv_get(default=[[]])
+        objects = match_long_repeat([vertices_s, directions_s])
+
+        for vertices, directions in zip(*objects):
+            if any_direction:
+                direction = None
+            else:
+                direction = directions[0]
+            diam = diameter(vertices, direction)
+            out_results.append([diam])
+
+        self.outputs['Diameter'].sv_set(out_results)
+
+
+def register():
+    bpy.utils.register_class(SvDiameterNode)
+
+def unregister():
+    bpy.utils.unregister_class(SvDiameterNode)
+

--- a/tests/diameter_tests.py
+++ b/tests/diameter_tests.py
@@ -1,0 +1,33 @@
+
+from math import sqrt
+from mathutils import Vector
+
+from sverchok.utils.logging import error
+from sverchok.utils.testing import *
+from sverchok.utils.geom import diameter
+
+class DiameterTests(SverchokTestCase):
+    def test_diameter_1(self):
+        p1 = (0, 0, 0)
+        p2 = (0, 1, 0)
+        diam = diameter([p1, p2], None)
+        expected = 1.0
+        self.assert_sverchok_data_equal(diam, expected, precision=8)
+
+    def test_diameter_2(self):
+        p1 = (0, 0, 0)
+        p2 = (0, 1, 0)
+        p3 = (1, 0, 0)
+        diam = diameter([p1, p2, p3], None)
+        expected = sqrt(2)
+        self.assert_sverchok_data_equal(diam, expected, precision=8)
+
+    def test_diameter_3(self):
+        p1 = (0, 0, 0)
+        p2 = (0, 1, 0)
+        p3 = (1, 0, 0)
+        direction = (1, 0, 0)
+        diam = diameter([p1, p2, p3], direction)
+        expected = 1
+        self.assert_sverchok_data_equal(diam, expected, precision=8)
+

--- a/utils/geom.py
+++ b/utils/geom.py
@@ -865,13 +865,36 @@ def diameter(vertices, axis):
     Calculate diameter of set of vertices along specified axis.
     
     vertices: list of mathutils.Vector or of 3-tuples of floats.
-    axis: 0, 1 or 2.
+    axis: either
+        * integer: 0, 1 or 2 for X, Y or Z
+        * string: 'X', 'Y' or 'Z'
+        * 3-tuple of floats or Vector: any direction
+        * None: calculate diameter regardless of direction
     returns float.
     """
-    xs = [vertex[axis] for vertex in vertices]
-    M = max(xs)
-    m = min(xs)
-    return (M-m)
+    if axis is None:
+        distances = [(mathutils.Vector(v1) - mathutils.Vector(v2)).length for v1 in vertices for v2 in vertices]
+        return max(distances)
+    elif isinstance(axis, tuple) or isinstance(axis, Vector):
+        axis = mathutils.Vector(axis).normalized()
+        ds = [mathutils.Vector(vertex).dot(axis) for vertex in vertices]
+        M = max(ds)
+        m = min(ds)
+        return (M-m)
+    else:
+        if axis == 'X':
+            axis == 0
+        elif axis == 'Y':
+            axis == 1
+        elif axis == 'Z':
+            axis = 2
+        elif isinstance(axis, str):
+            raise Exception("Unknown axis: {}".format(axis))
+
+        xs = [vertex[axis] for vertex in vertices]
+        M = max(xs)
+        m = min(xs)
+        return (M-m)
 
 def center(data):
     """


### PR DESCRIPTION
The node calculates a diameter of input set of vertices. There are two modes possible:
* When "Direction" input is not connected: calculate "true" diameter, i.e. maximum of all distances between all vertices.
* When "direction" input is connected: calculate "diameter" along specified vector, i.e. the length of projection of whole input objects to specified direction.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [x] Unit-tests implemented.
- [x] Ready for merge.

