### PR TITLE
Build docs with travis (b28)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ branches:
     - master
     - b28_prelease_master
 
-addons:
-  apt:
-    packages:
-      - python3-sphinx
-
 install:
   - |
     #set -x
@@ -60,6 +55,7 @@ script:
   - bash ./run_tests.sh
 
 before_deploy:
+  - sudo apt-get install python-sphinx3
   - bash ./build_docs.sh
 
 deploy:
@@ -71,7 +67,7 @@ deploy:
   draft: true
   on:
     condition: $DOCS_UPDATED = Y
-    branch: b28_prelease_master
+    branch: master
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_deploy:
   - bash ./build_docs.sh
 
 deploy:
-  provider: pages
+  provider: releases
   skip_cleanup: true
   api_key: $GITHUB_TOKEN
   github_token: $GITHUB_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ script:
   - bash ./run_tests.sh
 
 before_deploy:
-  - sudo apt-get update && sudo apt-get install -y python-sphinx3
+  - sudo apt-get update && sudo apt-get install -y python3-sphinx
   - bash ./build_docs.sh
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,16 @@ env:
 
 # Actually run all tests.
 script:
+  - |
+    CHANGES=$(git log --stat $TRAVIS_COMMIT_RANGE docs .travis.yml build_docs.sh | wc -l)
+    if [ $CHANGES -gt 0 ]
+    then DOCS_UPDATED=Y
+    else DOCS_UPDATED=N
+    fi
+    export DOCS_UPDATED
   - bash ./run_tests.sh
+
+before_deploy:
   - bash ./build_docs.sh
 
 deploy:
@@ -58,10 +67,10 @@ deploy:
   skip_cleanup: true
   api_key: $GITHUB_TOKEN
   keep_history: true
-  file: docs/_build/html.tar.bz2
+  file: docs/_build/sverchok_documentation.tar.bz2
   draft: true
   on:
-    tags: true
+    condition: $DOCS_UPDATED = Y
     branch: b28_prelease_master
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,18 @@ env:
 # Actually run all tests.
 script:
   - bash ./run_tests.sh
+  - bash ./build_docs.sh
+
+deploy:
+  provider: pages
+  skip_cleanup: true
+  api_key: $GITHUB_TOKEN
+  keep_history: true
+  file: docs/_build/html.tar.bz2
+  draft: true
+  on:
+    tags: true
+    branch: b28_prelease_master
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ script:
   - bash ./run_tests.sh
 
 before_deploy:
-  - sudo apt-get install python-sphinx3
+  - sudo apt-get update && sudo apt-get install -y python-sphinx3
   - bash ./build_docs.sh
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ branches:
     - master
     - b28_prelease_master
 
+addons:
+  apt:
+    packages:
+      - python3-sphinx
+
 install:
   - |
     #set -x

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ deploy:
   provider: pages
   skip_cleanup: true
   api_key: $GITHUB_TOKEN
+  github_token: $GITHUB_TOKEN
   keep_history: true
   file: docs/_build/sverchok_documentation.tar.bz2
   draft: true

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+cd docs/
+make html
+
+tar -C _build/html --exclude=_sources -cjf _build/html.tar.bz2 .
+

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -5,5 +5,5 @@ set -e
 cd docs/
 make html
 
-tar -C _build/html --exclude=_sources -cjf _build/html.tar.bz2 .
+tar -C _build/html --exclude=_sources -cjf _build/sverchok_documentation.tar.bz2 .
 


### PR DESCRIPTION
Build documentation upon repository update and publish it in github releases.

This will make Travis CI automatically build HTML documentation and publish it as a github release. This will be done only if:
* This commit is a push towards the master branch
* AND there were changes in the `docs/` directory, or in `.travis.yml`, or in `build_docs.sh` files.

Automatically created releases are marked as draft, so they are not public by default - we can remove them, or rename, or whatever, before publishing.

We may want to update this condition, for example, to make it deploy only if commit message contains "MAKE_RELEASE" string. Or take option which travis suggests: make release only if the commit has any tag.

NB: Travis can not automatically deploy to releases from pull-request branches.

I've set up similar thing for master branch, so here we go, first automatic release with documentation (it is marked as draft, so it is not public yet): https://github.com/nortikin/sverchok/releases/tag/untagged-88b88e6e7be0a07b4cb2

@zeffii  FYI.
