### PR TITLE
Normal vector node

### DIFF
--- a/index.md
+++ b/index.md
@@ -246,6 +246,7 @@
     VectorDropNode
     VectorPolarInNode
     VectorPolarOutNode
+    SvVectorNormalIn
     SvAttractorNode
     ---
     SvVectorLerp

--- a/nodes/vector/vector_normal_in.py
+++ b/nodes/vector/vector_normal_in.py
@@ -5,7 +5,11 @@
 # SPDX-License-Identifier: GPL3
 # License-Filename: LICENSE
 
+
 from itertools import chain, cycle
+
+from collections import namedtuple
+from math import pi
 
 import bpy
 from mathutils import Quaternion, Vector
@@ -14,14 +18,25 @@ from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode
 
 
-quat_x90 = Quaternion((1, 0, 0), 1.57)
+Modes = namedtuple('Modes', ['x', 'y', 'z', 'custom'])
+MODE = Modes('X', 'Y', 'Z', 'Custom')
+MODE_DIR = Modes(Vector((1, 0, 0)), Vector((0, 1, 0)), Vector((0, 0, 1)), None)
+
+QUAT_X90 = Quaternion((1, 0, 0), pi / 2)
+QUAT_Y270 = Quaternion((0, 1, 0), -pi / 2)
 
 
-def get_costume_norm(normal, space_normal):
+def get_costume_norm(normal, space_normal, mode=MODE.z):
+    space_normal = Vector(space_normal).normalized() if mode == MODE.custom else getattr(MODE_DIR, mode.lower())
+    if space_normal == MODE_DIR.z:
+        return [normal[:]]
     quat_rotation_xy = Vector((0, -1, 0)).rotation_difference(Vector(space_normal[:2] + (0,)))
-    quat_rotation_z = Vector(space_normal[:2] + (0,)).rotation_difference(Vector(space_normal))
+    quat_rotation_z = Vector(space_normal[:2] + (0,)).rotation_difference(space_normal)
     quat_rotation = quat_rotation_z @ quat_rotation_xy
-    quat = quat_rotation @ quat_x90
+    quat = quat_rotation @ QUAT_X90
+    if space_normal == MODE_DIR.y:
+        #corner case for quaternion
+        quat = QUAT_Y270 @ quat
     return [(quat @ normal)[:]]
 
 
@@ -40,12 +55,13 @@ class SvVectorNormalIn(bpy.types.Node, SverchCustomTreeNode):
         def set_hide(socket, state):
             if state != socket.hide:
                 socket.hide = state
-        if self.modes == 'Custom':
+        if self.mode == 'Custom':
             set_hide(self.inputs['Verts'], False)
         else:
             set_hide(self.inputs['Verts'], True)
+        updateNode(self, context)
 
-    modes: bpy.props.EnumProperty(items=[(n, n, '') for n in ('X', 'Y', 'Z', 'Custom')], default='Z',
+    mode: bpy.props.EnumProperty(items=[(n, n, '') for n in ('X', 'Y', 'Z', 'Custom')], default='Z',
                                   update=update_node)
     vector: bpy.props.FloatVectorProperty(default=(0.0, 0.0, 1.0), subtype='DIRECTION', update=updateNode)
     custom_vector: bpy.props.FloatVectorProperty(default=(0.0, 0.0, 1.0), update=updateNode)
@@ -56,10 +72,12 @@ class SvVectorNormalIn(bpy.types.Node, SverchCustomTreeNode):
         layout.prop(self, 'vector', text='')
 
     def draw_buttons_ext(self, context, layout):
+        col = layout.column(align=True)
+        col.prop(self, 'vector', text='Normal', expand=True)
         layout.prop(self, 'draw_3dpanel')
 
     def draw_socket(self, socket, context, layout):
-        layout.prop(self, 'modes', expand=True)
+        layout.prop(self, 'mode', expand=True)
 
     def draw_buttons_3dpanel(self, layout):
         layout.label(text=f"{self.label or self.name}")
@@ -74,7 +92,7 @@ class SvVectorNormalIn(bpy.types.Node, SverchCustomTreeNode):
     def process(self):
         out = []
         for space in self.inputs['Verts'].sv_get(deepcopy=False):
-            out.append(get_costume_norm(self.vector, space[0]))
+            out.append(get_costume_norm(self.vector, space[0], self.mode))
         self.outputs['Verts'].sv_set(out)
 
 

--- a/nodes/vector/vector_normal_in.py
+++ b/nodes/vector/vector_normal_in.py
@@ -8,9 +8,21 @@
 from itertools import chain, cycle
 
 import bpy
+from mathutils import Quaternion, Vector
 
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode
+
+
+quat_x90 = Quaternion((1, 0, 0), 1.57)
+
+
+def get_costume_norm(normal, space_normal):
+    quat_rotation_xy = Vector((0, -1, 0)).rotation_difference(Vector(space_normal[:2] + (0,)))
+    quat_rotation_z = Vector(space_normal[:2] + (0,)).rotation_difference(Vector(space_normal))
+    quat_rotation = quat_rotation_z @ quat_rotation_xy
+    quat = quat_rotation @ quat_x90
+    return [(quat @ normal)[:]]
 
 
 class SvVectorNormalIn(bpy.types.Node, SverchCustomTreeNode):
@@ -36,21 +48,34 @@ class SvVectorNormalIn(bpy.types.Node, SverchCustomTreeNode):
     modes: bpy.props.EnumProperty(items=[(n, n, '') for n in ('X', 'Y', 'Z', 'Custom')], default='Z',
                                   update=update_node)
     vector: bpy.props.FloatVectorProperty(default=(0.0, 0.0, 1.0), subtype='DIRECTION', update=updateNode)
+    custom_vector: bpy.props.FloatVectorProperty(default=(0.0, 0.0, 1.0), update=updateNode)
+    draw_3dpanel: bpy.props.BoolProperty(name='Show in 3d panel',
+                                         description='Show items of this node in 3d panel of 3d view screen')
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'vector', text='')
 
