### PR TITLE
Transform mesh node

### DIFF
--- a/docs/nodes/transforms/transform_mesh.rst
+++ b/docs/nodes/transforms/transform_mesh.rst
@@ -1,0 +1,100 @@
+Transform mesh
+==============
+
+.. image:: https://user-images.githubusercontent.com/28003269/73248778-010dbc80-41cd-11ea-90be-a778d398945f.png
+
+Functionality
+-------------
+The node takes mesh and transform it according parameters. It can move, scale and rotate parts of mesh.
+The logic is close how Blender manipulate with mesh itself. Selection elements determines by mask input.
+
+.. image:: https://user-images.githubusercontent.com/28003269/73249068-98730f80-41cd-11ea-8ae9-a939cfbe94de.gif
+
+Category
+--------
+
+Transforms -> Transform mesh
+
+Inputs
+------
+
+- **Verts** - vertices
+- **Edges** - edges (optionally), required if selection mode is `edges`  
+- **Faces** - faces (optionally), required if selection mode is `faces`
+- **Mask** - bool mask or index mask according mask mode
+- **Origin** - available with custom origin mode, custom origins
+- **Space direction** - available with custom space mode, custom normal
+- **Mask index** - available in index mask mode, indexes of mesh parts
+- **Direction** - transform vector, axis for rotation mode
+- **Factor** - factor of transform vector, radians for rotation mode
+
+Outputs
+-------
+
+- **Verts** - transformed vertices
+
+Parameters
+----------
+
++------------------------------+-------+--------------------------------------------------------------------------------+
+| Parameters                   | Type  | Description                                                                    |
++==============================+=======+================================================================================+
+| Transform mode               | enum  | Move, scale or rotate                                                          |
++------------------------------+-------+--------------------------------------------------------------------------------+
+| Mask mode                    | enum  | Bool mask or index mask                                                        |
++------------------------------+-------+--------------------------------------------------------------------------------+
+| Origin mode                  | enum  | Bounding box center, median center, individual center, custom center           |
++------------------------------+-------+--------------------------------------------------------------------------------+
+| Space mode                   | enum  | Global, normal, custom                                                         |
++------------------------------+-------+--------------------------------------------------------------------------------+
+| Selection mode (mask socket) | enum  | Vertexes, edges, faces                                                         |
++------------------------------+-------+--------------------------------------------------------------------------------+
+| Direction mode               | enum  | X, Y, Z or custom direction                                                    |
+|  (direction socket)          |       |                                                                                |
++------------------------------+-------+--------------------------------------------------------------------------------+
+
+**Boolean mask and values distribution:**
+Boolean mask split mesh into selected and unselected parts.
+The node apply only one parameter to all selected mesh.
+If multiple parameters such as direction vector are given they distributes between selected elements.
+Resulting direction vector is calculated by finding average value from distributed among selected elements parameters.
+
+**Index mask and values distribution:**
+Index mask marks different parts of mesh with different indexes.
+The node apply properties in this mode only for parts of mesh 
+with indexes equal to given indexes via `mask index` socket.
+
+For example: 
+
+given indexes - [1, 3], given parameters - [param1, param2]. 
+
+All parts of mesh masked by 1 will be assigned with param1.
+
+All parts of mesh masked by 3 will be assigned param2.
+
+All other parts will be unchanged.
+
+Examples
+--------
+
+Generating and moving lines on mesh level:
+
+.. image:: https://user-images.githubusercontent.com/28003269/73343086-616a3000-4299-11ea-8b7b-67110bf72fa8.png
+
+Moving disjoint parts =):
+
+.. image:: https://user-images.githubusercontent.com/28003269/73347577-469bb980-42a1-11ea-889b-b4d87c754f2d.gif
+
+.. image:: https://user-images.githubusercontent.com/28003269/73347608-53201200-42a1-11ea-96bb-358ada087da4.png
+
+randomly scaled faces:
+
+.. image:: https://user-images.githubusercontent.com/28003269/73352227-202e4c00-42aa-11ea-81ed-7d600ef1ce96.png
+
+Randomly scaled loops of torus:
+
+.. image:: https://user-images.githubusercontent.com/28003269/73356416-bfa40c80-42b3-11ea-95b5-43e7bab2918d.png
+
+Flatten monkey by nearby point:
+
+.. image:: https://user-images.githubusercontent.com/28003269/73169759-3905f880-4116-11ea-9c8d-d565371ff7a9.png

