### PR TITLE
"Fix faces" nodes

### DIFF
--- a/docs/nodes/modifier_change/modifier_change_index.rst
+++ b/docs/nodes/modifier_change/modifier_change_index.rst
@@ -26,6 +26,8 @@ Modifier Change
    recalc_normals
    remove_doubles
    triangulate
+   planar_faces
+   split_faces
    vertices_mask
    make_monotone
    dissolve_faces_2d

--- a/docs/nodes/modifier_change/planar_faces.rst
+++ b/docs/nodes/modifier_change/planar_faces.rst
@@ -42,3 +42,11 @@ This node has the following outputs:
 - **Vertices**.
 - **Edges**.
 - **Faces**.
+
+Example of Usage
+----------------
+
+Simple example:
+
+.. image:: https://user-images.githubusercontent.com/284644/71113600-c0934a00-21ef-11ea-8c41-498f5d12a8f2.png
+

--- a/docs/nodes/modifier_change/planar_faces.rst
+++ b/docs/nodes/modifier_change/planar_faces.rst
@@ -1,0 +1,44 @@
+Make Faces Planar
+=================
+
+Functionality
+-------------
+
+This node adjusts the positions of mesh vertices, trying to make all it's faces
+planar (flat). Obviously, this makes sense only for meshes with Quad and/or
+NGon faces.
+
+This node implements standard Blender_'s function "Make Planar Faces". Please
+refer to Blender documentation for more details.
+
+.. _Blender: https://docs.blender.org/manual/en/latest/modeling/meshes/editing/cleanup.html#make-planar-faces
+
+Inputs
+------
+
+This node has the following inputs:
+
+- **Vertices**. This input is mandatory.
+- **Edges**.
+- **Faces**. This input is mandatory.
+- **FaceMask**. The mask for faces to be considered. By default, all faces are considered.
+- **Iterations**. Number of times to repeat the operation. The default value is
+  1. This input can also be specified as a parameter. This input expects one
+  value per input mesh.
+- **Factor**. Distance to move the vertices each iteration. The default value
+  is 0.5. This input can also be specified as a parameter. This input expects
+  one value per input mesh.
+
+Parameters
+----------
+
+This node has no parameters.
+
+Outputs
+-------
+
+This node has the following outputs:
+
+- **Vertices**.
+- **Edges**.
+- **Faces**.

--- a/docs/nodes/modifier_change/split_faces.rst
+++ b/docs/nodes/modifier_change/split_faces.rst
@@ -1,0 +1,54 @@
+Split Faces
+===========
+
+Functionality
+-------------
+
+This node splits NGon faces of the input mesh into smaller faces by one of two available rules:
+
+* Split non-planar faces. In this mode, it will split NGon faces, that are not
+  planar (flat), into smaller planar (flat) faces. There is adjustable limit of
+  what exactly faces should be considered non-planar. For example, if the angle
+  between two parts of the face is less than 1 degree, we can consider it
+  planar.
+* Split concave faces. This will split faces that are not convex **polygons**.
+  Please note that this **does not** mean that it will split faces so that the
+  resulting mesh will make convex volume - it only checks for convex polygons.
+
+Inputs
+------
+
+This node has the following inputs:
+
+- **Vertices**. This input is mandatory.
+- **Edges**. 
+- **Faces**. This input is mandatory.
+- **FaceMask**. The mask for faces which should be considered. By default, all
+  faces are considered.
+- **MaxAngle**. Maximum angle (in degrees) between parts of the face for it to
+  be considered planar. The default value is 5 degrees. This input can also be
+  specified as parameter. This input is only visible when **Mode** parameter is
+  set to **Non-planar**.
+- **FaceData**. List containing an arbitrary data item for each face of input
+  mesh. For example, this may be used to provide material indexes of input
+  mesh faces. Optional input.
+
+Parameters
+----------
+
+This node has the following parameters:
+
+- **Mode**. This defines which faces should be split. Available values are
+  **Non-planar** and **Concave**. The default value is **Non-planar**.
+
+Outputs
+-------
+
+This node has the following outputs:
+
+- **Vertices**. Output mesh vertices.
+- **Edges**. Output mesh edges.
+- **Faces**. Output mesh faces.
+- **FaceData**. List containing data items from the **FaceData** input, which
+  contains one item for each output mesh face.
+

