### PR TITLE
Edge length node

### DIFF
--- a/docs/nodes/analyzer/analyzer_index.rst
+++ b/docs/nodes/analyzer/analyzer_index.rst
@@ -13,6 +13,7 @@ Analyzers
    distance_point_plane
    distance_line_line
    deformation
+   edge_length
    edge_angles
    intersect_line_sphere
    intersect_circle_circle

--- a/docs/nodes/analyzer/edge_length.rst
+++ b/docs/nodes/analyzer/edge_length.rst
@@ -1,0 +1,31 @@
+Edge Lengths
+============
+
+Functionality
+-------------
+
+This node calculates lengths of edges of the provided mesh. It can output either the length of each edge, or total sum of all edge lengths.
+
+Inputs
+------
+
+This node has the following inputs:
+
+- **Vertices**. Object vertices. This input is mandatory.
+- **Edges**. Object edges.  Note that this input should be connected in order for output lengths to be in correct order.
+- **Faces**. Object faces.
+
+Parameters
+----------
+
+This node has the following parameters:
+
+- **Sum**. If checked, then the node will calculate total sum of all object edges. Otherwise, it will output length of each edge. Unchecked by default.
+
+Outputs
+-------
+
+This node has the following outputs:
+
+- **Length**. Lengths of each edge, if **Sum** parameter is not checked; otherwise, total sum of all edge lengths.
+

--- a/docs/nodes/analyzer/edge_length.rst
+++ b/docs/nodes/analyzer/edge_length.rst
@@ -29,3 +29,10 @@ This node has the following outputs:
 
 - **Length**. Lengths of each edge, if **Sum** parameter is not checked; otherwise, total sum of all edge lengths.
 
+Example of usage
+----------------
+
+A simple example:
+
+.. image:: https://user-images.githubusercontent.com/284644/70642102-7bf03780-1c60-11ea-941c-e207a2a1e825.png
+

--- a/index.md
+++ b/index.md
@@ -69,6 +69,7 @@
     SvKDTreePathNode
     SvBvhOverlapNodeNew
     SvMeshFilterNode
+    SvEdgeLengthNode
     SvEdgeAnglesNode
     SvPointInside
     SvProportionalEditNode

--- a/nodes/analyzer/edge_length.py
+++ b/nodes/analyzer/edge_length.py
@@ -1,0 +1,97 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import bpy
+from bpy.props import BoolProperty, EnumProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode, match_long_repeat
+from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata, pydata_from_bmesh
+
+def untangle_edges(orig_edges, bmesh_edges, lengths):
+    result = []
+    edges = bmesh_edges[:]
+    for orig_edge in orig_edges:
+        i,e = [(i,e) for i,e in enumerate(edges) if set(v.index for v in e.verts) == set(orig_edge)][0]
+        result.append(lengths[i])
+    return result
+
+class SvEdgeLengthNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: edge length
+    Tooltip: Calculate length of object's edges
+    """
+
+    bl_idname = 'SvEdgeLengthNode'
+    bl_label = 'Edge Lengths'
+    bl_icon = 'OUTLINER_OB_EMPTY'
+    sv_icon = 'SV_ANGLES_AT_EDGES'
+
+    calc_sum : BoolProperty(
+            name = "Sum",
+            description = "Calculate sum of all edge lengths",
+            default = False,
+            update=updateNode)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "calc_sum")
+
+    def sv_init(self, context):
+        self.inputs.new('SvVerticesSocket', "Vertices")
+        self.inputs.new('SvStringsSocket', "Edges")
+        self.inputs.new('SvStringsSocket', "Faces")
+
+        self.outputs.new('SvStringsSocket', "Length")
+
+    def process(self):
+
+        if not self.outputs['Length'].is_linked:
+            return
+
+        vertices_s = self.inputs['Vertices'].sv_get()
+        edges_s = self.inputs['Edges'].sv_get(default=[[]])
+        faces_s = self.inputs['Faces'].sv_get(default=[[]])
+
+        result_lengths = []
+        meshes = match_long_repeat([vertices_s, edges_s, faces_s])
+        for vertices, edges, faces in zip(*meshes):
+            new_lengths = []
+            length_sum = 0
+            bm = bmesh_from_pydata(vertices, edges, faces)
+            for edge in bm.edges:
+                length = edge.calc_length()
+                if self.calc_sum:
+                    length_sum += length
+                else:
+                    new_lengths.append(length)
+            if self.calc_sum:
+                new_lengths = [length_sum]
+            if edges and not self.calc_sum:
+                new_lengths = untangle_edges(edges, bm.edges, new_lengths)
+            bm.free()
+
+            result_lengths.append(new_lengths)
+
+        self.outputs['Length'].sv_set(result_lengths)
+
+def register():
+    bpy.utils.register_class(SvEdgeLengthNode)
+
+def unregister():
+    bpy.utils.unregister_class(SvEdgeLengthNode)
+


### PR DESCRIPTION
I found it odd that we still did not have this node. It outputs length of each object's edge. As an option, it can calculate total sum of all edge lengths.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

