### PR TITLE
Bevel Curve node update

### DIFF
--- a/docs/nodes/modifier_make/bevel_curve.rst
+++ b/docs/nodes/modifier_make/bevel_curve.rst
@@ -116,6 +116,16 @@ This node has the following parameters:
   Manhattan, Chebyshev, Points. Default value is Euclidean. The default metric
   usually gives good results. If you do not like results, try other options.
   This parameter is available only in the N panel. 
+- **Taper Metric**. Defines the metric to use to calculate the spline for taper
+  object. Available values are:
+  * **Same as Curve** - use the same metric as for main curve. This is the
+    default value. In many cases, this algorithm may be very imprecise.
+  * **Orientation Axis** - use coordinates of taper object's vertices along the
+    orientation axis. This usually gives more precise result. This mode
+    assumes, that the taper object is oriented along that orientation axis: for
+    example, if orientation axis is Z, then each following vertex of taper
+    object must have Z coordinate bigger than previous vertex.
+
 - **Tangent precision**. Step to be used to calculate tangents of the spline.
   Lesser values correspond to better precision. In most cases, you will not
   have to change the default value. This parameter is available only in the N panel. 

--- a/utils/geom.py
+++ b/utils/geom.py
@@ -464,6 +464,18 @@ class Spline(object):
             tknots = np.max(np.absolute(pts[1:] - pts[:-1]), 1)
             tknots = np.insert(tknots, 0, 0).cumsum()
             tknots = tknots / tknots[-1]
+        elif metric == "X":
+            tknots = pts[:,0]
+            tknots = tknots - tknots[0]
+            tknots = tknots / tknots[-1]
+        elif metric == "Y":
+            tknots = pts[:,1]
+            tknots = tknots - tknots[0]
+            tknots = tknots / tknots[-1]
+        elif metric == "Z":
+            tknots = pts[:,2]
+            tknots = tknots - tknots[0]
+            tknots = tknots / tknots[-1]
 
         return tknots
 


### PR DESCRIPTION
Introduce more precise mode for taper object interpolation. See N panel
-> "Taper Metric" -> "Orientation Axis".

Default value "Same as Curve" leads to imprecise results in many cases, but I left it for compatibility reasons. Maybe when merging to 2.8 branch, we should set "Orientation Axis" as default option.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

