### PR TITLE
Vector In and Vector Out numpy mode

### DIFF
--- a/data_structure.py
+++ b/data_structure.py
@@ -286,6 +286,18 @@ def dataCorrect(data, nominal_dept=2):
         output = dataStandart(data, dept, nominal_dept)
         return output
 
+def dataCorrect_np(data, nominal_dept=2):
+    """data from nasting to standart: TO container( objects( lists( floats, ), ), )
+    """
+    dept = levels_of_list_or_np(data)
+    output = []
+    if not dept: # for empty lists
+        return []
+    if dept < 2:
+        return data #[dept, data]
+    else:
+        output = dataStandart(data, dept, nominal_dept)
+        return output
 
 def dataSpoil(data, dept):
     """from standart data to initial levels: to nested lists

--- a/docs/nodes/vector/math_mk3.rst
+++ b/docs/nodes/vector/math_mk3.rst
@@ -11,6 +11,13 @@ The node expects correct input for the chosen operation (called mode),
 but it will fail gracefully with a message in the console if the input
 is not right for the selected mode.
 
+The node will accept lists of NumPy arrays. Flat arrays for scalar lists
+and two axis arrays for vectors with shape [n,3]
+
+It can also output Numpy arrays in the same format when using the NumPy
+implementation and the "Output NumPy" parameter activated.
+(See advanced parameters)
+
 Input and Output
 ^^^^^^^^^^^^^^^^
 

--- a/docs/nodes/vector/vector_in.rst
+++ b/docs/nodes/vector/vector_in.rst
@@ -6,36 +6,50 @@ Functionality
 
 Inputs vector from ranges or number values either integer of floats.
 
+With the NumPy implementation the node will accept regular lists or lists of NumPy arrays if the arrays have two axis arrays with shape [n,3]
+
+It can also output Numpy arrays (flat arrays) when using the activating the "Output NumPy" parameter.
+(See advanced parameters)
+
 Inputs
 ------
 
-**x** - velue or series of values
-**y** - velue or series of values
-**z** - velue or series of values
+**x** - value or series of values
+**y** - value or series of values
+**z** - value or series of values
+
+Advanced Parameters
+-------------------
+
+In the N-Panel (and on the right-click menu) you can find:
+
+**Implementation**: Python or NumPy. Python is the default and is usually faster if you input regular lists and want to get regular list. The NumPy implementation will be faster if you are using/getting lists of NumPy arrays.
+
+**Output NumPy**: Get NumPy arrays in stead of regular lists.
 
 Outputs
 -------
 
 **Vector** - Vertex or series of vertices
 
+
 Operators
 ---------
 
-This node has two buttons: 
+This node has two buttons:
 
 - **3D Cursor**. This button is available only when no of inputs are connected. When pressed, this button assigns current location of Blender's 3D Cursor to X, Y, Z parameters.
-- **Object mode**. This button do the generation of points for several objects correctly.
 
 Examples
 --------
 
 .. image:: https://cloud.githubusercontent.com/assets/5783432/4905358/0a4e7df4-644f-11e4-8ff1-1530c7aac8dc.png
   :alt: with vector out
-   
+
 .. image:: https://cloud.githubusercontent.com/assets/5783432/4905359/0a56565a-644f-11e4-91b3-24ac4d78cb11.png
   :alt: generating line
 
 .. image:: https://user-images.githubusercontent.com/28003269/34647574-202304d2-f39f-11e7-8113-87047546b81e.gif
   :alt: object mode
-  
+
 Gist: https://gist.github.com/cf884ea62f9960d609158ef2d5c994ed

--- a/docs/nodes/vector/vector_out.rst
+++ b/docs/nodes/vector/vector_out.rst
@@ -6,10 +6,22 @@ Functionality
 
 Outputs values/numbers from vertices.
 
+The node will accept regular lists or lists of NumPy arrays if the arrays have two axis arrays with shape [n,3]
+
+It can also output Numpy arrays (flat arrays) when using the activating the "Output NumPy" parameter.
+(See advanced parameters)
+
 Inputs
 -------
 
 **Vector** - Vertex or series of vertices
+
+Advanced Parameters
+-------------------
+
+In the N-Panel (and on the right-click menu) you can find:
+
+**Output NumPy**: Get NumPy arrays in stead of regular lists (makes the node faster if you input NumPy arrays).
 
 Outputs
 -------

--- a/nodes/number/numbers.py
+++ b/nodes/number/numbers.py
@@ -54,7 +54,8 @@ class SvNumberNode(bpy.types.Node, SverchCustomTreeNode):
             prop = kind + '_'
             self.inputs[0].replace_socket('SvStringsSocket', kind.title()).prop_name = prop
             self.outputs[0].replace_socket('SvStringsSocket', kind.title()).custom_draw = 'mode_custom_draw'
-            self.process_node(context)
+
+        self.process_node(context)
 
     int_: IntProperty(
         default=0, name="an int", update=updateNode,

--- a/nodes/number/numbers.py
+++ b/nodes/number/numbers.py
@@ -49,16 +49,17 @@ class SvNumberNode(bpy.types.Node, SverchCustomTreeNode):
     bl_icon = 'DOT'
 
     def wrapped_update(self, context):
-        kind = self.selected_mode
-        prop = kind + '_'
-        self.inputs[0].replace_socket('SvStringsSocket', kind.title()).prop_name = prop
-        self.outputs[0].replace_socket('SvStringsSocket', kind.title()).custom_draw = 'mode_custom_draw'
-        self.process_node(context)
+        with self.sv_throttle_tree_update():
+            kind = self.selected_mode
+            prop = kind + '_'
+            self.inputs[0].replace_socket('SvStringsSocket', kind.title()).prop_name = prop
+            self.outputs[0].replace_socket('SvStringsSocket', kind.title()).custom_draw = 'mode_custom_draw'
+            self.process_node(context)
 
     int_: IntProperty(
         default=0, name="an int", update=updateNode,
         get=lambda s: uget(s, 'int_'),
-        set=lambda s, val: uset(s, val, 'int_')) 
+        set=lambda s, val: uset(s, val, 'int_'))
     int_min: IntProperty(default=-1024, description='minimum')
     int_max: IntProperty(default=1024, description='maximum')
 
@@ -70,7 +71,7 @@ class SvNumberNode(bpy.types.Node, SverchCustomTreeNode):
     float_max: FloatProperty(default=500.0, description='maximum')
 
     mode_options = [(k, k, '', i) for i, k in enumerate(["float", "int"])]
-    
+
     selected_mode: bpy.props.EnumProperty(
         items=mode_options, default="float", update=wrapped_update)
 
@@ -97,7 +98,7 @@ class SvNumberNode(bpy.types.Node, SverchCustomTreeNode):
             c.prop(self, kind + '_max', text='max')
             c = layout.column()
             c.prop(self, 'show_limits', icon='SETTINGS', text='')
-                
+
             c.prop(self, 'to3d', icon='PLUGIN', text='')
 
     def draw_buttons_ext(self, context, layout):
@@ -121,7 +122,7 @@ class SvNumberNode(bpy.types.Node, SverchCustomTreeNode):
         else:
             return self.label or self.name
 
-            
+
     def process(self):
 
         if not self.inputs[0].is_linked:

--- a/nodes/vector/math_mk3.py
+++ b/nodes/vector/math_mk3.py
@@ -108,12 +108,12 @@ class SvVectorMathNodeMK3(bpy.types.Node, SverchCustomTreeNode):
     v3_input_0: FloatVectorProperty(size=3, default=(0,0,0), name='input a', update=updateNode)
     v3_input_1: FloatVectorProperty(size=3, default=(0,0,0), name='input b', update=updateNode)
 
-    implentation_modes = [
+    implementation_modes = [
         ("NumPy", "NumPy", "NumPy", 0),
         ("MathUtils", "MathUtils", "MathUtils", 1)]
 
     implementation : EnumProperty(
-        name='Implementation', items=implentation_modes,
+        name='Implementation', items=implementation_modes,
         description='Choose calculation method',
         default="NumPy", update=updateNode)
     implementation_func_dict ={

--- a/nodes/vector/math_mk3.py
+++ b/nodes/vector/math_mk3.py
@@ -89,7 +89,7 @@ def recurse_fxy(l1, l2, func, level):
 class SvVectorMathNodeMK3(bpy.types.Node, SverchCustomTreeNode):
     '''Vector: Add, Dot P..'''
     bl_idname = 'SvVectorMathNodeMK3'
-    bl_label = 'Vector Math Numpy'
+    bl_label = 'Vector Math'
     bl_icon = 'THREE_DOTS'
     sv_icon = 'SV_VECTOR_MATH'
 

--- a/nodes/vector/math_mk3.py
+++ b/nodes/vector/math_mk3.py
@@ -144,7 +144,6 @@ class SvVectorMathNodeMK3(bpy.types.Node, SverchCustomTreeNode):
 
     def rclick_menu(self, context, layout):
         layout.prop_menu_enum(self, "current_op", text="Function")
-        #layout.prop_menu_enum(self, "list_match", text="List Match")
         layout.prop_menu_enum(self, "implementation", text="Implementation")
         if self.implementation == "NumPy":
             layout.prop(self, "output_numpy", toggle=True)

--- a/nodes/vector/vector_in.py
+++ b/nodes/vector/vector_in.py
@@ -17,10 +17,11 @@
 # ##### END GPL LICENSE BLOCK #####
 
 import bpy
-from bpy.props import FloatProperty, BoolProperty, StringProperty
+from bpy.props import FloatProperty, BoolProperty, StringProperty, EnumProperty
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import updateNode, fullList, fullList_deep_copy
+from sverchok.data_structure import updateNode, fullList, fullList_deep_copy, numpy_match_long_repeat
 from sverchok.utils.sv_itertools import sv_zip_longest
+from numpy import array
 
 class SvVectorFromCursor(bpy.types.Operator):
     "Vector from 3D Cursor"
@@ -33,12 +34,31 @@ class SvVectorFromCursor(bpy.types.Operator):
     treename: StringProperty(name='treename')
 
     def execute(self, context):
-        cursor = bpy.context.scene.cursor_location
+        cursor = bpy.context.scene.cursor.location
 
         node = bpy.data.node_groups[self.treename].nodes[self.nodename]
         node.x_, node.y_, node.z_ = tuple(cursor)
 
         return{'FINISHED'}
+
+def python_pack_vecs(X_, Y_, Z_, output_numpy):
+    series_vec = []
+    for x, y, z in zip(X_, Y_, Z_):
+        max_v = max(map(len, (x, y, z)))
+        fullList(x, max_v)
+        fullList(y, max_v)
+        fullList(z, max_v)
+        series_vec.append(array([x,y,z]).T if output_numpy else list(zip(x, y, z)))
+    return series_vec
+
+def numpy_pack_vecs(X_, Y_, Z_, output_numpy):
+    series_vec = []
+    for obj in zip(X_, Y_, Z_):
+        np_obj = [array(p) for p in obj]
+        x, y, z = numpy_match_long_repeat(np_obj)
+        vecs = array([x,y,z]).T
+        series_vec.append(vecs if output_numpy else vecs.tolist())
+    return series_vec
 
 class GenVectorsNode(bpy.types.Node, SverchCustomTreeNode):
     ''' Generator vectors '''
@@ -52,6 +72,19 @@ class GenVectorsNode(bpy.types.Node, SverchCustomTreeNode):
 
     advanced_mode: BoolProperty(name='deep copy', update=updateNode, default=True)
     show_3d_cursor_button: BoolProperty(name='show button', update=updateNode, default=False)
+    implentation_modes = [
+        ("NumPy", "NumPy", "NumPy", 0),
+        ("Python", "Python", "Python", 1)]
+
+    implementation: EnumProperty(
+        name='Implementation', items=implentation_modes,
+        description='Choose calculation method',
+        default="NumPy", update=updateNode)
+
+    output_numpy: BoolProperty(
+        name='Output NumPy',
+        description='Output NumPy arrays',
+        default=False, update=updateNode)
 
     def sv_init(self, context):
         self.inputs.new('SvStringsSocket', "X").prop_name = 'x_'
@@ -71,9 +104,14 @@ class GenVectorsNode(bpy.types.Node, SverchCustomTreeNode):
 
     def draw_buttons_ext(self, context, layout):
         layout.row().prop(self, 'advanced_mode')
+        layout.label(text="Implementation:")
+        layout.prop(self, "implementation", expand=True)
+        layout.prop(self, "output_numpy", toggle=False)
 
     def rclick_menu(self, context, layout):
         layout.prop(self, "advanced_mode", text="use deep copy")
+        layout.prop_menu_enum(self, "implementation", text="Implementation")
+        layout.prop(self, "output_numpy", toggle=True)
         layout.prop(self, "show_3d_cursor_button", text="show 3d cursor button")
         if not any(s.is_linked for s in self.inputs):
             opname = 'node.sverchok_vector_from_cursor'
@@ -90,19 +128,13 @@ class GenVectorsNode(bpy.types.Node, SverchCustomTreeNode):
         Z_ = inputs['Z'].sv_get()
         series_vec = []
         max_obj = max(map(len, (X_, Y_, Z_)))
-
+        pack_func = numpy_pack_vecs if self.implementation == 'NumPy' else python_pack_vecs
         fullList_main = fullList_deep_copy if self.advanced_mode else fullList
         fullList_main(X_, max_obj)
         fullList_main(Y_, max_obj)
         fullList_main(Z_, max_obj)
+        series_vec = pack_func(X_, Y_, Z_, self.output_numpy)
 
-        for i in range(max_obj):
-
-            max_v = max(map(len, (X_[i], Y_[i], Z_[i])))
-            fullList(X_[i], max_v)
-            fullList(Y_[i], max_v)
-            fullList(Z_[i], max_v)
-            series_vec.append(list(zip(X_[i], Y_[i], Z_[i])))
 
         self.outputs['Vectors'].sv_set(series_vec)
 

--- a/nodes/vector/vector_in.py
+++ b/nodes/vector/vector_in.py
@@ -72,12 +72,12 @@ class GenVectorsNode(bpy.types.Node, SverchCustomTreeNode):
 
     advanced_mode: BoolProperty(name='deep copy', update=updateNode, default=True)
     show_3d_cursor_button: BoolProperty(name='show button', update=updateNode, default=False)
-    implentation_modes = [
+    implementation_modes = [
         ("NumPy", "NumPy", "NumPy", 0),
         ("Python", "Python", "Python", 1)]
 
     implementation: EnumProperty(
-        name='Implementation', items=implentation_modes,
+        name='Implementation', items=implementation_modes,
         description='Choose calculation method',
         default="Python", update=updateNode)
 

--- a/nodes/vector/vector_in.py
+++ b/nodes/vector/vector_in.py
@@ -79,7 +79,7 @@ class GenVectorsNode(bpy.types.Node, SverchCustomTreeNode):
     implementation: EnumProperty(
         name='Implementation', items=implentation_modes,
         description='Choose calculation method',
-        default="NumPy", update=updateNode)
+        default="Python", update=updateNode)
 
     output_numpy: BoolProperty(
         name='Output NumPy',

--- a/nodes/vector/vector_out.py
+++ b/nodes/vector/vector_out.py
@@ -19,7 +19,7 @@
 import bpy
 from bpy.props import BoolProperty
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import dataCorrect, dataCorrect_np, updateNode
+from sverchok.data_structure import dataCorrect_np, updateNode
 from numpy import ndarray, array
 
 def unpack_np(obj):

--- a/nodes/vector/vector_out.py
+++ b/nodes/vector/vector_out.py
@@ -17,32 +17,53 @@
 # ##### END GPL LICENSE BLOCK #####
 
 import bpy
-
+from bpy.props import BoolProperty
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import dataCorrect
+from sverchok.data_structure import dataCorrect, dataCorrect_np, updateNode
+from numpy import ndarray, array
 
+def unpack_np(obj):
+    return (obj[:, 0], obj[:, 1], obj[:, 2])
+
+def unpack_list(obj):
+    return (list(x) for x in zip(*obj))
+
+def unpack_list_to_np(obj):
+    return (array(x) for x in zip(*obj))
 
 class VectorsOutNode(bpy.types.Node, SverchCustomTreeNode):
     ''' Vectors out '''
     bl_idname = 'VectorsOutNode'
     bl_label = 'Vector out'
     sv_icon = 'SV_VECTOR_OUT'
+    output_numpy: BoolProperty(
+        name='Output NumPy',
+        description='Output NumPy arrays',
+        default=False, update=updateNode)
 
     def sv_init(self, context):
         self.inputs.new('SvVerticesSocket', "Vectors")
         self.outputs.new('SvStringsSocket', "X")
         self.outputs.new('SvStringsSocket', "Y")
         self.outputs.new('SvStringsSocket', "Z")
+    def draw_buttons_ext(self, ctx, layout):
+        layout.prop(self, "output_numpy", toggle=False)
+
+    def rclick_menu(self, context, layout):
+        layout.prop(self, "output_numpy", toggle=True)
 
     def process(self):
-        # inputs
         if self.inputs['Vectors'].is_linked:
             xyz = self.inputs['Vectors'].sv_get(deepcopy=False)
 
-            data = dataCorrect(xyz)
+            data = dataCorrect_np(xyz)
             X, Y, Z = [], [], []
+            if self.output_numpy:
+                unpack_func = unpack_np if isinstance(data[0], ndarray) else unpack_list_to_np
+            else:
+                unpack_func = unpack_list
             for obj in data:
-                x_, y_, z_ = (list(x) for x in zip(*obj))
+                x_, y_, z_ = unpack_func(obj)
                 X.append(x_)
                 Y.append(y_)
                 Z.append(z_)


### PR DESCRIPTION
In *Vector In* there are both implementations, the regular python implementation(default) is faster if you are using regular lists and getting regular lists. The Numpy  implementation accepts lists of flat NumPy arrays and is faster if you want numpy Arrays.
In *Vector out* now lists of NumPy arrays are accepted with shape [n,3] and can output NumPy arrays.

This node-tree shows nodes that accept and create numpy arrays. They can be used with out converting the data to regular lists. Using the this method the tree update was more than 6 times faster than using regular lists
![image](https://user-images.githubusercontent.com/10011941/69488031-a40c2800-0e64-11ea-9fea-38d3535ee2cc.png)

- [x] Ready for merge.