--- a/docs/nodes/transforms/transforms_index.rst
+++ b/docs/nodes/transforms/transforms_index.rst
@@ -18,3 +18,4 @@ Transforms
    transform_select
    randomize
    align_mesh_by_mesh
+   transform_mesh

--- a/index.md
+++ b/index.md
@@ -96,6 +96,7 @@
     SvAlignMeshByMesh
     ---
     SvTransformSelectNode
+    SvTransformMesh
     SvSimpleDeformNode
     SvBendAlongPathNode
     SvBendAlongSurfaceNode

--- a/nodes/transforms/transform_mesh.py
+++ b/nodes/transforms/transform_mesh.py
@@ -6,12 +6,72 @@
 # License-Filename: LICENSE
 
 
+from collections import namedtuple
 from itertools import chain, cycle
 
 import bpy
+import bmesh
+from mathutils import Matrix, Vector
 
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode
+
+
+Transform_mode = namedtuple('Transform_mode', ('move', 'scale', 'rotate'))
+Select_mode = namedtuple('Select_mode', ('vert', 'edge', 'face'))
+Origin_mode = namedtuple('Origin_mode', ('individ', 'median', 'bound', 'cust'))
+Space_mode = namedtuple('Space_mode', ('norm', 'glob', 'cust'))
+Direction_mode = namedtuple('Direction_mode', ('x', 'y', 'z', 'cust'))
+
+TR_MODE = Transform_mode('Move', 'Scale', 'Rotate')
+SEL_MODE = Select_mode('Verts', 'Edges', 'Faces')
+OR_MODE = Origin_mode('Individual', 'Median', 'Center bound box', 'Custom')
+SP_MODE = Space_mode('Normal', 'Global', 'Custom')
+DIR_MODE = Direction_mode('X', 'Y', 'Z', 'Custom')
+DIR_VEC = Direction_mode(Vector((1, 0, 0)), Vector((0, 1, 0)), Vector((0, 0, 1)), None)
+
+
+def transform_mesh(verts, edges=None, faces=None, mask=None, custom_origin=None, custom_direction=None, factor=None, 
+                   transform_mode=TR_MODE.move, origin_mode=OR_MODE.individ,
+                   direction_mode=DIR_MODE.x, selection_mode=SEL_MODE.vert, space_mode=SP_MODE.glob):
+    bm = bmesh.new()
+    bm_verts = [bm.verts.new(co) for co in verts]
+    bm_edges = [bm.edges.new((bm_verts[i1], bm_verts[i2])) for i1, i2 in edges] if edges else []
+    bm_faces = [bm.faces.new([bm_verts[i] for i in face]) for face in faces] if faces else []
+
+    if mask:
+        if selection_mode == SEL_MODE.vert:
+            for vert, select in zip(bm_verts, mask):
+                if select:
+                    vert.select = True
+        elif selection_mode == SEL_MODE.edge and bm_edges:
+            for edge, select in zip(bm_edges, mask):
+                if select:
+                    edge.select_set(True)
+        elif selection_mode == SEL_MODE.face and bm_faces:
+            for face, select in zip(bm_faces, mask):
+                if select:
+                    face.select_set(True)
+    else:
+        [setattr(vert, 'select', True) for vert in bm_verts]
+        [setattr(edge, 'select', True) for edge in bm_edges]
+        [setattr(face, 'select', True) for face in bm_faces]
+
+    bmesh.ops.translate(bm, vec=get_move_vector(custom_direction, factor, direction_mode),
+                        space=Matrix(), verts=[v for v in bm_verts if v.select])
+
+    return [v.co[:] for v in bm_verts]
+
+
+def get_move_vector(direction, factor, direction_mode=DIR_MODE.x):
+    if direction_mode in DIR_MODE[:-1]:
+        return getattr(DIR_VEC, direction_mode.lower()) * factor[0]
+    else:
+        return Vector(direction) * factor[0]
+
+
+def iter_last(l):
+    return chain(l, cycle([l[-1]]))
 
 
 class SvTransformMesh(bpy.types.Node, SverchCustomTreeNode):
@@ -25,33 +85,38 @@ class SvTransformMesh(bpy.types.Node, SverchCustomTreeNode):
     bl_label = 'Transform Mesh'
     bl_icon = 'MOD_BOOLEAN'
 
