### PR TITLE
Calculate Mask node.

### DIFF
--- a/data_structure.py
+++ b/data_structure.py
@@ -365,6 +365,42 @@ def describe_data_shape(data):
     nesting, result = helper(data)
     return "Level {}: {}".format(nesting, result)
 
+def calc_mask(subset_data, set_data, level=0, negate=False, ignore_order=True):
+    """
+    Calculate mask: for each item in set_data, return True if it is present in subset_data.
+    The function can work at any specified level.
+
+    subset_data: subset, for example [1]
+    set_data: set, for example [1, 2, 3]
+    level: 0 to check immediate members of set and subset; 1 to work with lists of lists and so on.
+    negate: if True, then result will be negated (True if item of set is not present in subset).
+    ignore_order: when comparing lists, ignore items order.
+
+    Raises an exception if nesting level of input sets is less than specified level parameter.
+
+    calc_mask([1], [1,2,3]) == [True, False, False])
+    calc_mask([1], [1,2,3], negate=True) == [False, True, True]
+    """
+    if level == 0:
+        if not isinstance(subset_data, (tuple, list)):
+            raise Exception("Specified level is too high for given Subset")
+        if not isinstance(set_data, (tuple, list)):
+            raise Exception("Specified level is too high for given Set")
+
+        if ignore_order and get_data_nesting_level(subset_data) > 1:
+            if negate:
+                return [set(item) not in map(set, subset_data) for item in set_data]
+            else:
+                return [set(item) in map(set, subset_data) for item in set_data]
+        else:
+            if negate:
+                return [item not in subset_data for item in set_data]
+            else:
+                return [item in subset_data for item in set_data]
+    else:
+        sub_objects = match_long_repeat([subset_data, set_data])
+        return [calc_mask(subset_item, set_item, level - 1, negate, ignore_order) for subset_item, set_item in zip(*sub_objects)]
+
 #####################################################
 ################### matrix magic ####################
 #####################################################

--- a/docs/nodes/list_masks/calc_mask.rst
+++ b/docs/nodes/list_masks/calc_mask.rst
@@ -1,0 +1,59 @@
+Calculate Mask
+==============
+
+Functionality
+-------------
+
+This node calculates masks from two input lists (Set and Subset). For each item
+in the Set, it returns True if the item is present in Subset, otherwise it
+returns False.
+
+There are nodes, which output, for example, "All faces" and "Processed faces"
+or smth like that. To do something with that output, it would be usually more
+effective to deal with "All faces" and "Processed faces mask" instead.
+
+The node can work on different levels of data trees. For example, given Subset
+= `[[1, 2], [3,4]]` and Set = `[[1, 2], [3, 4], [5, 6]]`:
+
+*   with level = 0 it will output `[True, True, False]`
+*   with level = 1 it will output `[[True, True], [True, True], [False, False]]`
+
+Given Subset = `[[1], [5,6]]` and Set = `[[1, 2, 3], [7, 8, 9]]`:
+
+*   with level = 0 it will output `[False, False]` (because, for example, there
+  is no `[1, 2, 3]` in the `[[1], [5,6]]`)
+*   with level = 1, it will output `[[True, False, False], [False, False, False]]`
+
+Inputs
+------
+
+This node has the following inputs:
+
+* **Subset**. List of "good" data items to be checked against.
+* **Set**. The whole set of data items.
+
+Parameters
+----------
+
+This node has the following parameters:
+
+* **Negate**. If checked, then the resulting mask will be negated. I.e., the
+  node will output True if item of Set is *not* present in Subset. Unchecked by
+  default.
+* **Ignore order**. If checked, then, while comparing lists, the node will not
+  take into account the order of items in these lists. For example, is `[1, 2]`
+  the same as `[2, 1]`? No, if **Ignore order** is not checked.
+
+Outputs
+-------
+
+This node has only one output: **Mask**. Number of items in this outuput is
+equal to number of items in the **Set** input.
+
+Example of usage
+----------------
+
+This node can, for example, be used to apply **Inset Special** node iteratively:
+
+.. image:: https://user-images.githubusercontent.com/284644/58757902-82715a00-852d-11e9-9288-369607f5229d.png
+

--- a/docs/nodes/list_masks/list_masks_index.rst
+++ b/docs/nodes/list_masks/list_masks_index.rst
@@ -8,4 +8,5 @@ List Masks
    mask
    mask_join
    mask_converter
+   calc_mask
 

--- a/index.md
+++ b/index.md
@@ -140,6 +140,7 @@
     MaskListNode
     SvMaskJoinNode
     SvMaskConvertNode
+    SvCalcMaskNode
 
 ## List Mutators
     SvListModifierNode

