### PR TITLE
Implement node search under the T panel.

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -251,6 +251,10 @@ class SverchSeparator(object):
         return True
 
 class SvOperatorLayout(object):
+    """
+    Abstract layout class for operator buttons.
+    Wraps standard Blender's UILayout.
+    """
     def __init__(self, parent):
         self.parent = parent
         self._prev_is_separator = False
@@ -271,6 +275,11 @@ class SvOperatorLayout(object):
             return SvNamedButtonsLayout(parent)
     
 class SvIconsLayout(SvOperatorLayout):
+    """
+    Layout class that shows operator buttons
+    with icons only (or with text if the operator does not have icon),
+    in the specified number of columns.
+    """
     def __init__(self, parent, columns=4):
         super().__init__(parent)
         self.columns = columns
@@ -305,6 +314,10 @@ class SvIconsLayout(SvOperatorLayout):
             return self.parent.operator(operator_name, **params)
 
 class SvNamedButtonsLayout(SvOperatorLayout):
+    """
+    Layout class that shows operator buttons in a standard way
+    (icon and text).
+    """
     def operator(self, operator_name, **params):
         self._prev_is_separator = False
         return self.parent.operator(operator_name, **params)
@@ -471,6 +484,8 @@ def register_node_panels(identifier, cat_list):
                     col = SvOperatorLayout.get(prefs.node_panels_icons_only, layout.column(align=True), prefs.node_panels_columns)
 
                     needle = context.scene.sv_node_search
+                    # We will search either by category selected in the popup menu,
+                    # or by search term.
                     check_search = needle != ""
                     check_category = not check_search
                     category_is_first = True
@@ -491,9 +506,13 @@ def register_node_panels(identifier, cat_list):
                                     continue
                             if not isinstance(item, SverchSeparator):
                                 has_nodes = True
+                            # Do not show separators if we are searching by text -
+                            # otherwise search results would take too much vertical space.
                             if not (check_search and isinstance(item, SverchSeparator)):
                                 items_to_draw.append(item)
 
+                        # Show category only if it has some nodes to display
+                        # according to search terms.
                         if has_nodes:
                             if check_search:
                                 if not category_is_first:

--- a/menu.py
+++ b/menu.py
@@ -28,6 +28,7 @@ import bl_operators
 
 import sverchok
 from sverchok.utils import get_node_class_reference
+from sverchok.utils.logging import info
 from sverchok.utils.sv_help import build_help_remap
 from sverchok.ui.sv_icons import node_icon, icon
 from sverchok.utils.context_managers import sv_preferences
@@ -36,7 +37,6 @@ class SverchNodeCategory(NodeCategory):
     @classmethod
     def poll(cls, context):
         return context.space_data.tree_type == 'SverchCustomTreeType'
-
 
 def make_node_cats():
     '''
@@ -72,7 +72,6 @@ def make_node_cats():
     
     return node_cats
 
-
 def juggle_and_join(node_cats):
     '''
     this step post processes the extended catagorization used
@@ -104,6 +103,18 @@ def juggle_and_join(node_cats):
     node_cats["Generator"].extend(gen_ext)
 
     return node_cats
+
+class SvResetNodeSearchOperator(bpy.types.Operator):
+    """
+    Reset node search string and return to selection of node by category
+    """
+    bl_idname = "node.sv_reset_node_search"
+    bl_label = "Reset search"
+    bl_options = {'REGISTER', 'INTERNAL'}
+
+    def execute(self, context):
+        context.scene.sv_node_search = ""
+        return {'FINISHED'}
 
 # We are creating and registering node adding operators dynamically.
 # So, we have to remember them in order to unregister them when needed.
@@ -146,6 +157,31 @@ class SverchNodeItem(object):
 
     def get_node_class(self):
         return get_node_class_reference(self.nodetype)
