### PR TITLE
UI for GitHub gist creation API token.

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -8,8 +8,8 @@ from sverchok import data_structure
 from sverchok.core import handlers
 from sverchok.core import update_system
 from sverchok.utils import sv_panels_tools, logging
+from sverchok.utils.sv_gist_tools import TOKEN_HELP_URL
 from sverchok.ui import color_def
-
 
 def get_params(settings_and_fallbacks):
     """
@@ -236,6 +236,10 @@ class SverchokPreferences(AddonPreferences):
     external_editor: StringProperty(description='which external app to invoke to view sources')
     real_sverchok_path: StringProperty(description='use with symlinked to get correct src->dst')
 
+    github_token : StringProperty(name = "GitHub API Token",
+                    description = "GitHub API access token. Should have 'gist' OAuth scope.",
+                    subtype="PASSWORD")
+
     # Logging settings
 
     def update_log_level(self, context):
@@ -302,6 +306,13 @@ class SverchokPreferences(AddonPreferences):
             col1.prop(self, "enable_live_objin", text='Enable Live Object-In')
             col1.prop(self, "external_editor", text="Ext Editor")
             col1.prop(self, "real_sverchok_path", text="Src Directory")
+
+            box = col1.box()
+            box.label(text="Export to Gist")
+            box.prop(self, "github_token")
+            box.label(text="To export node trees to gists, you have to create a GitHub API access token.")
+            box.label(text="For more information, visit " + TOKEN_HELP_URL)
+            box.operator("node.sv_github_api_token_help", text="Visit documentation page")
 
             col2 = col_split.split().column()
             col2.label(text="Frame change handler:")

--- a/ui/sv_IO_panel.py
+++ b/ui/sv_IO_panel.py
@@ -21,7 +21,6 @@ import bpy
 from sverchok.node_tree import SverchCustomTree
 from sverchok.node_tree import SverchCustomTreeNode
 
-from sverchok.utils.sv_git_connection import login_found
 from sverchok.utils.sv_IO_panel_tools import (
     _EXPORTER_REVISION_,
     get_file_obj_from_zip,
@@ -72,10 +71,9 @@ class SV_PT_IOLayoutsMenu(bpy.types.Panel):
             imp.id_tree = ntree.name
             imp.compress = io_props.compress_output
 
-            if login_found:
-                row1b = col.row(align=True)
-                exp = row1b.operator('node.tree_export_to_gist', text='Export to gist', icon='URL')
-                exp.selected_only = io_props.export_selected_only
+            row1b = col.row(align=True)
+            exp = row1b.operator('node.tree_export_to_gist', text='Export to gist', icon='URL')
+            exp.selected_only = io_props.export_selected_only
 
             ziprow = col.row(align=True)
             ziprow.label(text='Archive .blend as')

--- a/utils/sv_IO_panel_operators.py
+++ b/utils/sv_IO_panel_operators.py
@@ -21,7 +21,7 @@ from sverchok.utils.sv_IO_panel_tools import (
     load_json_from_gist,
     import_tree,
     write_json)
-
+from sverchok.utils.sv_gist_tools import show_token_help, TOKEN_HELP_URL
 from sverchok.utils.logging import debug, info, warning, error, exception
 
 
@@ -229,15 +229,21 @@ class SvNodeTreeExportToGist(bpy.types.Operator):
 
         try:
             gist_url = sv_gist_tools.main_upload_function(gist_filename, gist_description, gist_body, show_browser=False)
+            if not gist_url:
+                self.report({'ERROR'}, "You have not specified GitHub API access token, which is " +
+                                "required to create gists from Sverchok. Please see " +
+                                TOKEN_HELP_URL +
+                                " for more information.")
+                return {'CANCELLED'}
             
             context.window_manager.clipboard = gist_url   # full destination url
             info(gist_url)
-            self.report({'WARNING'}, "Copied gistURL to clipboad")
+            self.report({'WARNING'}, "Copied gist URL to clipboad")
 
             sv_gist_tools.write_or_append_datafiles(gist_url, gist_filename)
             return {'FINISHED'}
         except Exception as err:
-            info(err)
+            exception(err)
             self.report({'ERROR'}, "Error 222: net connection or github login failed!")
 
         return {'CANCELLED'}
@@ -297,6 +303,17 @@ class SvBlendToArchive(bpy.types.Operator):
 
         return {'CANCELLED'}
 
+class SvOpenTokenHelpOperator(bpy.types.Operator):
+    """Open a wiki page with information about GitHub API tokens creation
+    in the browser"""
+    
+    bl_idname = "node.sv_github_api_token_help"
+    bl_label = "GitHub API token help"
+    bl_options = {'REGISTER', 'INTERNAL'}
+
+    def execute(self, context):
+        show_token_help()
+        return {'FINISHED'}
 
 classes = [
     SvNodeTreeExporter,
@@ -304,7 +321,8 @@ classes = [
     SvNodeTreeImporter,
     SvNodeTreeImporterSilent,
     SvNodeTreeImportFromGist,
-    SvBlendToArchive
+    SvBlendToArchive,
+    SvOpenTokenHelpOperator
 ]
 
 

--- a/utils/sv_IO_panel_tools.py
+++ b/utils/sv_IO_panel_tools.py
@@ -23,7 +23,6 @@ import zipfile
 import json
 import re
 import urllib
-from urllib.request import urlopen
 from itertools import chain
 
 import bpy
@@ -32,6 +31,7 @@ from sverchok import old_nodes
 from sverchok.utils.sv_node_utils import recursive_framed_location_finder
 from sverchok.utils.sv_IO_monad_helpers import pack_monad, unpack_monad
 from sverchok.utils.logging import debug, info, warning, error, exception
+from sverchok.utils.sv_requests import urlopen
 
 # pylint: disable=w0621
 

--- a/utils/sv_gist_tools.py
+++ b/utils/sv_gist_tools.py
@@ -20,30 +20,19 @@ import os
 import json
 import base64
 from time import gmtime, strftime
-from urllib.request import urlopen, Request
+from urllib.request import Request
+import webbrowser
 
 import bpy
+from sverchok.utils.logging import info, debug, error
+from sverchok.utils.context_managers import sv_preferences
+from sverchok.utils.sv_requests import urlopen
 
 API_URL = 'https://api.github.com/gists'
+TOKEN_HELP_URL = "https://github.com/nortikin/sverchok/wiki/Set-up-GitHub-account-for-exporting-node-trees-from-Sverchok"
 
-
-def get_git_login_hash():
-    
-    # arp = '%s:%s' % (user, pw)
-    # base64.b64encode(arp.encode())
-    # format_login(git.username, git.password).decode('utf-8')
-    try:
-        dirpath = os.path.join(bpy.utils.user_resource('DATAFILES', path='sverchok'))
-        fullpath = os.path.join(dirpath, "sv_fx.wad")
-        with open(fullpath) as fx:
-            return ''.join(fx).strip()
-    except Exception as err:
-        # print(err)
-        print('If you want to upload gists from the Sverchok UI, you need to make an "sv_fx.wad" file.')
-        print('See for instructions: https://github.com/nortikin/sverchok/pull/2197#issuecomment-419891718')
-    
-    return 
-
+def show_token_help():
+    webbrowser.open(TOKEN_HELP_URL)
 
 def main_upload_function(gist_filename, gist_description, gist_body, show_browser=False):
 
@@ -69,19 +58,22 @@ def main_upload_function(gist_filename, gist_description, gist_body, show_browse
 
     def upload_gist():
 
-        git_hash = get_git_login_hash()
-        if not git_hash:
-            return
+        with sv_preferences() as prefs:
+            token = prefs.github_token
+            if not token:
+                info("GitHub API access token is not specified")
+                show_token_help()
+                return
 
-        print('sending')
-        headers = {"Authorization": "Basic " + git_hash}
-    
-        req = Request(API_URL, data=json_post_data, headers=headers)
-        json_to_parse = urlopen(req, data=json_post_data)
+            info("Uploading: %s", gist_filename)
+            headers = {"Authorization": "token " + token}
         
-        print('received response from server')
-        found_json = json_to_parse.read().decode()
-        return get_gist_url(found_json)
+            req = Request(API_URL, data=json_post_data, headers=headers)
+            json_to_parse = urlopen(req, data=json_post_data)
+            
+            info('Received response from server')
+            found_json = json_to_parse.read().decode()
+            return get_gist_url(found_json)
 
     return upload_gist()
 

--- a/utils/sv_git_connection.py
+++ b/utils/sv_git_connection.py
@@ -5,11 +5,11 @@
 # SPDX-License-Identifier: GPL3
 # License-Filename: LICENSE
 
-from sverchok.utils.sv_gist_tools import get_git_login_hash
+from sverchok.utils.context_managers import sv_preferences
 
 login_found = False
 
-if get_git_login_hash():
-    login_found = True
+with sv_preferences() as prefs:
+    login_found = bool(prefs.github_token)
 
 

--- a/utils/sv_requests.py
+++ b/utils/sv_requests.py
@@ -6,18 +6,34 @@
 # License-Filename: LICENSE
 
 
+import os
+import ssl
 import json
 import urllib.request as rq
 
+# version of urllib.request.urlopen()
+# which handles certificate issues properly
+def urlopen(url, **kwargs):
+
+    def certifi_open(url, **kwargs):
+        try:
+            import certifi
+            ssl_context = ssl.create_default_context(cafile = os.path.relpath(certifi.where()))
+            return rq.urlopen(url, context=ssl_context, **kwargs)
+        except ImportException:
+            return rq.urlopen(url, **kwargs)
+
+    if os.name == 'posix':
+        return certifi_open(url, **kwargs)
+    else:
+        return rq.urlopen(url, **kwargs)
 
 # we dont use requests for anything significant other than getting 
 # a json, this is a dummy module with one feature implemented (.get )
-
-
 def get(url):
 
     def get_json():
-        json_to_parse = rq.urlopen(url)
+        json_to_parse = urlopen(url)
         found_json = json_to_parse.read().decode()
         wfile = json.JSONDecoder()
         return wfile.decode(found_json)        


### PR DESCRIPTION
## Addressed problem description

This addresses a long-standing issue of Sverchok not being able to export node trees to gist.github.com without manual and tricky creation of some file, which contained your unprotected github password.
The issue was also discussed in #2197.

## Solution description

* Add an instruction for users at https://github.com/nortikin/sverchok/wiki/Set-up-GitHub-account-for-exporting-node-trees-from-Sverchok about how to create a "github access token"
* Add a setting into preferences to store that access token
* Use that token for authentication when creating gists
* Remove old "wad" file support - b28 branch is a point to drop this kind of compatibility
* Show "export to gist" button always; but if user has no github access token configured, display a message and open documentation page in the browser.

Known issue: when trying to open documentation page, a python error may appear. This bug is fixed in Python 3.7.1. 
https://bugs.python.org/issue31014
On my system, the error appears when I press the button first time; but if I press it second time, there is no error.

This PR also takes care of "CERTIFICATE_VERIFY_FAILED" error, which may appear in some blender builds when trying to access HTTPS URL. As far as I understand, the problem is that on some platforms Blender's built-in python does not use system's trusted certificates storage, so we have to use python's own storage, which is accessible via `certifi` package.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [ ] Ready for merge.

