### PR TITLE
B28 update throttle3

### DIFF
--- a/node_tree.py
+++ b/node_tree.py
@@ -84,6 +84,19 @@ class SvLinkNewNodeInput(bpy.types.Operator):
 
 @contextmanager
 def throttle_tree_update(node):
+    """ usage
+    from sverchok.node_tree import throttle_tree_update
+
+    inside your node, f.ex inside a wrapped_update that creates a socket
+
+    def wrapped_update(self, context):
+        with throttle_tree_update(self):
+            self.inputs.new(...)
+            self.outputs.new(...)
+
+    that's it. 
+
+    """
     node.id_data.skip_tree_update = True
     yield node
     node.id_data.skip_tree_update = False

--- a/node_tree.py
+++ b/node_tree.py
@@ -83,10 +83,10 @@ class SvLinkNewNodeInput(bpy.types.Operator):
 
 
 @contextmanager
-def throttle_tree_update(self):
-    self.id_data.skip_tree_update = True
-    yield self
-    self.id_data.skip_tree_update = False
+def throttle_tree_update(node):
+    node.id_data.skip_tree_update = True
+    yield node
+    node.id_data.skip_tree_update = False
 
 
 class SvNodeTreeCommon(object):

--- a/node_tree.py
+++ b/node_tree.py
@@ -84,9 +84,9 @@ class SvLinkNewNodeInput(bpy.types.Operator):
 
 @contextmanager
 def throttle_tree_update(self):
-    self.id_data.throttle_tree_update = True
+    self.id_data.skip_tree_update = True
     yield self
-    self.id_data.throttle_tree_update = False
+    self.id_data.skip_tree_update = False
 
 
 class SvNodeTreeCommon(object):
@@ -96,7 +96,7 @@ class SvNodeTreeCommon(object):
 
     has_changed: BoolProperty(default=False)
     limited_init: BoolProperty(default=False)
-    throttle_tree_update: BoolProperty(default=False)
+    skip_tree_update: BoolProperty(default=False)
 
 
     def build_update_list(self):
@@ -194,7 +194,7 @@ class SverchCustomTree(NodeTree, SvNodeTreeCommon):
         Tags tree for update for handle
         get update list for debug info, tuple (fulllist, dictofpartiallists)
         '''
-        if self.throttle_tree_update:
+        if self.skip_tree_update:
             print('throttled update from context manager')
             return
 

--- a/node_tree.py
+++ b/node_tree.py
@@ -97,9 +97,11 @@ def throttle_tree_update(node):
     that's it. 
 
     """
-    node.id_data.skip_tree_update = True
-    yield node
-    node.id_data.skip_tree_update = False
+    try:
+        node.id_data.skip_tree_update = True
+        yield node
+    finally:
+        node.id_data.skip_tree_update = False
 
 
 class SvNodeTreeCommon(object):


### PR DESCRIPTION
events like `self.inputs.new()` trigger `tree.update()` 

this context manager will enable nodes to have control over whether to end early inside the `tree.update` function, and avoid processing the tree.