### PR TITLE
VD attribute node

### DIFF
--- a/index.md
+++ b/index.md
@@ -147,6 +147,7 @@
     SvListModifierNode
     SvFixEmptyObjectsNode
     SvDatetimeStrings
+    SvVDAttrsNode
 
 ## List Main
     ListJoinNode

--- a/nodes/list_mutators/vd_attr_node.py
+++ b/nodes/list_mutators/vd_attr_node.py
@@ -13,6 +13,22 @@ import bpy
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode
 
+maximum_spec_vd_dict = dict(
+    vector_light="light direction (3f)",
+    vert_color="points rgba (4f)",
+    edge_color="edge rgba (4f)",
+    face_color="face rgba (4f)",
+    display_verts="display verts (b)",
+    display_edges="edges verts (b)",
+    display_faces="faces verts (b)",
+    selected_draw_mode="shade mode (enum)",
+    draw_gl_wireframe="wireframe (b)",
+    draw_gl_polygonoffset="fix zfighting (b)",
+    point_size="point size (i)",
+    line_width="line width (i)",
+    extended_matrix="extended matrix (b)"
+)
+
 class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):
     ''' a SvVDAttrsNode f '''
     bl_idname = 'SvVDAttrsNode'
@@ -29,7 +45,7 @@ class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):
         inew("SvStringsSocket", "display verts (b)")
         inew("SvStringsSocket", "edges verts (b)")
         inew("SvStringsSocket", "faces verts (b)")
-        inew("SvStringsSocket", "shade mode (0..2)")
+        inew("SvStringsSocket", "shade mode (enum)")
         inew("SvStringsSocket", "wireframe (b)")
         inew("SvStringsSocket", "fix zfighting (b)")
         inew("SvStringsSocket", "point size (i)")

--- a/nodes/list_mutators/vd_attr_node.py
+++ b/nodes/list_mutators/vd_attr_node.py
@@ -38,6 +38,13 @@ maximum_spec_vd_dict = dict(
 
 get_socket_str = lambda socket_type: getattr(sock_str, '_' + socket_type) 
 
+"""
+items:
+    attr_name | show_socket | use_default | default 
+                                            (default type, default_property)
+
+
+"""
 
 
 
@@ -52,7 +59,7 @@ class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):
 
     bl_idname = 'SvVDAttrsNode'
     bl_label = 'VD Attributes'
-    bl_icon = 'GREASEPENCIL'
+    bl_icon = 'MOD_HUE_SATURATION'
 
     def sv_init(self, context):
         self.outputs.new("SvStringsSocket", name="attrs")
@@ -61,6 +68,11 @@ class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):
             inew(get_socket_str(socket_type), socket_name).hide = True
 
     def draw_buttons(self, context, layout):
+        ...
+
+    def draw_buttons_ext(self, context, layout):
+        ...
+        ...
         ...
 
     def process(self):

--- a/nodes/list_mutators/vd_attr_node.py
+++ b/nodes/list_mutators/vd_attr_node.py
@@ -29,38 +29,44 @@ sock_str._4f = "SvColorSocket"
 sock_str._i = "SvStringsSocket"
 sock_str._b = "SvStringsSocket"
 
