### PR TITLE
start pr for textrendering in idxviewer

### DIFF
--- a/nodes/viz/viewer_idx28.py
+++ b/nodes/viz/viewer_idx28.py
@@ -227,8 +227,8 @@ class SvIDXViewer28(bpy.types.Node, SverchCustomTreeNode):
                     for idx, vpos in enumerate(final_verts):
                         concat_vert((idx, vpos))
                     if geom.text:
-                        # autolong text_items to final_verts...
-                        text_items = geom.text[obj_index]
+                        
+                        text_items = self.get_text_of_correct_length(obj_index, geom, len(final_verts))                        
                         for text_item, vpos in zip(text_items, final_verts):
                             concat_text(text_item)
 
@@ -243,9 +243,24 @@ class SvIDXViewer28(bpy.types.Node, SverchCustomTreeNode):
                         median = calc_median(poly_verts)
                         concat_face((face_index, median))
 
-                # .......
-
             return display_topology
+
+    def get_text_of_correct_length(self, obj_index, geom, num_elements_to_fill):
+        """ get text elements, and extend if needed"""
+        if obj_index < len(geom.text):
+            text_items = geom.text[obj_index]
+        else:
+            text_items = geom.text[len(geom.text)-1]
+
+        if not (len(text_items) == num_elements_to_fill):
+            # for now... there is no auto extending...
+            pass  #text_items
+
+        return text_items
+
+ 
+
+
 
     def process(self):
         n_id = node_id(self)

--- a/nodes/viz/viewer_idx28.py
+++ b/nodes/viz/viewer_idx28.py
@@ -256,9 +256,9 @@ class SvIDXViewer28(bpy.types.Node, SverchCustomTreeNode):
             
             # ---- this doesn't touch the data, but returns a copy, or a modified copy -----
             if len(text_items) < num_elements_to_fill:
-                return text_items[:num_elements_to_fill]
-            else:
                 return text_items + [text_items[-1], ] * (num_elements_to_fill - len(text_items))
+            else:
+                return text_items[:num_elements_to_fill]
 
         return text_items
 

--- a/nodes/viz/viewer_idx28.py
+++ b/nodes/viz/viewer_idx28.py
@@ -228,9 +228,9 @@ class SvIDXViewer28(bpy.types.Node, SverchCustomTreeNode):
                         concat_vert((idx, vpos))
                     if geom.text:
                         # autolong text_items to final_verts...
-                        text_items = []
+                        text_items = geom.text[obj_index]
                         for text_item, vpos in zip(text_items, final_verts):
-                            concat_text((text_item, vpos))
+                            concat_text(text_item)
 
                 if self.display_edge_index and obj_index < len(geom.edges):
                     for edge_index, (idx1, idx2) in enumerate(geom.edges[obj_index]):

--- a/nodes/viz/viewer_idx28.py
+++ b/nodes/viz/viewer_idx28.py
@@ -58,9 +58,9 @@ class SvIDXViewer28(bpy.types.Node, SverchCustomTreeNode):
         default=True,
         update=updateNode)
 
-    # draw_bg: BoolProperty(
-    #     name='draw_bg', description='draw background poly?',
-    #     default=False, update=updateNode)
+    draw_bg: BoolProperty(
+        name='draw_bg', description='draw background poly?',
+        default=False, update=updateNode)
 
     draw_bface: BoolProperty(
         name='draw_bface', description='draw backfacing indices?',
@@ -87,6 +87,7 @@ class SvIDXViewer28(bpy.types.Node, SverchCustomTreeNode):
         inew('SvStringsSocket', 'edges')
         inew('SvStringsSocket', 'faces')
         inew('SvMatrixSocket', 'matrix')
+        inew('SvStringsSocket', 'text')
 
 
     def draw_buttons(self, context, layout):
@@ -187,7 +188,7 @@ class SvIDXViewer28(bpy.types.Node, SverchCustomTreeNode):
         inputs = self.inputs
         geom = lambda: None
 
-        for socket in ['matrix', 'verts', 'edges', 'faces']:
+        for socket in ['matrix', 'verts', 'edges', 'faces', 'text']:
             input_stream = inputs[socket].sv_get(default=[])
             if socket == 'verts' and input_stream:
                 
@@ -212,6 +213,7 @@ class SvIDXViewer28(bpy.types.Node, SverchCustomTreeNode):
             display_topology.vert_data = []
             display_topology.edge_data = []
             display_topology.face_data = []
+            display_topology.text_data = []
 
             concat_vert = display_topology.vert_data.append
             concat_edge = display_topology.edge_data.append
@@ -233,6 +235,8 @@ class SvIDXViewer28(bpy.types.Node, SverchCustomTreeNode):
                         poly_verts = [final_verts[idx] for idx in f]
                         median = calc_median(poly_verts)
                         concat_face((face_index, median))
+
+                # .......
 
             return display_topology
 

--- a/nodes/viz/viewer_idx28.py
+++ b/nodes/viz/viewer_idx28.py
@@ -58,9 +58,9 @@ class SvIDXViewer28(bpy.types.Node, SverchCustomTreeNode):
         default=True,
         update=updateNode)
 
