### PR TITLE
svnodecommon has a throttle_tree_update wrapper (sv_throttle_tree_upd…

### DIFF
--- a/node_tree.py
+++ b/node_tree.py
@@ -267,6 +267,9 @@ class SverchCustomTreeNode:
             self.n_id = str(hash(self) ^ hash(time.monotonic()))
         return self.n_id
 
+    def sv_throttle_tree_update(self):
+        return throttle_tree_update(self)
+
     def mark_error(self, err):
         """
         marks the with system error color

--- a/nodes/viz/viewer_bmesh.py
+++ b/nodes/viz/viewer_bmesh.py
@@ -27,7 +27,7 @@ import bpy
 from bpy.props import BoolProperty, StringProperty, BoolVectorProperty
 from mathutils import Matrix, Vector
 
-from sverchok.node_tree import SverchCustomTreeNode, throttle_tree_update
+from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import dataCorrect, fullList, updateNode
 from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata
 from sverchok.utils.sv_viewer_utils import natural_plus_one, greek_alphabet
@@ -318,7 +318,7 @@ class SvBmeshViewerNodeV28(bpy.types.Node, SverchCustomTreeNode, SvObjHelper):
                 fullList(mrest[idx], maxlen)
 
         # we need to suppress depsgraph updates emminating from this part of the process/            
-        with throttle_tree_update(self):
+        with self.sv_throttle_tree_update():
 
             if self.merge:
                 obj_index = 0


### PR DESCRIPTION
instead of forcing me to import throttle_tree_update from node_tree, we now have an alias, that you can use like 
```python
    def process(self):

        with self.sv_throttle_tree_update():
           ...do your stuff....
```