### PR TITLE
Turning live update mode from Operator to Handler

### DIFF
--- a/core/handlers.py
+++ b/core/handlers.py
@@ -82,11 +82,14 @@ def sv_main_handler(scene):
 
 @persistent
 def sv_object_live_update(scene):
+    # This handler is created especially for objects in nodes. When live updated is enabled in 3d panel this handler
+    # detects user changes of objects and call process of appropriate objects in node.
     if not scene.SvShowIn3D_active:
         return
 
     obj_nodes = []
     for ng in bpy.data.node_groups:
+        # search of objects in nodes
         if ng.bl_idname == 'SverchCustomTreeType':
             if ng.sv_process:
                 nodes = []

--- a/settings.py
+++ b/settings.py
@@ -160,9 +160,6 @@ class SverchokPreferences(AddonPreferences):
     over_sized_buttons = BoolProperty(
         default=False, name="Big buttons", description="Very big buttons")
 
-    enable_live_objin = BoolProperty(
-        description="Objects in edit mode will be updated in object-in Node")
-
     render_scale = FloatProperty(
         default=1.0, min=0.01, step=0.01, description='default render scale')
 
@@ -234,7 +231,6 @@ class SverchokPreferences(AddonPreferences):
             col1.label(text="UI:")
             col1.prop(self, "show_icons")
             col1.prop(self, "over_sized_buttons")
-            col1.prop(self, "enable_live_objin", text='Enable Live Object-In')
             col1.prop(self, "external_editor", text="Ext Editor")
             col1.prop(self, "real_sverchok_path", text="Src Directory")
 


### PR DESCRIPTION
## Addressed problem description

#2458 
Previous pull request have revealed that Operators are not appropriate for monitoring objects changes. 
I decided that having two different modes of `live update` mode is too much in spite of this approach is completely different. So I have deleted old approach. If it will be found that it had some benefits we can return it back. There is need in testing new approach. I expect that it can become part of update system in 2.8. 

Also i deleted options of enabling this mode in preferences of Sverchok. I don't see that 3D panel is overweight now and can't keep button of this node constantly.

If there will not be any objections against such changes I merge it to master. 

## Preflight checklist

- [x] Code changes complete.
- [x] Code documentation complete.
- [ ] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