+def props(**x):
+    prop = lambda: None
+    prop.name = x['name']
+    prop.kind = x['kind']
+    return prop
+
 maximum_spec_vd_dict = dict(
-    vector_light=dict(name="light direction", kind="3f"),
-    vert_color=dict(name="points rgba", kind="4f"),
-    edge_color=dict(name="edge rgba", kind="4f"),
-    face_color=dict(name="face rgba", kind="4f"),
-    display_verts=dict(name="display verts", kind="b"),
-    display_edges=dict(name="display edges", kind="b"),
-    display_faces=dict(name="display faces", kind="b"),
-    selected_draw_mode=dict(name="shade mode", kind="enum"),
-    draw_gl_wireframe=dict(name="wireframe", kind="b"),
-    draw_gl_polygonoffset=dict(name="fix zfighting", kind="b"),
-    point_size=dict(name="point size", kind="i"),
-    line_width=dict(name="line width", kind="i"),
-    extended_matrix=dict(name="extended matrix", kind="b")
+    vector_light=props(name="light direction", kind="3f"),
+    vert_color=props(name="points rgba", kind="4f"),
+    edge_color=props(name="edge rgba", kind="4f"),
+    face_color=props(name="face rgba", kind="4f"),
+    display_verts=props(name="display verts", kind="b"),
+    display_edges=props(name="display edges", kind="b"),
+    display_faces=props(name="display faces", kind="b"),
+    selected_draw_mode=props(name="shade mode", kind="enum"),
+    draw_gl_wireframe=props(name="wireframe", kind="b"),
+    draw_gl_polygonoffset=props(name="fix zfighting", kind="b"),
+    point_size=props(name="point size", kind="i"),
+    line_width=props(name="line width", kind="i"),
+    extended_matrix=props(name="extended matrix", kind="b")
 )
 
 get_socket_str = lambda socket_type: getattr(sock_str, '_' + socket_type) 
 
 class SvVDMK3Item(bpy.types.PropertyGroup):
-    attr_name = bpy.props.StringProperty() 
-    show_socket = bpy.props.BoolProperty(default=False)
-    use_default = bpy.props.BoolProperty(default=False)
-    default_type = bpy.props.StringProperty()
-    default_3f =  bpy.props.FloatVectorProperty(
+    attr_name: bpy.props.StringProperty() 
+    show_socket: bpy.props.BoolProperty(default=False)
+    use_default: bpy.props.BoolProperty(default=False)
+    default_type: bpy.props.StringProperty()
+    default_3f: bpy.props.FloatVectorProperty(
         name='normal', subtype='DIRECTION', min=0, max=1, size=3,
         default=(0.2, 0.6, 0.4)) #, update=updateNode)
-    default_4f = bpy.props.FloatVectorProperty(
+    default_4f: bpy.props.FloatVectorProperty(
         subtype='COLOR', min=0, max=1, default=(0.5, 1.0, 0.5, 1.0),
         name='color', size=4) #, update=updateNode)
-    default_i = bpy.props.IntProperty(min=0)
-    default_b = bpy.props.BoolProperty(default=False)
-    default_enum = bpy.props.IntProperty(min=0, default=0)
+    default_i: bpy.props.IntProperty(min=0)
+    default_b: bpy.props.BoolProperty(default=False)
+    default_enum: bpy.props.IntProperty(min=0, default=0)
 
 
 class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):
@@ -85,11 +91,11 @@ class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):
             inew(get_socket_str(socket.kind), socket.name).hide = True
   
     def vd_init_uilayout_data(self, context):
-        for key, value in maximum_spec_vd_dict.items()
-            item = self.vd_items_group.new()
+        for key, value in maximum_spec_vd_dict.items():
+            item = self.vd_items_group.add()
             item.attr_name = key
             item.show_socket = False
-            item.default_type = value[1]
+            item.default_type = value.kind
 
 
     def sv_init(self, context):
@@ -108,8 +114,8 @@ class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):
         for item in self.vd_items_group:
             row = box.row()
             row.label(text=item.attr_name)
-            row.prop(item, "show_socket", text="Show Socket")
-            row.prop(item, "use_default", text="Use Default")
+            row.prop(item, "show_socket", text="", icon='TRACKING', toggle=True)
+            row.prop(item, "use_default", text="", icon='SETTINGS', toggle=True)
 
     def process(self):
 

--- a/nodes/list_mutators/vd_attr_node.py
+++ b/nodes/list_mutators/vd_attr_node.py
@@ -60,7 +60,7 @@ class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):
     def process(self):
         ...
 
-        self.outputs['attrs'].sv_set([{'activate': True, 'display_verts': False}])
+        self.outputs['attrs'].sv_set([{'activate': True, 'display_verts': False, 'draw_gl_polygonoffset': True}])
 
 
 classes = [SvVDAttrsNode]

