### PR TITLE
Dictionary in and dictionary out nodes

### DIFF
--- a/core/socket_data.py
+++ b/core/socket_data.py
@@ -89,7 +89,7 @@ def SvGetSocket(socket, deepcopy=True):
     set to False and increase performance substanstilly
     """
     global socket_data_cache
-    if socket.is_linked:
+    if socket.links:
         other = socket.other
         s_id = other.socket_id
         s_ng = other.id_data.name

--- a/core/socket_data.py
+++ b/core/socket_data.py
@@ -89,7 +89,7 @@ def SvGetSocket(socket, deepcopy=True):
     set to False and increase performance substanstilly
     """
     global socket_data_cache
-    if socket.links:
+    if socket.is_linked or socket.sv_is_linked:
         other = socket.other
         s_id = other.socket_id
         s_ng = other.id_data.name

--- a/core/socket_data.py
+++ b/core/socket_data.py
@@ -89,7 +89,7 @@ def SvGetSocket(socket, deepcopy=True):
     set to False and increase performance substanstilly
     """
     global socket_data_cache
-    if socket.is_linked or socket.sv_is_linked:
+    if socket.is_linked:
         other = socket.other
         s_id = other.socket_id
         s_ng = other.id_data.name

--- a/core/sockets.py
+++ b/core/sockets.py
@@ -62,7 +62,7 @@ class SvSocketCommon:
     expanded: BoolProperty(default=False)
     custom_draw: StringProperty(description="For name of method which will draw socket UI (optionally)")
     prop_name: StringProperty(default='', description="For displaying node property in socket UI")
-    sv_is_linked: BoolProperty(description="Node is linked if (node.is_linked or node.sv_is_linked). "
+    sv_is_linked: BoolProperty(description="Socket is linked if (socket.is_linked or socket.sv_is_linked). "
                                            "`Sv_is_linked` should be set manually. "
                                            "Useful for socket created dynamically during update event.")
 

--- a/core/sockets.py
+++ b/core/sockets.py
@@ -62,6 +62,9 @@ class SvSocketCommon:
     expanded: BoolProperty(default=False)
     custom_draw: StringProperty(description="For name of method which will draw socket UI (optionally)")
     prop_name: StringProperty(default='', description="For displaying node property in socket UI")
+    sv_is_linked: BoolProperty(description="Node is linked if (node.is_linked or node.sv_is_linked). "
+                                           "`Sv_is_linked` should be set manually. "
+                                           "Useful for socket created dynamically during update event.")
 
     quicklink_func_name: StringProperty(default="", name="quicklink_func_name")
 
@@ -282,7 +285,7 @@ class SvObjectSocket(NodeSocket, SvSocketCommon):
             layout.label(text=text)
 
     def sv_get(self, default=sentinel, deepcopy=True, implicit_conversions=None):
-        if self.links and not self.is_output:
+        if (self.is_linked or self.sv_is_linked) and not self.is_output:
             return self.convert_data(SvGetSocket(self, deepcopy), implicit_conversions)
         elif self.object_ref:
             obj_ref = bpy.data.objects.get(self.object_ref)
@@ -310,7 +313,7 @@ class SvTextSocket(NodeSocket, SvSocketCommon):
         return (0.68,  0.85,  0.90, 1)
 
     def sv_get(self, default=sentinel, deepcopy=True, implicit_conversions=None):
-        if self.links and not self.is_output:
+        if (self.is_linked or self.sv_is_linked) and not self.is_output:
             return self.convert_data(SvGetSocket(self, deepcopy), implicit_conversions)
         elif self.text:
             return [self.text]
@@ -341,7 +344,7 @@ class SvMatrixSocket(NodeSocket, SvSocketCommon):
 
     def sv_get(self, default=sentinel, deepcopy=True, implicit_conversions=None):
         self.num_matrices = 0
-        if self.links and not self.is_output:
+        if (self.is_linked or self.sv_is_linked) and not self.is_output:
             source_data = SvGetSocket(self, deepcopy = True if self.needs_data_conversion() else deepcopy)
             return self.convert_data(source_data, implicit_conversions)
 
@@ -369,7 +372,7 @@ class SvVerticesSocket(NodeSocket, SvSocketCommon):
             return {}
 
     def sv_get(self, default=sentinel, deepcopy=True, implicit_conversions=None):
-        if self.links and not self.is_output:
+        if (self.is_linked or self.sv_is_linked) and not self.is_output:
             source_data = SvGetSocket(self, deepcopy = True if self.needs_data_conversion() else deepcopy)
             return self.convert_data(source_data, implicit_conversions)
 
@@ -401,7 +404,7 @@ class SvQuaternionSocket(NodeSocket, SvSocketCommon):
             return {}
 
     def sv_get(self, default=sentinel, deepcopy=True, implicit_conversions=None):
-        if self.links and not self.is_output:
+        if (self.is_linked or self.sv_is_linked) and not self.is_output:
             source_data = SvGetSocket(self, deepcopy = True if self.needs_data_conversion() else deepcopy)
             return self.convert_data(source_data, implicit_conversions)
 
@@ -433,7 +436,7 @@ class SvColorSocket(NodeSocket, SvSocketCommon):
             return {}
 
     def sv_get(self, default=sentinel, deepcopy=True, implicit_conversions=None):
-        if self.links and not self.is_output:
+        if (self.is_linked or self.sv_is_linked) and not self.is_output:
             return self.convert_data(SvGetSocket(self, deepcopy), implicit_conversions)
 
         if self.prop_name:
@@ -458,7 +461,7 @@ class SvDummySocket(NodeSocket, SvSocketCommon):
         return self.other.get_prop_data()
 
     def sv_get(self):
-        if self.links:
+        if (self.sv_linked or self.sv_is_linked):
             return self.links[0].bl_idname
 
     def sv_type_conversion(self, new_self):
@@ -500,7 +503,7 @@ class SvStringsSocket(NodeSocket, SvSocketCommon):
         # debug("Node %s, socket %s, is_linked: %s, is_output: %s",
         #         self.node.name, self.name, self.is_linked, self.is_output)
 
-        if self.links and not self.is_output:
+        if (self.is_linked or self.sv_is_linked) and not self.is_output:
             return self.convert_data(SvGetSocket(self, deepcopy), implicit_conversions)
         elif self.prop_name:
             # to deal with subtype ANGLE, this solution should be considered temporary...
@@ -529,7 +532,7 @@ class SvDictionarySocket(NodeSocket, SvSocketCommon):
             return {}
 
     def sv_get(self, default=sentinel, deepcopy=True, implicit_conversions=None):
-        if self.links and not self.is_output:
+        if (self.is_linked or self.sv_is_linked) and not self.is_output:
             source_data = SvGetSocket(self, deepcopy=True if self.needs_data_conversion() else deepcopy)
             return self.convert_data(source_data, implicit_conversions)
 

--- a/core/sockets.py
+++ b/core/sockets.py
@@ -546,7 +546,20 @@ class SvChameleonSocket(NodeSocket, SvSocketCommon):
     bl_idname = "SvChameleonSocket"
     bl_label = "Chameleon Socket"
 
-    dynamic_color: FloatVectorProperty(default=(0.0, 0.0, 0.0, 0.0), size=4)
+    dynamic_color: FloatVectorProperty(default=(0.0, 0.0, 0.0, 0.0), size=4,
+                                       description="For storing color of other socket via catch_props method")
+    dynamic_type: StringProperty(default='SvChameleonSocket',
+                                 description="For storing type of other socket via catch_props method")
+
+    def catch_props(self):
+        # should be called during update event of a node for catching its property
+        other = self.other
+        if other:
+            self.dynamic_color = socket_colors[other.bl_idname]
+            self.dynamic_type = other.bl_idname
+        else:
+            self.dynamic_color = (0.0, 0.0, 0.0, 0.0)
+            self.dynamic_type = self.bl_idname
 
     def get_prop_data(self):
         if self.prop_name:
@@ -564,13 +577,6 @@ class SvChameleonSocket(NodeSocket, SvSocketCommon):
             raise SvNoDataError(self)
         else:
             return default
-
-    def set_color(self):
-        other = self.other
-        if other:
-            self.dynamic_color = socket_colors[other.bl_idname]
-        else:
-            self.dynamic_color = (0.0, 0.0, 0.0, 0.0)
 
     def draw_color(self, context, node):
         return self.dynamic_color

--- a/core/sockets.py
+++ b/core/sockets.py
@@ -458,7 +458,7 @@ class SvDummySocket(NodeSocket, SvSocketCommon):
         return self.other.get_prop_data()
 
     def sv_get(self):
-        if self.sv_linked:
+        if self.is_linked:
             return self.links[0].bl_idname
 
     def sv_type_conversion(self, new_self):

--- a/core/sockets.py
+++ b/core/sockets.py
@@ -45,7 +45,7 @@ socket_colors = {
     "SvSeparatorSocket": (0.0, 0.0, 0.0, 0.0),
     "SvObjectSocket": (0.69, 0.74, 0.73, 1.0),
     "SvTextSocket": (0.68, 0.85, 0.90, 1),
-    "SvDictionarySocket": (0.40, 0.02, 1.00, 1.00)
+    "SvDictionarySocket": (1.0, 1.0, 1.0, 1.0)
 }
 
 def process_from_socket(self, context):

--- a/data_structure.py
+++ b/data_structure.py
@@ -839,7 +839,7 @@ def get_other_socket(socket):
     Will return None if there isn't a another socket connect
     so no need to check socket.links
     """
