### PR TITLE
Menu restructuration change-make-sanitize

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@
 >
 > Failing to follow these points will break the node category parser.
 
-## Generator
+## Generate
     SvLineNodeMK3
     SvPlaneNodeMK2
     SvNGonNode
@@ -29,7 +29,7 @@
     SvSNFunctorB
     ImageNode
 
-## Generators Extended
+## Generate Extended
     SvBoxRoundedNode
     SvBricksNode
     SvPolygonGridNode
@@ -46,7 +46,7 @@
     SvSuperEllipsoidNode
     SvRegularSolid
 
-## Analyzers
+## Analyze
     SvBBoxNode
     SvVolumeNode
     SvAreaNode
@@ -59,6 +59,7 @@
     CentersPolsNodeMK3
     GetNormalsNode
     VectorNormalNode
+    Pols2EdgsNode
     SvIntersectLineSphereNode
     SvIntersectPlanePlaneNode
     SvKDTreeNodeMK2
@@ -76,61 +77,71 @@
     SvDeformationNode
     SvLinkedVertsNode
 
-## Transforms
-    SvRotationNodeMK2
-    SvScaleNodeMK2
-    SvMoveNodeMK2
-    SvMirrorNode
-    MatrixApplyNode
-    SvSimpleDeformNode
-    SvBarycentricTransformNode
-    ---
-    Svb28MatrixArrayNode
-
-## Modifier Change
+##  Sanitate
     SvDeleteLooseNode
     SvRemoveDoublesNode
     SvSeparateMeshNode
     SvLimitedDissolve
     SvMeshBeautify
     SvTriangulateNode
-    ---
-    PolygonBoomNode
-    Pols2EdgsNode
-    SvMeshJoinNode
-    ---
-    SvFillsHoleNode
     SvRecalcNormalsNode
     SvFlipNormalsNode
-    SvRandomizeVerticesNode
+    SvFillsHoleNode
+    SvVertMaskNode
+
+##  Change
+    SvRotationNodeMK2
+    SvScaleNodeMK2
+    SvMoveNodeMK2
+    SvMirrorNode
+    MatrixApplyNode
     ---
+    PolygonBoomNode
+    SvMeshJoinNode
+    ---
+    SvSmoothNode
     SvIterateNode
+    SvBendAlongPathNode
+    SvBendAlongSurfaceNode
+    SvSimpleDeformNode
+    SvBarycentricTransformNode
+    SvRandomizeVerticesNode
+    SvTransformSelectNode
+
+##  Make
+    LineConnectNodeMK2
+    ---
+    SvBevelNode
+    SvSmoothLines    
+    SvOffsetNode
+    SvLatheNode
+    SvBevelCurveNode
+    ---
+    SvSubdivideNode
+    SvSplitEdgesNode
+    SvIntersectEdgesNodeMK2
+    CrossSectionNode
+    SvBisectNode
+    SvWafelNode
+    ---
     SvExtrudeEdgesNode
     SvExtrudeSeparateNode
     SvExtrudeRegionNode
-    SvBendAlongPathNode
-    SvBendAlongSurfaceNode
-    SvVertMaskNode
-    SvTransformSelectNode
-    SvSplitEdgesNode
-
-## Modifier Make
-    LineConnectNodeMK2
-    ---
-    SvConvexHullNode
-    SvConvexHullNodeMK2
-    SvSubdivideNode
-    DelaunayTriangulation2DNode
-    Voronoi2DNode
-    ---
-    SvBevelCurveNode
-    SvAdaptiveEdgeNode
-    AdaptivePolsNode
-    SvDuplicateAlongEdgeNode
     SvSolidifyNode
+    ---
     SvWireframeNode
     SvPipeNode
     SvMatrixTubeNode
+    ---
+    Svb28MatrixArrayNode
+    SvAdaptiveEdgeNode
+    AdaptivePolsNode
+    SvDuplicateAlongEdgeNode
+    ---
+    SvConvexHullNode
+    SvConvexHullNodeMK2
+    DelaunayTriangulation2DNode
+    Voronoi2DNode
 
 ## List Masks
     MaskListNode
@@ -166,18 +177,6 @@
     ListShuffleNode
     ListSortNodeMK2
     ListFlipNode
-
-## CAD
-    SvBevelNode
-    SvIntersectEdgesNodeMK2
-    SvOffsetNode
-    SvLatheNode
-    SvSmoothNode
-    SvSmoothLines
-    ---
-    CrossSectionNode
-    SvBisectNode
-    SvWafelNode
 
 ## Number
     SvNumberNode