+
+    def get_node_strings(self):
+        node_class = self.get_node_class()
+        if hasattr(node_class, 'get_shorthand'):
+            shorthand = node_class.get_shorthand()
+        else: 
+            shorthand = ""
+
+        if hasattr(node_class, 'get_tooltip'):
+            tooltip = node_class.get_tooltip()
+        else:
+            tooltip = ""
+
+        if hasattr(node_class, "label"):
+            label = item.label
+        else:
+            label = ""
+
+        return label, shorthand, tooltip
+
+    def search_match(self, needle):
+        needle = needle.upper()
+        label, shorthand, tooltip = self.get_node_strings()
+        #info("shorthand: %s, tooltip: %s, label: %s, needle: %s", shorthand, tooltip, label, needle)
+        return (needle in label.upper()) or (needle in shorthand.upper()) or (needle in tooltip.upper())
 
     def get_idname(self):
         return get_node_idname_for_operator(self.nodetype)
@@ -211,38 +247,67 @@ class SverchSeparator(object):
     def poll(cls, context):
         return context.space_data.tree_type == 'SverchCustomTreeType'
 
-class SvPackedLayout(object):
-    def __init__(self, parent, columns=4):
+    def search_match(self, needle):
+        return True
+
+class SvOperatorLayout(object):
+    def __init__(self, parent):
         self.parent = parent
-        self.columns = columns
-        self._column = 0
-        self._row = None
+        self._prev_is_separator = False
+
+    def label(self, text):
+        self.parent.label(text=text)
+
+    def separator(self):
+        if not self._prev_is_separator:
+            self.parent.separator()
+        self._prev_is_separator = True
 
     @staticmethod
     def get(icons_only, parent, columns):
         if icons_only:
-            return SvPackedLayout(parent, columns)
+            return SvIconsLayout(parent, columns)
         else:
-            return parent
+            return SvNamedButtonsLayout(parent)
+    
+class SvIconsLayout(SvOperatorLayout):
+    def __init__(self, parent, columns=4):
+        super().__init__(parent)
+        self.columns = columns
+        self._column = 0
+        self._row = None
+
+    def _tick_column(self):
+        self._column = (self._column + 1) % self.columns
+        if self._column == 0:
+            self._row = None
 
     def separator(self):
-        self.parent.separator()
+        if not self._prev_is_separator:
+            self._row = None
+            self._column = 0
+            self.parent.separator()
+        self._prev_is_separator = True
 
     def operator(self, operator_name, **params):
+        self._prev_is_separator = False
         if 'icon_value' in params or 'icon' in params:
             if self._row is None:
                 self._row = self.parent.row(align=True)
                 self._row.scale_x = self._row.scale_y = 1.5
             params['text'] = ""
             op = self._row.operator(operator_name, **params)
-            self._column = (self._column + 1) % self.columns
-            if self._column == 0:
-                self._row = None
+            self._tick_column()
             return op
         else:
             self._row = None
             self._column = 0
             return self.parent.operator(operator_name, **params)
+
+class SvNamedButtonsLayout(SvOperatorLayout):
+    def operator(self, operator_name, **params):
+        self._prev_is_separator = False
+        return self.parent.operator(operator_name, **params)
 
 def get_node_idname_for_operator(nodetype):
     """Select valid bl_idname for node to create node adding operator bl_idname."""
@@ -365,7 +430,7 @@ def register_node_panels(identifier, cat_list):
 
             def draw_node_item(self, context):
                 layout = self.layout
-                col = SvPackedLayout.get(prefs.node_panels_icons_only, layout.column(align=True), prefs.node_panels_columns)
+                col = SvOperatorLayout.get(prefs.node_panels_icons_only, layout.column(align=True), prefs.node_panels_columns)
                 for item in self.category.items(context):
                     item.draw(item, col, context)
 
@@ -397,14 +462,47 @@ def register_node_panels(identifier, cat_list):
 
                 def draw(self, context):
                     layout = self.layout
