### PR TITLE
Matrix_in vectorized

### DIFF
--- a/docs/nodes/matrix/euler.rst
+++ b/docs/nodes/matrix/euler.rst
@@ -1,2 +1,9 @@
 Euler
 =====
+
+This node creates a transformation Matrix by defining the angles with X, Y and Z and the rotation order.
+
+On the right-click menu there is a "Flat Output" toggle. While active (as it is by default)
+it will join the first level to output a regular matrix list ([M,M,..]) that can be
+plugged to any other node. If it is disabled the node will keep the original structure
+outputting a list of matrix lists ([[M,M,..],[M,M,..],..]).

--- a/docs/nodes/matrix/matrix_in_mk2.rst
+++ b/docs/nodes/matrix/matrix_in_mk2.rst
@@ -4,7 +4,7 @@ Matrix In
 This node creates a transformation Matrix by defining its Location, Scale and Rotation.
 The rotation will be defined by rotation axis (vector) and angle or vector difference.
 
-On the right-click menu the "Flat Output" toggle. While active (as it is by default)
+On the right-click menu there is a "Flat Output" toggle. While active (as it is by default)
 it will join the first level to output a regular matrix list ([M,M,..]) that can be
 plugged to any other node. If it is disabled the node will keep the original structure
-outputting a list of matrix lists ([[M,M,..],[M,M,..],..]). 
+outputting a list of matrix lists ([[M,M,..],[M,M,..],..]).

--- a/docs/nodes/matrix/matrix_in_mk2.rst
+++ b/docs/nodes/matrix/matrix_in_mk2.rst
@@ -1,2 +1,10 @@
-Matrix In & Out
-===============
+Matrix In
+=========
+
+This node creates a transformation Matrix by defining its Location, Scale and Rotation.
+The rotation will be defined by rotation axis (vector) and angle or vector difference.
+
+On the right-click menu the "Flat Output" toggle. While active (as it is by default)
+it will join the first level to output a regular matrix list ([M,M,..]) that can be
+plugged to any other node. If it is disabled the node will keep the original structure
+outputting a list of matrix lists ([[M,M,..],[M,M,..],..]). 

--- a/docs/nodes/matrix/matrix_normal.rst
+++ b/docs/nodes/matrix/matrix_normal.rst
@@ -17,6 +17,11 @@ Inputs & Parameters
 | Up                | Parameter to sort the other axis                                                                 |
 +-------------------+--------------------------------------------------------------------------------------------------+
 
+On the right-click menu there is a "Flat Output" toggle. While active (as it is by default)
+it will join the first level to output a regular matrix list ([M,M,..]) that can be
+plugged to any other node. If it is disabled the node will keep the original structure
+outputting a list of matrix lists ([[M,M,..],[M,M,..],..]).
+
 Outputs
 -------
 

--- a/docs/nodes/matrix/matrix_track_to.rst
+++ b/docs/nodes/matrix/matrix_track_to.rst
@@ -61,6 +61,7 @@ Extra Parameters
 A set of extra parameters are available on the property panel. These parameters do not receive external input.
 
 - **Normalize Vectors**
+- **Flat Output**
 
 +-------------------------+------------+------------+-----------------------------------------------+
 | Extra Param             |  Type      |  Default   |  Description                                  |
@@ -70,6 +71,13 @@ A set of extra parameters are available on the property panel. These parameters 
 |                         |            |            |                                               |
 |                         |            |            |  Turn this OFF when normalization is not      |
 |                         |            |            |  needed to optimize computation.              |
++-------------------------+------------+------------+-----------------------------------------------+
+|  **Flat Output**        | Bool       | True       |  While active it will join the first level to |
+|                         |            |            |  output a regular  matrix list ([M,M,..]) that|
+|                         |            |            |  can be plugged  to any other node.           |
+|                         |            |            |  If it is disabled the node will keep the     |
+|                         |            |            |  original structure outputting a list of      |
+|                         |            |            |   matrix lists ([[M,M,..],[M,M,..],..]).      |
 +-------------------------+------------+------------+-----------------------------------------------+
 
 Outputs
@@ -89,4 +97,3 @@ Notes:
 
 Example of usage
 ----------------
