### PR TITLE
Node access to dependency graph - ParticlesMK2 particle data

### DIFF
--- a/core/handlers.py
+++ b/core/handlers.py
@@ -146,6 +146,8 @@ def sv_post_load(scene):
     sv_types = {'SverchCustomTreeType', 'SverchGroupTreeType'}
     sv_trees = list(ng for ng in bpy.data.node_groups if ng.bl_idname in sv_types and ng.nodes)
     for ng in sv_trees:
+        if hasattr(ng, "deps_graph"):
+            ng.deps_graph = bpy.context.evaluated_depsgraph_get()
         ng.freeze(True)
         try:
             old_nodes.load_old(ng)

--- a/node_tree.py
+++ b/node_tree.py
@@ -172,6 +172,18 @@ class SverchCustomTree(NodeTree, SvNodeTreeCommon):
             self.tree_link_count = link_count
             return True
 
+    @property
+    def deps_graph(self):
+        if getattr(self, "_deps_graph", None) is None:
+            print('initializing depsgrah reference')
+            setattr(self, "_deps_graph", bpy.context.evaluated_depsgraph_get())
+        return self._deps_graph
+    
+    @deps_graph.setter
+    def deps_graph(self, value):
+        print('resetting depsgrah reference')
+        setattr(self, "_deps_graph", value)
+
     def update(self):
         '''
         Tags tree for update for handle

--- a/nodes/scene/particles_MK2.py
+++ b/nodes/scene/particles_MK2.py
@@ -45,7 +45,8 @@ class SvParticlesMK2Node(bpy.types.Node, SverchCustomTreeNode):
     def process(self):
         O, V, L, S = self.inputs
         outL, outV = self.outputs
-        listobj = [i.particle_systems.active.particles for i in O.sv_get() if i.particle_systems]
+        evalO = [i.evaluated_get(self.id_data.deps_graph) for i in O.sv_get()]
+        listobj = [i.particle_systems[0].particles for i in evalO if i.particle_systems]
         if V.is_linked:
             for i, i2 in zip(listobj, V.sv_get()):
                 i.foreach_set('velocity', np.array(safc(i, i2)).flatten())


### PR DESCRIPTION
## Addressed problem description

ParticlesMK2 node returns empty particle data, issue #2355. This happens because the way to access particle data has changed.

## Solution description

The ParticlesMK2 node requires access to the evaluated dependency graph in order to retrieve the particle data. We add a reference to the graph in the node tree, so that the node can get the particle data via the graph (discussed in  #2355).

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [ ] Code documentation complete.
- [ ] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [ ] Ready for merge.