--- a/nodes/list_mutators/vd_attr_node.py
+++ b/nodes/list_mutators/vd_attr_node.py
@@ -43,6 +43,7 @@ items:
     attr_name | show_socket | use_default | default 
                                             (default type, default_property)
 
+https://gist.github.com/zeffii/06e2b5f6ccda02b2854e004afe039f8f
 
 """
 

--- a/nodes/list_mutators/vd_attr_node.py
+++ b/nodes/list_mutators/vd_attr_node.py
@@ -48,10 +48,13 @@ maximum_spec_vd_dict = dict(
 
 get_socket_str = lambda socket_type: getattr(sock_str, '_' + socket_type) 
 
+# def property_change(self, context, socket_name, attr_name):
+#    self.inputs[socket_name].hide = 
+
 class SvVDMK3Item(bpy.types.PropertyGroup):
     attr_name: bpy.props.StringProperty() 
     show_socket: bpy.props.BoolProperty(default=False)
-    use_default: bpy.props.BoolProperty(default=False)
+    use_default: bpy.props.BoolProperty(default=False) #, lambda s, c: property_change(s, c, 'input_mode_one'))
     default_type: bpy.props.StringProperty()
     default_3f: bpy.props.FloatVectorProperty(
         name='normal', subtype='DIRECTION', min=0, max=1, size=3,

--- a/nodes/list_mutators/vd_attr_node.py
+++ b/nodes/list_mutators/vd_attr_node.py
@@ -7,9 +7,9 @@
 
 
 import bpy
-# import mathutils
-# from mathutils import Vector
-# from bpy.props import FloatProperty, BoolProperty
+from bpy.props import (
+    FloatProperty, BoolProperty, StringProperty, 
+    FloatVectorProperty, IntProperty)
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode
 
@@ -53,12 +53,15 @@ class SvVDMK3Item(bpy.types.PropertyGroup):
     show_socket = bpy.props.BoolProperty(default=False)
     use_default = bpy.props.BoolProperty(default=False)
     default_type = bpy.props.StringProperty()
-    # default_3f = ...
-    # default_4f = ...
-    # default_i = ...
-    # default_b = bpy.props.BoolProperty(default=False)
-    # default_enum = bpy.props.IntProperty(min=0, max=) ..?
-
+    default_3f =  bpy.props.FloatVectorProperty(
+        name='vector light', subtype='DIRECTION', min=0, max=1, size=3,
+        default=(0.2, 0.6, 0.4)) #, update=updateNode)
+    default_4f = bpy.props.FloatVectorProperty(
+        subtype='COLOR', min=0, max=1, default=(0.5, 1.0, 0.5, 1.0),
+        name='color', size=4) #, update=updateNode)
+    default_i = bpy.props.IntProperty(min=0)
+    default_b = bpy.props.BoolProperty(default=False)
+    default_enum = bpy.props.IntProperty(min=0, default=0)
 
 
 class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):

--- a/nodes/list_mutators/vd_attr_node.py
+++ b/nodes/list_mutators/vd_attr_node.py
@@ -1,0 +1,51 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+
+import bpy
+# import mathutils
+# from mathutils import Vector
+# from bpy.props import FloatProperty, BoolProperty
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode
+
+class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):
+    ''' a SvVDAttrsNode f '''
+    bl_idname = 'SvVDAttrsNode'
+    bl_label = 'VD Attributes'
+    bl_icon = 'GREASEPENCIL'
+
+    def sv_init(self, context):
+        self.outputs.new("SvStringsSocket", name="attrs dict")
+        inew = self.inputs.new
+        inew("SvVerticesSocket", "light direction (3f)")
+        inew("SvColorSocket", "points rgba (4f)")
+        inew("SvStringsSocket", "edge rgba (4f)")
+        inew("SvStringsSocket", "face rgba (4f)")
+        inew("SvStringsSocket", "display verts (b)")
+        inew("SvStringsSocket", "edges verts (b)")
+        inew("SvStringsSocket", "faces verts (b)")
+        inew("SvStringsSocket", "shade mode (0..2)")
+        inew("SvStringsSocket", "wireframe (b)")
+        inew("SvStringsSocket", "fix zfighting (b)")
+        inew("SvStringsSocket", "point size (i)")
+        inew("SvStringsSocket", "line width (i)")
+        inew("SvStringsSocket", "extended matrix (b)")
+        for input_socket in self.inputs:
+            input_socket.hide = True
+
+    def draw_buttons(self, context, layout):
+        ...
+
+    def process(self):
+        ...
+
+        self.outputs['attrs'].sv_set([{'activate': True, 'display_verts': False}])
+
+
+classes = [SvVDAttrsNode]
+register, unregister = bpy.utils.register_classes_factory(classes)

--- a/nodes/list_mutators/vd_attr_node.py
+++ b/nodes/list_mutators/vd_attr_node.py
@@ -14,12 +14,7 @@ from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode
 
 """
