### PR TITLE
Fractal curve node vectorization.

### DIFF
--- a/docs/nodes/modifier_make/fractal_curve.rst
+++ b/docs/nodes/modifier_make/fractal_curve.rst
@@ -17,8 +17,11 @@ NB 3: Usually you will want to use curves, edges of which have nearly the same l
 Inputs
 ------
 
-This node has one input: **Vertices** - vertices of input curve. Vertices
-should go in the order in which they appear in the curve.
+This node has the following inputs:
+
+* **Iterations** - number of iterations.
+* **MinLength** - minimum length of edge to substitute.
+* **Vertices** - vertices of input curve. Vertices should go in the order in which they appear in the curve.
 
 Parameters
 ----------
@@ -26,11 +29,13 @@ Parameters
 This node has the following parameters:
 
 * **Iterations**. Number of iterations. If zero, then output curve will be
-  exactly the same as input one. Default value is 3. 
+  exactly the same as input one. Default value is 3. This parameter can also be
+  provided from input.
 * **Min. length**. Minimum length of edge to substitute. Fractal substitution
   process will stop for specific edge if it's length became less than specified
   value. Minimal value of zero means that fractal substitution process is
-  stopped only when maximum number of iterations is reached.
+  stopped only when maximum number of iterations is reached. This parameter can
+  also be provided from input. Default value is 0.01.
 * **Precision**. Precision of intermediate calculations (number of decimal
   digits). Default value is 8. This parameter is available only in the **N** panel.
 
@@ -55,4 +60,8 @@ Another example:
 This node can process 3D curves as well:
 
 .. image:: https://user-images.githubusercontent.com/284644/57985246-970a1880-7a7e-11e9-84f3-198244d92df0.png
+
+Vectorization example:
+
+.. image:: https://user-images.githubusercontent.com/284644/58745914-074a6e00-8471-11e9-889d-f41f416fb744.png
 


### PR DESCRIPTION
"Iterations" and "min_length" properties of Fractal Curve node are now possible to be specified as inputs.
These inputs expect one number per curve. For example, it is possible to make one curve with 3 iterations and another with 8.

Backward compatibility is preserved by checking if there are new inputs.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

