### PR TITLE
add example of onboard help

### DIFF
--- a/nodes/viz/vd_draw_experimental.py
+++ b/nodes/viz/vd_draw_experimental.py
@@ -348,13 +348,8 @@ class SvVDExperimental(bpy.types.Node, SverchCustomTreeNode):
     @property
     def help(self):
         if bpy.context.area.type == 'CONSOLE':
-            from console_python import add_scrollback #, get_console
+            from console_python import add_scrollback
             history_append = bpy.ops.console.history_append
-            
-            # get line in console, add to history to show it as 'handled'
-            # m = bpy.context.space_data.history[-1].body
-            # m = m.strip()            
-            # history_append(text=m, remove_duplicates=True)
 
             # print the lines to the console
             add_scrollback(self.console_help, 'INFO')

--- a/nodes/viz/vd_draw_experimental.py
+++ b/nodes/viz/vd_draw_experimental.py
@@ -315,15 +315,21 @@ class SvVDExperimental(bpy.types.Node, SverchCustomTreeNode):
     sv_icon = 'SV_DRAW_VIEWER'
 
     node_dict = {}
+    console_help = vd_exp_help
 
     @property
     def help(self):
         if bpy.context.area.type == 'CONSOLE':
-            from console_python import add_scrollback, get_console
-            # history_append = bpy.ops.console.history_append
-
+            from console_python import add_scrollback #, get_console
+            history_append = bpy.ops.console.history_append
+            
+            # get line in console, add to history to show it as 'handled'
+            # m = bpy.context.space_data.history[-1].body
+            # m = m.strip()            
             # history_append(text=m, remove_duplicates=True)
-            add_scrollback(vd_exp_help, 'INFO')
+
+            # print the lines to the console
+            add_scrollback(self.console_help, 'INFO')
             return
         
         # fallback behaviour

--- a/nodes/viz/vd_draw_experimental.py
+++ b/nodes/viz/vd_draw_experimental.py
@@ -300,6 +300,13 @@ This seems like a good idea, but i'm not sure anymore.
 
 """
 
+def custom_add_scrollback(area, text, type):
+    # https://blender.stackexchange.com/questions/6101/
+    override = bpy.context.copy()
+    override['area'] = area
+    for line in text.split('\n'):
+        bpy.ops.console.scrollback_append(override, text=line, type='INFO')
+
 
 class SvVDExperimental(bpy.types.Node, SverchCustomTreeNode):
     """
@@ -316,6 +323,27 @@ class SvVDExperimental(bpy.types.Node, SverchCustomTreeNode):
 
     node_dict = {}
     console_help = vd_exp_help
+
+
+    
+    def find_console_to_print_to(self, context):
+        
+        # break on first found console, could test for size and display on largest console.
+        AREA = 'CONSOLE'
+        for window in bpy.context.window_manager.windows:
+            for area in window.screen.areas:
+                if not area.type == AREA: continue
+
+                for s in area.spaces:
+                    if s.type == AREA:
+                        custom_add_scrollback(area, self.console_help, type='INFO')
+                        break
+
+    # i am just using this as a proto operator
+    selected_help: bpy.props.EnumProperty(
+        items=enum_item_5(["help"], ["QUESTION"]),
+        description="offers....", default="help", update=find_console_to_print_to
+    )
 
     @property
     def help(self):
@@ -475,6 +503,7 @@ class SvVDExperimental(bpy.types.Node, SverchCustomTreeNode):
 
     def rclick_menu(self, context, layout):
         self.draw_additional_props(context, layout)
+        layout.prop(self, 'selected_help', icon='QUESTION', expand=True)
 
     def draw_additional_props(self, context, layout):
         layout.prop(self, 'vector_light', text='')

--- a/nodes/viz/vd_draw_experimental.py
+++ b/nodes/viz/vd_draw_experimental.py
@@ -265,6 +265,40 @@ def get_shader_data(named_shader=None):
     names = ['vertex_shader', 'fragment_shader', 'draw_fragment']
     return [local_vars.get(name) for name in names]
 
+vd_exp_help = """\
+## VD Experimental
+
+This is the defacto visualizer of Sverchok, it is reasonably well tested on various machines, and
+appears to be reliable. It is called Experimental because we are not professional graphics programmers,
+and wish to recognize our ignorance.
+
+# How to get at node options?
+
+This node has a right click menu with options. Most options are listed there and in the N panel 
+menu node/properties.
+
+# features:
+
+- draw to 3d view / multiple 3d views
+- Draw Points
+- Draw Edges  (optional: > Dashed Lines, > offset from faces)
+- Draw Faces
+- Draw any combination of Points/Edges/Faces
+- Draw Edges if they can be inferred from Faces
+- Draw Matrices
+- Manipulate and duplicate Drawing Geometry using the input Matrices
+- Define colors of Points, Edges, Faces
+- Set Face color to Flat, Facet and Smooth shading
+- In Facet and Smooth shading mode the Light Vector attribute can be used to adjust the direction of light
+- Use a user defined fragment shader (loaded from bpy.data.texts )
+- Pass these properties via the Attributes socket
+
+# Attributes socket
+
+This seems like a good idea, but i'm not sure anymore.
+
+
+"""
 
 
 class SvVDExperimental(bpy.types.Node, SverchCustomTreeNode):
@@ -281,6 +315,19 @@ class SvVDExperimental(bpy.types.Node, SverchCustomTreeNode):
     sv_icon = 'SV_DRAW_VIEWER'
 
     node_dict = {}
+
+    @property
+    def help(self):
+        if bpy.context.area.type == 'CONSOLE':
+            from console_python import add_scrollback, get_console
+            # history_append = bpy.ops.console.history_append
+
+            # history_append(text=m, remove_duplicates=True)
+            add_scrollback(vd_exp_help, 'INFO')
+            return
+        
+        # fallback behaviour
+        return vd_exp_help
 
     def populate_node_with_custom_shader_from_text(self):
         if self.custom_shader_location in bpy.data.texts:


### PR DESCRIPTION
adds console context awareness to node.help invocation

![image](https://user-images.githubusercontent.com/619340/67142134-ac6cb400-f263-11e9-8803-dc1fabd25863.png)

something like this is possible, the exact visual representation and whether `n.help` should be added to the history before displaying items is for later implementation