-

--- a/nodes/matrix/matrix_in_mk2.py
+++ b/nodes/matrix/matrix_in_mk2.py
@@ -33,7 +33,11 @@ def matrix_in(params):
     return matrixes
 
 class SvMatrixGenNodeMK2(bpy.types.Node, SverchCustomTreeNode):
-    ''' MatrixGeneratorMK2 '''
+    """
+    Triggers: From loc, scale, rot
+    Tooltip:  Creates a transformation Matrix by defining its Location, Scale and Rotation.
+
+    """
     bl_idname = 'SvMatrixGenNodeMK2'
     bl_label = 'Matrix in'
     bl_icon = 'OUTLINER_OB_EMPTY'

--- a/nodes/matrix/matrix_in_mk2.py
+++ b/nodes/matrix/matrix_in_mk2.py
@@ -18,10 +18,19 @@
 
 import bpy
 import mathutils
-from bpy.props import FloatProperty, FloatVectorProperty
+from bpy.props import FloatProperty, FloatVectorProperty, BoolProperty
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import (matrixdef, Vector_generate, updateNode)
+from sverchok.data_structure import (matrixdef, Vector_generate, updateNode, match_long_repeat)
 
+def matrix_in(params):
+    loc, scale, rot, angle, rotA = params
+    max_l = max(len(loc), len(scale), len(rot), len(angle), len(rotA))
+    orig = []
+    for l in range(max_l):
+        M = mathutils.Matrix()
+        orig.append(M)
+    matrixes = matrixdef(orig, [loc], [scale], [rot], [angle], [rotA])
+    return matrixes
 
 class SvMatrixGenNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     ''' MatrixGeneratorMK2 '''
@@ -31,14 +40,19 @@ class SvMatrixGenNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     sv_icon = 'SV_MATRIX_IN'
 
     l_: FloatVectorProperty(
-        name='L', default=(0.0,0.0,0.0), description='Location', precision=3, update=updateNode)
+        name='L', default=(0.0, 0.0, 0.0), description='Location', precision=3, update=updateNode)
     s_: FloatVectorProperty(
-        name='S', default=(1.0,1.0,1.0), description='Scale', precision=3, update=updateNode)
+        name='S', default=(1.0, 1.0, 1.0), description='Scale', precision=3, update=updateNode)
     r_: FloatVectorProperty(
-        name='R', default=(0.0,0.0,1.0), description='Rotation', precision=3, update=updateNode)
+        name='R', default=(0.0, 0.0, 1.0), description='Rotation', precision=3, update=updateNode)
     a_: FloatProperty(
         name='A', description='Angle', default=0.0, precision=3, update=updateNode)
 
+    flat_output: BoolProperty(
+        name="Flat output",
+        description="Flatten output by list-joining level 1",
+        default=True,
+        update=updateNode)
     def sv_init(self, context):
 
         inew = self.inputs.new
@@ -49,11 +63,20 @@ class SvMatrixGenNodeMK2(bpy.types.Node, SverchCustomTreeNode):
 
         self.outputs.new('SvMatrixSocket', "Matrix")
 
+    def draw_buttons_ext(self, context, layout):
+        layout.prop(self, "flat_output", text="Flat Output", expand=False)
+
+    def rclick_menu(self, context, layout):
+        layout.prop(self, "flat_output", text="Flat Output", expand=False)
+
+
+
     def process(self):
-        L,S,R,A = self.inputs
+        L, S, R, A = self.inputs
         Ma = self.outputs[0]
         if not Ma.is_linked:
             return
+
         loc = Vector_generate(L.sv_get())
         scale = Vector_generate(S.sv_get())
         rot = Vector_generate(R.sv_get())
@@ -71,13 +94,16 @@ class SvMatrixGenNodeMK2(bpy.types.Node, SverchCustomTreeNode):
             angle = A.sv_get()
             rotA = [[]]
 