-items:
-    attr_name | show_socket | use_default | default 
-                                            (default type, default_property)
-
 https://gist.github.com/zeffii/06e2b5f6ccda02b2854e004afe039f8f
-
 """
 
 sock_str = lambda: None

--- a/nodes/list_mutators/vd_attr_node.py
+++ b/nodes/list_mutators/vd_attr_node.py
@@ -62,14 +62,23 @@ class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):
     bl_label = 'VD Attributes'
     bl_icon = 'MOD_HUE_SATURATION'
 
-    def sv_init(self, context):
+    def vd_init_sockets(self, context):
         self.outputs.new("SvStringsSocket", name="attrs")
         inew = self.inputs.new
         for prop_name, (socket_name, socket_type) in maximum_spec_vd_dict.items():
             inew(get_socket_str(socket_type), socket_name).hide = True
+  
+    def vd_init_uilayout_data(self, context):
+        ...
+ 
+
+    def sv_init(self, context):
+        self.vd_init_sockets(context)
+        self.vd_init_uilayout_data(context)
 
     def draw_buttons(self, context, layout):
         ...
+        # maybe offer to show here..
 
     def draw_buttons_ext(self, context, layout):
         ...

--- a/nodes/list_mutators/vd_attr_node.py
+++ b/nodes/list_mutators/vd_attr_node.py
@@ -36,7 +36,7 @@ class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):
     bl_icon = 'GREASEPENCIL'
 
     def sv_init(self, context):
-        self.outputs.new("SvStringsSocket", name="attrs dict")
+        self.outputs.new("SvStringsSocket", name="attrs")
         inew = self.inputs.new
         inew("SvVerticesSocket", "light direction (3f)")
         inew("SvColorSocket", "points rgba (4f)")

--- a/nodes/list_mutators/vd_attr_node.py
+++ b/nodes/list_mutators/vd_attr_node.py
@@ -19,8 +19,8 @@ maximum_spec_vd_dict = dict(
     edge_color="edge rgba (4f)",
     face_color="face rgba (4f)",
     display_verts="display verts (b)",
-    display_edges="edges verts (b)",
-    display_faces="faces verts (b)",
+    display_edges="display edges (b)",
+    display_faces="display faces (b)",
     selected_draw_mode="shade mode (enum)",
     draw_gl_wireframe="wireframe (b)",
     draw_gl_polygonoffset="fix zfighting (b)",
@@ -43,8 +43,8 @@ class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):
         inew("SvStringsSocket", "edge rgba (4f)")
         inew("SvStringsSocket", "face rgba (4f)")
         inew("SvStringsSocket", "display verts (b)")
-        inew("SvStringsSocket", "edges verts (b)")
-        inew("SvStringsSocket", "faces verts (b)")
+        inew("SvStringsSocket", "display edges (b)")
+        inew("SvStringsSocket", "display faces (b)")
         inew("SvStringsSocket", "shade mode (enum)")
         inew("SvStringsSocket", "wireframe (b)")
         inew("SvStringsSocket", "fix zfighting (b)")

--- a/nodes/list_mutators/vd_attr_node.py
+++ b/nodes/list_mutators/vd_attr_node.py
@@ -13,31 +13,6 @@ from bpy.props import (
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode
 
-sock_str = lambda: None
-sock_str._enum = "SvStringsSocket"
-sock_str._3f = "SvVerticesSocket"
-sock_str._4f = "SvColorSocket"
-sock_str._i = "SvStringsSocket"
-sock_str._b = "SvStringsSocket"
-
-maximum_spec_vd_dict = dict(
-    vector_light=["light direction", "3f"],
-    vert_color=["points rgba", "4f"],
-    edge_color=["edge rgba", "4f"],
-    face_color=["face rgba", "4f"],
-    display_verts=["display verts", "b"],
-    display_edges=["display edges", "b"],
-    display_faces=["display faces", "b"],
-    selected_draw_mode=["shade mode", "enum"],
-    draw_gl_wireframe=["wireframe", "b"],
-    draw_gl_polygonoffset=["fix zfighting", "b"],
-    point_size=["point size", "i"],
-    line_width=["line width", "i"],
-    extended_matrix=["extended matrix", "b"]
-)
-
-get_socket_str = lambda socket_type: getattr(sock_str, '_' + socket_type) 
-
 """
 items:
     attr_name | show_socket | use_default | default 