-    if not (socket.is_linked or socket.sv_is_linked):
+    if not socket.is_linked:
         return None
     if not socket.is_output:
         other = socket.links[0].from_socket

--- a/data_structure.py
+++ b/data_structure.py
@@ -839,7 +839,7 @@ def get_other_socket(socket):
     Will return None if there isn't a another socket connect
     so no need to check socket.links
     """
-    if not socket.links:
+    if not (socket.is_linked or socket.sv_is_linked):
         return None
     if not socket.is_output:
         other = socket.links[0].from_socket

--- a/data_structure.py
+++ b/data_structure.py
@@ -839,7 +839,7 @@ def get_other_socket(socket):
     Will return None if there isn't a another socket connect
     so no need to check socket.links
     """
-    if not socket.is_linked:
+    if not socket.links:
         return None
     if not socket.is_output:
         other = socket.links[0].from_socket

--- a/docs/nodes/dictionary/dictionary_in.rst
+++ b/docs/nodes/dictionary/dictionary_in.rst
@@ -1,0 +1,41 @@
+Dictionary in
+=============
+
+.. image:: https://user-images.githubusercontent.com/28003269/71763474-bd89a080-2ef5-11ea-9b5d-e4526c1e5357.png
+
+Functionality
+-------------
+
+The node creates dictionary with costume keys and given data.
+It can be used for preparing data structure which is required for some nodes.
+
+Category
+--------
+
+Dictionary -> dictionary in
+
+Inputs
+------
+
+- **-----** - can be connected with any other output socket of any type (10 maximum connections)
+
+Outputs
+-------
+
+- **Dict** - dictionary(ies)
+
+
+Examples
+--------
+
+**Creating complex data structure:**
+
+.. image:: https://user-images.githubusercontent.com/28003269/71763703-51f50280-2ef8-11ea-845a-f924cd53f79d.png
+
+**Does not use the same keys:**
+
+.. image:: https://user-images.githubusercontent.com/28003269/71763737-be700180-2ef8-11ea-8cf9-4f8cf94286cb.png
+
+**Does not try join dictionaries with different keys, only keys of first dictionary in a list are taken in account:**
+
+.. image:: https://user-images.githubusercontent.com/28003269/71763756-fe36e900-2ef8-11ea-8ae0-300aebc95ad1.png