--- a/docs/nodes/modifier_change/split_faces.rst
+++ b/docs/nodes/modifier_change/split_faces.rst
@@ -52,3 +52,14 @@ This node has the following outputs:
 - **FaceData**. List containing data items from the **FaceData** input, which
   contains one item for each output mesh face.
 
+Examples of usage
+-----------------
+
+Simple example of splitting non-planar faces:
+
+.. image:: https://user-images.githubusercontent.com/284644/71113680-e91b4400-21ef-11ea-87a8-51b5b947e9c7.png
+
+An example of splitting concave faces:
+
+.. image:: https://user-images.githubusercontent.com/284644/71113601-c0934a00-21ef-11ea-9b75-50decaba0094.png
+

--- a/index.md
+++ b/index.md
@@ -103,6 +103,7 @@
     SvRemoveDoublesNode
     SvSeparateMeshNode
     SvLimitedDissolve
+    SvPlanarFacesNode
     SvMeshBeautify
     SvTriangulateNode
     SvMakeMonotone

--- a/index.md
+++ b/index.md
@@ -104,6 +104,7 @@
     SvSeparateMeshNode
     SvLimitedDissolve
     SvPlanarFacesNode
+    SvSplitFacesNode
     SvMeshBeautify
     SvTriangulateNode
     SvMakeMonotone

