### PR TITLE
New KDT Closest Path Node

### DIFF
--- a/docs/nodes/analyzers/kd_tree_path.rst
+++ b/docs/nodes/analyzers/kd_tree_path.rst
@@ -1,0 +1,56 @@
+KDT Closest Path
+=================
+
+Functionality
+-------------
+
+Using a K-dimensional Tree it will create a path starting at the desired index joining each vertex to the closest free vertex. If no vertex is found in the desired range the path will break and will start a new path at the next unused vertex.
+
+
+Inputs / Parameter
+-------------------
+
++--------------+---------+-----------------------------------------------------------+
+| Name         | Type    | Description                                               |  
++==============+=========+===========================================================+
+| Verts        | Vectors | Vertices to make path                                     |   
++--------------+---------+-----------------------------------------------------------+
+| Max Distance | float   | Maximum Distance to accept a pair                         |
++--------------+---------+-----------------------------------------------------------+
+| Start Index  | Int     | Vert index where path will start                          |
++--------------+---------+-----------------------------------------------------------+
+| Cyclic       | Boolean | Enable to join the first and last vertices                |
++--------------+---------+-----------------------------------------------------------+
+
+Advanced Parameters
+-------------------
+
+In the N-Panel (and on the right-click menu) you can find:
+
+**Match List Global**: Define how list with different lengths should be matched. Refers to the matching of groups 
+
+**Match List Local**: Define how list with different lengths should be matched. Refers to the matching of max distances and vertices
+
+Outputs
+-------
+
+- Edges, which can connect the pool of incoming Vertices to make a path.
+
+Examples
+--------
+
+Creating paths in a random vector field.
+
+.. image:: https://github.com/vicdoval/sverchok/raw/docs_images/images_for_docs/analyzer/kd_tree_path/KDT_closest_path_examples.png
+  :alt: Distance_point_line_procedural.PNG
+
+Find the best starting index to make the minimum path by starting at every vertex and comparing the path lengths and taking the shortest one.
+
+.. image:: https://github.com/vicdoval/sverchok/raw/docs_images/images_for_docs/analyzer/kd_tree_path/KDT_closest_path_examples1.png
+  :alt: Sverchok_Distance_point_line.PNG
+
+Find a coherent short path among shuffled vertices.
+
+.. image:: https://github.com/vicdoval/sverchok/raw/docs_images/images_for_docs/analyzer/kd_tree_path/KDT_closest_path_examples2.png
+  :alt: Blender_distance_point_line.PNG
+

--- a/docs/nodes/analyzers/kd_tree_path.rst
+++ b/docs/nodes/analyzers/kd_tree_path.rst
@@ -42,15 +42,15 @@ Examples
 Creating paths in a random vector field.
 
 .. image:: https://github.com/vicdoval/sverchok/raw/docs_images/images_for_docs/analyzer/kd_tree_path/KDT_closest_path_examples.png
-  :alt: Distance_point_line_procedural.PNG
+  :alt: Blender_sverchok_KDT_closest_path_examples.png
 
 Find the best starting index to make the minimum path by starting at every vertex and comparing the path lengths and taking the shortest one.
 
 .. image:: https://github.com/vicdoval/sverchok/raw/docs_images/images_for_docs/analyzer/kd_tree_path/KDT_closest_path_examples1.png
-  :alt: Sverchok_Distance_point_line.PNG
+  :alt: procedural_sverchok_KDT_closest_path_examples1.png
 
 Find a coherent short path among shuffled vertices.
 
 .. image:: https://github.com/vicdoval/sverchok/raw/docs_images/images_for_docs/analyzer/kd_tree_path/KDT_closest_path_examples2.png
-  :alt: Blender_distance_point_line.PNG
+  :alt: parametric_sverchok_KDT_closest_path_examples2.png
 

--- a/index.md
+++ b/index.md
@@ -60,6 +60,7 @@
     VectorNormalNode
     SvKDTreeNodeMK2
     SvKDTreeEdgesNodeMK2
+    SvKDTreePathNode
     SvBvhOverlapNodeNew
     SvMeshFilterNode
     SvEdgeAnglesNode

--- a/nodes/analyzer/kd_tree_MK2.py
+++ b/nodes/analyzer/kd_tree_MK2.py
@@ -21,10 +21,14 @@ import mathutils
 from bpy.props import FloatProperty, EnumProperty, IntProperty
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import (updateNode, match_long_repeat as mlr)
-
+from sverchok.utils.sv_KDT_utils import kdt_closest_verts, kdt_closest_verts_range, kdt_closest_verts_find_n
 
 class SvKDTreeNodeMK2(bpy.types.Node, SverchCustomTreeNode):
