### PR TITLE
add external function

### DIFF
--- a/utils/sv_obj_helper.py
+++ b/utils/sv_obj_helper.py
@@ -251,7 +251,7 @@ class SvObjHelper():
         name='basedata name',
         default='Alpha',
         description="which base name the object and data will use",
-        update=updateNode
+        update=rename_updateNode
     )    
 
     # most importantly, what kind of base data are we making?
@@ -286,6 +286,16 @@ class SvObjHelper():
         bpy.context.scene.SvGreekAlphabet_index += 1
         self.use_custom_color = True        
 
+    def perform_rename(self, new_name):
+        if hasattr(self, "grouping"):
+            named = self.custom_collection_name or self.basedata_name
+            if named == new_name:
+                print('this is a no op, suggested name is same as current')
+                return
+
+            # the following might trigger updates to the nodetree, we dont want that yet
+            with self.sv_throttle_tree_update():
+                ...
 
     def icons(self, TYPE):
         NAMED_ICON = {


### PR DESCRIPTION
since the start the Object Viewers have not supported renaming the `basedata_name` or the resulting group. Now with `collections` being implemented i'm looking into a low impact (ie..doesn't require massive recode) option to allow users to rename collection/basedata_name . collection will still be linked to basedata_name.  (like Henri ford...all colours you want, as long as it's black )