### PR TITLE
Inset special node: more precise normal calculation.

### DIFF
--- a/utils/geom.py
+++ b/utils/geom.py
@@ -1441,6 +1441,27 @@ def linear_approximation(data):
     result.eigenvalues, result.eigenvectors = linalg.eig(matrix)
     return result
 
+def calc_normal(vertices):
+    """
+    Calculate normal for a face defined by specified vertices.
+    For tris or quads, mathutils.geometry.normal() is used.
+    Ngon will be triangulated, and then the average normal of
+    all resulting tris will be returned.
+
+    input: list of 3-tuples or list of mathutils.Vector.
+    output: mathutils.Vector.
+    """
+    n = len(vertices)
+    vertices = list(map(mathutils.Vector, vertices))
+    if n <= 4:
+        return mathutils.geometry.normal(*vertices)
+    else:
+        # Triangluate
+        triangle_idxs = [[0, k, k+1] for k in range(1, n-1)]
+        triangles = [[vertices[i] for i in idxs] for idxs in triangle_idxs]
+        subnormals = [mathutils.geometry.normal(*triangle) for triangle in triangles]
+        return mathutils.Vector(center(subnormals))
+
 def multiply_vectors(M, vlist):
     # (4*4 matrix)  X   (3*1 vector)
 


### PR DESCRIPTION
## Addressed problem description

Currently "Inset special" node calculates face normals by taking first 3 vertices of the face. This may be very imprecise for ngons.

On the other hand, current algorithm is fast enough, and some existing setups may rely on existing behaviour.

## Solution description

Introduce new node parameter, visible in the N panel only: "Normal calculation mode", with two possible values: "Fast" and "Exact". "Fast" is the default value, for backwards compatibility.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [ ] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