-    '''Find nearest verts'''
+    '''
+    Triggers: Find nearest verts
+    Tooltip: Find nearest verts to another verts group
+    '''
+    
     bl_idname = 'SvKDTreeNodeMK2'
     bl_label = 'KDT Closest Verts MK2'
     bl_icon = 'OUTLINER_OB_EMPTY'
@@ -34,6 +38,11 @@ class SvKDTreeNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         ('find_range', 'find_range', 'find closest tree vectors in range', '', 1),
     ]
 
+    func_dict = {
+        'find_n': kdt_closest_verts_find_n,
+        'find_range': kdt_closest_verts_range
+        }
+        
     number = IntProperty(
         min=1, default=1, name='Number',
         description="find this amount", update=updateNode)
@@ -56,29 +65,32 @@ class SvKDTreeNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         row.prop(self, 'mode', expand=True)
 
     def sv_init(self, context):
-        self.inputs.new('VerticesSocket', 'insert')
-        self.inputs.new('VerticesSocket', 'find').use_prop = True
-        self.inputs.new('StringsSocket', 'number').prop_name = "number"
-        self.inputs.new('StringsSocket', 'radius').prop_name = "radius"
-        self.inputs['radius'].hide_safe = True
-        self.outputs.new('VerticesSocket', 'Co')
-        self.outputs.new('StringsSocket', 'index')
-        self.outputs.new('StringsSocket', 'distance')
+        
+        si = self.inputs
+        so = self.outputs
+        si.new('VerticesSocket', 'insert')
+        si.new('VerticesSocket', 'find').use_prop = True
+        si.new('StringsSocket', 'number').prop_name = "number"
+        si.new('StringsSocket', 'radius').prop_name = "radius"
+        si['radius'].hide_safe = True
+        so.new('VerticesSocket', 'Co')
+        so.new('StringsSocket', 'index')
+        so.new('StringsSocket', 'distance')
 
     def process(self):
-        V1, V2, N, R = [i.sv_get() for i in self.inputs]
+        '''main node function called every update'''
+        si = self.inputs
+        so = self.outputs
+        if not (any(s.is_linked for s in so) and si[0].is_linked):
+            return
+        V1, V2, N, R = mlr([i.sv_get() for i in si])
         out = []
-        Co, ind, dist = self.outputs
+        Co, ind, dist = so
         find_n = self.mode == "find_n"
+        func = self.func_dict[self.mode]
         for v, v2, k in zip(V1, V2, (N if find_n else R)):
-            kd = mathutils.kdtree.KDTree(len(v))
-            for idx, co in enumerate(v):
-                kd.insert(co, idx)
-            kd.balance()
-            if find_n:
-                out.extend([kd.find_n(vert, num) for vert, num in zip(*mlr([v2, k]))])
-            else:
-                out.extend([kd.find_range(vert, dist) for vert, dist in zip(*mlr([v2, k]))])
+            func(v, v2, k, out)
+
         if Co.is_linked:
             Co.sv_set([[i[0][:] for i in i2] for i2 in out])
         if ind.is_linked:

--- a/nodes/analyzer/kd_tree_edges_mk2.py
+++ b/nodes/analyzer/kd_tree_edges_mk2.py
@@ -22,11 +22,13 @@ import mathutils
 
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode
+from sverchok.utils.sv_KDT_utils import kdt_closest_edges
 
-
-# documentation/blender_python_api_2_70_release/mathutils.kdtree.html
 class SvKDTreeEdgesNodeMK2(bpy.types.Node, SverchCustomTreeNode):
-    '''Create Edges by distance'''
+    '''
+    Triggers: Create Edges by distance
+    Tooltip: Join verts pairs by defining distance range and number of connections
+    '''
     bl_idname = 'SvKDTreeEdgesNodeMK2'
     bl_label = 'KDT Closest Edges MK2'
     bl_icon = 'OUTLINER_OB_EMPTY'
@@ -82,51 +84,7 @@ class SvKDTreeEdgesNodeMK2(bpy.types.Node, SverchCustomTreeNode):
                 sock_input = s_default_value
             socket_inputs.append(sock_input)
 
