### PR TITLE
B28 join fix

### DIFF
--- a/nodes/list_main/join.py
+++ b/nodes/list_main/join.py
@@ -49,7 +49,7 @@ class ListJoinNode(bpy.types.Node, SverchCustomTreeNode):
 
     def update(self):
 
-        if len(self.outputs) > 0:
+        if 'data' in self.outputs:
             multi_socket(self, min=1)
 
 

--- a/nodes/list_main/join.py
+++ b/nodes/list_main/join.py
@@ -48,22 +48,24 @@ class ListJoinNode(bpy.types.Node, SverchCustomTreeNode):
         layout.prop(self, "JoinLevel", text="JoinLevel lists")
 
     def update(self):
-        # inputs
-        multi_socket(self, min=1)
 
-        if 'data' in self.inputs and len(self.inputs['data'].links) > 0:
-            inputsocketname = 'data'
-            outputsocketname = ['data']
-            changable_sockets(self, inputsocketname, outputsocketname)
+        if len(self.inputs) > 0:
+            multi_socket(self, min=1)
+
 
     def process(self):
+
         if not self.outputs['data'].is_linked:
             return
 
         slots = []
+        slot_bl_idnames = []
         for socket in self.inputs:
-            if socket.is_linked:
-                slots.append(socket.sv_get())
+            if socket.is_linked and socket.links:
+                if socket.other:
+                    slots.append(socket.sv_get())
+                    slot_bl_idnames.append(socket.other.bl_idname)
+
         if len(slots) == 0:
             return
 
@@ -81,8 +83,25 @@ class ListJoinNode(bpy.types.Node, SverchCustomTreeNode):
                 list_wrap_mix = wrapper_2(slots, list_mix, self.JoinLevel)
                 result = list_wrap_mix.copy()
 
+        self.set_output_socketype(slot_bl_idnames)
         self.outputs[0].sv_set(result)
 
+    def set_output_socketype(self, slot_bl_idnames):
+        """
+        1) if the input sockets are a mixed bag of bl_idnames we convert the output socket
+        to a generic SvStringsSocket type
+        2) if all input sockets where sv_get is successful are of identical bl_idname
+        then set the output socket type to match that.
+        3) no op if current output socket matches proposed new socket type. 
+        """
+
+        if not slot_bl_idnames: return
+
+        num_bl_idnames = len(set(slot_bl_idnames)) 
+        new_socket_type = slot_bl_idnames[0] if num_bl_idnames == 1 else "SvStringsSocket"
+
+        if self.outputs[0].bl_idname != new_socket_type:
+            self.outputs[0].replace_socket(new_socket_type)
 
     def draw_label(self):
         """ this gives quick param display for when the node is minimzed """

--- a/nodes/list_main/join.py
+++ b/nodes/list_main/join.py
@@ -50,6 +50,7 @@ class ListJoinNode(bpy.types.Node, SverchCustomTreeNode):
     def update(self):
 
         if 'data' in self.outputs:
+            print('join update')
             multi_socket(self, min=1)
 
 

--- a/nodes/list_main/join.py
+++ b/nodes/list_main/join.py
@@ -49,7 +49,7 @@ class ListJoinNode(bpy.types.Node, SverchCustomTreeNode):
 
     def update(self):
 
-        if len(self.inputs) > 0:
+        if len(self.outputs) > 0:
             multi_socket(self, min=1)
 
 


### PR DESCRIPTION
simpler code, but doesn't solve the real problem either.

doing anything inside `self.update`,  will trigger any time the update function of any other node is triggered.

so if you do a print('hahah') in list join's  `def update()` it is triggered by connecting/touching a socket of any other node, even if that node is not connected to anything..