--- a/docs/nodes/dictionary/dictionary_index.rst
+++ b/docs/nodes/dictionary/dictionary_index.rst
@@ -1,0 +1,9 @@
+**********
+Dictionary
+**********
+
+.. toctree::
+   :maxdepth: 2
+
+   dictionary_in
+   dictionary_out

--- a/docs/nodes/dictionary/dictionary_out.rst
+++ b/docs/nodes/dictionary/dictionary_out.rst
@@ -1,0 +1,29 @@
+Dictionary out
+==============
+
+.. image:: https://user-images.githubusercontent.com/28003269/71804968-6a8f2500-307e-11ea-85ce-8c3c7619ee0a.png
+
+Functionality
+-------------
+
+The node unpacks dictionary and assign values of each key to sockets with names of keys.
+
+Category
+--------
+
+Dictionary -> dictionary out
+
+Inputs
+------
+
+- **Dict** - dictionary(ies)
+
+Outputs
+-------
+
+According keys of input dictionary. If multiple dictionary are given only keys of first dictionary are taken in account.
+
+Examples
+--------
+
+.. image:: https://user-images.githubusercontent.com/28003269/71805215-218ba080-307f-11ea-8321-1886a62837c5.png

--- a/index.md
+++ b/index.md
@@ -186,6 +186,10 @@
     ListShuffleNode
     ListSortNodeMK2
     ListFlipNode