-    draw_bg: BoolProperty(
-        name='draw_bg', description='draw background poly?',
-        default=False, update=updateNode)
+    # draw_bg: BoolProperty(
+    #     name='draw_bg', description='draw background poly?',
+    #     default=False, update=updateNode)
 
     draw_bface: BoolProperty(
         name='draw_bface', description='draw backfacing indices?',

--- a/nodes/viz/viewer_idx28.py
+++ b/nodes/viz/viewer_idx28.py
@@ -218,9 +218,11 @@ class SvIDXViewer28(bpy.types.Node, SverchCustomTreeNode):
             concat_vert = display_topology.vert_data.append
             concat_edge = display_topology.edge_data.append
             concat_face = display_topology.face_data.append
+            concat_text = display_topology.text_data.append
             
             for obj_index, final_verts in enumerate(geom.verts):
 
+                # can't display vert idx and text simultaneously - ...
                 if self.display_vert_index:
                     for idx, vpos in enumerate(final_verts):
                         concat_vert((idx, vpos))

--- a/nodes/viz/viewer_idx28.py
+++ b/nodes/viz/viewer_idx28.py
@@ -226,6 +226,11 @@ class SvIDXViewer28(bpy.types.Node, SverchCustomTreeNode):
                 if self.display_vert_index:
                     for idx, vpos in enumerate(final_verts):
                         concat_vert((idx, vpos))
+                    if geom.text:
+                        # autolong text_items to final_verts...
+                        text_items = []
+                        for text_item, vpos in zip(text_items, final_verts):
+                            concat_text((text_item, vpos))
 
                 if self.display_edge_index and obj_index < len(geom.edges):
                     for edge_index, (idx1, idx2) in enumerate(geom.edges[obj_index]):

--- a/nodes/viz/viewer_idx28.py
+++ b/nodes/viz/viewer_idx28.py
@@ -253,15 +253,16 @@ class SvIDXViewer28(bpy.types.Node, SverchCustomTreeNode):
             text_items = geom.text[len(geom.text)-1]
 
         if not (len(text_items) == num_elements_to_fill):
-            # for now... there is no auto extending...
-            pass  #text_items
+            
+            # ---- this doesn't touch the data, but returns a copy, or a modified copy -----
+            if len(text_items) < num_elements_to_fill:
+                return text_items[:num_elements_to_fill]
+            else:
+                return text_items + [text_items[-1], ] * (num_elements_to_fill - len(text_items))
 
         return text_items
 
  
-
-
-
     def process(self):
         n_id = node_id(self)
         callback_disable(n_id)

--- a/utils/sv_idx_viewer28_draw.py
+++ b/utils/sv_idx_viewer28_draw.py
@@ -132,8 +132,12 @@ def draw_indices_2D(context, args):
     if draw_bface:
 
         blf.color(font_id, *vert_idx_color)
-        for vidx in geom.vert_data:
-            draw_index(*vidx)
+        if geom.vert_data and geom.text_data:
+            for text_item, (idx, location) in zip(geom.text_data, geom.vert_data):
+                draw_index(text_item, location)
+        else:
+            for vidx in geom.vert_data:
+                draw_index(*vidx)
     
         blf.color(font_id, *edge_idx_color)
         for eidx in geom.edge_data:

--- a/utils/sv_idx_viewer28_draw.py
+++ b/utils/sv_idx_viewer28_draw.py
@@ -123,7 +123,7 @@ def draw_indices_2D(context, args):
         x = region_mid_width + region_mid_width * (vec_4d.x / vec_4d.w)
         y = region_mid_height + region_mid_height * (vec_4d.y / vec_4d.w)
 
-        # ''' draw text '''
+        # ---- draw text ----
         index_str = str(index)
         txt_width, txt_height = blf.dimensions(0, index_str)
         blf.position(0, x - (txt_width / 2), y - (txt_height / 2), 0)


### PR DESCRIPTION
adresses longstanding regression in idxviewer - unable to draw arbitrary strings on vertex locations.

- [x] allow text input  
- [x] auto repeat, in a meaningful way

"background" feature will not be implemented in this PR.