### PR TITLE
track origin of error in objin node after loading .blend

### DIFF
--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -16,6 +16,8 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
+import traceback
+
 import bpy
 from bpy.props import BoolProperty, StringProperty
 import bmesh
@@ -219,8 +221,10 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
 
         if not self.object_names:
             return
+        else:
+            print('self.object_names found =>', [o.name for o in self.object_names])
 
-        scene = bpy.context.scene
+        # scene = bpy.context.scene
         data_objects = bpy.data.objects
         outputs = self.outputs
 
@@ -289,7 +293,8 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
 
 
                 except Exception as err:
-                    print('failure in process between frozen area', self.name, err)
+                    print('failure in process between frozen area', self.name)
+                    traceback.print_exc()
 
             vers_out.append(vers)
             edgs_out.append(edgs)


### PR DESCRIPTION
This problem will only be noticed if the object that Objects In is referencing requires you to pick up modifier data too - and that requires despgraph  evaluation.

the new depsgraph acquisition code, has a problem when a .blend is loaded from disk, it seems
```
Traceback (most recent call last):
  File "C:\Users\zeffi\Desktop\scripts\addons_contrib\sverchok\nodes\scene\objects_mk3.py", line 281, in process
    obj = depsgraph.objects[obj.name]
KeyError: 'bpy_prop_collection[key]: key "Sv_0" not found'
```
depsgraph.objects is empty until triggered or sometehing?

no eta.  but maybe the` .blend load ` handler must be scrutinized. (rather than fixing it in the objects in Process function...)