--- a/index.md
+++ b/index.md
@@ -77,7 +77,7 @@
     SvDeformationNode
     SvLinkedVertsNode
 
-##  Sanitate
+##  Sanitize
     SvDeleteLooseNode
     SvRemoveDoublesNode
     SvSeparateMeshNode

--- a/menu.py
+++ b/menu.py
@@ -68,7 +68,7 @@ def make_node_cats():
 
         # final append
         node_cats[category] = temp_list
-    
+
     return node_cats
 
 
@@ -99,8 +99,8 @@ def juggle_and_join(node_cats):
     node_cats['BPY Data'].extend(objects_cat)
 
     # add extended gens to Gens menu
-    gen_ext = node_cats.pop("Generators Extended")
-    node_cats["Generator"].extend(gen_ext)
+    gen_ext = node_cats.pop("Generate Extended")
+    node_cats["Generate"].extend(gen_ext)
 
     return node_cats
 
@@ -143,12 +143,12 @@ class SverchNodeItem(object):
     def make_add_operator(self):
         """
         Create operator class which adds specific type of node.
-        Tooltip (docstring) for that operator is copied from 
+        Tooltip (docstring) for that operator is copied from
         node class docstring.
         """
 
         global node_add_operators
-        
+
         class SverchNodeAddOperator(bl_operators.node.NodeAddOperator, bpy.types.Operator):
             """Wrapper for node.add_node operator to add specific node"""
 