-        max_l = max(len(loc[0]), len(scale[0]), len(rot[0]), len(angle[0]), len(rotA[0]))
-        orig = []
-        for l in range(max_l):
-            M = mathutils.Matrix()
-            orig.append(M)
-        matrixes_ = matrixdef(orig, loc, scale, rot, angle, rotA)
-        Ma.sv_set(matrixes_)
+        result = []
+
+        m_add = result.extend if  self.flat_output else result.append
+        params = match_long_repeat([loc, scale, rot, angle, rotA])
+
+        for par in zip(*params):
+            matrixes = matrix_in(par)
+            m_add(matrixes)
+
+        Ma.sv_set(result)
 
 
 def register():

--- a/nodes/matrix/matrix_normal.py
+++ b/nodes/matrix/matrix_normal.py
@@ -17,15 +17,29 @@
 # ##### END GPL LICENSE BLOCK #####
 
 import bpy
-from bpy.props import EnumProperty
+from bpy.props import EnumProperty, BoolProperty
 import mathutils
 from mathutils import Vector, Matrix
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import (updateNode, second_as_first_cycle as safc, enum_item as e)
+from sverchok.data_structure import (updateNode, second_as_first_cycle as safc, enum_item as e,Vector_generate, match_long_repeat)
 
+def matrix_normal(params, T, U):
+    loc, nor = params
+    out = []
+    nor = safc(loc, nor)
+    for V, N in zip(loc, nor):
+        n = N.to_track_quat(T, U)
+        m = Matrix.Translation(V) @ n.to_matrix().to_4x4()
+        out.append(m)
+    return out
 
 class SvMatrixNormalNode(bpy.types.Node, SverchCustomTreeNode):
-    ''' Construct a Matirx from Normal '''
+    """
+    Triggers: M. from Loc & Normal
+    Tooltip:  Construct a Matirx from  Location and Normal vectors
+
+    """
+
     bl_idname = 'SvMatrixNormalNode'
     bl_label = 'Matrix normal'
     bl_icon = 'OUTLINER_OB_EMPTY'
@@ -36,6 +50,11 @@ class SvMatrixNormalNode(bpy.types.Node, SverchCustomTreeNode):
 
     track: EnumProperty(name="track", default=F[4], items=e(F), update=updateNode)
     up: EnumProperty(name="up", default=S[2], items=e(S), update=updateNode)
+    flat_output: BoolProperty(
+        name="Flat output",
+        description="Flatten output by list-joining level 1",
+        default=True,
+        update=updateNode)
 
     def sv_init(self, context):
         self.inputs.new('SvVerticesSocket', "Location").use_prop = True
@@ -46,20 +65,32 @@ class SvMatrixNormalNode(bpy.types.Node, SverchCustomTreeNode):
         layout.prop(self, "track", text="track")
         layout.prop(self, "up", text="up")
 
+    def draw_buttons_ext(self, context, layout):
+        layout.prop(self, "track", text="track")
+        layout.prop(self, "up", text="up")
+        self.draw_buttons(context, layout)
+        layout.prop(self, "flat_output", text="Flat Output", expand=False)
+
+    def rclick_menu(self, context, layout):
+        layout.prop_menu_enum(self, "track", text="Track:")
+        layout.prop_menu_enum(self, "up", text="Up:")
+        layout.prop(self, "flat_output", text="Flat Output", expand=False)
+
     def process(self):
         Ma = self.outputs[0]
         if not Ma.is_linked:
             return
         L, N = self.inputs
-        out = []
-        loc = L.sv_get()[0]
-        nor = [Vector(i) for i in N.sv_get()[0]]
-        nor = safc(loc, nor)
         T, U = self.track, self.up
-        for V, N in zip(loc, nor):
-            n = N.to_track_quat(T, U)
-            m = Matrix.Translation(V) @ n.to_matrix().to_4x4()
-            out.append(m)
+        loc = L.sv_get()
+        nor = Vector_generate(N.sv_get())
+        out = []
+        m_add = out.extend if  self.flat_output else out.append
+        params = match_long_repeat([loc, nor])
+
+        for par in zip(*params):
+            matrixes = matrix_normal(par, T, U)
+            m_add(matrixes)
         Ma.sv_set(out)
 
 

--- a/nodes/matrix/matrix_track_to.py
+++ b/nodes/matrix/matrix_track_to.py
@@ -18,13 +18,18 @@
 
 import bpy
 from bpy.props import BoolProperty, EnumProperty, FloatVectorProperty
