### PR TITLE
texture evaluate mapping mode

### DIFF
--- a/docs/nodes/vector/texture_evaluate.rst
+++ b/docs/nodes/vector/texture_evaluate.rst
@@ -9,6 +9,10 @@ Inputs & Parameters
 +----------------+-------------------------------------------------------------------------+
 | Parameters     | Description                                                             |
 +================+=========================================================================+
+| Mapping        | Vectors mapping mode. Offers:                                           |
+|                | UV Coordinates (with domain 0 to 1) and                                 |
+|                | Object (with domain -1 to 1)                                            |
++----------------+-------------------------------------------------------------------------+
 | Channel        | Color channel to output                                                 |
 |                | Offers: Red, Green, Blue, Hue, Saturation, Value, Alpha, RGB Average,   |
 |                | Luminosity and Color                                                    |
@@ -40,4 +44,8 @@ Blender procedural textures work in 3D space
 
 .. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/vector/texture_evaluate/texture_evaluate_sverchok_blender_example_4.png
 
-You can input multiple textures, when joined [[texture,texture,..],[..],..] they will be used in a single set of vertices with a single output list
+You can input multiple textures, when joined [[texture, texture,..],[..],..] they will be used in a single set of vertices with a single output list
+
+.. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/vector/texture_evaluate/texture_evaluate_sverchok_blender_example_5.png
+
+Differences between Object Mapping and UV Coordinates mapping

--- a/nodes/transforms/texture_displace.py
+++ b/nodes/transforms/texture_displace.py
@@ -237,8 +237,8 @@ class SvDisplaceNode(bpy.types.Node, SverchCustomTreeNode):
 
 
     name_texture: StringProperty(
-        name='image_name',
-        description='image name',
+        name='Texture',
+        description='Texture(s) to evaluate',
         default='',
         update=updateNode)
 