+    def draw_buttons_ext(self, context, layout):
+        layout.prop(self, 'draw_3dpanel')
+
     def draw_socket(self, socket, context, layout):
         layout.prop(self, 'modes', expand=True)
 
+    def draw_buttons_3dpanel(self, layout):
+        layout.label(text=f"{self.label or self.name}")
+        layout.prop(self, 'vector', text='')
+
     def sv_init(self, context):
         sock_in = self.inputs.new('SvVerticesSocket', 'Verts')
-        sock_in.prop_name = 'vector'
+        sock_in.prop_name = 'custom_vector'
         sock_in.hide = True
         self.outputs.new('SvVerticesSocket', 'Verts').custom_draw = 'draw_socket'
 
     def process(self):
-        self.outputs['Verts'].sv_set(self.inputs['Verts'].sv_get())
+        out = []
+        for space in self.inputs['Verts'].sv_get(deepcopy=False):
+            out.append(get_costume_norm(self.vector, space[0]))
+        self.outputs['Verts'].sv_set(out)
 
 
 def register():

--- a/nodes/vector/vector_normal_in.py
+++ b/nodes/vector/vector_normal_in.py
@@ -1,0 +1,61 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+from itertools import chain, cycle
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode
+
+
+class SvVectorNormalIn(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: normal
+
+    ...
+    ...
+    """
+    bl_idname = 'SvVectorNormalIn'
+    bl_label = 'Vector Normal In'
+    bl_icon = 'MOD_BOOLEAN'
+
+    def update_node(self, context):
+        def set_hide(socket, state):
+            if state != socket.hide:
+                socket.hide = state
+        if self.modes == 'Custom':
+            set_hide(self.inputs['Verts'], False)
+        else:
+            set_hide(self.inputs['Verts'], True)
+
+    modes: bpy.props.EnumProperty(items=[(n, n, '') for n in ('X', 'Y', 'Z', 'Custom')], default='Z',
+                                  update=update_node)
+    vector: bpy.props.FloatVectorProperty(default=(0.0, 0.0, 1.0), subtype='DIRECTION', update=updateNode)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'vector', text='')
+
+    def draw_socket(self, socket, context, layout):
+        layout.prop(self, 'modes', expand=True)
+
+    def sv_init(self, context):
+        sock_in = self.inputs.new('SvVerticesSocket', 'Verts')
+        sock_in.prop_name = 'vector'
+        sock_in.hide = True
+        self.outputs.new('SvVerticesSocket', 'Verts').custom_draw = 'draw_socket'
+
+    def process(self):
+        self.outputs['Verts'].sv_set(self.inputs['Verts'].sv_get())
+
+
+def register():
+    bpy.utils.register_class(SvVectorNormalIn)
+
+
+def unregister():
+    bpy.utils.unregister_class(SvVectorNormalIn)


### PR DESCRIPTION
## Addressed problem description

I'm searching a way for setting direction by `direction` widget.
![vector normal](https://user-images.githubusercontent.com/28003269/72584462-8e1a6100-3903-11ea-8779-eee4cf8c442d.gif)
![2020-01-17_08-30-17](https://user-images.githubusercontent.com/28003269/72584474-9d011380-3903-11ea-8f7f-4476166bafcf.png)

It is not obvious how this should be implemented. By default the space has next view.
![2020-01-14_14-06-03](https://user-images.githubusercontent.com/28003269/72584668-71caf400-3904-11ea-96c6-5efa76e84ed6.png)

I gives opportunity to change it. Instead Z axis custom axis can be set in this case Z axis will replace Y axis.
Any suggestions are welcome.

## Preflight checklist

- [ ] Code changes complete.
- [ ] Code documentation complete.
- [ ] Documentation for users complete.
- [ ] Manual testing done. 
- [ ] Ready for merge.

