### PR TITLE
Post modifiers Objects_In fix

### DIFF
--- a/core/handlers.py
+++ b/core/handlers.py
@@ -131,20 +131,24 @@ def sv_main_handler(scene):
     global sv_depsgraph
     global depsgraph_need
 
-    if not pre_running:
-        pre_running = True
-        if depsgraph_need:
-            sv_depsgraph = bpy.context.evaluated_depsgraph_get()
-        for ng in sverchok_trees():
-            # if P (sv_process is False, we can skip this node tree.
-            if not ng.sv_process:
-                continue
+    # when this handler is called from inside another call to this handler we end early
+    # to avoid stack overflow.
+    if pre_running:
+        return
 
-            if ng.has_changed:
-                print('depsgraph_update_pre called - ng.has_changed -> ')
+    pre_running = True
+    if depsgraph_need:
+        sv_depsgraph = bpy.context.evaluated_depsgraph_get()
+    for ng in sverchok_trees():
+        # if P (sv_process is False, we can skip this node tree.
+        if not ng.sv_process:
+            continue
 
-                ng.process()
-        pre_running = False
+        if ng.has_changed:
+            print('depsgraph_update_pre called - ng.has_changed -> ')
+
+            ng.process()
+    pre_running = False
 
 
 @persistent

--- a/core/handlers.py
+++ b/core/handlers.py
@@ -14,6 +14,22 @@ from sverchok.utils import app_handler_ops
 
 _state = {'frame': None}
 
+pre_running = False
+sv_depsgraph = []
+depsgraph_need = False
+
+def get_sv_depsgraph():
+    global sv_depsgraph
+    global depsgraph_need
+    if not depsgraph_need:
+
+        sv_depsgraph = bpy.context.evaluated_depsgraph_get()
+        depsgraph_need = True
+    return sv_depsgraph
+
+def set_sv_depsgraph_need(val):
+    global depsgraph_need
+    depsgraph_need = val
 
 def sverchok_trees():
     for ng in bpy.data.node_groups:
@@ -30,9 +46,9 @@ def has_frame_changed(scene):
 #  app.handlers.undo_post and app.handlers.undo_pre are necessary to help remove stale
 #  draw callbacks (bgl / gpu / blf). F.ex the rightlick menu item "attache viewer draw"
 #  will invoke a number of commands as one event, if you undo that event (ctrl+z) then
-#  there is never a point where the node can ask "am i connected to anything, do i need 
+#  there is never a point where the node can ask "am i connected to anything, do i need
 #  to stop drawing?". When the Undo event causes a node to be removed, its node.free function
-#  is not called. (maybe it should be...) 
+#  is not called. (maybe it should be...)
 #
 #  If at any time the undo system is fixed and does call "node.free()" when a node is removed
 #  after ctrl+z. then these two functions and handlers are no longer needed.
@@ -52,7 +68,7 @@ def sv_handler_undo_post(scene):
     print('called undo post')
     # this function appears to be hoisted into an environment that does not have the same locals()
     # hence this dict must be imported. (jan 2019)
-    
+
     from sverchok.core import undo_handler_node_count
 
     num_to_test_against = 0
