### PR TITLE
List Math Node: Added warp property to node buttons and to Docs

### DIFF
--- a/docs/nodes/list_main/func.rst
+++ b/docs/nodes/list_main/func.rst
@@ -26,6 +26,8 @@ Maximum             Maximum value of the list
 Minimum             Minimum value of the list
 =================== ======================================
 
+**Warp:** Adds one level of warping (output becomes [output])
+
 Outputs
 -------
 

--- a/nodes/list_main/func.py
+++ b/nodes/list_main/func.py
@@ -1,7 +1,7 @@
 # This file is part of project Sverchok. It's copyrighted by the contributors
 # recorded in the version control history of the file, available from
 # its original location https://github.com/nortikin/sverchok/commit/master
-#  
+#
 # SPDX-License-Identifier: GPL3
 # License-Filename: LICENSE
 
@@ -33,12 +33,12 @@ func_dict = {
     "MIN": min,
     "MAX": max,
     "AVR": avr,
-    "SUM": sum 
+    "SUM": sum
 }
 
 class ListFuncNode(bpy.types.Node, SverchCustomTreeNode):
     '''
-    Triggers: List functions
+    Triggers: Average, Sum, Min...
     Tooltip: Operations with list, sum, average, min, max
     '''
     bl_idname = 'ListFuncNode'
@@ -56,22 +56,23 @@ class ListFuncNode(bpy.types.Node, SverchCustomTreeNode):
     func_: EnumProperty(
         name="Function", description="Function choice",
         default="AVR", items=mode_items, update=updateNode)
-    
+
     level: IntProperty(
         name='level_to_count',
         default=1, min=0, update=updateNode)
-    
+
     wrap: BoolProperty(
-        name='wrap', description='extra level add', 
-        default=False,update=updateNode)
+        name='wrap', description='extra level add',
+        default=True, update=updateNode)
 
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "level", text="level")
         layout.prop(self, "func_", text="Functions:")
+        layout.prop(self, "wrap", text="Warp")
 
     def draw_buttons_ext(self, context, layout):
-        layout.prop(self, "wrap")
+        self.draw_buttons(context, layout)
 
     def sv_init(self, context):
         self.inputs.new('SvStringsSocket', "Data")


### PR DESCRIPTION
Also I made it True by Default (as I have never used with out warping)
![list_math_warp](https://user-images.githubusercontent.com/10011941/64488441-80afe480-d248-11e9-9ce8-7f3d8cded9cc.png)


- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