+    
+## Dictionary
+    SvDictionaryIn
+    SvDictionaryOut
 
 ## CAD
     SvBevelNode

--- a/nodes/dictionary/dictionary_in.py
+++ b/nodes/dictionary/dictionary_in.py
@@ -1,0 +1,108 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+
+from itertools import chain, cycle
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode
+
+
+class SvDictionaryIn(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: ...
+    ...
+
+    ...
+    """
+    bl_idname = 'SvDictionaryIn'
+    bl_label = 'Dictionary in'
+    bl_icon = 'MOD_BOOLEAN'
+
+    def lift_item(self, context):
+        if self.up:
+            sock_ind = list(self.inputs).index(context.socket)
+            if sock_ind > 0:
+                self.inputs.move(sock_ind, sock_ind - 1)
+            self.up = False
+
+    def down_item(self, context):
+        if self.down:
+            sock_ind = list(self.inputs).index(context.socket)
+            if sock_ind < len(self.inputs) - 2:
+                self.inputs.move(sock_ind, sock_ind + 1)
+            self.down = False
+
+    keys = set(f"key_{i}" for i in range(10))
+
+    up: bpy.props.BoolProperty(update=lift_item)
+    down: bpy.props.BoolProperty(update=down_item)
+    key_0: bpy.props.StringProperty(name="", default='Key 1', update=updateNode)
+    key_1: bpy.props.StringProperty(name="", default='Key 2', update=updateNode)
+    key_2: bpy.props.StringProperty(name="", default='Key 3', update=updateNode)
+    key_3: bpy.props.StringProperty(name="", default='Key 4', update=updateNode)
+    key_4: bpy.props.StringProperty(name="", default='Key 5', update=updateNode)
+    key_5: bpy.props.StringProperty(name="", default='Key 6', update=updateNode)
+    key_6: bpy.props.StringProperty(name="", default='Key 7', update=updateNode)
+    key_7: bpy.props.StringProperty(name="", default='Key 8', update=updateNode)
+    key_8: bpy.props.StringProperty(name="", default='Key 9', update=updateNode)
+    key_9: bpy.props.StringProperty(name="", default='Key 10', update=updateNode)
+
+    def sv_init(self, context):
+        self.inputs.new('SvSeparatorSocket', 'Empty')
+        self.outputs.new('SvDictionarySocket', 'Dict')['keys'] = []
+
+    def update(self):
+        print(f'Update {self.name}')
+        # Remove unused sockets
+        for sock in self.inputs:
+            if sock.bl_idname != 'SvSeparatorSocket' and not sock.links:
+                self.inputs.remove(sock)
+
+        # add property to new socket and add extra empty socket
+        free_keys = self.keys - set(sock.prop_name for sock in self.inputs if sock.bl_idname != 'SvSeparatorSocket')
+        if list(self.inputs)[-1].links and len(self.inputs) < 11:
+            socket_from = self.inputs[-1].other
+            self.inputs.remove(list(self.inputs)[-1])
+            re_socket = self.inputs.new(socket_from.bl_idname, 'Dict in sock')
+            re_socket.prop_name = free_keys.pop()
+            re_socket.custom_draw = 'draw_socket'
+            re_link = self.id_data.links.new(socket_from, re_socket)
+            re_link.is_valid = True
+            self.inputs.new('SvSeparatorSocket', 'Empty')
+
+        # set order of output data
+        self.outputs['Dict']['order'] = [(getattr(self, sock.prop_name), sock.bl_idname) for sock in list(self.inputs)[:-1]]
+        print("Socket order", self.outputs['Dict']['order'])
+
+    def draw_socket(self, socket, context, layout):
+        layout.prop(self, 'up', text='', icon='TRIA_UP')
+        layout.prop(self, 'down', text='', icon='TRIA_DOWN')
+        layout.prop(self, socket.prop_name)
+
+    def process(self):
+
+        if not any((sock.links for sock in self.inputs)):
+            return
+
+        max_len = max([len(sock.sv_get()) for sock in list(self.inputs)[:-1]])
+        data = [chain(sock.sv_get(), cycle([None])) for sock in list(self.inputs)[:-1]]
+        keys = [sock.prop_name for sock in list(self.inputs)[:-1]]
+        out = []
+        for i, *props in zip(range(max_len), *data):
+            out.append({getattr(self, key): prop for key, prop in zip(keys, props) if prop is not None})
+        self.outputs[0].sv_set(out)
+
+
+def register():
+    [bpy.utils.register_class(cl) for cl in [SvDictionaryIn]]
+
+
+def unregister():
+    [bpy.utils.unregister_class(cl) for cl in [SvDictionaryIn][::-1]]

--- a/nodes/dictionary/dictionary_in.py
+++ b/nodes/dictionary/dictionary_in.py
@@ -56,7 +56,7 @@ class SvDictionaryIn(bpy.types.Node, SverchCustomTreeNode):
 
     def sv_init(self, context):
         self.inputs.new('SvSeparatorSocket', 'Empty')
-        self.outputs.new('SvDictionarySocket', 'Dict')['keys'] = []
+        self.outputs.new('SvDictionarySocket', 'Dict')
 
     def update(self):
         print(f'Update {self.name}')
@@ -75,11 +75,8 @@ class SvDictionaryIn(bpy.types.Node, SverchCustomTreeNode):
             re_socket.custom_draw = 'draw_socket'
             re_link = self.id_data.links.new(socket_from, re_socket)
             re_link.is_valid = True
+            setattr(self, re_socket.prop_name, re_socket.other.name)
             self.inputs.new('SvSeparatorSocket', 'Empty')
-
-        # set order of output data
-        self.outputs['Dict']['order'] = [(getattr(self, sock.prop_name), sock.bl_idname) for sock in list(self.inputs)[:-1]]
-        print("Socket order", self.outputs['Dict']['order'])
 
     def draw_socket(self, socket, context, layout):
         layout.prop(self, 'up', text='', icon='TRIA_UP')

--- a/nodes/dictionary/dictionary_in.py
+++ b/nodes/dictionary/dictionary_in.py
@@ -100,7 +100,7 @@ class SvDictionaryIn(bpy.types.Node, SverchCustomTreeNode):
     def update(self):
         # Remove unused sockets
         [self.inputs.remove(sock) for sock in list(self.inputs)[:-1] if not sock.is_linked]
-        [sock.set_color() for sock in self.inputs if sock.links]
+        [sock.catch_props() for sock in self.inputs if sock.links]
 
         # add property to new socket and add extra empty socket
         if list(self.inputs)[-1].is_linked and len(self.inputs) < 11:
@@ -150,9 +150,9 @@ class SvDictionaryIn(bpy.types.Node, SverchCustomTreeNode):
             out_dict = SvDict({getattr(self, key): prop for key, prop in zip(keys, props) if prop is not None})
             for sock in list(self.inputs)[:-1]:
                 out_dict.inputs[sock.identifier] = {
-                    'type': sock.other.bl_idname,
+                    'type': sock.dynamic_type,
                     'name': getattr(self, sock.prop_name),
-                    'nest': sock.sv_get()[0].inputs if sock.bl_idname == 'SvDictionarySocket' else None}
+                    'nest': sock.sv_get()[0].inputs if sock.dynamic_type == 'SvDictionarySocket' else None}
             out.append(out_dict)
         self.outputs[0].sv_set(out)
 

--- a/nodes/dictionary/dictionary_in.py
+++ b/nodes/dictionary/dictionary_in.py
@@ -83,6 +83,7 @@ class SvDictionaryIn(bpy.types.Node, SverchCustomTreeNode):
             socket_from = self.inputs[-1].other
             self.inputs.remove(list(self.inputs)[-1])
             re_socket = self.inputs.new(socket_from.bl_idname, 'Dict in sock')
+            re_socket.sv_is_linked = True
             re_socket.prop_name = free_keys.pop()
             re_socket.custom_draw = 'draw_socket'
             re_link = self.id_data.links.new(socket_from, re_socket)

--- a/nodes/dictionary/dictionary_out.py
+++ b/nodes/dictionary/dictionary_out.py
@@ -96,11 +96,13 @@ class SvDictionaryOut(bpy.types.Node, SverchCustomTreeNode):
         if not self.inputs['Dict'].links:
             return
         self.rebuild_output()
-        out = []
+        out = dict()
         for d in self.inputs['Dict'].sv_get():
-            out.append(list(d.values()))
-        for sock, *data in zip(list(self.outputs), zip(*out)):
-            sock.sv_set(data[0])
+            for key in d:
+                if key not in out:
+                    out[key] = []
+                out[key].append(d[key])
+        [self.outputs[key].sv_set(out[key]) for key in out if key in self.outputs]
 
 
 def register():

--- a/nodes/dictionary/dictionary_out.py
+++ b/nodes/dictionary/dictionary_out.py
@@ -62,12 +62,9 @@ class SvDictionaryOut(bpy.types.Node, SverchCustomTreeNode):
         self['order'] = []  # keeps keys of given dictionary since last update event
 
     def update(self):
-        if not self.id_data.skip_tree_update:
-            if self.inputs['Dict'].links:  # if link is unconnected from the socket, `is_linked` is steal True
-                self.rebuild_output()
-            else:
-                self.outputs.clear()
-                self['order'] = []
+        if not self.inputs['Dict'].links:  # if link is unconnected from the socket, `is_linked` is steal True
+            self.outputs.clear()
+            self['order'] = []
 
     def rebuild_output(self):
         # draw output sockets according given keys of input dictionary

--- a/nodes/dictionary/dictionary_out.py
+++ b/nodes/dictionary/dictionary_out.py
@@ -47,7 +47,7 @@ class SvDictionaryOut(bpy.types.Node, SverchCustomTreeNode):
     """
     bl_idname = 'SvDictionaryOut'
     bl_label = 'Dictionary out'
-    bl_icon = 'MOD_BOOLEAN'
+    bl_icon = 'OUTLINER_DATA_GP_LAYER'
 
     def sv_init(self, context):
         self.inputs.new('SvDictionarySocket', 'Dict')
@@ -96,12 +96,11 @@ class SvDictionaryOut(bpy.types.Node, SverchCustomTreeNode):
         if not self.inputs['Dict'].links:
             return
         self.rebuild_output()
-        out = dict()
+        out = {key: [] for key in self.inputs['Dict'].sv_get()[0]}
         for d in self.inputs['Dict'].sv_get():
             for key in d:
-                if key not in out:
-                    out[key] = []
-                out[key].append(d[key])
+                if key in out:
+                    out[key].append(d[key])
         [self.outputs[key].sv_set(out[key]) for key in out if key in self.outputs]
 
 

--- a/nodes/dictionary/dictionary_out.py
+++ b/nodes/dictionary/dictionary_out.py
@@ -15,6 +15,14 @@ from sverchok.node_tree import SverchCustomTreeNode
 
 
 def get_socket_type(data, sub_cls=None, size=None):
+    """
+    If input dictionary does not have metadata
+    this function is used for determining type of output socket according given data type
+    :param data: any data
+    :param sub_cls: always None, for internal usage only
+    :param size: always None, for internal usage only
+    :return: returns one of Sverchok socket type, string
+    """
     types = {bpy.types.Object: 'SvObjectSocket',
              Matrix: 'SvMatrixSocket',
              Quaternion: 'SvQuaternionSocket',
@@ -40,10 +48,10 @@ def get_socket_type(data, sub_cls=None, size=None):
 
 class SvDictionaryOut(bpy.types.Node, SverchCustomTreeNode):
     """
-    Triggers: ...
-    ...
+    Triggers: Unwrap given dictionary
 
-    ...
+    For each key of dictionary new socket is created
+    Keys of first given dictionary in a list are taken in account
     """
     bl_idname = 'SvDictionaryOut'
     bl_label = 'Dictionary out'
@@ -51,56 +59,67 @@ class SvDictionaryOut(bpy.types.Node, SverchCustomTreeNode):
 
     def sv_init(self, context):
         self.inputs.new('SvDictionarySocket', 'Dict')
-        self['order'] = []
+        self['order'] = []  # keeps keys of given dictionary since last update event
 
     def update(self):
-        print(f"Update {self.name}")
         if not self.id_data.skip_tree_update:
-            if self.inputs['Dict'].links:
+            if self.inputs['Dict'].links:  # if link is unconnected from the socket, `is_linked` is steal True
                 self.rebuild_output()
             else:
                 self.outputs.clear()
                 self['order'] = []
 
     def rebuild_output(self):
+        # draw output sockets according given keys of input dictionary
+        # dictionary with metadata kept in `inputs` attribute can be handled
         # this can be called during node update event and from process of the node (after update event)
         out_dict = self.inputs['Dict'].sv_get()[0]
         if hasattr(out_dict, 'inputs'):
-            if (self.outputs and 'identifier' not in list(self.outputs)[0]) or \
-                    [sock['identifier'] for sock in self.outputs] != list(out_dict.inputs.keys()):
+            # handle dictionary with metadata
+            if self['order'] != list(out_dict.inputs.keys()):
+                # order is changed, sockets should be rebuild
                 with self.sv_throttle_tree_update():
                     links = {sock.name: [link.to_socket for link in sock.links] for sock in self.outputs}
                     self.outputs.clear()
+                    new_order = []
                     new_socks = []
                     for key, data in out_dict.inputs.items():
                         sock = self.outputs.new(data['type'], data['name'])
-                        sock['identifier'] = key
+                        new_order.append(key)
                         new_socks.append(sock)
+                    self['order'] = new_order
                     [self.id_data.links.new(sock, other_socket) for sock in new_socks if sock.name in links
                                                                 for other_socket in links[sock.name]]
             else:
-                # renaming
-                for sock in self.outputs:
-                    sock.name = out_dict.inputs[sock['identifier']]['name']
+                # order is unchanged but renaming of sockets should be done anywhere
+                # in case keys of a dictionary was changed
+                for sock, sock_id in zip(self.outputs, self['order']):
+                    sock.name = out_dict.inputs[sock_id]['name']
         else:
-            if list(self['order']) != list(self.inputs['Dict'].sv_get()[0].keys()):
+            # handle dictionary without metadata
+            if self['order'] != list(self.inputs['Dict'].sv_get()[0].keys()):
                 with self.sv_throttle_tree_update():
                     links = {sock.name: [link.to_socket for link in sock.links] for sock in self.outputs}
                     self.outputs.clear()
-                    new_socks = [self.outputs.new(get_socket_type(data), key) for key, data in self.inputs['Dict'].sv_get()[0].items()]
+                    new_socks = [self.outputs.new(get_socket_type(data), key) for key, data in
+                                 self.inputs['Dict'].sv_get()[0].items()]
                     self['order'] = list(self.inputs['Dict'].sv_get()[0].keys())
                     [self.id_data.links.new(sock, other_socket) for sock in new_socks if sock.name in links
                                                                 for other_socket in links[sock.name]]
 
     def process(self):
+
         if not self.inputs['Dict'].links:
             return
+
         self.rebuild_output()
+
         out = {key: [] for key in self.inputs['Dict'].sv_get()[0]}
         for d in self.inputs['Dict'].sv_get():
             for key in d:
                 if key in out:
                     out[key].append(d[key])
+
         [self.outputs[key].sv_set(out[key]) for key in out if key in self.outputs]
 
 

--- a/nodes/dictionary/dictionary_out.py
+++ b/nodes/dictionary/dictionary_out.py
@@ -1,0 +1,95 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+
+from itertools import chain, cycle
+
+import bpy
+from mathutils import Matrix, Quaternion
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+def get_socket_type(data, sub_cls=None, size=None):
+    types = {bpy.types.Object: 'SvObjectSocket',
+             Matrix: 'SvMatrixSocket',
+             Quaternion: 'SvQuaternionSocket',
+             float: ('SvStringsSocket', 'SvVerticesSocket', 'SvColorSocket'),
+             int: 'SvStringsSocket'}
+
+    if type(data) is dict:
+        return 'SvDictionarySocket'
+    if hasattr(data, '__iter__'):
+        return get_socket_type(data[0], type(data), len(data))
+    elif type(data) in types:
+        socket_type = types[type(data)]
+        if socket_type == ('SvStringsSocket', 'SvVerticesSocket', 'SvColorSocket'):
+            if sub_cls is tuple:
+                return 'SvVerticesSocket' if size == 3 else 'SvColorSocket'
+            else:
+                return 'SvStringsSocket'
+        else:
+            return socket_type
+    else:
+        raise TypeError(f"Which type of socket this type ({type(data)}) of data should be?")
+
+
+class SvDictionaryOut(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: ...
+    ...
+
+    ...
+    """
+    bl_idname = 'SvDictionaryOut'
+    bl_label = 'Dictionary out'
+    bl_icon = 'MOD_BOOLEAN'
+
+    def sv_init(self, context):
+        self.inputs.new('SvDictionarySocket', 'Dict')
+        self['order'] = []
+
+    def update(self):
+        print(f"Update {self.name}")
+        if not self.id_data.skip_tree_update:
+            if self.inputs['Dict'].links:
+                if list(self['order']) != list(self.inputs['Dict'].sv_get()[0].keys()):
+                    self.rebuild_output()
+            else:
+                self.outputs.clear()
+                self['order'] = []
+
+    def rebuild_output(self):
+        # this can be called during node update event and from process of the node (after update event)
+        with self.sv_throttle_tree_update():
+            links = {sock.name: [link.to_socket for link in sock.links] for sock in self.outputs}
+            self.outputs.clear()
+            new_socks = [self.outputs.new(get_socket_type(data), key) for key, data in self.inputs['Dict'].sv_get()[0].items()]
+            self['order'] = list(self.inputs['Dict'].sv_get()[0].keys())
+            [self.id_data.links.new(sock, other_socket) for sock in new_socks if sock.name in links
+                                                        for other_socket in links[sock.name]]
+        # [self.outputs.new(data, key) for key, data in self.inputs['Dict'].other['order']]
+        # self['order'] = self.inputs['Dict'].other['order']
+
+    def process(self):
+        if not self.inputs['Dict'].links:
+            return
+        if list(self['order']) != list(self.inputs['Dict'].sv_get()[0].keys()):
+            self.rebuild_output()
+        out = []
+        for d in self.inputs['Dict'].sv_get():
+            out.append(list(d.values()))
+        for sock, *data in zip(list(self.outputs), zip(*out)):
+            sock.sv_set(data[0])
+
+
+def register():
+    [bpy.utils.register_class(cl) for cl in [SvDictionaryOut]]
+
+
+def unregister():
+    [bpy.utils.unregister_class(cl) for cl in [SvDictionaryOut][::-1]]

--- a/ui/nodeview_space_menu.py
+++ b/ui/nodeview_space_menu.py
@@ -120,7 +120,7 @@ class NODEVIEW_MT_Dynamic_Menu(bpy.types.Menu):
         layout.menu("NODEVIEW_MT_AddQuaternion", **icon('SV_QUATERNION'))
         layout.menu("NODEVIEW_MT_AddLogic", **icon("SV_LOGIC"))
         layout.menu("NODEVIEW_MT_AddListOps", **icon('NLA'))
-        layout.menu("NODEVIEW_MT_AddDictionary")
+        layout.menu("NODEVIEW_MT_AddDictionary", icon='OUTLINER_OB_FONT')
         layout.separator()
         layout.menu("NODEVIEW_MT_AddViz", **icon('RESTRICT_VIEW_OFF'))
         layout.menu("NODEVIEW_MT_AddText", icon='TEXT')

--- a/ui/nodeview_space_menu.py
+++ b/ui/nodeview_space_menu.py
@@ -120,6 +120,7 @@ class NODEVIEW_MT_Dynamic_Menu(bpy.types.Menu):
         layout.menu("NODEVIEW_MT_AddQuaternion", **icon('SV_QUATERNION'))
         layout.menu("NODEVIEW_MT_AddLogic", **icon("SV_LOGIC"))
         layout.menu("NODEVIEW_MT_AddListOps", **icon('NLA'))
+        layout.menu("NODEVIEW_MT_AddDictionary")
         layout.separator()
         layout.menu("NODEVIEW_MT_AddViz", **icon('RESTRICT_VIEW_OFF'))
         layout.menu("NODEVIEW_MT_AddText", icon='TEXT')
@@ -187,6 +188,7 @@ classes = [
     make_class('Layout', "Layout"),
     make_class('Listmain', "List Main"),
     make_class('Liststruct', "List Struct"),
+    make_class('Dictionary', "Dictionary"),
     make_class('Number', "Number"),
     make_class('Vector', "Vector"),
     make_class('Matrix', "Matrix"),


### PR DESCRIPTION
## Addressed problem description

#2766

![image](https://user-images.githubusercontent.com/28003269/71539998-01146580-295e-11ea-8cfa-9b28914e8575.png)

**Todo:**

- [x] Take default name of key from linked socket.
- [x] Keep links of `dictionary out` nodes when a key of a dictionary was renamed. ~Next time or probably it even does not worth complicate too much.~ Simplest solutions was adding custom attribute for dictionaries.
- [x] Robustness of determining type of output sockets. ~Next time.~ Simplest solutions was adding custom attribute for dictionaries.
- [x] Consider handling of several dictionaries in list (ignoring mismatched keys?).
- [x] Сustom draw for all sockets.
- [x] `Is_linked` should have name `was_linked` before start of update event, more correct test is `socket.links` but as I suppose more expensive as well. Looks like in `sv_get` method `is_linked` should be replaced by `links`.
- ~deepcopy = False where it possible~ Deep copy is not implemented for dictionaries. In next PR.
- [x] New dictionary icons :smile: 

## Preflight checklist

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete.
- [x] Manual testing done. 
- [x] Ready for merge.