@@ -76,7 +92,7 @@ def sv_update_handler(scene):
     """
     if not has_frame_changed(scene):
         return
-    
+
     for ng in sverchok_trees():
         try:
             # print('sv_update_handler')
@@ -111,19 +127,24 @@ def sv_main_handler(scene):
     """
     Main Sverchok handler for updating node tree upon editor changes
     """
-    for ng in sverchok_trees():
-        # print("Scene handler looking at tree {}".format(ng.name))
+    global pre_running
+    global sv_depsgraph
+    global depsgraph_need
 
-        # if P (sv_process is False, we can skip this node tree.
-        if not ng.sv_process:
-            continue
+    if not pre_running:
+        pre_running = True
+        if depsgraph_need:
+            sv_depsgraph = bpy.context.evaluated_depsgraph_get()
+        for ng in sverchok_trees():
+            # if P (sv_process is False, we can skip this node tree.
+            if not ng.sv_process:
+                continue
 
+            if ng.has_changed:
+                print('depsgraph_update_pre called - ng.has_changed -> ')
 
-        if ng.has_changed:
-            print('depsgraph_update_pre called - ng.has_changed -> ')
-            # print('sv_main_handler')
-            # print("Edit detected in {}".format(ng.name))
-            ng.process()
+                ng.process()
+        pre_running = False
 
 
 @persistent

--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -53,9 +53,12 @@ class SvOB3Callback(bpy.types.Operator):
 
 
 class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
-    ''' Objects Input slot MK3'''
+    """
+    Triggers: Input Scene Objects
+    Tooltip: Get Scene Objects into Sverchok Tree
+    """
     bl_idname = 'SvObjectsNodeMK3'
-    bl_label = 'Objects in mk3'
+    bl_label = 'Objects in'
     bl_icon = 'OUTLINER_OB_EMPTY'
     sv_icon = 'SV_OBJECTS_IN'
 

--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -71,6 +71,10 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
         elif not self.vergroups and showing_vg:
             outs.remove(outs['Vers_grouped'])
 
+    def modifiers_handle(self, context):
+        set_sv_depsgraph_need(self.modifiers)
+        updateNode(self, context)
+
     groupname: StringProperty(
         name='groupname', description='group of objects (green outline CTRL+G)',
         default='', update=updateNode)
@@ -78,7 +82,7 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
     modifiers: BoolProperty(
         name='Modifiers',
         description='Apply modifier geometry to import (original untouched)',
-        default=False, update=updateNode)
+        default=False, update=modifiers_handle)
 
     vergroups: BoolProperty(
         name='Vergroups',

--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -221,6 +221,7 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
 
     def free(self):
         set_sv_depsgraph_need(False)
+
     def process(self):
 
         if not self.object_names:
@@ -238,7 +239,7 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
         mtrx_out = []
         materials_out = []
 
-        if self.modifiers or self.vergroups:
+        if self.modifiers:
             sv_depsgraph = get_sv_depsgraph()
 
         # iterate through references
@@ -278,7 +279,8 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
                         - or vertex groups are desired
 
                         """
-                        if self.modifiers or self.vergroups:
+
+                        if self.modifiers:
 
                             obj = sv_depsgraph.objects[obj.name]
                             obj_data = obj.to_mesh(preserve_all_data_layers=True, depsgraph=sv_depsgraph)

--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -24,7 +24,7 @@ import sverchok
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode
 from sverchok.utils.sv_bmesh_utils import pydata_from_bmesh
-
+from sverchok.core.handlers import get_sv_depsgraph, set_sv_depsgraph_need
 
 class SvOB3Callback(bpy.types.Operator):
 
@@ -216,6 +216,8 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
     def get_materials_from_mesh(self, mesh):
         return [face.material_index for face in mesh.polygons[:]]
 
+    def free(self):
+        set_sv_depsgraph_need(False)
     def process(self):
 
         if not self.object_names:
@@ -225,6 +227,7 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
         data_objects = bpy.data.objects
         outputs = self.outputs
 
+
         edgs_out = []
         vers_out = []
         vers_out_grouped = []
@@ -233,8 +236,7 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
         materials_out = []
 
         if self.modifiers or self.vergroups:
-            with self.sv_throttle_tree_update():
-                depsgraph = bpy.context.evaluated_depsgraph_get()
+            sv_depsgraph = get_sv_depsgraph()
 
         # iterate through references
         for obj in (data_objects.get(o.name) for o in self.object_names):
@@ -268,15 +270,15 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
 
                         """
                         this is where the magic happens.
-                        because we are in throttled tree update state at this point, we can aquire a depsgraph if 
+                        because we are in throttled tree update state at this point, we can aquire a depsgraph if
                         - modifiers
                         - or vertex groups are desired
 
                         """
                         if self.modifiers or self.vergroups:
-                            # depsgraph = bpy.context.evaluated_depsgraph_get()
-                            obj = depsgraph.objects[obj.name]
-                            obj_data = obj.to_mesh(preserve_all_data_layers=True, depsgraph=depsgraph)
+
+                            obj = sv_depsgraph.objects[obj.name]
+                            obj_data = obj.to_mesh(preserve_all_data_layers=True, depsgraph=sv_depsgraph)
                         else:
                             obj_data = obj.to_mesh()
 


### PR DESCRIPTION
This fixes the problem of crashing Blender when deleting one random object if you have Objects_in mk3 with post modifiers active using suggestions from #2511