### PR TITLE
adds wrapper to nodecommon

### DIFF
--- a/node_tree.py
+++ b/node_tree.py
@@ -458,6 +458,22 @@ class SverchCustomTreeNode:
                 print(f'failed to remove {self.name} from tree={self.id_data.name}')
 
 
+    def wrapper_tracked_ui_draw_op(self, layout_element, operator_idname, **keywords):
+        """
+        this wrapper allows you to track the origin of a clicked operator, by automatically passing
+        the idname and idtree of the tree.
+
+        example usage:
+
+            row.separator()
+            self.wrapper_tracked_ui_draw_op(row, "node.view3d_align_from", icon='CURSOR', text='')
+
+        """
+        op = layout_element.operator(operator_idname, **keywords)
+        op.idname = self.name
+        op.idtree = self.id_data.name      
+
+
 classes = [
     SverchCustomTree, 
     SvLinkNewNodeInput

--- a/nodes/viz/vd_draw_experimental.py
+++ b/nodes/viz/vd_draw_experimental.py
@@ -352,14 +352,9 @@ class SvVDExperimental(bpy.types.Node, SverchCustomTreeNode):
                 colors_column.prop(self, "custom_shader_location", icon='TEXT', text='')
 
         row = layout.row(align=True)
-        op1 = row.operator('node.sverchok_mesh_baker_mk3',icon='OUTLINER_OB_MESH', text="B A K E")
-        op1.idname = self.name
-        op1.idtree = self.id_data.name
-
+        self.wrapper_tracked_ui_draw_op(row, "node.sverchok_mesh_baker_mk3", icon='OUTLINER_OB_MESH', text="B A K E")
         row.separator()
-        op2 = row.operator("node.view3d_align_from", text='', icon='CURSOR')
-        op2.idname = self.name
-        op2.idtree = self.id_data.name
+        self.wrapper_tracked_ui_draw_op(row, "node.view3d_align_from", icon='CURSOR', text='')
 
     def draw_buttons_ext(self, context, layout):
         self.draw_buttons(context, layout)


### PR DESCRIPTION
makes it easier to write a tracked operator (which when executed must pass on treename / nodename info )