--- a/nodes/modifier_change/planar_faces.py
+++ b/nodes/modifier_change/planar_faces.py
@@ -1,0 +1,109 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+
+import bpy
+from bpy.props import IntProperty, EnumProperty, BoolProperty, FloatProperty
+import bmesh.ops
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode, match_long_repeat, fullList
+from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata, pydata_from_bmesh
+
+class SvPlanarFacesNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: planar faces
+    Tooltip: Make Quad/NGon faces planar (flat).
+    """
+    bl_idname = 'SvPlanarFacesNode'
+    bl_label = 'Make Faces Planar'
+    bl_icon = 'MOD_BEVEL'
+
+    iterations : IntProperty(
+        name = "Iterations",
+        description = " Number of times to flatten faces (for when connected faces are used)",
+        default = 1, min = 1,
+        update = updateNode)
+
+    factor : FloatProperty(
+        name = "Factor",
+        description = "Influence for making planar each iteration",
+        min = 0, max = 1, default = 0.5,
+        update = updateNode)
+
+    def sv_init(self, context):
+        self.inputs.new('SvVerticesSocket', 'Vertices')
+        self.inputs.new('SvStringsSocket', 'Edges')
+        self.inputs.new('SvStringsSocket', 'Faces')
+        self.inputs.new('SvStringsSocket', 'FaceMask')
+        self.inputs.new('SvStringsSocket', 'Iterations').prop_name = 'iterations'
+        self.inputs.new('SvStringsSocket', 'Factor').prop_name = 'factor'
+
+        self.outputs.new('SvVerticesSocket', 'Vertices')
+        self.outputs.new('SvStringsSocket', 'Edges')
+        self.outputs.new('SvStringsSocket', 'Faces')
+
+    def process(self):
+        if not any (socket.is_linked for socket in self.outputs):
+            return
+
+        vertices_s = self.inputs['Vertices'].sv_get()
+        edges_s = self.inputs['Edges'].sv_get(default=[[]])
+        faces_s = self.inputs['Faces'].sv_get(default=[[]])
+        masks_s = self.inputs['FaceMask'].sv_get(default=[[1]])
+        factors_s = self.inputs['Factor'].sv_get()
+        iterations_s = self.inputs['Iterations'].sv_get()
+
+        verts_out = []
+        edges_out = []
+        faces_out = []
+
+        meshes = match_long_repeat([vertices_s, edges_s, faces_s, masks_s, factors_s, iterations_s])
+        for vertices, edges, faces, masks, factor, iterations in zip(*meshes):
+            if isinstance(iterations, (list, tuple)):
+                iterations = iterations[0]
+            if isinstance(factor, (list, tuple)):
+                factor = factor[0]
+            fullList(masks, len(faces))
+
+            bm = bmesh_from_pydata(vertices, edges, faces, normal_update=True)
+            bm_faces = [face for mask, face in zip(masks, bm.faces[:]) if mask]
+
+            bmesh.ops.planar_faces(bm,
+                    faces = bm_faces,
+                    iterations = iterations,
+                    factor = factor)
+
+            new_verts, new_edges, new_faces = pydata_from_bmesh(bm)
+            bm.free()
+
+            verts_out.append(new_verts)
+            edges_out.append(new_edges)
+            faces_out.append(new_faces)
+
+        self.outputs['Vertices'].sv_set(verts_out)
+        self.outputs['Edges'].sv_set(edges_out)
+        self.outputs['Faces'].sv_set(faces_out)
+
+def register():
+    bpy.utils.register_class(SvPlanarFacesNode)
+
+
+def unregister():
+    bpy.utils.unregister_class(SvPlanarFacesNode)
+

--- a/nodes/modifier_change/split_faces.py
+++ b/nodes/modifier_change/split_faces.py
@@ -120,8 +120,8 @@ class SvSplitFacesNode(bpy.types.Node, SverchCustomTreeNode):
                 new_geom = bmesh.ops.connect_verts_concave(bm,
                         faces = bm_faces)
 
-            new_verts, _, _ = pydata_from_bmesh(bm)
-            new_edges, new_faces = get_bm_geom(new_geom)
+            new_verts, new_edges, new_faces = pydata_from_bmesh(bm)
+            #new_edges, new_faces = get_bm_geom(new_geom)
             if not face_data:
                 new_face_data = []
             else:

--- a/nodes/modifier_change/split_faces.py
+++ b/nodes/modifier_change/split_faces.py
@@ -1,0 +1,146 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+from math import radians
+
+import bpy
+from bpy.props import IntProperty, EnumProperty, BoolProperty, FloatProperty
+import bmesh.ops
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode, match_long_repeat, fullList
+from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata, pydata_from_bmesh, face_data_from_bmesh_faces
+
+def get_bm_geom(geom):
+    bm_edges = geom['edges']
+    edges = [(edge.verts[0].index, edge.verts[1].index) for edge in bm_edges]
+    bm_faces = geom['faces']
+    faces = [[vert.index for vert in face.verts] for face in bm_faces]
+    return edges, faces
+
+class SvSplitFacesNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: split nonplanar concave faces
+    Tooltip: Split non-planar / concave faces
+    """
+    bl_idname = 'SvSplitFacesNode'
+    bl_label = 'Split Faces'
+    bl_icon = 'MOD_BEVEL'
+
+    modes = [
+            ('NONPLANAR', "Non-planar", "Split faces by connecting edges along non planer faces", 0),
+            ('CONCAVE', "Concave", "Ensures all faces are convex faces", 1)
+        ]
+
+    def mode_change(self, context):
+        self.inputs['MaxAngle'].hide_safe = self.split_mode != 'NONPLANAR'
+        updateNode(self, context)
+
+    split_mode : EnumProperty(
+        name = "Mode",
+        description = "Which faces to split",
+        items = modes,
+        default = 'NONPLANAR',
+        update = mode_change)
+
+    max_angle : FloatProperty(
+        name = "Max. angle",
+        description = "total rotation angle (degrees)",
+        default = 5,
+        min = 0, max = 180,
+        update = updateNode)
+
+    def sv_init(self, context):
+        self.inputs.new('SvVerticesSocket', 'Vertices')
+        self.inputs.new('SvStringsSocket', 'Edges')
+        self.inputs.new('SvStringsSocket', 'Faces')
+        self.inputs.new('SvStringsSocket', 'FaceMask')
+        self.inputs.new('SvStringsSocket', 'MaxAngle').prop_name = 'max_angle'
+        self.inputs.new('SvStringsSocket', 'FaceData')
+
+        self.outputs.new('SvVerticesSocket', 'Vertices')
+        self.outputs.new('SvStringsSocket', 'Edges')
+        self.outputs.new('SvStringsSocket', 'Faces')
+        self.outputs.new('SvStringsSocket', 'FaceData')
+
+        self.mode_change(context)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "split_mode")
+
+    def process(self):
+        if not any (socket.is_linked for socket in self.outputs):
+            return
+
+        vertices_s = self.inputs['Vertices'].sv_get()
+        edges_s = self.inputs['Edges'].sv_get(default=[[]])
+        faces_s = self.inputs['Faces'].sv_get(default=[[]])
+        masks_s = self.inputs['FaceMask'].sv_get(default=[[1]])
+        max_angle_s = self.inputs['MaxAngle'].sv_get()
+        face_data_s = self.inputs['FaceData'].sv_get(default=[[]])
+
+        verts_out = []
+        edges_out = []
+        faces_out = []
+        face_data_out = []
+
+        meshes = match_long_repeat([vertices_s, edges_s, faces_s, masks_s, max_angle_s, face_data_s])
+        for vertices, edges, faces, masks, max_angle, face_data in zip(*meshes):
+            if self.split_mode == 'NONPLANAR':
+                if isinstance(max_angle, (list, tuple)):
+                    max_angle = max_angle[0]
+
+            fullList(masks, len(faces))
+            if face_data:
+                fullList(face_data, len(faces))
+
+            bm = bmesh_from_pydata(vertices, edges, faces, normal_update=True, markup_face_data=True)
+            bm_faces = [face for mask, face in zip(masks, bm.faces[:]) if mask]
+
+            if self.split_mode == 'NONPLANAR':
+                new_geom = bmesh.ops.connect_verts_nonplanar(bm,
+                        angle_limit = radians(max_angle),
+                        faces = bm_faces)
+            else:
+                new_geom = bmesh.ops.connect_verts_concave(bm,
+                        faces = bm_faces)
+
+            new_verts, _, _ = pydata_from_bmesh(bm)
+            new_edges, new_faces = get_bm_geom(new_geom)
+            if not face_data:
+                new_face_data = []
+            else:
+                new_face_data = face_data_from_bmesh_faces(bm, face_data)
+
+            verts_out.append(new_verts)
+            edges_out.append(new_edges)
+            faces_out.append(new_faces)
+            face_data_out.append(new_face_data)
+
+        self.outputs['Vertices'].sv_set(verts_out)
+        self.outputs['Edges'].sv_set(edges_out)
+        self.outputs['Faces'].sv_set(faces_out)
+        self.outputs['FaceData'].sv_set(face_data_out)
+
+def register():
+    bpy.utils.register_class(SvSplitFacesNode)
+
+
+def unregister():
+    bpy.utils.unregister_class(SvSplitFacesNode)
+

