### PR TITLE
Optionally register node category panels for the N or T panel.

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -218,6 +218,13 @@ class SvPackedLayout(object):
         self._column = 0
         self._row = None
 
+    @staticmethod
+    def get(icons_only, parent, columns):
+        if icons_only:
+            return SvPackedLayout(parent, columns)
+        else:
+            return parent
+
     def separator(self):
         self.parent.separator()
 
@@ -358,7 +365,7 @@ def register_node_panels(identifier, cat_list):
 
             def draw_node_item(self, context):
                 layout = self.layout
-                col = SvPackedLayout(layout.column(align=True))
+                col = SvPackedLayout.get(prefs.node_panels_icons_only, layout.column(align=True), prefs.node_panels_columns)
                 for item in self.category.items(context):
                     item.draw(item, col, context)
 
@@ -391,7 +398,7 @@ def register_node_panels(identifier, cat_list):
                 def draw(self, context):
                     layout = self.layout
                     layout.prop(context.scene, "sv_selected_category", text="")
-                    col = SvPackedLayout(layout.column(align=True))
+                    col = SvPackedLayout.get(prefs.node_panels_icons_only, layout.column(align=True), prefs.node_panels_columns)
 
                     for category in cat_list:
                         if category.identifier != context.scene.sv_selected_category:

--- a/menu.py
+++ b/menu.py
@@ -316,7 +316,7 @@ def register_node_panels(identifier, cat_list):
 
             def draw_node_item(self, context):
                 layout = self.layout
-                col = layout.column()
+                col = layout.column(align=True)
                 for item in self.category.items(context):
                     item.draw(item, col, context)
 
@@ -349,12 +349,13 @@ def register_node_panels(identifier, cat_list):
                 def draw(self, context):
                     layout = self.layout
                     layout.prop(context.scene, "sv_selected_category", text="")
+                    col = layout.column(align=True)
 
                     for category in cat_list:
                         if category.identifier != context.scene.sv_selected_category:
                             continue
                         for item in category.items(context):
-                            item.draw(item, layout, context)
+                            item.draw(item, col, context)
 
             node_panels.append(SV_PT_NodesTPanel)
             bpy.utils.register_class(SV_PT_NodesTPanel)

--- a/menu.py
+++ b/menu.py
@@ -130,6 +130,13 @@ class SverchNodeItem(object):
 
         self.make_add_operator()
 
+    @staticmethod
+    def new(name):
+        if name == 'separator':
+            return SverchSeparator()
+        else:
+            return SverchNodeItem(name)
+
     @property
     def label(self):
         if self._label:
@@ -194,6 +201,15 @@ class SverchNodeItem(object):
             ops = add.settings.add()
             ops.name = setting[0]
             ops.value = setting[1]
+
+class SverchSeparator(object):
+    @staticmethod
+    def draw(self, layout, context):
+        layout.separator()
+
+    @classmethod
+    def poll(cls, context):
+        return context.space_data.tree_type == 'SverchCustomTreeType'
 
 def get_node_idname_for_operator(nodetype):
     """Select valid bl_idname for node to create node adding operator bl_idname."""
@@ -303,7 +319,7 @@ def make_categories():
             SverchNodeCategory(
                 name_big,
                 category,
-                items=[SverchNodeItem(props[0]) for props in nodes if not props[0] == 'separator']))
+                items=[SverchNodeItem.new(props[0]) for props in nodes]))
         node_count += len(nodes)
     node_categories.append(SverchNodeCategory("SVERCHOK_GROUPS", "Groups", items=sv_group_items))
 

--- a/settings.py
+++ b/settings.py
@@ -185,11 +185,18 @@ class SverchokPreferences(AddonPreferences):
 
     over_sized_buttons: BoolProperty(
         default=False, name="Big buttons", description="Very big buttons")
+    
+    node_panel_modes = [
+            ("X", "Do not show", "Do not show node buttons", 0),
+            ("T", "T panel", "Show node buttons under the T panel", 1),
+            ("N", "N panel", "Show node under the N panel", 2)
+        ]
 