-        self.run_kdtree(verts, socket_inputs)
-
-    def run_kdtree(self, verts, socket_inputs):
-        mindist, maxdist, maxNum, skip = socket_inputs
-
-        # make kdtree
-        # documentation/blender_python_api_2_78_release/mathutils.kdtree.html
-        size = len(verts)
-        kd = mathutils.kdtree.KDTree(size)
-
-        for i, xyz in enumerate(verts):
-            kd.insert(xyz, i)
-        kd.balance()
-
-        # set minimum values
-        maxNum = max(maxNum, 1)
-        skip = max(skip, 0)
-
-        # makes edges
-        e = set()
-
-        for i, vtx in enumerate(verts):
-            num_edges = 0
-
-            # this always returns closest first followed by next closest, etc.
-            #              co  index  dist
-            for edge_idx, (_, index, dist) in enumerate(kd.find_range(vtx, abs(maxdist))):
-
-                if skip > 0:
-                    if edge_idx < skip:
-                        continue
-
-                if (dist <= abs(mindist)) or (i == index):
-                    continue
-
-                edge = tuple(sorted([i, index]))
-                if not edge in e:
-                    e.add(edge)
-                    num_edges += 1
-
-                if num_edges == maxNum:
-                    break
-
-
-        self.outputs['Edges'].sv_set([list(e)])
+        kdt_closest_edges(verts, socket_inputs, outputs['Edges'])
 
 
 def register():

--- a/nodes/analyzer/kd_tree_path.py
+++ b/nodes/analyzer/kd_tree_path.py
@@ -1,0 +1,123 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import bpy
+from bpy.props import IntProperty, FloatProperty, EnumProperty, BoolProperty
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode, list_match_func, list_match_modes
+from sverchok.utils.sv_KDT_utils import kdt_closest_path
+
+
+class SvKDTreePathNode(bpy.types.Node, SverchCustomTreeNode):
+    '''
+    Triggers: Nearest Verts Path
+    Tooltip: Make a path (edges) verts joining each verts to the closest neighbor
+    '''
+
+    bl_idname = 'SvKDTreePathNode'
+    bl_label = 'KDT Closest Path'
+    bl_icon = 'OUTLINER_OB_EMPTY'
+
+    mindist = FloatProperty(
+        name='mindist', description='Minimum dist', min=0.0,
+        default=0.1, update=updateNode)
+
+    maxdist = FloatProperty(
+        name='Max Distance', description='Maximum dist', min=0.0,
+        default=2.0, update=updateNode)
+
+    start_index = IntProperty(
+        name='Start Index', description='Vertes Index to start path',
+        default=0, min=0, update=updateNode)
+
+    skip = IntProperty(
+        name='skip', description='skip first n',
+        default=0, min=0, update=updateNode)
+
+    cycle = BoolProperty(
+        name='Cyclic', description='Join first and last vertices',
+        default=False, update=updateNode)
+        
+    list_match_global = EnumProperty(
+        name="Match Global",
+        description="Behavior on different list lengths, multiple objects level",
+        items=list_match_modes, default="REPEAT",
+        update=updateNode)
+        
+    list_match_local = EnumProperty(
+        name="Match Local",
+        description="Behavior on different list lengths, object level",
+        items=list_match_modes, default="REPEAT",
+        update=updateNode)
+
+    def sv_init(self, context):
+        self.inputs.new('VerticesSocket', 'Verts')
+        self.inputs.new('StringsSocket', 'maxdist').prop_name = 'maxdist'
+        self.inputs.new('StringsSocket', 'start_index').prop_name = 'start_index'
+
+        self.outputs.new('StringsSocket', 'Edges')
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "cycle", toggle=False)
+
+    def draw_buttons_ext(self, context, layout):
+        '''draw buttons on the N-panel'''
+        layout.prop(self, "cycle", toggle=False)
+        layout.separator()
+        layout.label(text="List Match:")
+        layout.prop(self, "list_match_global", text="Global Match", expand=False)
+        layout.prop(self, "list_match_local", text="Local Match", expand=False)
+
+    def rclick_menu(self, context, layout):
+        '''right click sv_menu items'''
+        layout.prop_menu_enum(self, "list_match_global", text="List Match Global")
+        layout.prop_menu_enum(self, "list_match_local", text="List Match Local")
+        
+    def get_data(self):
+        '''get all data from sockets and match lengths'''
+        si = self.inputs
+        return list_match_func[self.list_match_global]([s.sv_get(default=[[]]) for s in si])
+
+    def process(self):
+    
+        inputs = self.inputs
+        outputs = self.outputs
+        so = self.outputs
+        si = self.inputs
+        if not so[0].is_linked and si[0].is_linked:
+            return
+
+        result = []
+        group = self.get_data()
+        
+        match_func = list_match_func[self.list_match_local]
+        
+        for verts, radius, start_indexes in zip(*group):
+            verts, radius = match_func([verts, radius])
+            for st in start_indexes:
+                kdt_closest_path(verts, radius, st%len(verts), result, self.cycle)
+
+        so[0].sv_set(result)
+        
+
+def register():
+    bpy.utils.register_class(SvKDTreePathNode)
+
+
+def unregister():
+    bpy.utils.unregister_class(SvKDTreePathNode)

