### PR TITLE
Introduce optional coverage reports.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ __MACOSX
 #Ignore sphinx build folder
 docs/404_custom.html
 docs/_build
+docs/_sources
 docs/.make.bat.swp
 
 nodes/generator/meta_balls.py
@@ -71,3 +72,5 @@ nodes/generator/meta_balls.py
 *.swp
 
 local_test.py
+htmlcov/
+


### PR DESCRIPTION

[htmlcov.zip](https://github.com/nortikin/sverchok/files/4143755/htmlcov.zip)
This adds a possibility to generate code coverage reports from our tests. Coverage reports are generated by well-known Python module named `coverage`.
The module is not within Blender distribution, and may be this is even good: you have to install the module if you want to see reports, otherwise you don't have to bother.

It does not make sense to look at global coverage numbers (they are low for Sverchok anyway); but it may be very useful to look at the report for the code you are about to change. In the ideal world, if the code is not marked red, you may change it without any fear: if you break, you will see it in failing tests. Many of our tests are not very good (for example, ones that import `json` examples, do not actually check what is the result of node tree processing); but for a dynamic language such as python, if you know that the code was run during the test, then you at least know that there are no trivial errors such as undeclared variables.

## How to use

1. Install pip: https://github.com/nortikin/sverchok/wiki/Non-standard-Python-modules-installation
2. Install coverage:

```
/path/to/blender/2.xx/python/bin/python3.7m -m pip install coverage
```

3. Run tests:
```
BLENDER=/path/to/blender/blender ./run_tests.sh
```

4. Look at coverage reports under `htmlcov/index.html`.

FYI: @zeffii @Durman @vicdoval 

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

