### PR TITLE
add Monad docs

### DIFF
--- a/docs/nodes/scene/monad.rst
+++ b/docs/nodes/scene/monad.rst
@@ -1,0 +1,51 @@
+Monad
+=====
+
+Functionality
+-------------
+
+    Warning: This feature is a work in progress in 2.8+. Expect stuff to be broken and breakages during usage.
+    -- zeffii
+
+This node encapsulates several selected nodes (Ctrl+G) into a single node, similar to a shadertree node group. 
+
+There are two parts to this node, 
+ 
+ - (Monad) the outer node shell "Monad", this Node is dynamically defined with new properties and sockets whenever required by the Tree inside.
+ - (Tree) the internal node tree, with its own input and output nodes. Interaction with the input and output nodes will update the "Monad" shell.
+
+When editing the Tree you can 
+
+ - rearrange sockets
+ - rename sockets
+ - set slider limits
+ - change socket types
+
+Parameters
+----------
+
+The UI hints at a few fundamental features of the Monad:
+
+ - Vectorize , Vectorize with Split
+ - Loop n times
+
+*Vectorize* tries to match incoming datastreams by repeating data in those sockets that don't have the same number of internal lists.
+
+*Vectorize with Split*
+The more complicated this gets, the harder it is to explain in text. Please see some examples below.
+
+*Loop n times*
+This can be used for repeatedly applying an effect to a mesh, the number of iteration is currently only configurable via the node UI - it's too easy to accidentally grind your computer to a halt if that was set dynamically via an input socket.
+
+
+Inputs and Outputs
+------------------
+
+Are entirely defined by the Tree that Monad encapsulates
+
+
+Example of usage
+----------------
+
+The github issue tracker has many issues (question and answers) regarding this node, it's a good place to start.
+

--- a/docs/nodes/scene/scene_index.rst
+++ b/docs/nodes/scene/scene_index.rst
@@ -11,3 +11,4 @@ Scene
    dupli_instances_mk4
    obj_remote_mk2
    3dview_props
+   monad

--- a/tests/docs_tests.py
+++ b/tests/docs_tests.py
@@ -135,7 +135,6 @@ cache.py
 objects_in_lite.py
 particles.py
 group.py
-monad.py
 curve_in.py
 uv_texture.py
 instancer.py


### PR DESCRIPTION
monad is unexplored territory inside B28. It's a worthy feature, which is perhaps destined for a rewrite and huge simplification -- but here are some prelim docs.

if people are interested , maybe we can start a redesign of the monad beginning with a design document listing 

- stuff that's currently broken
- stuff that would be easy to implement and have immediate usefulness
- stuff that's hard but important for proper functionality
- iojson store/restore
- is it useful to let users to edit with active updates while inside the Monad Tree ?