### PR TITLE
Adaptation for extra nodes addons

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -38,6 +38,9 @@ class SverchNodeCategory(NodeCategory):
     def poll(cls, context):
         return context.space_data.tree_type == 'SverchCustomTreeType'
 
+    def __repr__(self):
+        return f"<SverchNodeCategory {self.identifier}>"
+
 def make_node_cats():
     '''
     this loads the index.md file and converts it to an OrderedDict of node categories.
@@ -442,8 +445,15 @@ def make_categories():
 
     return node_categories, node_count, original_categories
 
-def register_node_panels(identifier, cat_list):
+def register_node_panels(identifier, std_menu):
     global node_panels
+
+    def get_cat_list():
+        extra_categories = get_extra_categories()
+        cat_list = std_menu[:]
+        cat_list.extend(extra_categories)
+        return cat_list
+
     with sv_preferences() as prefs:
         if prefs.node_panels == "N":
 
@@ -453,7 +463,7 @@ def register_node_panels(identifier, cat_list):
                 for item in self.category.items(context):
                     item.draw(item, col, context)
 
-            for category in cat_list:
+            for category in get_cat_list():
                 panel_type = type("NODE_PT_category_sv_" + category.identifier, (bpy.types.Panel,), {
                         "bl_space_type": "NODE_EDITOR",
                         "bl_region_type": "UI",
@@ -496,7 +506,7 @@ def register_node_panels(identifier, cat_list):
                     check_category = not check_search
                     category_is_first = True
 
-                    for category in cat_list:
+                    for category in get_cat_list():
                         category_ok = category.identifier == context.scene.sv_selected_category
                         if check_category:
                             if not category_ok:
@@ -561,6 +571,42 @@ def unregister_node_add_operators():
     for idname in node_add_operators:
         bpy.utils.unregister_class(node_add_operators[idname])
 
+extra_category_providers = []
+
+def register_extra_category_provider(provider):
+    global extra_category_providers
+    extra_category_providers.append(provider)
+
+def unregister_extra_category_provider(identifier):
+    global extra_category_providers
+    idx = None
+    for i, provider in enumerate(extra_category_providers):
+        if provider.identifier == identifier:
+            idx = i
+    if idx is None:
+        raise Exception(f"Provider {identifier} was not registered")
+    del extra_category_providers[idx]
+
+def get_extra_categories():
+    global extra_category_providers
+    result = []
+    for provider in extra_category_providers:
+        result.extend(provider.get_categories())
+    return result
+
+def get_all_categories(std_categories):
+
+    def generate(self, context):
+        nonlocal std_categories
+        extra_categories = get_extra_categories()
+        n = len(std_categories)
+        all_categories = std_categories[:]
+        for category in extra_categories:
+            n += 1
+            all_categories.append((category.identifier, category.name, category.name, n))
+        return all_categories
+    return generate
+
 def register():
     menu, node_count, original_categories = make_categories()
     if 'SVERCHOK' in nodeitems_utils._node_categories:
@@ -572,7 +618,7 @@ def register():
     bpy.types.Scene.sv_selected_category = bpy.props.EnumProperty(
                         name = "Category",
                         description = "Select nodes category",
-                        items = categories
+                        items = get_all_categories(categories)
                     )
     bpy.types.Scene.sv_node_search = bpy.props.StringProperty(
                         name = "Search",

--- a/menu.py
+++ b/menu.py
@@ -32,6 +32,7 @@ from sverchok.utils.logging import info, error, exception
 from sverchok.utils.sv_help import build_help_remap
 from sverchok.ui.sv_icons import node_icon, icon
 from sverchok.utils.context_managers import sv_preferences
+from sverchok.utils.extra_categories import get_extra_categories
 
 class SverchNodeCategory(NodeCategory):
     @classmethod
@@ -571,29 +572,6 @@ def unregister_node_add_operators():
     for idname in node_add_operators:
         bpy.utils.unregister_class(node_add_operators[idname])
 
-extra_category_providers = []
-
-def register_extra_category_provider(provider):
-    global extra_category_providers
-    extra_category_providers.append(provider)
-
-def unregister_extra_category_provider(identifier):
-    global extra_category_providers
-    idx = None
-    for i, provider in enumerate(extra_category_providers):
-        if provider.identifier == identifier:
-            idx = i
-    if idx is None:
-        raise Exception(f"Provider {identifier} was not registered")
-    del extra_category_providers[idx]
-
-def get_extra_categories():
-    global extra_category_providers
-    result = []
-    for provider in extra_category_providers:
-        result.extend(provider.get_categories())
-    return result
-
 def get_all_categories(std_categories):
 
     def generate(self, context):
@@ -631,7 +609,6 @@ def register():
 
     build_help_remap(original_categories)
     print(f"sv: {node_count} nodes.")
-
 
 def unregister():
     if 'SVERCHOK' in nodeitems_utils._node_categories:

--- a/nodes/vector/attractor.py
+++ b/nodes/vector/attractor.py
@@ -22,29 +22,15 @@ from mathutils import Vector, Matrix
 from mathutils.kdtree import KDTree
 import math
 
-from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.node_tree import SverchCustomTreeNode, throttled
 from sverchok.data_structure import updateNode, match_long_repeat, fullList
+from sverchok.utils.math import inverse, inverse_square, inverse_cubic, inverse_exp, gauss
 
 def get_avg_vector(vectors):
     result = Vector((0,0,0))
     for vector in vectors:
         result += vector
     return result / len(vectors)
-
-def inverse(c, x):
-    return 1.0/x
-
-def inverse_square(c, x):
-    return 1.0/(x*x)
-
-def inverse_cubic(c, x):
-    return 1.0/(x*x*x)
-
-def inverse_exp(c, x):
-    return math.exp(-c*x)
-
-def gauss(c, x):
-    return math.exp(-c*x*x/2.0)
 
 class SvAttractorNode(bpy.types.Node, SverchCustomTreeNode):
     '''Attraction vectors calculator'''
@@ -67,10 +53,10 @@ class SvAttractorNode(bpy.types.Node, SverchCustomTreeNode):
             ("gauss", "Gauss - Exp(-R^2/2)", "", 4)
         ]
 
+    @throttled
     def update_type(self, context):
         self.inputs['Direction'].hide_safe = (self.attractor_type == 'Point')
         self.inputs['Coefficient'].hide_safe = (self.falloff_type not in ['inverse_exp', 'gauss'])
-        updateNode(self, context)
 
     attractor_type: EnumProperty(
         name="Attractor type", items=types, default='Point', update=update_type)

--- a/ui/nodeview_space_menu.py
+++ b/ui/nodeview_space_menu.py
@@ -26,8 +26,9 @@ but massively condensed for sanity.
 
 import bpy
 
-from sverchok.menu import make_node_cats, draw_add_node_operator, get_extra_categories
+from sverchok.menu import make_node_cats, draw_add_node_operator
 from sverchok.utils import get_node_class_reference
+from sverchok.utils.extra_categories import get_extra_categories
 from sverchok.ui.sv_icons import node_icon, icon, get_icon_switch, custom_icon
 from sverchok.ui import presets
 # from nodeitems_utils import _node_categories

--- a/ui/sv_icons.py
+++ b/ui/sv_icons.py
@@ -7,7 +7,31 @@ import sverchok
 
 # custom icons dictionary
 _icon_collection = {}
+
+class SvIconProviderRecord(object):
+    def __init__(self, provider_id, provider):
+        self.provider_id = provider_id
+        self.provider = provider
+        self.provider_inited = False
+
+    def init(self, custom_icons):
+        if self.provider_inited:
+            return
+        for icon_id, path in self.provider.get_icons():
+            custom_icons.load(icon_id, path, "IMAGE")
+
+_icon_providers = dict()
+
 addon_name = sverchok.__name__
+
+def register_custom_icon_provider(provider_id, provider):
+    global _icon_providers
+    # make sure that _icon_collection["main"] is initialized
+    load_custom_icons()
+    record = SvIconProviderRecord(provider_id, provider)
+    _icon_providers[provider_id] = record
+    custom_icons = _icon_collection["main"]
+    record.init(custom_icons)
 
 def custom_icon(name):
     load_custom_icons()  # load in case they custom icons not already loaded
@@ -35,6 +59,9 @@ def load_custom_icons():
         iconName = os.path.splitext(iconFile)[0]
         iconID = iconName.upper()
         custom_icons.load(iconID, os.path.join(iconsDir, iconFile), "IMAGE")
+
+    for provider in _icon_providers.values():
+        provider.init(custom_icons)
 
     _icon_collection["main"] = custom_icons
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -59,7 +59,7 @@ def register_node_classes_factory(node_class_references, ops_class_references=No
 
         return register, unregister
 
-def auto_gather_node_classes():
+def auto_gather_node_classes(start_module = None):
     """ 
     this produces a dict with mapping from bl_idname to class reference at runtime 
     f.ex   
@@ -67,8 +67,10 @@ def auto_gather_node_classes():
     """
 
     import inspect
+    if start_module is None:
+        start_module = sverchok.nodes
 
-    node_cats = inspect.getmembers(sverchok.nodes, inspect.ismodule)
+    node_cats = inspect.getmembers(start_module, inspect.ismodule)
     for catname, nodecat in node_cats:
         node_files = inspect.getmembers(nodecat, inspect.ismodule)
         for filename, fileref in node_files:

--- a/utils/extra_categories.py
+++ b/utils/extra_categories.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+extra_category_providers = []
+
+def register_extra_category_provider(provider):
+    global extra_category_providers
+    extra_category_providers.append(provider)
+
+def unregister_extra_category_provider(identifier):
+    global extra_category_providers
+    idx = None
+    for i, provider in enumerate(extra_category_providers):
+        if provider.identifier == identifier:
+            idx = i
+    if idx is None:
+        raise Exception(f"Provider {identifier} was not registered")
+    del extra_category_providers[idx]
+
+def get_extra_categories():
+    global extra_category_providers
+    result = []
+    for provider in extra_category_providers:
+        result.extend(provider.get_categories())
+    return result
+

--- a/utils/math.py
+++ b/utils/math.py
@@ -40,6 +40,21 @@ def sphere(x):
 def invsquare(x):
     return x*x
 
+def inverse(c, x):
+    return 1.0/x
+
+def inverse_square(c, x):
+    return 1.0/(x*x)
+
+def inverse_cubic(c, x):
+    return 1.0/(x*x*x)
+
+def inverse_exp(c, x):
+    return math.exp(-c*x)
+
+def gauss(c, x):
+    return math.exp(-c*x*x/2.0)
+
 def falloff(type, radius, rho):
     if rho <= 0:
         return 1.0

--- a/utils/modules/eval_formula.py
+++ b/utils/modules/eval_formula.py
@@ -111,6 +111,29 @@ def get_variables(string):
     result = visitor.variables
     return result.difference(safe_names.keys())
 
+def sv_compile(string):
+    try:
+        root = ast.parse(string, mode='eval')
+        return compile(root, "<expression>", 'eval')
+    except SyntaxError as e:
+        logging.exception(e)
+        raise Exception("Invalid expression syntax: " + str(e))
+
+def safe_eval_compiled(compiled, variables):
+    """
+    Evaluate expression, allowing only functions known to be "safe"
+    to be used.
+    """
+    try:
+        env = dict()
+        env.update(safe_names)
+        env.update(variables)
+        env["__builtins__"] = {}
+        return eval(compiled, env)
+    except SyntaxError as e:
+        logging.exception(e)
+        raise Exception("Invalid expression syntax: " + str(e))
+
 # It could be safer...
 def safe_eval(string, variables):
     """


### PR DESCRIPTION
This adds basic support for extension addons, that would be installed together with Sverchok and add new nodes and node categories.

This adds API methods for such addons to register their nodes and node categories in Sverchok's menus and panels.

Currently I use these functions in my "Sverchok-Extra" addon (discussed in #2837). Later this (or similar) API can be used by other addons that extend Sverchok's functionality.

I do not consider this implementation as final, it may be improved and generalized later.

If you do not have any "extra" addons installed, you should not notice any difference in Sverchok's work.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [ ] Code changes complete.
- [ ] Code documentation complete.
- [ ] Documentation for users complete (or not required, if user never sees these changes).
- [ ] Manual testing done. 
- [ ] Unit-tests implemented.
- [ ] Ready for merge.