-                    layout.prop(context.scene, "sv_selected_category", text="")
-                    col = SvPackedLayout.get(prefs.node_panels_icons_only, layout.column(align=True), prefs.node_panels_columns)
+                    row = layout.row(align=True)
+                    row.prop(context.scene, "sv_node_search", text="")
+                    row.operator("node.sv_reset_node_search", icon="X", text="")
+                    if not context.scene.sv_node_search:
+                        layout.prop(context.scene, "sv_selected_category", text="")
+
+                    col = SvOperatorLayout.get(prefs.node_panels_icons_only, layout.column(align=True), prefs.node_panels_columns)
+
+                    needle = context.scene.sv_node_search
+                    check_search = needle != ""
+                    check_category = not check_search
+                    category_is_first = True
 
                     for category in cat_list:
-                        if category.identifier != context.scene.sv_selected_category:
-                            continue
+                        category_ok = category.identifier == context.scene.sv_selected_category
+                        if check_category:
+                            if not category_ok:
+                                continue
+
+                        items_to_draw = []
+                        has_nodes = False
                         for item in category.items(context):
-                            item.draw(item, col, context)
+                            if check_search:
+                                if not hasattr(item, 'search_match'):
+                                    continue
+                                if not item.search_match(needle):
+                                    continue
+                            if isinstance(item, SverchNodeItem):
+                                has_nodes = True
+                            if not (check_search and isinstance(item, SverchSeparator)):
+                                items_to_draw.append(item)
+
+                        if has_nodes:
+                            if check_search:
+                                if not category_is_first:
+                                    col.separator()
+                                col.label(category.name + ":")
+                            for item in items_to_draw:
+                                item.draw(item, col, context)
+
+                        category_is_first = False
 
             node_panels.append(SV_PT_NodesTPanel)
             bpy.utils.register_class(SV_PT_NodesTPanel)
@@ -447,8 +545,15 @@ def register():
     categories = [(category.identifier, category.name, category.name, i) for i, category in enumerate(menu)]
     bpy.types.Scene.sv_selected_category = bpy.props.EnumProperty(
                         name = "Category",
+                        description = "Select nodes category",
                         items = categories
                     )
+    bpy.types.Scene.sv_node_search = bpy.props.StringProperty(
+                        name = "Search",
+                        description = "Enter search term and press Enter to search; clear the field to return to selection of node category."
+                    )
+
+    bpy.utils.register_class(SvResetNodeSearchOperator)
 
     register_node_panels("SVERCHOK", menu)
 
@@ -461,5 +566,7 @@ def unregister():
         unregister_node_panels()
         nodeitems_utils.unregister_node_categories("SVERCHOK")
     unregister_node_add_operators()
+    bpy.utils.unregister_class(SvResetNodeSearchOperator)
     del bpy.types.Scene.sv_selected_category
+    del bpy.types.Scene.sv_node_search
 

--- a/menu.py
+++ b/menu.py
@@ -170,8 +170,8 @@ class SverchNodeItem(object):
         else:
             tooltip = ""
 
-        if hasattr(node_class, "label"):
-            label = item.label
+        if hasattr(node_class, "bl_label"):
+            label = node_class.bl_label
         else:
             label = ""
 
@@ -489,7 +489,7 @@ def register_node_panels(identifier, cat_list):
                                     continue
                                 if not item.search_match(needle):
                                     continue
-                            if isinstance(item, SverchNodeItem):
+                            if not isinstance(item, SverchSeparator):
                                 has_nodes = True
                             if not (check_search and isinstance(item, SverchSeparator)):
                                 items_to_draw.append(item)


### PR DESCRIPTION
This adds a searchbox into T panel (shown only if the panel with nodes is displayed in the T panel). 
To search something, you have to enter the search term and press enter.
When you are searching by text, category selection popup disappears and instead search results appears, separated by node category.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [ ] Code changes complete.
- [ ] Code documentation complete.
- [ ] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [ ] Ready for merge.