--- a/utils/sv_bmesh_utils.py
+++ b/utils/sv_bmesh_utils.py
@@ -70,19 +70,23 @@ def pydata_from_bmesh(bm, face_data=None):
     if face_data is None:
         return verts, edges, faces
     else:
-        initial_index = bm.faces.layers.int.get("initial_index")
-        if initial_index is None:
-            raise Exception("bmesh has no initial_index layer")
-        face_data_out = []
-        n_face_data = len(face_data)
-        for face in bm.faces:
-            idx = face[initial_index]
-            if idx < 0 or idx >= n_face_data:
-                debug("Unexisting face_data[%s] [0 - %s]", idx, n_face_data)
-                face_data_out.append(None)
-            else:
-                face_data_out.append(face_data[idx])
+        face_data_out = face_data_from_bmesh_faces(bm, face_data)
         return verts, edges, faces, face_data_out
+
+def face_data_from_bmesh_faces(bm, face_data):
+    initial_index = bm.faces.layers.int.get("initial_index")
+    if initial_index is None:
+        raise Exception("bmesh has no initial_index layer")
+    face_data_out = []
+    n_face_data = len(face_data)
+    for face in bm.faces:
+        idx = face[initial_index]
+        if idx < 0 or idx >= n_face_data:
+            debug("Unexisting face_data[%s] [0 - %s]", idx, n_face_data)
+            face_data_out.append(None)
+        else:
+            face_data_out.append(face_data[idx])
+    return face_data_out
 
 def with_bmesh(method):
     '''Decorator for methods which can work with BMesh.


### PR DESCRIPTION
This introduces two new nodes:

* "Split faces". Split NGon faces into smaller ones. This can split either non-planar faces, or concave faces (NB: this means concave polygons, not that it tries to make mesh convex). This is a wrapper for bmesh.ops.connect_verts_nonplanar and bmesh.ops.connect_verts_concave.
* "Make faces planar". Move vertices to make NGon/Quad faces planar (flat). This is a wrapper for bmesh.ops.planar_faces.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [ ] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [ ] Ready for merge.