--- a/nodes/list_masks/calc_mask.py
+++ b/nodes/list_masks/calc_mask.py
@@ -1,0 +1,96 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import bpy
+from bpy.props import BoolProperty, EnumProperty, IntProperty
+from sverchok.node_tree import SverchCustomTreeNode, StringsSocket, VerticesSocket
+from sverchok.data_structure import updateNode, match_long_repeat, fullList
+
+class SvCalcMaskNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: Calculate Mask
+    Tooltip: Calculate mask from two sets of objects
+    """
+    bl_idname = 'SvCalcMaskNode'
+    bl_label = 'Calculate Mask'
+    bl_icon = 'OUTLINER_OB_EMPTY'
+
+    level = IntProperty(name = 'Level',
+                description = "List level to operate on",
+                min = 0, default = 0, update=updateNode)
+    
+    negate = BoolProperty(name = 'Negate',
+                description = 'Negate mask', update=updateNode)
+
+    ignore_order = BoolProperty(name = 'Ignore order',
+                    description = "Ignore items order while comparing lists",
+                    default = True, update=updateNode)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'level')
+        layout.prop(self, 'negate')
+        layout.prop(self, 'ignore_order')
+
+    def sv_init(self, context):
+        self.inputs.new('StringsSocket', "Subset")
+        self.inputs.new('StringsSocket', "Set")
+        self.outputs.new('StringsSocket', 'Mask')
+
+    def calc(self, subset_data, set_data, level):
+        if level == 0:
+            if not isinstance(subset_data, (tuple, list)):
+                raise Exception("Specified level is too high for given Subset")
+            if not isinstance(set_data, (tuple, list)):
+                raise Exception("Specified level is too high for given Set")
+
+            if self.ignore_order:
+                if self.negate:
+                    return [set(item) not in map(set, subset_data) for item in set_data]
+                else:
+                    return [set(item) in map(set, subset_data) for item in set_data]
+            else:
+                if self.negate:
+                    return [item not in subset_data for item in set_data]
+                else:
+                    return [item in subset_data for item in set_data]
+        else:
+            sub_objects = match_long_repeat([subset_data, set_data])
+            return [self.calc(subset_item, set_item, level - 1) for subset_item, set_item in zip(*sub_objects)]
+
+    def process(self):
+
+        if not any(output.is_linked for output in self.outputs):
+            return
+
+        subset_s = self.inputs['Subset'].sv_get(default=[[]])
+        set_s = self.inputs['Set'].sv_get(default=[[]])
+        out_masks = []
+
+        objects = match_long_repeat([subset_s, set_s])
+        for subset, set in zip(*objects):
+            mask = self.calc(subset, set, self.level)
+            out_masks.append(mask)
+
+        self.outputs['Mask'].sv_set(out_masks)
+
+def register():
+    bpy.utils.register_class(SvCalcMaskNode)
+
+def unregister():
+    bpy.utils.unregister_class(SvCalcMaskNode)
+

--- a/tests/data_structure_tests.py
+++ b/tests/data_structure_tests.py
@@ -111,3 +111,10 @@ class CalcMaskTests(SverchokTestCase):
         expected = [[True, False, False], [False, False, False]]
         self.assertEquals(mask, expected)
 
+    def test_calc_mask_7(self):
+        subset = [[1, 2], [3, 4]]
+        set = [[2, 1], [5, 6]]
+        mask = calc_mask(subset, set, ignore_order=True)
+        expected = [True, False]
+        self.assertEquals(mask, expected)
+

--- a/tests/data_structure_tests.py
+++ b/tests/data_structure_tests.py
@@ -68,3 +68,46 @@ class DataStructureTests(SverchokTestCase):
         self.subtest_assert_equals(describe_data_shape([1]), 'Level 1: list [1] of int')
         self.subtest_assert_equals(describe_data_shape([[(1,2,3)]]), 'Level 3: list [1] of list [1] of tuple [3] of int')
 
+class CalcMaskTests(SverchokTestCase):
+    def test_calc_mask_1(self):
+        subset = [1]
+        set = [1, 2, 3]
+        mask = calc_mask(subset, set, level=0)
+        expected = [True, False, False]
+        self.assertEquals(mask, expected)
+
+    def test_calc_mask_2(self):
+        subset = [1]
+        set = [1, 2, 3]
+        mask = calc_mask(subset, set, negate=True)
+        expected = [False, True, True]
+        self.assertEquals(mask, expected)
+
+    def test_calc_mask_3(self):
+        subset = [[1, 2], [3, 4]]
+        set = [[1, 2], [3, 4], [5, 6]]
+        mask = calc_mask(subset, set, level=0)
+        expected = [True, True, False]
+        self.assertEquals(mask, expected)
+
+    def test_calc_mask_4(self):
+        subset = [[1, 2], [3, 4]]
+        set = [[1, 2], [3, 4], [5, 6]]
+        mask = calc_mask(subset, set, level=1)
+        expected = [[True, True], [True, True], [False, False]]
+        self.assertEquals(mask, expected)
+
+    def test_calc_mask_5(self):
+        subset = [[1], [5,6]]
+        set = [[1, 2, 3], [7, 8, 9]]
+        mask = calc_mask(subset, set, level=0)
+        expected = [False, False]
+        self.assertEquals(mask, expected)
+
+    def test_calc_mask_6(self):
+        subset = [[1], [5,6]]
+        set = [[1, 2, 3], [7, 8, 9]]
+        mask = calc_mask(subset, set, level=1)
+        expected = [[True, False, False], [False, False, False]]
+        self.assertEquals(mask, expected)
+


### PR DESCRIPTION
## Addressed problem description

There are nodes, which output, for example, "All faces" and "Processed faces" or smth like that. To do something with that output, it would be usually more effective to deal with "All faces" and "Processed faces mask" instead.

## Solution description
The new node takes two sets of objects (numbers, vertices, edges, faces, whatever) and returns a mask: True if item is in subset, otherwise False.

The node can work on different levels of data trees. For example, given Subset = `[[1, 2], [3,4]]` and Set = `[[1, 2], [3, 4], [5, 6]]`:

* with level = 0 it will output `[True, True, False]`
* with level = 1 it will output `[[True, True], [True, True], [False, False]]` 

Given Subset = `[[1], [5,6]]` and Set = `[[1, 2, 3], [7, 8, 9]]`:

* with level = 0 it will output `[False, False]` (because, for example, there is no `[1, 2, 3]` in the `[[1], [5,6]]`)
* with level = 1, it will output `[[True, False, False], [False, False, False]]`

There is also new API `data_structure.calc_mask`, which may be used by other nodes, including scripted ones.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [x] Unit-tests implemented.
- [x] Ready for merge.

