### PR TITLE
Random points on mesh: ability to disable "proportional" mode.

### DIFF
--- a/docs/nodes/modifier_make/random_points_on_mesh.rst
+++ b/docs/nodes/modifier_make/random_points_on_mesh.rst
@@ -21,6 +21,16 @@ Inputs
 - **Number** (one value per mesh) - number of vertices which should be distributed on given mesh
 - **Seed** (one value per mesh) - seed for generation random vertices
 
+Parameters
+----------
+
+This node has the following parameters:
+
+- **Proportional**. If checked, then the number of points on each face will be
+  proportional to the area of the face (and to the weight provided in the
+  **Face weight** input). If not checked, then the number of points on each
+  face will be only defined by **Face weight** input. Checked by default.
+
 Outputs
 -------
 


### PR DESCRIPTION
Default behaviour is unchanged ("proportional" mode is enabled by default).
If it is disabled, then the number of points at each face is conrtolled only by the "weight" input.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