+    def update_sockets(self, context):
+        if self.origin_mode != OR_MODE.cust:
+            self.inputs['Origin'].hide = True
+        else:
+            self.inputs['Origin'].hide = False
+        updateNode(self, context)
+
     transform_mode_items = [(i, i, '') for i in ('Move', 'Scale', 'Rotate')]
     select_mode_items = [(n, n, '', ic, i) for i, (n, ic) in enumerate(zip(
         ('Verts', 'Edges', 'Faces'), ('VERTEXSEL', 'EDGESEL', 'FACESEL')))]
     origin_mode_items = [(n, n, '', ic, i) for i, (n, ic) in enumerate(zip(
         ('Individual', 'Median', 'Center bound box', 'Custom'),
         ('PIVOT_INDIVIDUAL', 'PIVOT_MEDIAN', 'PIVOT_BOUNDBOX', 'PIVOT_CURSOR')))]
-    direction_mode_items = [(n, n, '', ic, i) for i, (n, ic) in enumerate(zip(
+    space_mode_items = [(n, n, '', ic, i) for i, (n, ic) in enumerate(zip(
         ('Normal', 'Global', 'Custom'), ('ORIENTATION_NORMAL', 'ORIENTATION_GLOBAL', 'ORIENTATION_CURSOR')))]
+    direction_mode_items = [(n, n, '') for n in DIR_MODE]
 
     transform_mode: bpy.props.EnumProperty(items=transform_mode_items)
     select_mode: bpy.props.EnumProperty(items=select_mode_items)
-    origin_mode: bpy.props.EnumProperty(items=origin_mode_items, name='Origin')
+    origin_mode: bpy.props.EnumProperty(items=origin_mode_items, name='Origin', default='Custom', update=update_sockets)
+    space_mode: bpy.props.EnumProperty(items=space_mode_items, name='Space')
     direction_mode: bpy.props.EnumProperty(items=direction_mode_items, name='Direction')
     origin: bpy.props.FloatVectorProperty(name='Origin')
     direction: bpy.props.FloatVectorProperty(name='Direction')
-    factor: bpy.props.FloatProperty(name='Factor')
+    factor: bpy.props.FloatProperty(name='Factor', default=1.0)
 
     def draw_buttons(self, context, layout):
         row = layout.row()
         row.scale_y = 1.5
         row.prop(self, 'transform_mode', expand=True)
         layout.prop(self, 'origin_mode')
-        layout.prop(self, 'direction_mode')
-
-    def draw_mask_socket(self, socket, context, layout):
-        layout.label(text='Mask')
-        layout.prop(self, 'select_mode', expand=True, icon_only=True)
+        layout.prop(self, 'space_mode')
 
     def draw_buttons_ext(self, context, layout):
         pass
@@ -62,12 +127,42 @@ class SvTransformMesh(bpy.types.Node, SverchCustomTreeNode):
         self.inputs.new('SvStringsSocket', 'Faces')
         self.inputs.new('SvStringsSocket', "Mask").custom_draw = 'draw_mask_socket'
         self.inputs.new('SvVerticesSocket', "Origin").prop_name = 'origin'
-        self.inputs.new('SvVerticesSocket', "Direction").prop_name = 'direction'
+        dir_sock = self.inputs.new('SvVerticesSocket', "Direction")
+        dir_sock.custom_draw = 'draw_direction_socket'
+        dir_sock.prop_name = 'direction'
         self.inputs.new('SvStringsSocket', "Factor").prop_name = 'factor'
         self.outputs.new('SvVerticesSocket', 'Verts')
 
+    def draw_mask_socket(self, socket, context, layout):
+        layout.label(text='Mask')
+        layout.prop(self, 'select_mode', expand=True, icon_only=True)
+
+    def draw_direction_socket(self, socket, context, layout):
+        if socket.is_linked:
+            layout.label(text='Direction')
+        else:
+            col = layout.column()
+            row = col.row()
+            row.prop(self, 'direction_mode', expand=True)
+            if self.direction_mode == DIR_MODE.cust:
+                socket.draw_expander_template(context, col, self, 'direction')
+
     def process(self):
-        pass
+        if not self.inputs['Verts'].is_linked:
+            return
+
+        verts = self.inputs['Verts'].sv_get(deepcopy=False)
+        edges = self.inputs['Edges'].sv_get(deepcopy=False) if self.inputs['Edges'].is_linked else cycle([None])
+        faces = self.inputs['Faces'].sv_get(deepcopy=False) if self.inputs['Faces'].is_linked else cycle([None])
+        mask = iter_last(self.inputs['Mask'].sv_get(deepcopy=False)) if self.inputs['Mask'].is_linked else cycle([None])
+        origin = iter_last(self.inputs['Origin'].sv_get(deepcopy=False))
+        direction = iter_last(self.inputs['Direction'].sv_get(deepcopy=False))
+        factor = iter_last(self.inputs['Factor'].sv_get(deepcopy=False))
+        out = []
+        for v, e, f, m , o, d, fac in zip(verts, edges,faces, mask, origin, direction, factor):
+            out.append(transform_mesh(v, e, f, m, o, d, fac, self.transform_mode, self.origin_mode,
+                                      self.direction_mode, self.select_mode, self.space_mode))
+        self.outputs['Verts'].sv_set(out)
 
 
 def register():

--- a/nodes/transforms/transform_mesh.py
+++ b/nodes/transforms/transform_mesh.py
@@ -6,6 +6,8 @@
 # License-Filename: LICENSE
 
 
+from contextlib import contextmanager
+from functools import reduce, lru_cache
 from collections import namedtuple
 from itertools import chain, cycle
 
@@ -34,31 +36,67 @@ DIR_VEC = Direction_mode(Vector((1, 0, 0)), Vector((0, 1, 0)), Vector((0, 0, 1))
 def transform_mesh(verts, edges=None, faces=None, mask=None, custom_origin=None, custom_direction=None, factor=None, 
                    transform_mode=TR_MODE.move, origin_mode=OR_MODE.individ,
                    direction_mode=DIR_MODE.x, selection_mode=SEL_MODE.vert, space_mode=SP_MODE.glob):
-    bm = bmesh.new()
-    bm_verts = [bm.verts.new(co) for co in verts]
-    bm_edges = [bm.edges.new((bm_verts[i1], bm_verts[i2])) for i1, i2 in edges] if edges else []
-    bm_faces = [bm.faces.new([bm_verts[i] for i in face]) for face in faces] if faces else []
-    sel_verts = get_selected_verts(bm_verts, bm_edges, bm_faces, mask, selection_mode)
-    if space_mode == SP_MODE.norm:
-        bm.normal_update()
-        space = Matrix.Rotation(factor)
+    if mask and selection_mode == SEL_MODE.face and not faces:
+        raise LookupError("Faces should be connected")
+    if mask and selection_mode == SEL_MODE.edge and not any([faces, edges]):
+        raise LookupError("Faces or edges should be connected")
+    if not any(mask):
+        return verts
 
-    if transform_mode == TR_MODE.move:
-        bmesh.ops.translate(bm, vec=get_move_vector(custom_direction, factor, direction_mode),
-                            space=Matrix(), verts=sel_verts)
-    elif transform_mode == TR_MODE.rotate:
-        bmesh.ops.rotate(bm, cent=(0, 0, 0),
-                         matrix=Matrix.Rotation(factor[0], 3, get_move_axis(custom_direction, direction_mode)),
-                         verts=sel_verts, space=Matrix())
-    elif transform_mode == TR_MODE.scale:
-        bmesh.ops.scale(bm, vec=custom_direction[0], space=Matrix.Translation(custom_origin[0]), verts=sel_verts)
+    with get_bmesh(verts, edges, faces, space_mode == SP_MODE.norm) as bm:
+        sel_verts = get_selected_verts(bm, mask, selection_mode)
+        space = get_space(bm, mask, selection_mode, space_mode, origin_mode)
 
-    return [v.co[:] for v in bm_verts]
+        if transform_mode == TR_MODE.move:
+            # space matrix applies to bmesh vertices
+            bmesh.ops.translate(bm, vec=space.to_quaternion() @ get_move_vector(custom_direction, factor, direction_mode),
+                                space=Matrix(), verts=sel_verts)
+        elif transform_mode == TR_MODE.rotate:
+            bmesh.ops.rotate(bm, cent=space.to_translation(),
+                             matrix=Matrix.Rotation(factor[0], 3, space.to_quaternion() @ get_move_axis(custom_direction, direction_mode)),
+                             verts=sel_verts, space=Matrix())
+        elif transform_mode == TR_MODE.scale:
+            bmesh.ops.scale(bm, vec=get_scale_vector(custom_direction, factor, direction_mode),
+                            space=space.inverted(), verts=sel_verts)
+
+        return [v.co[:] for v in bm.verts]
+
+
+@contextmanager
+def get_bmesh(verts, edges=None, faces=None, update_normals=False, use_operators=True):
+    error = None
+    bm = bmesh.new(use_operators=use_operators)
+    try:
+        bm_verts = [bm.verts.new(co) for co in verts]
+        [bm.edges.new((bm_verts[i1], bm_verts[i2])) for i1, i2 in edges or []]
+        [bm.faces.new([bm_verts[i] for i in face]) for face in faces or []]
+        bm.verts.ensure_lookup_table()
+        bm.edges.ensure_lookup_table()
+        bm.faces.ensure_lookup_table()
+        if update_normals:
+            bm.normal_update()
+        yield bm
+    except Exception as Ex:
+        error = Ex
+    finally:
+        bm.free()
+    if error:
+        raise error
 
 
 def get_move_vector(direction, factor, direction_mode=DIR_MODE.x):
     if direction_mode in DIR_MODE[:-1]:
         return getattr(DIR_VEC, direction_mode.lower()) * factor[0]
+    else:
+        return Vector(direction[0]) * factor[0]
+
+
+def get_scale_vector(direction, factor, direction_mode=DIR_MODE.x):
+    index = {'X': 0, 'Y': 1, 'Z': 2}
+    if direction_mode in DIR_MODE[:-1]:
+        vec = [1, 1]
+        vec.insert(index[direction_mode], 1 * factor[0])
+        return Vector(vec)
     else:
         return Vector(direction[0]) * factor[0]
 
@@ -70,40 +108,137 @@ def get_move_axis(direction, direction_mode):
         return direction[0]
 
 
-def get_selected_verts(bm_verts, bm_edges, bm_faces, mask, sel_mode):
+def get_selected_verts(bm, mask, sel_mode):
     if mask:
         if sel_mode == SEL_MODE.vert:
-            return [vert for vert, select in zip(bm_verts, mask) if select]
-        elif sel_mode == SEL_MODE.edge and bm_edges:
-            return list({vert for edge, select in zip(bm_edges, mask) if select for vert in edge.verts})
-        elif sel_mode == SEL_MODE.face and bm_faces:
-            return list({vert for face, select in zip(bm_faces, mask) if select for vert in face.verts})
+            return [vert for vert, select in zip(bm.verts, mask) if select]
+        elif sel_mode == SEL_MODE.edge and bm.edges:
+            return list({vert for edge, select in zip(bm.edges, mask) if select for vert in edge.verts})
+        elif sel_mode == SEL_MODE.face and bm.faces:
+            return list({vert for face, select in zip(bm.faces, mask) if select for vert in face.verts})
     else:
-        return bm_verts
+        return bm.verts
 
 
-def get_normal_tangent(bm_verts, bm_edges, bm_faces, mask, sel_mode):
+def get_space(bm, mask, sel_mode, space_mode, origin_mode):
     if sel_mode == SEL_MODE.vert:
-        return calc_average_normal([vert.noraml for vert, sel in zip(bm_verts, mask) if mask])
+        selected = [v for v, m in zip(bm.verts, mask or cycle([True])) if m]
     elif sel_mode == SEL_MODE.edge:
-        return calc_average_normal(
-            [v.normal for v in {vert for edge, sel in zip(bm_edges, mask) if edge for vert in edge.verts}])
+        selected = [e for e, m in zip(bm.edges, mask or cycle([True])) if m]
     elif sel_mode == SEL_MODE.face:
-        return calc_average_normal([face.normal for face, sel in zip(bm_faces, mask) if sel])
+        selected = [f for f, m in zip(bm.faces, mask or cycle([True])) if m]
+    else:
+        raise ValueError(f"Given selection mode: {sel_mode} is unsupported")
+    origin = get_origin(selected, origin_mode)
+    if space_mode == SP_MODE.glob:
+        return Matrix.Translation(origin)
+    elif space_mode == SP_MODE.norm:
+        normal = get_normals(selected)
+        tangent = get_tangents(selected)
+        return build_matrix(origin, normal, tangent)
+
+
+def get_origin(mesh_component, origin_mode):
+    if type(mesh_component[0]) == bmesh.types.BMVert:
+        return get_verts_origin(mesh_component, origin_mode)
+    elif type(mesh_component[0]) == bmesh.types.BMEdge:
+        return get_edges_origin(mesh_component, origin_mode)
+    elif type(mesh_component[0]) == bmesh.types.BMFace:
+        return get_faces_origin(mesh_component, origin_mode)
+    else:
+        raise ValueError(f"Such type: {type(mesh_component)} is not supported")
+
+
+def get_verts_origin(verts, origin_mode):
+    if origin_mode == OR_MODE.bound:
+        return get_bound_center([v.co for v in verts])
+
+
+def get_edges_origin(edges, origin_mode):
+    if origin_mode == OR_MODE.bound:
+        return get_bound_center([e.verts[0].co.lerp(e.verts[1].co, 0.5) for e in edges])
+
+
+def get_faces_origin(faces, origin_mode):
+    if origin_mode == OR_MODE.bound:
+        return get_bound_center([f.calc_center_bounds() for f in faces])
+
+
+def get_bound_center(verts):
+    x_min = min(v.x for v in verts)
+    y_min = min(v.y for v in verts)
+    z_min = min(v.z for v in verts)
+    x_max = max(v.x for v in verts)
+    y_max = max(v.y for v in verts)
+    z_max = max(v.z for v in verts)
+    return Vector(((x_min + x_max) / 2, (y_min + y_max) / 2, (z_min + z_max) / 2))
+
+
+def get_normals(mesh_component):
+    if type(mesh_component[0]) == bmesh.types.BMVert:
+        return calc_average_normal([v.normal for v in mesh_component])
+    elif type(mesh_component[0]) == bmesh.types.BMEdge:
+        return calc_average_normal([get_edge_normal_tangent(e)[0] for e in mesh_component])
+    elif type(mesh_component[0]) == bmesh.types.BMFace:
+        return calc_average_normal([f.normal for f in mesh_component])
+    else:
+        raise ValueError(f"Such type: {type(mesh_component)} is not supported")
+
+
+def get_tangents(mesh_component):
+    if type(mesh_component[0]) == bmesh.types.BMVert:
+        return calc_average_normal([get_vert_tang(v) for v in mesh_component])
+    elif type(mesh_component[0]) == bmesh.types.BMEdge:
+        return calc_average_normal([get_edge_normal_tangent(e)[1] for e in mesh_component])
+    elif type(mesh_component[0]) == bmesh.types.BMFace:
+        return calc_average_normal([get_face_tangent(f) for f in mesh_component])
+    else:
+        raise ValueError(f"Such type: {type(mesh_component)} is not supported")
 
 
 def calc_average_normal(normals):
-    n1 = normals.pop()
-    for n2 in normals:
-        n1 = (n1 + n2).normalized()
-    return n1
+    return reduce(lambda v1, v2: v1 + v2, normals).normalized()
+    # n1 = normals.pop()
+    # for n2 in normals:
+    #     n1 = (n1 + n2).normalized()
+    # return n1
 
 
-def calc_edge_normal(edge):
+@lru_cache(maxsize=None)
+def get_edge_normal_tangent(edge):
     direct = (edge.verts[1].co - edge.verts[0].co).normalized()
     _normal = (edge.verts[0].normal + edge.verts[1].normal).normalized()
     tang = direct.cross(_normal)
-    return tang.cross(direct)
+    return tang.cross(direct), tang
+
+
+def get_vert_tang(vert):
+    # returns tangent close to Blender logic in normal mode
+    # vert - bmesh vertex
+    if len(vert.link_edges) == 2:
+        return vert.link_loops[0].calc_tangent().cross(vert.normal)
+    elif vert.normal == Vector((0, 0, 1)):
+        return Vector((-1, 0, 0))
+    elif vert.normal == Vector((0, 0, -1)):
+        return Vector((1, 0, 0))
+    else:
+        return vert.normal.cross(vert.normal.cross(Vector((0, 0, 1)))).normalized()
+
+
+def get_face_tangent(face):
+    # returns tangent close to Blender logic in normal mode
+    # face - bmesh face
+    if len(face.edges) > 3:
+        return face.calc_tangent_edge_pair().normalized() * -1
+    else:
+        return face.calc_tangent_edge_diagonal()
+
+
+def build_matrix(center, normal, tangent):
+    # build matrix from 3 vectors (center, normal(z), tangent(y))
+    x_axis = tangent.cross(normal)
+    # x_axis = normal.cross(tangent)
+    return Matrix(list(zip(x_axis.resized(4), tangent.resized(4), normal.resized(4), center.to_4d())))
 
 
 def iter_last(l):

--- a/nodes/transforms/transform_mesh.py
+++ b/nodes/transforms/transform_mesh.py
@@ -1,0 +1,78 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+
+from itertools import chain, cycle
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode
+
+
+class SvTransformMesh(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: ...
+
+    ...
+    ...
+    """
+    bl_idname = 'SvTransformMesh'
+    bl_label = 'Transform Mesh'
+    bl_icon = 'MOD_BOOLEAN'
+
+    transform_mode_items = [(i, i, '') for i in ('Move', 'Scale', 'Rotate')]
+    select_mode_items = [(n, n, '', ic, i) for i, (n, ic) in enumerate(zip(
+        ('Verts', 'Edges', 'Faces'), ('VERTEXSEL', 'EDGESEL', 'FACESEL')))]
+    origin_mode_items = [(n, n, '', ic, i) for i, (n, ic) in enumerate(zip(
+        ('Individual', 'Median', 'Center bound box', 'Custom'),
+        ('PIVOT_INDIVIDUAL', 'PIVOT_MEDIAN', 'PIVOT_BOUNDBOX', 'PIVOT_CURSOR')))]
+    direction_mode_items = [(n, n, '', ic, i) for i, (n, ic) in enumerate(zip(
+        ('Normal', 'Global', 'Custom'), ('ORIENTATION_NORMAL', 'ORIENTATION_GLOBAL', 'ORIENTATION_CURSOR')))]
+
+    transform_mode: bpy.props.EnumProperty(items=transform_mode_items)
+    select_mode: bpy.props.EnumProperty(items=select_mode_items)
+    origin_mode: bpy.props.EnumProperty(items=origin_mode_items, name='Origin')
+    direction_mode: bpy.props.EnumProperty(items=direction_mode_items, name='Direction')
+    origin: bpy.props.FloatVectorProperty(name='Origin')
+    direction: bpy.props.FloatVectorProperty(name='Direction')
+    factor: bpy.props.FloatProperty(name='Factor')
+
+    def draw_buttons(self, context, layout):
+        row = layout.row()
+        row.scale_y = 1.5
+        row.prop(self, 'transform_mode', expand=True)
+        layout.prop(self, 'origin_mode')
+        layout.prop(self, 'direction_mode')
+
+    def draw_mask_socket(self, socket, context, layout):
+        layout.label(text='Mask')
+        layout.prop(self, 'select_mode', expand=True, icon_only=True)
+
+    def draw_buttons_ext(self, context, layout):
+        pass
+
+    def sv_init(self, context):
+        self.inputs.new('SvVerticesSocket', 'Verts')
+        self.inputs.new('SvStringsSocket', "Edges")
+        self.inputs.new('SvStringsSocket', 'Faces')
+        self.inputs.new('SvStringsSocket', "Mask").custom_draw = 'draw_mask_socket'
+        self.inputs.new('SvVerticesSocket', "Origin").prop_name = 'origin'
+        self.inputs.new('SvVerticesSocket', "Direction").prop_name = 'direction'
+        self.inputs.new('SvStringsSocket', "Factor").prop_name = 'factor'
+        self.outputs.new('SvVerticesSocket', 'Verts')
+
+    def process(self):
+        pass
+
+
+def register():
+    bpy.utils.register_class(SvTransformMesh)
+
+
+def unregister():
+    bpy.utils.unregister_class(SvTransformMesh)


### PR DESCRIPTION
## Addressed problem description

The node is summoned for reproducing standard Blender transform operations on the mesh level. Also the node is adapted for using `index mask` according #2764 proposal.

![2020-01-28_12-52-00](https://user-images.githubusercontent.com/28003269/73248778-010dbc80-41cd-11ea-90be-a778d398945f.png)

Solution of using index mask is close to `set material index` node. `Transform mesh` node get map of (index: parameters) and applies them according `index mask`.

![transform mesh](https://user-images.githubusercontent.com/28003269/73249068-98730f80-41cd-11ea-8ae9-a939cfbe94de.gif)

## Preflight checklist

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete.
- [x] Manual testing done. 
- [x] Ready for merge.