-    node_panels: BoolProperty(
-        name = "Display node category panels",
-        description = "Will show panels with node categories in the N panel. Restart Blender to apply changes.",
-        default = False)
+    node_panels: EnumProperty(
+        items = node_panel_modes,
+        name = "Display node buttons",
+        description = "Where to show node insertion buttons. Restart Blender to apply changes.",
+        default = "X")
 
     enable_live_objin: BoolProperty(
         description="Objects in edit mode will be updated in object-in Node")

--- a/settings.py
+++ b/settings.py
@@ -186,6 +186,11 @@ class SverchokPreferences(AddonPreferences):
     over_sized_buttons: BoolProperty(
         default=False, name="Big buttons", description="Very big buttons")
 
+    node_panels: BoolProperty(
+        name = "Display node category panels",
+        description = "Will show panels with node categories in the N panel. Restart Blender to apply changes.",
+        default = False)
+
     enable_live_objin: BoolProperty(
         description="Objects in edit mode will be updated in object-in Node")
 
@@ -264,6 +269,7 @@ class SverchokPreferences(AddonPreferences):
             col1 = col_split.column()
             col1.label(text="UI:")
             col1.prop(self, "show_icons")
+            col1.prop(self, "node_panels")
             col1.prop(self, "over_sized_buttons")
             col1.prop(self, "enable_live_objin", text='Enable Live Object-In')
             col1.prop(self, "external_editor", text="Ext Editor")

--- a/settings.py
+++ b/settings.py
@@ -197,6 +197,19 @@ class SverchokPreferences(AddonPreferences):
         name = "Display node buttons",
         description = "Where to show node insertion buttons. Restart Blender to apply changes.",
         default = "X")
+    
+    node_panels_icons_only : BoolProperty(
+            name = "Display icons only",
+            description = "Show node icon only when icon has an icon, otherwise show it's name",
+            default = True
+        )
+
+    node_panels_columns : IntProperty(
+            name = "Columns",
+            description = "Number of icon panels per row",
+            default = 4,
+            min = 2, max = 12
+        )
 
     enable_live_objin: BoolProperty(
         description="Objects in edit mode will be updated in object-in Node")
@@ -276,7 +289,15 @@ class SverchokPreferences(AddonPreferences):
             col1 = col_split.column()
             col1.label(text="UI:")
             col1.prop(self, "show_icons")
-            col1.prop(self, "node_panels")
+
+            toolbar_box = col1.box()
+            toolbar_box.label(text="Node toolbars")
+            toolbar_box.prop(self, "node_panels")
+            if self.node_panels != "X":
+                toolbar_box.prop(self, "node_panels_icons_only")
+                if self.node_panels_icons_only:
+                    toolbar_box.prop(self, "node_panels_columns")
+
             col1.prop(self, "over_sized_buttons")
             col1.prop(self, "enable_live_objin", text='Enable Live Object-In')
             col1.prop(self, "external_editor", text="Ext Editor")

--- a/ui/sv_panels.py
+++ b/ui/sv_panels.py
@@ -281,7 +281,7 @@ class SV_PT_ToolsMenu(bpy.types.Panel):
     bl_label = "SV " + version_and_sha
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
-    # bl_category = 'Sverchok'
+    bl_category = 'Sverchok'
     use_pin = True
 
     @classmethod


### PR DESCRIPTION
In Blender 2.80, the T panel does not support tabs; so there are no automatically registered panels for node categories under T panel.

This adds the following options to preferences:

* Display node buttons:
  * Under T panel (with popup menu for categories selection)
  * Under N panel (categories are selected with tabs)
  * Do not show (default)
* Display icons only: if set, then for nodes that have icons, only icons will be shown, to save screen space. Checked by default.
* Number of columns to show in "icons only" mode. 4 by default.


![Screenshot_20190929_153810](https://user-images.githubusercontent.com/284644/65831116-56919580-e2cf-11e9-9c02-1f9c4e40838e.png)

With new icons from #2536:

![Screenshot_20190929_152012](https://user-images.githubusercontent.com/284644/65831115-56919580-e2cf-11e9-9225-20e2444717bd.png)


![Screenshot_20190929_151900](https://user-images.githubusercontent.com/284644/65831114-56919580-e2cf-11e9-8c00-ad4330aebac8.png)


## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [ ] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