@@ -47,6 +22,30 @@ https://gist.github.com/zeffii/06e2b5f6ccda02b2854e004afe039f8f
 
 """
 
+sock_str = lambda: None
+sock_str._enum = "SvStringsSocket"
+sock_str._3f = "SvVerticesSocket"
+sock_str._4f = "SvColorSocket"
+sock_str._i = "SvStringsSocket"
+sock_str._b = "SvStringsSocket"
+
+maximum_spec_vd_dict = dict(
+    vector_light=dict(name="light direction", kind="3f"),
+    vert_color=dict(name="points rgba", kind="4f"),
+    edge_color=dict(name="edge rgba", kind="4f"),
+    face_color=dict(name="face rgba", kind="4f"),
+    display_verts=dict(name="display verts", kind="b"),
+    display_edges=dict(name="display edges", kind="b"),
+    display_faces=dict(name="display faces", kind="b"),
+    selected_draw_mode=dict(name="shade mode", kind="enum"),
+    draw_gl_wireframe=dict(name="wireframe", kind="b"),
+    draw_gl_polygonoffset=dict(name="fix zfighting", kind="b"),
+    point_size=dict(name="point size", kind="i"),
+    line_width=dict(name="line width", kind="i"),
+    extended_matrix=dict(name="extended matrix", kind="b")
+)
+
+get_socket_str = lambda socket_type: getattr(sock_str, '_' + socket_type) 
 
 class SvVDMK3Item(bpy.types.PropertyGroup):
     attr_name = bpy.props.StringProperty() 
@@ -54,7 +53,7 @@ class SvVDMK3Item(bpy.types.PropertyGroup):
     use_default = bpy.props.BoolProperty(default=False)
     default_type = bpy.props.StringProperty()
     default_3f =  bpy.props.FloatVectorProperty(
-        name='vector light', subtype='DIRECTION', min=0, max=1, size=3,
+        name='normal', subtype='DIRECTION', min=0, max=1, size=3,
         default=(0.2, 0.6, 0.4)) #, update=updateNode)
     default_4f = bpy.props.FloatVectorProperty(
         subtype='COLOR', min=0, max=1, default=(0.5, 1.0, 0.5, 1.0),
@@ -82,12 +81,16 @@ class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):
     def vd_init_sockets(self, context):
         self.outputs.new("SvStringsSocket", name="attrs")
         inew = self.inputs.new
-        for prop_name, (socket_name, socket_type) in maximum_spec_vd_dict.items():
-            inew(get_socket_str(socket_type), socket_name).hide = True
+        for prop_name, socket in maximum_spec_vd_dict.items():
+            inew(get_socket_str(socket.kind), socket.name).hide = True
   
     def vd_init_uilayout_data(self, context):
-        ...
- 
+        for key, value in maximum_spec_vd_dict.items()
+            item = vd_items_group.new()
+            item.attr_name = key
+            item.show_socket = False
+            item.default_type = value[1]
+
 
     def sv_init(self, context):
         self.vd_init_sockets(context)

--- a/nodes/list_mutators/vd_attr_node.py
+++ b/nodes/list_mutators/vd_attr_node.py
@@ -86,7 +86,7 @@ class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):
   
     def vd_init_uilayout_data(self, context):
         for key, value in maximum_spec_vd_dict.items()
-            item = vd_items_group.new()
+            item = self.vd_items_group.new()
             item.attr_name = key
             item.show_socket = False
             item.default_type = value[1]
@@ -101,9 +101,15 @@ class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):
         # maybe offer to show here..
 
     def draw_buttons_ext(self, context, layout):
-        ...
-        ...
-        ...
+        self.draw_group(context, layout)
+
+    def draw_group(self, context, layout):
+        box = layout.box()
+        for item in self.vd_items_group:
+            row = box.row()
+            row.label(text=item.attr_name)
+            row.prop(item, "show_socket", text="Show Socket")
+            row.prop(item, "use_default", text="Use Default")
 
     def process(self):
 

--- a/nodes/list_mutators/vd_attr_node.py
+++ b/nodes/list_mutators/vd_attr_node.py
@@ -13,24 +13,43 @@ import bpy
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode
 
+sock_str = lambda: None
+sock_str._enum = "SvStringsSocket"
+sock_str._3f = "SvVerticesSocket"
+sock_str._4f = "SvColorSocket"
+sock_str._i = "SvStringsSocket"
+sock_str._b = "SvStringsSocket"
+
 maximum_spec_vd_dict = dict(
-    vector_light="light direction (3f)",
-    vert_color="points rgba (4f)",
-    edge_color="edge rgba (4f)",
-    face_color="face rgba (4f)",
-    display_verts="display verts (b)",
-    display_edges="display edges (b)",
-    display_faces="display faces (b)",
-    selected_draw_mode="shade mode (enum)",
-    draw_gl_wireframe="wireframe (b)",
-    draw_gl_polygonoffset="fix zfighting (b)",
-    point_size="point size (i)",
-    line_width="line width (i)",
-    extended_matrix="extended matrix (b)"
+    vector_light=["light direction", "3f"],
+    vert_color=["points rgba", "4f"],
+    edge_color=["edge rgba", "4f"],
+    face_color=["face rgba", "4f"],
+    display_verts=["display verts", "b"],
+    display_edges=["display edges", "b"],
+    display_faces=["display faces", "b"],
+    selected_draw_mode=["shade mode", "enum"],
+    draw_gl_wireframe=["wireframe", "b"],
+    draw_gl_polygonoffset=["fix zfighting", "b"],
+    point_size=["point size", "i"],
+    line_width=["line width", "i"],
+    extended_matrix=["extended matrix", "b"]
 )
 
+get_socket_str = lambda socket_type: getattr(sock_str, '_' + socket_type) 
+
+
+
+
 class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):
-    ''' a SvVDAttrsNode f '''
+    """
+    Triggers: vd attr 
+    Tooltip: Attribute Node for Viewer Draw Experimental
+    
+    Allows access to VD Experimental's attributes which control how the
+    node draws faces/edges. It can also switch off the node.
+    """
+
     bl_idname = 'SvVDAttrsNode'
     bl_label = 'VD Attributes'
     bl_icon = 'GREASEPENCIL'
@@ -38,21 +57,8 @@ class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):
     def sv_init(self, context):
         self.outputs.new("SvStringsSocket", name="attrs")
         inew = self.inputs.new
-        inew("SvVerticesSocket", "light direction (3f)")
-        inew("SvColorSocket", "points rgba (4f)")
-        inew("SvStringsSocket", "edge rgba (4f)")
-        inew("SvStringsSocket", "face rgba (4f)")
-        inew("SvStringsSocket", "display verts (b)")
-        inew("SvStringsSocket", "display edges (b)")
-        inew("SvStringsSocket", "display faces (b)")
-        inew("SvStringsSocket", "shade mode (enum)")
-        inew("SvStringsSocket", "wireframe (b)")
-        inew("SvStringsSocket", "fix zfighting (b)")
-        inew("SvStringsSocket", "point size (i)")
-        inew("SvStringsSocket", "line width (i)")
-        inew("SvStringsSocket", "extended matrix (b)")
-        for input_socket in self.inputs:
-            input_socket.hide = True
+        for prop_name, (socket_name, socket_type) in maximum_spec_vd_dict.items():
+            inew(get_socket_str(socket_type), socket_name).hide = True
 
     def draw_buttons(self, context, layout):
         ...

--- a/nodes/list_mutators/vd_attr_node.py
+++ b/nodes/list_mutators/vd_attr_node.py
@@ -58,9 +58,9 @@ class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):
         ...
 
     def process(self):
-        ...
 
-        self.outputs['attrs'].sv_set([{'activate': True, 'display_verts': False, 'draw_gl_polygonoffset': True}])
+        testing_default = {'activate': True, 'display_verts': False, 'draw_gl_polygonoffset': True}
+        self.outputs['attrs'].sv_set([testing_default])
 
 
 classes = [SvVDAttrsNode]

--- a/nodes/list_mutators/vd_attr_node.py
+++ b/nodes/list_mutators/vd_attr_node.py
@@ -48,6 +48,18 @@ https://gist.github.com/zeffii/06e2b5f6ccda02b2854e004afe039f8f
 """
 
 
