### PR TITLE
Auto-Removal of Depreciated Frame when updating a node 

### DIFF
--- a/ui/nodes_replacement.py
+++ b/ui/nodes_replacement.py
@@ -50,7 +50,7 @@ class SvReplaceNode(bpy.types.Operator):
 
     This operator removes old node and creates a new node.
     It tries to preserve all links and properties that old
-    node had. For cases when new node has other names of 
+    node had. For cases when new node has other names of
     inputs and/or outputs, it is possible to define mapping.
     In the end, this operator calls `migrate_from' method
     of the new node, so the new node can copy it's settings
@@ -136,7 +136,11 @@ class SvReplaceNode(bpy.types.Operator):
                 new_node.name, new_node.bl_idname)
         info(msg)
         self.report({'INFO'}, msg)
-
+        
+        if old_node.parent and old_node.parent.label == "Deprecated node!":
+            if old_node.parent.parent:
+                new_node.parent = old_node.parent.parent
+            tree.nodes.remove(old_node.parent)
         tree.nodes.remove(old_node)
 
         return {'FINISHED'}


### PR DESCRIPTION
Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