@@ -269,16 +269,16 @@ class SvDisplaceNode(bpy.types.Node, SverchCustomTreeNode):
         update=updateNode)
 
     custom_axis: FloatVectorProperty(
-        name='Custom Axis', description='Scale of the added vector',
+        name='Custom Axis', description='Axis to use in displacement',
         size=3, default=(1, 1, 1),
         update=updateNode)
 
     strength: FloatProperty(
-        name='Strength', description='Size of line',
+        name='Strength', description='Scalar displacement multiplier',
         default=1.0, update=updateNode)
 
     mid_level: FloatProperty(
-        name='Middle Level', description='Size of line',
+        name='Middle Level', description='Texture middle level',
         default=0.0, update=updateNode)
 
     list_match: EnumProperty(

--- a/nodes/vector/texture_evaluate.py
+++ b/nodes/vector/texture_evaluate.py
@@ -31,9 +31,9 @@ class EmptyTexture():
     def evaluate(self, vec):
         return [1, 1, 1, 1]
 
-def texture_evaluate(params, extract_func):
+def texture_evaluate(params, mapper_func, extract_func):
     vertex, texture = params
-    v_vertex = Vector(vertex)
+    v_vertex = mapper_func(vertex)
     col = texture.evaluate(v_vertex)
     eval_s = extract_func(col)
     return eval_s
@@ -52,21 +52,26 @@ def meshes_texture_evaluate(params, constant, matching_f):
     matching_f stands for list matching formula to use
     '''
     result = []
-    color_channel, match_mode = constant
+    color_channel, mapping_mode, match_mode = constant
     params = matching_f(params)
     local_match = iter_list_match_func[match_mode]
+    mapper_func = mapper_funcs[mapping_mode]
     extract_func = color_channels[color_channel][1]
     for props in zip(*params):
         verts, texture = props
         if  not type(texture) == list:
             texture = [texture]
         m_texture = local_match([texture])[0]
-        result.append([texture_evaluate(v_prop, extract_func) for v_prop in zip(verts, m_texture)])
+        result.append([texture_evaluate(v_prop, mapper_func, extract_func) for v_prop in zip(verts, m_texture)])
 
     return result
 
 color_channels_modes = [(t, t, t, '', color_channels[t][0]) for t in color_channels if not t == 'RGBA']
 
+mapper_funcs = {
+    'UV': lambda v_uv: Vector((v_uv[0]*2-1, v_uv[1]*2-1, v_uv[2])),
+    'Object': lambda v: Vector(v),
+}
 
 class SvTextureEvaluateNode(bpy.types.Node, SverchCustomTreeNode):
     """
@@ -87,9 +92,8 @@ class SvTextureEvaluateNode(bpy.types.Node, SverchCustomTreeNode):
         ('HLS to XYZ', 'HLS', 'Texture displacement with HSV as vector', '', 4)]
 
     texture_coord_modes = [
-        ('UV', 'UV coords', 'Input UV coordinates to evaluate texture', '', 1),
-        ('Mesh Matrix', 'Mesh Matrix', 'Matrix to apply to verts before evaluating texture', '', 2),
-        ('Texture Matrix', 'Texture Matrix', 'Matrix of texture (External Object matrix)', '', 3),
+        ('UV', 'UV coordinates', 'Input UV coordinates to evaluate texture. (0 to 1 as domain)', '', 1),
+        ('Object', 'Object', 'Input Object coordinates to evaluate texture. (-1 to 1 as domain)', '', 2),
 
     ]
 
@@ -102,8 +106,8 @@ class SvTextureEvaluateNode(bpy.types.Node, SverchCustomTreeNode):
             outputs[0].replace_socket('SvColorSocket', 'Color')
 
     name_texture: StringProperty(
-        name='image_name',
-        description='image name',
+        name='Texture',
+        description='texture name',
         default='',
         update=updateNode)
 
@@ -112,6 +116,13 @@ class SvTextureEvaluateNode(bpy.types.Node, SverchCustomTreeNode):
         items=color_channels_modes,
         default='Alpha',
         description="Channel to use from texture",
+        update=change_mode)
+
+    tex_coord_type: EnumProperty(
+        name='Texture Coord',
+        items=texture_coord_modes,
+        default='Object',
+        description="Mapping method",
         update=change_mode)
 
     use_alpha: BoolProperty(default=False, update=updateNode)
@@ -132,14 +143,17 @@ class SvTextureEvaluateNode(bpy.types.Node, SverchCustomTreeNode):
 
     def draw_texture_socket(self, socket, context, layout):
         if not socket.is_linked:
-            c = layout.split(factor=0.3, align=False)
+            c = layout.split(factor=0.33, align=False)
             c.label(text=socket.name+ ':')
 
             c.prop_search(self, "name_texture", bpy.data, 'textures', text="")
         else:
             layout.label(text=socket.name+ '. ' + SvGetSocketInfo(socket))
     def draw_buttons(self, context, layout):
-        c = layout.split(factor=0.3, align=True)
+        b = layout.split(factor=0.33, align=True)
+        b.label(text='Mapping:')
+        b.prop(self, 'tex_coord_type', expand=False, text='')
+        c = layout.split(factor=0.33, align=True)
         c.label(text='Channel:')
         c.prop(self, 'color_channel', text="")
         if self.color_channel == 'Color':
@@ -175,9 +189,12 @@ class SvTextureEvaluateNode(bpy.types.Node, SverchCustomTreeNode):
         matching_f = list_match_func[self.list_match]
         desired_levels = [3, 2]
         if self.color_channel == 'Color' and self.use_alpha:
-            ops = ['RGBA', self.list_match]
+            channel = 'RGBA'
         else:
-            ops = [self.color_channel, self.list_match]
+            channel = self.color_channel
+
+        ops = [channel, self.tex_coord_type, self.list_match]
+
         result = recurse_f_level_control(params, ops, meshes_texture_evaluate, matching_f, desired_levels)
 
         self.outputs[0].sv_set(result)


### PR DESCRIPTION

Added mapping option to match with standard UV coordinates 
![texture_evaluate_sverchok_blender_example_5](https://user-images.githubusercontent.com/10011941/73558333-42af9900-4453-11ea-94c8-ed96954903a0.png)


- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