@@ -230,7 +230,7 @@ def draw_add_node_operator(layout, nodetype, label=None, icon_name=None, params=
         params.update(**node_icon(node_rna))
 
     add = layout.operator("node.sv_add_" + get_node_idname_for_operator(nodetype), **params)
-                            
+
     add.type = nodetype
     add.use_transform = True
 
@@ -314,7 +314,7 @@ def reload_menu():
         unregister_node_add_operators()
     nodeitems_utils.register_node_categories("SVERCHOK", menu)
     register_node_add_operators()
-    
+
     build_help_remap(original_categories)
     print("Reload complete, press update")
 
@@ -342,4 +342,3 @@ def unregister():
     if 'SVERCHOK' in nodeitems_utils._node_categories:
         nodeitems_utils.unregister_node_categories("SVERCHOK")
     unregister_node_add_operators()
-

--- a/ui/nodeview_space_menu.py
+++ b/ui/nodeview_space_menu.py
@@ -112,7 +112,7 @@ class NODEVIEW_MT_Dynamic_Menu(bpy.types.Menu):
         layout.menu("NODEVIEW_MT_AddAnalyze", **icon('VIEWZOOM'))
         layout.menu("NODEVIEW_MT_AddChange", **icon('ORIENTATION_LOCAL'))
         layout.menu("NODEVIEW_MT_AddMake", **icon('MODIFIER'))
-        layout.menu("NODEVIEW_MT_AddSanitate", **icon('MOD_DECIM'))
+        layout.menu("NODEVIEW_MT_AddSanitize", **icon('MOD_DECIM'))
         layout.separator()
         layout.menu("NODEVIEW_MT_AddNumber")
         layout.menu("NODEVIEW_MT_AddVector")
@@ -193,7 +193,7 @@ classes = [
     make_class('Matrix', "Matrix"),
     make_class('Change', "Change"),
     make_class('Make', "Make"),
-    make_class('Sanitate', "Sanitate"),
+    make_class('Sanitize', "Sanitize"),
     make_class('Logic', "Logic"),
     make_class('Network', "Network"),
     make_class('Betas', "Beta Nodes"),

--- a/ui/nodeview_space_menu.py
+++ b/ui/nodeview_space_menu.py
@@ -108,11 +108,11 @@ class NODEVIEW_MT_Dynamic_Menu(bpy.types.Menu):
 
 
         layout.separator()
-        layout.menu("NODEVIEW_MT_AddGenerators", **icon('OBJECT_DATAMODE'))
-        layout.menu("NODEVIEW_MT_AddTransforms", **icon('ORIENTATION_LOCAL'))
-        layout.menu("NODEVIEW_MT_AddAnalyzers", **icon('VIEWZOOM'))
-        layout.menu("NODEVIEW_MT_AddModifiers", **icon('MODIFIER'))
-        layout.menu("NODEVIEW_MT_AddCAD", **icon('TOOL_SETTINGS'))
+        layout.menu("NODEVIEW_MT_AddGenerate", **icon('OBJECT_DATAMODE'))
+        layout.menu("NODEVIEW_MT_AddAnalyze", **icon('VIEWZOOM'))
+        layout.menu("NODEVIEW_MT_AddChange", **icon('ORIENTATION_LOCAL'))
+        layout.menu("NODEVIEW_MT_AddMake", **icon('MODIFIER'))
+        layout.menu("NODEVIEW_MT_AddSanitate", **icon('MOD_DECIM'))
         layout.separator()
         layout.menu("NODEVIEW_MT_AddNumber")
         layout.menu("NODEVIEW_MT_AddVector")
@@ -129,18 +129,18 @@ class NODEVIEW_MT_Dynamic_Menu(bpy.types.Menu):
         layout.menu("NODEVIEW_MT_AddNetwork", **icon("SYSTEM"))
         layout.menu("NODEVIEW_MT_AddBetas", **icon("SV_BETA"))
         layout.menu("NODEVIEW_MT_AddAlphas", **icon("SV_ALPHA"))
-        layout.separator() 
+        layout.separator()
         layout.menu("NODE_MT_category_SVERCHOK_GROUPS", icon="RNA")
         layout.menu("NODEVIEW_MT_AddPresetOps", icon="SETTINGS")
 
 
-class NODEVIEW_MT_AddGenerators(bpy.types.Menu):
-    bl_label = "Generator"
+class NODEVIEW_MT_AddGenerate(bpy.types.Menu):
+    bl_label = "Generate"
 
     def draw(self, context):
         layout = self.layout
         layout_draw_categories(self.layout, node_cats[self.bl_label])
-        layout.menu("NODEVIEW_MT_AddGeneratorsExt", **icon('PLUGIN'))
+        layout.menu("NODEVIEW_MT_AddGenerateExt", **icon('PLUGIN'))
 
 
 class NODEVIEW_MT_AddModifiers(bpy.types.Menu):
@@ -150,6 +150,8 @@ class NODEVIEW_MT_AddModifiers(bpy.types.Menu):
         layout = self.layout
         layout.menu("NODEVIEW_MT_AddModifierChange")
         layout.menu("NODEVIEW_MT_AddModifierMake")
+        layout.menu("NODEVIEW_MT_AddModifierSanitate")
+        layout.menu("NODEVIEW_MT_AddModifierMultiply")
 
 
 class NODEVIEW_MT_AddListOps(bpy.types.Menu):
@@ -173,13 +175,13 @@ classes = [
     NODEVIEW_MT_Dynamic_Menu,
     NODEVIEW_MT_AddListOps,
     NODEVIEW_MT_AddModifiers,
-    NODEVIEW_MT_AddGenerators,
+    NODEVIEW_MT_AddGenerate,
     NODEVIEW_MT_AddPresetOps,
     # like magic.
     # make | NODEVIEW_MT_Add + class name , menu name
-    make_class('GeneratorsExt', "Generators Extended"),
+    make_class('GenerateExt', "Generate Extended"),
     make_class('Transforms', "Transforms"),
-    make_class('Analyzers', "Analyzers"),
+    make_class('Analyze', "Analyze"),
     make_class('Viz', "Viz"),
     make_class('Text', "Text"),
     make_class('Scene', "Scene"),
@@ -189,9 +191,9 @@ classes = [
     make_class('Number', "Number"),
     make_class('Vector', "Vector"),
     make_class('Matrix', "Matrix"),
-    make_class('CAD', "CAD"),
-    make_class('ModifierChange', "Modifier Change"),
-    make_class('ModifierMake', "Modifier Make"),
+    make_class('Change', "Change"),
+    make_class('Make', "Make"),
+    make_class('Sanitate', "Sanitate"),
     make_class('Logic', "Logic"),
     make_class('Network', "Network"),
     make_class('Betas', "Beta Nodes"),


### PR DESCRIPTION
Restructuring Add Menu based in #2523 and thoughts in #2522
Avoiding double-depth menus
Three categories:
Change: modifies current geometry
![change](https://user-images.githubusercontent.com/10011941/64493251-2d588900-d27e-11e9-8349-a9efb0727e31.png)
Make: creates new geometry from existing one
![make](https://user-images.githubusercontent.com/10011941/64493253-2fbae300-d27e-11e9-9cdc-c1c857e0507f.png)
Sanitate: Reduces  or simplifies existing geometry
![sanitate](https://user-images.githubusercontent.com/10011941/64493254-321d3d00-d27e-11e9-81d2-b99f2fd80870.png)




- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