-from mathutils import Vector, Matrix
+from mathutils import Matrix
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import (updateNode, match_long_repeat, enum_item as e)
+from sverchok.data_structure import (updateNode, Vector_generate, match_long_repeat, enum_item as e)
 
 
 class SvMatrixTrackToNode(bpy.types.Node, SverchCustomTreeNode):
-    ''' Construct a Matrix from arbitrary Track and Up vectors '''
+    """
+    Triggers: Align to Track & Up vectors
+    Tooltip:  Construct a Matrix from arbitrary Track and Up vectors
+
+    """
+
     bl_idname = 'SvMatrixTrackToNode'
     bl_label = 'Matrix Track To'
     bl_icon = 'OUTLINER_OB_EMPTY'
@@ -55,7 +60,11 @@ class SvMatrixTrackToNode(bpy.types.Node, SverchCustomTreeNode):
     vB: FloatVectorProperty(
         name='B', description='B direction',
         default=(0, 1, 0), update=updateNode)
-
+    flat_output: BoolProperty(
+        name="Flat output",
+        description="Flatten output by list-joining level 1",
+        default=True,
+        update=updateNode)
     TUM = ["A B", "A -B", "-A B", "-A -B", "B A", "B -A", "-B A", "-B -A"]
     tu_mapping: EnumProperty(
         name="Track/Up Mapping",
@@ -102,7 +111,15 @@ class SvMatrixTrackToNode(bpy.types.Node, SverchCustomTreeNode):
         cols[1].prop(self, "tu_mapping", text="")
 
     def draw_buttons_ext(self, context, layout):
+        self.draw_buttons(context, layout)
         layout.prop(self, "normalize")
+        layout.prop(self, "flat_output")
+
+    def rclick_menu(self, context, layout):
+        layout.prop_menu_enum(self, "tu_axes")
+        layout.prop_menu_enum(self, "tu_mapping")
+        layout.prop(self, "normalize")
+        layout.prop(self, "flat_output", text="Flat Output", expand=False)
 
     def orthogonalizeXY(self, X, Y):  # keep X, recalculate Z form X&Y then Y
         Z = X.cross(Y)
@@ -139,6 +156,41 @@ class SvMatrixTrackToNode(bpy.types.Node, SverchCustomTreeNode):
         orthogonalizer = eval("self.orthogonalize" + order)
         return lambda T, U: orthogonalizer(T, U)
 
+    def matrix_track_to(self, params, mT, mU, orthogonalize, gates):
+        x_list = []  # ortho-normal X vector list
+        y_list = []  # ortho-normal Y vector list
+        z_list = []  # ortho-normal Z vector list
+        matrix_list = []
+        print(len(params))
+        for L, S, A, B in zip(*params):
+            T = eval(mT)  # map T to one of A, B or its negative
+            U = eval(mU)  # map U to one of A, B or its negative
+
+            X, Y, Z = orthogonalize(T, U)
+
+            if gates[4]:
+                X.normalize()
+                Y.normalize()
+                Z.normalize()
+
+            # prepare the Ortho-Normalized outputs
+            if gates[1]:
+                x_list.append([X.x, X.y, X.z])
+            if gates[2]:
+                y_list.append([Y.x, Y.y, Y.z])
+            if gates[3]:
+                z_list.append([Z.x, Z.y, Z.z])
+            if gates[0]:
+                # composite matrix: M = T * R * S (Tanslation x Rotation x Scale)
+                m = [[X.x * S.x, Y.x * S.y, Z.x * S.z, L.x],
+                     [X.y * S.x, Y.y * S.y, Z.y * S.z, L.y],
+                     [X.z * S.x, Y.z * S.y, Z.z * S.z, L.z],
+                     [0, 0, 0, 1]]
+
+                matrix_list.append(Matrix(m))
+
+        return matrix_list, x_list, y_list, z_list
+
     def process(self):
         outputs = self.outputs
 
@@ -148,58 +200,31 @@ class SvMatrixTrackToNode(bpy.types.Node, SverchCustomTreeNode):
 
         # input values lists
         inputs = self.inputs
-        input_locations = inputs["Location"].sv_get()[0]
-        input_scales = inputs["Scale"].sv_get()[0]
-        input_vAs = inputs["A"].sv_get()[0]
-        input_vBs = inputs["B"].sv_get()[0]
-
-        locations = [Vector(i) for i in input_locations]
-        scales = [Vector(i) for i in input_scales]
-        vAs = [Vector(i) for i in input_vAs]
-        vBs = [Vector(i) for i in input_vBs]
-
-        params = match_long_repeat([locations, scales, vAs, vBs])
-
+        params = match_long_repeat([Vector_generate(s.sv_get()) for s in inputs])
         orthogonalize = self.orthogonalizer()
 
         mT, mU = self.tu_mapping.split(" ")
+        gates = [s.is_linked for s in outputs]
+        gates.append(self.normalize)
+        x_lists = []  # ortho-normal X vector list
+        y_lists = []  # ortho-normal Y vector list
+        z_lists = []  # ortho-normal Z vector list
+        matrix_lists = []
+        if self.flat_output:
+            m_add, x_add, y_add, z_add = matrix_lists.extend,  x_lists.extend, y_lists.extend, z_lists.extend
+        else:
+            m_add, x_add, y_add, z_add = matrix_lists.append, x_lists.append, y_lists.append, z_lists.append
+        for par in zip(*params):
+            matrix_list, x_list, y_list, z_list = self.matrix_track_to(match_long_repeat(par), mT, mU, orthogonalize, gates)
+            m_add(matrix_list)
+            x_add([x_list])
+            y_add(y_list)
+            z_add(z_list)
 
-        xList = []  # ortho-normal X vector list
-        yList = []  # ortho-normal Y vector list
-        zList = []  # ortho-normal Z vector list
-        matrixList = []
-        for L, S, A, B in zip(*params):
-            T = eval(mT)  # map T to one of A, B or its negative
-            U = eval(mU)  # map U to one of A, B or its negative
-
-            X, Y, Z = orthogonalize(T, U)
-
-            if self.normalize:
-                X.normalize()
-                Y.normalize()
-                Z.normalize()
-
-            # prepare the Ortho-Normalized outputs
-            if outputs["X"].is_linked:
-                xList.append([X.x, X.y, X.z])
-            if outputs["Y"].is_linked:
-                yList.append([Y.x, Y.y, Y.z])
-            if outputs["Z"].is_linked:
-                zList.append([Z.x, Z.y, Z.z])
-
-            # composite matrix: M = T * R * S (Tanslation x Rotation x Scale)
-            m = [[X.x * S.x, Y.x * S.y, Z.x * S.z, L.x],
-                 [X.y * S.x, Y.y * S.y, Z.y * S.z, L.y],
-                 [X.z * S.x, Y.z * S.y, Z.z * S.z, L.z],
-                 [0, 0, 0, 1]]
-
-            matrixList.append(Matrix(m))
-
-        outputs["Matrix"].sv_set(matrixList)
-        outputs["X"].sv_set([xList])
-        outputs["Y"].sv_set([yList])
-        outputs["Z"].sv_set([zList])
-
+        outputs["Matrix"].sv_set(matrix_lists)
+        outputs["X"].sv_set(x_lists)
+        outputs["Y"].sv_set(y_lists)
+        outputs["Z"].sv_set(z_lists)
 
 def register():
     bpy.utils.register_class(SvMatrixTrackToNode)


### PR DESCRIPTION
As seen in some issues #2734  and https://github.com/nortikin/sverchok/issues/2709#issuecomment-561712096
I added the possibility to feed Matrix In node with multiple obejcts.
I added a property "Flat Output" that will keep the matrix list as we are used to. When disabled it will maintain the input structure outputting lists of matrix list.

With "Flat Ouput" active (default):
![image](https://user-images.githubusercontent.com/10011941/70795311-ce843d80-1d9f-11ea-9ed7-b850d82a4fdc.png)

With "Flat Output" disabled:
![image](https://user-images.githubusercontent.com/10011941/70795670-a47f4b00-1da0-11ea-977a-0bc0ac02206e.png)


- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

PD: I added the same functionality to matrix_normal, matrix_euler and matrix_track_to :) 