### PR TITLE
Intersection edges new "Blender" mode

### DIFF
--- a/docs/nodes/modifier_change/edges_intersect_mk2.rst
+++ b/docs/nodes/modifier_change/edges_intersect_mk2.rst
@@ -1,7 +1,7 @@
 Intersect Edges
 ===============
 
-.. image:: https://user-images.githubusercontent.com/28003269/67563530-f48f4900-f731-11e9-9441-25d3708e0502.png
+.. image:: https://user-images.githubusercontent.com/28003269/70894030-a7c74080-2005-11ea-8594-dced40b05c03.png
 
 Functionality
 -------------
@@ -44,6 +44,34 @@ It takes two edges, removes Z coordinates and finds their intersection.
 But after intersection is found it projects intersection point back onto one of the given edges.
 This means that input mesh still should be flat but it can be located in space however you like.
 Only location of input flatten mesh along Z coordinate will bring the error.
+
+**Blender mode**  *- for 2D mode only*
+
+This mode is using internal Blender function from `mathutils` module. 
+It is pretty fast with not big number of intersections (about 1000) 
+but is quite unstable and can cause crash of Blender easily. 
+Also it is not design for such cases where one edge is intersect with all or most of all other edges. Use with care.
+It's available only with Blender 2.81+
+
+
+Benchmark of 2D algorithms
+--------------------------
+
+In seconds:
+
++-------------------------+---------+------------+---------+
+| number of intersections | Alg 1   | Sweep line | Blender |
++-------------------------+---------+------------+---------+
+| 100                     | 0.05    | 0.15       | 0.009   |
++-------------------------+---------+------------+---------+
+| 1 000                   | 1.43    | 2.20       | 0.12    |
++-------------------------+---------+------------+---------+
+| 10 000                  | 150     | 27         | 8.2     |
++-------------------------+---------+------------+---------+
+| 20 000                  | too long| 65         | 48      |
++-------------------------+---------+------------+---------+
+| 30 000                  | too long| 97         | 150     |
++-------------------------+---------+------------+---------+
 
 Inputs
 ------

--- a/nodes/modifier_change/edges_intersect_mk2.py
+++ b/nodes/modifier_change/edges_intersect_mk2.py
@@ -16,15 +16,20 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
+from time import time
+
 import bpy
-import bmesh
 from mathutils import Vector
 
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode
-from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata
 from sverchok.utils.geom_2d.intersections import intersect_sv_edges
 from sverchok.utils.intersect_edges import intersect_edges_3d, intersect_edges_2d, remove_doubles_from_edgenet
+
+try:
+    from mathutils.geometry import delaunay_2d_cdt as bl_intersect
+except ImportError:
+    bl_intersect = None
 
 modeItems = [("2D", "2D", "", 0), ("3D", "3D", "", 1)]
 
@@ -36,7 +41,7 @@ class SvIntersectEdgesNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     bl_label = 'Intersect Edges'
     sv_icon = 'SV_XALL'
 
-    mode_items_2d = [("Alg 1", "Alg 1", "", 0), ("Sweep line", "Sweep line", "", 1)]
+    mode_items_2d = [("Alg 1", "Alg 1", "", 0), ("Sweep line", "Sweep line", "", 1), ("Blender", "Blender", "", 2)]
 
     mode: bpy.props.EnumProperty(items=modeItems, default="3D", update=updateNode)
     rm_switch: bpy.props.BoolProperty(update=updateNode)
@@ -56,6 +61,8 @@ class SvIntersectEdgesNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         row.row(align=True).prop(self, "mode", expand=True)
         if self.mode == "2D":
             row.row(align=True).prop(self, "alg_mode_2d", expand=True)
+            if self.alg_mode_2d == 'Blender' and not bl_intersect:
+                row.label(text="For 2.81+ only", icon='ERROR')
         if self.mode == "3D" or self.mode == "2D" and self.alg_mode_2d == "Alg 1":
             r = layout.row(align=True)
             r1 = r.split(factor=0.32)
@@ -70,7 +77,7 @@ class SvIntersectEdgesNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     def process(self):
         inputs = self.inputs
         outputs = self.outputs
-
+        t = time()
         try:
             verts_in = inputs['Verts_in'].sv_get(deepcopy=False)[0]
             edges_in = inputs['Edges_in'].sv_get(deepcopy=False)[0]
@@ -78,17 +85,24 @@ class SvIntersectEdgesNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         except (IndexError, KeyError) as e:
             return
 
+        if self.mode == "2D" and self.alg_mode_2d == "Blender" and not bl_intersect:
+            return
+
         if self.mode == "3D":
             verts_out, edges_out = intersect_edges_3d(verts_in, edges_in, 1 / 10 ** self.epsilon)
         elif self.alg_mode_2d == "Alg 1":
             verts_out, edges_out = intersect_edges_2d(verts_in, edges_in, 1 / 10 ** self.epsilon)
-        else:
+        elif self.alg_mode_2d == "Sweep line":
             verts_out, edges_out = intersect_sv_edges(verts_in, edges_in, self.epsilon)
+        else:
+            verts_out, edges_out, _, _, _, _ = bl_intersect([Vector(co[:2]) for co in verts_in], edges_in, [], 2,
+                                                            1 / 10 ** self.epsilon)
+            verts_out = [v.to_3d()[:] for v in verts_out]
 
         # post processing step to remove doubles
         if self.rm_switch and self.mode == "3D" or self.alg_mode_2d == "Alg 1":
             verts_out, edges_out = remove_doubles_from_edgenet(verts_out, edges_out, self.rm_doubles)
-
+        print(self.alg_mode_2d, ": ", time() - t)
         outputs['Verts_out'].sv_set([verts_out])
         outputs['Edges_out'].sv_set([edges_out])
 

--- a/nodes/modifier_change/edges_intersect_mk2.py
+++ b/nodes/modifier_change/edges_intersect_mk2.py
@@ -16,8 +16,6 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
-from time import time
-
 import bpy
 from mathutils import Vector
 
@@ -77,7 +75,6 @@ class SvIntersectEdgesNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     def process(self):
         inputs = self.inputs
         outputs = self.outputs
-        t = time()
         try:
             verts_in = inputs['Verts_in'].sv_get(deepcopy=False)[0]
             edges_in = inputs['Edges_in'].sv_get(deepcopy=False)[0]
@@ -102,7 +99,6 @@ class SvIntersectEdgesNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         # post processing step to remove doubles
         if self.rm_switch and self.mode == "3D" or self.alg_mode_2d == "Alg 1":
             verts_out, edges_out = remove_doubles_from_edgenet(verts_out, edges_out, self.rm_doubles)
-        print(self.alg_mode_2d, ": ", time() - t)
         outputs['Verts_out'].sv_set([verts_out])
         outputs['Edges_out'].sv_set([edges_out])
 


### PR DESCRIPTION
## Addressed problem description

New mode among 2D modes which use Blender function from mathutils.

Benchmark in seconds:

| number of intersections | Alg 1 | Sweep line | Blender |
| --- | --- | --- | --- |
| 100 | 0.05 | 0.15 | 0.009 |
| 1 000 | 1.43 | 2.20 | 0.12 |
| 10 000 | 150 | 27 | 8.2 |
| 20 000 | too long | 65 | 48 |
| 30 000 | too long | 97 | 150 |

## Preflight checklist

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete.
- [x] Manual testing done. 
- [x] Ready for merge.