+class SvVDMK3Item(bpy.types.PropertyGroup):
+    attr_name = bpy.props.StringProperty() 
+    show_socket = bpy.props.BoolProperty(default=False)
+    use_default = bpy.props.BoolProperty(default=False)
+    default_type = bpy.props.StringProperty()
+    # default_3f = ...
+    # default_4f = ...
+    # default_i = ...
+    # default_b = bpy.props.BoolProperty(default=False)
+    # default_enum = bpy.props.IntProperty(min=0, max=) ..?
+
+
 
 class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):
     """
@@ -61,6 +73,8 @@ class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):
     bl_idname = 'SvVDAttrsNode'
     bl_label = 'VD Attributes'
     bl_icon = 'MOD_HUE_SATURATION'
+
+    vd_items_group: bpy.props.CollectionProperty(name="vd attrs", type=SvVDMK3Item)
 
     def vd_init_sockets(self, context):
         self.outputs.new("SvStringsSocket", name="attrs")
@@ -91,5 +105,5 @@ class SvVDAttrsNode(bpy.types.Node, SverchCustomTreeNode):
         self.outputs['attrs'].sv_set([testing_default])
 
 
-classes = [SvVDAttrsNode]
+classes = [SvVDMK3Item, SvVDAttrsNode]
 register, unregister = bpy.utils.register_classes_factory(classes)


### PR DESCRIPTION
gives a dedicated node to ViewerDraw for setting internal properties of that node. using a dict.

- [ ] complete 1-1 ability to control current VD EXp attributes
- [ ] add quicklink span operator to attr-socket (to save us from hoving to locate it)


for now the dict would (if entirely specified by the user) look like:
```python
[
dict(
    vector_light="light direction (3f)",
    vert_color="points rgba (4f)",
    edge_color="edge rgba (4f)",
    face_color="face rgba (4f)",
    display_verts="display verts (b)",
    display_edges="display edges (b)",
    display_faces="display faces (b)",
    selected_draw_mode="shade mode (enum)",
    draw_gl_wireframe="wireframe (b)",
    draw_gl_polygonoffset="fix zfighting (b)",
    point_size="point size (i)",
    line_width="line width (i)",
    extended_matrix="extended matrix (b)"
)

]
```