--- a/utils/sv_KDT_utils.py
+++ b/utils/sv_KDT_utils.py
@@ -1,0 +1,106 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+from mathutils import kdtree
+from sverchok.data_structure import match_long_repeat as mlr
+
+# documentation/blender_python_api_2_70_release/mathutils.kdtree.html
+def create_kdt(verts):
+    '''Basic kdt setup'''
+    size = len(verts)
+    kd = kdtree.KDTree(size)
+    for i, xyz in enumerate(verts):
+        kd.insert(xyz, i)
+    kd.balance()
+
+    return kd
+
+
+def kdt_closest_verts_range(verts, v_find, dists, out):
+    '''Find vertices in desired distance'''
+    kd = create_kdt(verts)
+    out.extend([kd.find_range(vert, dist) for vert, dist in zip(*mlr([v_find, dists]))])
+
+
+def kdt_closest_verts_find_n(verts, v_find, nums, out):
+    '''Find  the N closest vertices ordered by distance'''
+    kd = create_kdt(verts)
+    out.extend([kd.find_n(vert, num) for vert, num in zip(*mlr([v_find, nums]))])
+
+
+def kdt_closest_path(verts, radius, start_index, result, cycle):
+    '''Creates path joining each vertice with the closest free neighbor'''
+    kd = create_kdt(verts)
+    edges = [[]]
+    edge_set = set()
+    seen = set()
+    seen_end = set()
+    r = radius
+
+    idx = start_index
+
+    for id in range(len(verts)):
+
+        n_list = kd.find_range(verts[idx], r[idx])
+        seen_end.add(idx)
+        found = False
+        for co, index, dist in n_list:
+            if (index == idx) or (index in seen_end):
+                continue
+            seen_end.add(index)
+            edge_set.add(tuple(sorted([idx, index])))
+            idx = index
+            found = True
+            break
+        if not found and id <  len(verts):
+            for id_new in range(len(verts)):
+                if id_new not in seen_end:
+                    idx = id_new
+                    break
+    if cycle:
+        edge_set.add(tuple(sorted([start_index, idx])))
+
+    result.append(list(edge_set))
+
+
+def kdt_closest_edges(verts, socket_inputs, egdes_output):
+    '''Join verts pairs by defining distance range and number of connections'''
+    mindist, maxdist, maxNum, skip = socket_inputs
+
+    # make kdtree
+    kd = create_kdt(verts)
+
+    # set minimum values
+    maxNum = max(maxNum, 1)
+    skip = max(skip, 0)
+
+    # makes edges
+    e = set()
+
+    for i, vtx in enumerate(verts):
+        num_edges = 0
+
+        # this always returns closest first followed by next closest, etc.
+        #              co  index  dist
+        for edge_idx, (_, index, dist) in enumerate(kd.find_range(vtx, abs(maxdist))):
+
+            if skip > 0:
+                if edge_idx < skip:
+                    continue
+
+            if (dist <= abs(mindist)) or (i == index):
+                continue
+
+            edge = tuple(sorted([i, index]))
+            if not edge in e:
+                e.add(edge)
+                num_edges += 1
+
+            if num_edges == maxNum:
+                break
+
+    egdes_output.sv_set([list(e)])


### PR DESCRIPTION
KDT Closest Path Node:
Using a K-dimensional Tree it will create a path starting at the desired index joining each vertex to the closest free vertex. If no vertex is found in the desired range the path will break and will start a new path at the next unused vertex.
![KDT_closest_path_examples1.png](https://github.com/vicdoval/sverchok/raw/docs_images/images_for_docs/analyzer/kd_tree_path/KDT_closest_path_examples.png)
Find the best starting index to make the minimum path by starting at every vertex and comparing the path lengths and taking the shortest one.
![KDT_closest_path_examples1.png](https://github.com/vicdoval/sverchok/raw/docs_images/images_for_docs/analyzer/kd_tree_path/KDT_closest_path_examples1.png)
Find a coherent short path among shuffled vertices.
![KDT_closest_path_examples2.png](https://github.com/vicdoval/sverchok/raw/docs_images/images_for_docs/analyzer/kd_tree_path/KDT_closest_path_examples2.png)

Also moved all the KDT functions (Closest Edges and Closest Points) to` sverchok.utils.sv_KDT_utils`
- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

