### PR TITLE
Draft mode

### DIFF
--- a/core/monad.py
+++ b/core/monad.py
@@ -160,6 +160,15 @@ class SverchGroupTree(NodeTree, SvNodeTreeCommon):
     float_props: CollectionProperty(type=SvFloatPropertySettingsGroup)
     int_props: CollectionProperty(type=SvIntPropertySettingsGroup)
 
+    @property
+    def sv_draft(self):
+        # One monad tree can be used in several trees simultaneously;
+        # they can have different draft mode status.
+        # Let's assume that the monad tree is in Draft mode if *all*
+        # trees that use it are in the draft mode.
+        affected_trees = {instance.id_data for instance in self.instances}
+        return all(hasattr(tree, 'sv_draft') and tree.sv_draft for tree in affected_trees)
+
     def get_current_as_default(self, prop_dict, node, prop_name):
         prop_dict['default'] = getattr(node, prop_name)
         # if not prop_dict['name']:

--- a/core/sockets.py
+++ b/core/sockets.py
@@ -67,7 +67,7 @@ class SvSocketCommon:
     quicklink_func_name: StringProperty(default="", name="quicklink_func_name")
 
     def get_prop_name(self):
-        if self.node.id_data.sv_draft:
+        if hasattr(self.node.id_data, 'sv_draft') and self.node.id_data.sv_draft:
             if self.prop_name_draft:
                 return self.prop_name_draft
             else:

--- a/core/sockets.py
+++ b/core/sockets.py
@@ -62,14 +62,14 @@ class SvSocketCommon:
     expanded: BoolProperty(default=False)
     custom_draw: StringProperty(description="For name of method which will draw socket UI (optionally)")
     prop_name: StringProperty(default='', description="For displaying node property in socket UI")
-    prop_name_draft: StringProperty(default='', description="For displaying node property in socket UI in the Draft mode")
 
     quicklink_func_name: StringProperty(default="", name="quicklink_func_name")
 
     def get_prop_name(self):
-        if hasattr(self.node.id_data, 'sv_draft') and self.node.id_data.sv_draft:
-            if self.prop_name_draft:
-                return self.prop_name_draft
+        if self.node.does_support_draft_mode() and hasattr(self.node.id_data, 'sv_draft') and self.node.id_data.sv_draft:
+            prop_name_draft = self.node.draft_properties_mapping.get(self.prop_name, None)
+            if prop_name_draft:
+                return prop_name_draft
             else:
                 return self.prop_name
         else:

--- a/core/sockets.py
+++ b/core/sockets.py
@@ -62,16 +62,26 @@ class SvSocketCommon:
     expanded: BoolProperty(default=False)
     custom_draw: StringProperty(description="For name of method which will draw socket UI (optionally)")
     prop_name: StringProperty(default='', description="For displaying node property in socket UI")
+    prop_name_draft: StringProperty(default='', description="For displaying node property in socket UI in the Draft mode")
 
     quicklink_func_name: StringProperty(default="", name="quicklink_func_name")
+
+    def get_prop_name(self):
+        if self.node.id_data.sv_draft:
+            if self.prop_name_draft:
+                return self.prop_name_draft
+            else:
+                return self.prop_name
+        else:
+            return self.prop_name
 
     @property
     def other(self):
         return get_other_socket(self)
 
     def set_default(self, value):
-        if self.prop_name:
-            setattr(self.node, self.prop_name, value)
+        if self.get_prop_name():
+            setattr(self.node, self.get_prop_name(), value)
 
     @property
     def socket_id(self):
@@ -195,14 +205,14 @@ class SvSocketCommon:
                     return
             elif node.bl_idname in {'SvSNFunctor'} and not self.is_output:
                 if not self.is_linked:
-                    layout.prop(node, self.prop_name, text=self.name)
+                    layout.prop(node, self.get_prop_name(), text=self.name)
                     return
 
         if self.is_linked:  # linked INPUT or OUTPUT
             t = text
             if not self.is_output:
-                if self.prop_name:
-                    prop = node.rna_type.properties.get(self.prop_name, None)
+                if self.get_prop_name():
+                    prop = node.rna_type.properties.get(self.get_prop_name(), None)
                     t = prop.name if prop else text
             info_text = t + '. ' + SvGetSocketInfo(self)
             info_text += self.extra_info
@@ -212,8 +222,8 @@ class SvSocketCommon:
             layout.label(text=text)
 
         else:  # unlinked INPUT
-            if self.prop_name:  # has property
-                self.draw_expander_template(context, layout, prop_origin=node, prop_name=self.prop_name)
+            if self.get_prop_name():  # has property
+                self.draw_expander_template(context, layout, prop_origin=node, prop_name=self.get_prop_name())
 
             elif self.use_prop:  # no property but use default prop
                 self.draw_expander_template(context, layout, prop_origin=self)
@@ -360,8 +370,8 @@ class SvVerticesSocket(NodeSocket, SvSocketCommon):
     use_prop: BoolProperty(default=False)
 
     def get_prop_data(self):
-        if self.prop_name:
-            return {"prop_name": socket.prop_name}
+        if self.get_prop_name():
+            return {"prop_name": socket.get_prop_name()}
         elif self.use_prop:
             return {"use_prop": True,
                     "prop": self.prop[:]}
@@ -373,8 +383,8 @@ class SvVerticesSocket(NodeSocket, SvSocketCommon):
             source_data = SvGetSocket(self, deepcopy = True if self.needs_data_conversion() else deepcopy)
             return self.convert_data(source_data, implicit_conversions)
 
-        if self.prop_name:
-            return [[getattr(self.node, self.prop_name)[:]]]
+        if self.get_prop_name():
+            return [[getattr(self.node, self.get_prop_name())[:]]]
         elif self.use_prop:
             return [[self.prop[:]]]
         elif default is sentinel:
@@ -392,8 +402,8 @@ class SvQuaternionSocket(NodeSocket, SvSocketCommon):
     use_prop: BoolProperty(default=False)
 
     def get_prop_data(self):
-        if self.prop_name:
-            return {"prop_name": socket.prop_name}
+        if self.get_prop_name():
+            return {"prop_name": socket.get_prop_name()}
         elif self.use_prop:
             return {"use_prop": True,
                     "prop": self.prop[:]}
@@ -405,8 +415,8 @@ class SvQuaternionSocket(NodeSocket, SvSocketCommon):
             source_data = SvGetSocket(self, deepcopy = True if self.needs_data_conversion() else deepcopy)
             return self.convert_data(source_data, implicit_conversions)
 
-        if self.prop_name:
-            return [[getattr(self.node, self.prop_name)[:]]]
+        if self.get_prop_name():
+            return [[getattr(self.node, self.get_prop_name())[:]]]
         elif self.use_prop:
             return [[self.prop[:]]]
         elif default is sentinel:
@@ -424,8 +434,8 @@ class SvColorSocket(NodeSocket, SvSocketCommon):
     use_prop: BoolProperty(default=False)
 
     def get_prop_data(self):
-        if self.prop_name:
-            return {"prop_name": socket.prop_name}
+        if self.get_prop_name():
+            return {"prop_name": socket.get_prop_name()}
         elif self.use_prop:
             return {"use_prop": True,
                     "prop": self.prop[:]}
@@ -436,8 +446,8 @@ class SvColorSocket(NodeSocket, SvSocketCommon):
         if self.is_linked and not self.is_output:
             return self.convert_data(SvGetSocket(self, deepcopy), implicit_conversions)
 
-        if self.prop_name:
-            return [[getattr(self.node, self.prop_name)[:]]]
+        if self.get_prop_name():
+            return [[getattr(self.node, self.get_prop_name())[:]]]
         elif self.use_prop:
             return [[self.prop[:]]]
         elif default is sentinel:
@@ -488,8 +498,8 @@ class SvStringsSocket(NodeSocket, SvSocketCommon):
     prop_index: IntProperty()
 
     def get_prop_data(self):
-        if self.prop_name:
-            return {"prop_name": self.prop_name}
+        if self.get_prop_name():
+            return {"prop_name": self.get_prop_name()}
         elif self.prop_type:
             return {"prop_type": self.prop_type,
                     "prop_index": self.prop_index}
@@ -502,13 +512,13 @@ class SvStringsSocket(NodeSocket, SvSocketCommon):
 
         if self.is_linked and not self.is_output:
             return self.convert_data(SvGetSocket(self, deepcopy), implicit_conversions)
-        elif self.prop_name:
+        elif self.get_prop_name():
             # to deal with subtype ANGLE, this solution should be considered temporary...
-            _, prop_dict = getattr(self.node.rna_type, self.prop_name, (None, {}))
+            _, prop_dict = getattr(self.node.rna_type, self.get_prop_name(), (None, {}))
             subtype = prop_dict.get("subtype", "")
             if subtype == "ANGLE":
-                return [[math.degrees(getattr(self.node, self.prop_name))]]
-            return [[getattr(self.node, self.prop_name)]]
+                return [[math.degrees(getattr(self.node, self.get_prop_name()))]]
+            return [[getattr(self.node, self.get_prop_name())]]
         elif self.prop_type:
             return [[getattr(self.node, self.prop_type)[self.prop_index]]]
         elif default is not sentinel:
@@ -523,8 +533,8 @@ class SvDictionarySocket(NodeSocket, SvSocketCommon):
     bl_label = "Dictionary Socket"
 
     def get_prop_data(self):
-        if self.prop_name:
-            return {"prop_name": self.prop_name}
+        if self.get_prop_name():
+            return {"prop_name": self.get_prop_name()}
         else:
             return {}
 
@@ -533,8 +543,8 @@ class SvDictionarySocket(NodeSocket, SvSocketCommon):
             source_data = SvGetSocket(self, deepcopy=True if self.needs_data_conversion() else deepcopy)
             return self.convert_data(source_data, implicit_conversions)
 
-        if self.prop_name:
-            return [[getattr(self.node, self.prop_name)[:]]]
+        if self.get_prop_name():
+            return [[getattr(self.node, self.get_prop_name())[:]]]
         elif default is sentinel:
             raise SvNoDataError(self)
         else:
@@ -562,8 +572,8 @@ class SvChameleonSocket(NodeSocket, SvSocketCommon):
             self.dynamic_type = self.bl_idname
 
     def get_prop_data(self):
-        if self.prop_name:
-            return {"prop_name": self.prop_name}
+        if self.get_prop_name():
+            return {"prop_name": self.get_prop_name()}
         else:
             return {}
 
@@ -571,8 +581,8 @@ class SvChameleonSocket(NodeSocket, SvSocketCommon):
         if self.is_linked and not self.is_output:
             return SvGetSocket(self, deepcopy=True if self.needs_data_conversion() else deepcopy)
 
-        if self.prop_name:
-            return [[getattr(self.node, self.prop_name)[:]]]
+        if self.get_prop_name():
+            return [[getattr(self.node, self.get_prop_name())[:]]]
         elif default is sentinel:
             raise SvNoDataError(self)
         else:

--- a/node_tree.py
+++ b/node_tree.py
@@ -218,6 +218,7 @@ class SverchCustomTree(NodeTree, SvNodeTreeCommon):
     sv_bake: BoolProperty(name="Bake", default=True, description='Bake this layout')
     sv_process: BoolProperty(name="Process", default=True, description='Process layout')
     sv_user_colors: StringProperty(default="")
+    sv_draft : BoolProperty(name = "Draft", description="Draft (simplified processing) mode", default = False)
 
     tree_link_count: IntProperty(name='keep track of current link count', default=0)
     configuring_new_node: BoolProperty(name="indicate node initialization", default=False)

--- a/node_tree.py
+++ b/node_tree.py
@@ -218,7 +218,20 @@ class SverchCustomTree(NodeTree, SvNodeTreeCommon):
     sv_bake: BoolProperty(name="Bake", default=True, description='Bake this layout')
     sv_process: BoolProperty(name="Process", default=True, description='Process layout')
     sv_user_colors: StringProperty(default="")
-    sv_draft : BoolProperty(name = "Draft", description="Draft (simplified processing) mode", default = False)
+
+    def on_draft_mode_changed(self, context):
+        """
+        This is triggered when Draft mode of the tree is toggled.
+        """
+        for node in self.nodes:
+            if hasattr(node, 'does_support_draft_mode') and node.does_support_draft_mode():
+                node.on_draft_mode_changed(self.sv_draft)
+
+    sv_draft : BoolProperty(
+                name = "Draft",
+                description="Draft (simplified processing) mode",
+                default = False,
+                update=on_draft_mode_changed)
 
     tree_link_count: IntProperty(name='keep track of current link count', default=0)
     configuring_new_node: BoolProperty(name="indicate node initialization", default=False)
@@ -279,6 +292,13 @@ class SverchCustomTree(NodeTree, SvNodeTreeCommon):
 
         self.has_changed = False
 
+    def get_nodes_supporting_draft_mode(self):
+        draft_nodes = []
+        for node in self.nodes:
+            if hasattr(node, 'does_support_draft_mode') and node.does_support_draft_mode():
+                draft_nodes.append(node)
+        return draft_nodes
+
 
 class SverchCustomTreeNode:
 
@@ -286,6 +306,13 @@ class SverchCustomTreeNode:
     _docstring = None
 
     _implicit_conversion_policy = dict()
+
+    # In node classes that support draft mode
+    # and use separate properties in the draft mode,
+    # this should contain mapping from "standard"
+    # mode property names to draft mode property names.
+    # E.g., draft_properties_mapping = dict(count = 'count_draft').
+    draft_properties_mapping = dict()
 
     @classmethod
     def poll(cls, ntree):
@@ -304,6 +331,39 @@ class SverchCustomTreeNode:
         algorithm in draft mode, should return True here.
         """
         return False
+
+    def on_draft_mode_changed(self, new_draft_mode):
+        """
+        This is triggered when Draft mode of the tree is toggled.
+        Nodes should not usually override this, but may override
+        sv_draft_mode_changed() instead.
+        """
+        if self.does_support_draft_mode():
+            if new_draft_mode == True:
+                with self.sv_throttle_tree_update():
+                    if not self.was_in_draft_mode():
+                        # Copy values from standard properties
+                        # to draft mode ones, when the node enters the
+                        # draft mode first time.
+                        for prop_name, draft_prop_name in self.draft_properties_mapping.items():
+                            setattr(self, draft_prop_name, getattr(self, prop_name))
+                    self['_was_in_draft_mode'] = True
+        self.sv_draft_mode_changed(new_draft_mode)
+
+    def sv_draft_mode_changed(self, new_draft_mode):
+        """
+        This is triggered when Draft mode of the tree is toggled.
+        Nodes may override this if they need to do something specific
+        on this event.
+        """
+        pass
+
+    def was_in_draft_mode(self):
+        """
+        Whether this instance of the node ever has been in Draft mode.
+        Nodes should not usually override this.
+        """
+        return self.get('_was_in_draft_mode', False)
 
     def sv_throttle_tree_update(self):
         return throttle_tree_update(self)

--- a/node_tree.py
+++ b/node_tree.py
@@ -297,6 +297,14 @@ class SverchCustomTreeNode:
             self.n_id = str(hash(self) ^ hash(time.monotonic()))
         return self.n_id
 
+    def does_support_draft_mode(self):
+        """
+        Nodes that either store separate property values
+        for draft mode, or perform another version of
+        algorithm in draft mode, should return True here.
+        """
+        return False
+
     def sv_throttle_tree_update(self):
         return throttle_tree_update(self)
 

--- a/nodes/generator/plane_mk2.py
+++ b/nodes/generator/plane_mk2.py
@@ -190,6 +190,12 @@ class SvPlaneNodeMK2(bpy.types.Node, SverchCustomTreeNode):
                 row.prop(self, "linkSizes", icon="UNLINKED", text="")
             row.prop(self, "sizey")
 
+    def draw_label(self):
+        label = self.label or self.name
+        if self.id_data.sv_draft:
+            label = "[D] " + label
+        return label
+
     def process(self):
         if not any(s.is_linked for s in self.outputs):
             return

--- a/nodes/generator/plane_mk2.py
+++ b/nodes/generator/plane_mk2.py
@@ -102,12 +102,28 @@ class SvPlaneNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         name='N Verts Y', description='Number of vertices along Y',
         default=2, min=2, update=updateNode)
 
+    numx_draft: IntProperty(
+        name='[D] N Verts X', description='Number of vertices along X (draft mode)',
+        default=2, min=2, update=updateNode)
+
+    numy_draft: IntProperty(
+        name='[D] N Verts Y', description='Number of vertices along Y (draft mode)',
+        default=2, min=2, update=updateNode)
+
     stepx: FloatProperty(
         name='Step X', description='Step length X',
         default=1.0, update=updateNode)
 
     stepy: FloatProperty(
         name='Step Y', description='Step length Y',
+        default=1.0, update=updateNode)
+
+    stepx_draft: FloatProperty(
+        name='[D] Step X', description='Step length X (draft mode)',
+        default=1.0, update=updateNode)
+
+    stepy_draft: FloatProperty(
+        name='[D] Step Y', description='Step length Y (draft mode)',
         default=1.0, update=updateNode)
 
     separate: BoolProperty(
@@ -141,10 +157,18 @@ class SvPlaneNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         name='Syncing', description='Syncing flag', default=False)
 
     def sv_init(self, context):
-        self.inputs.new('SvStringsSocket', "Num X").prop_name = 'numx'
-        self.inputs.new('SvStringsSocket', "Num Y").prop_name = 'numy'
-        self.inputs.new('SvStringsSocket', "Step X").prop_name = 'stepx'
-        self.inputs.new('SvStringsSocket', "Step Y").prop_name = 'stepy'
+        inp = self.inputs.new('SvStringsSocket', "Num X")
+        inp.prop_name = 'numx'
+        inp.prop_name_draft = 'numx_draft'
+        inp = self.inputs.new('SvStringsSocket', "Num Y")
+        inp.prop_name = 'numy'
+        inp.prop_name_draft = 'numy_draft'
+        inp = self.inputs.new('SvStringsSocket', "Step X")
+        inp.prop_name = 'stepx'
+        inp.prop_name_draft = 'stepx_draft'
+        inp = self.inputs.new('SvStringsSocket', "Step Y")
+        inp.prop_name = 'stepy'
+        inp.prop_name_draft = 'stepy_draft'
         self.outputs.new('SvVerticesSocket', "Vertices")
         self.outputs.new('SvStringsSocket', "Edges")
         self.outputs.new('SvStringsSocket', "Polygons")
@@ -203,6 +227,8 @@ class SvPlaneNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         if outputs['Polygons'].is_linked:
             outputs['Polygons'].sv_set(polys)
 
+    def does_support_draft_mode(self):
+        return True
 
 def register():
     bpy.utils.register_class(SvPlaneNodeMK2)

--- a/nodes/generator/plane_mk2.py
+++ b/nodes/generator/plane_mk2.py
@@ -156,19 +156,18 @@ class SvPlaneNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     syncing: BoolProperty(
         name='Syncing', description='Syncing flag', default=False)
 
+    draft_properties_mapping = dict(
+            numx = 'numx_draft',
+            numy = 'numy_draft',
+            stepx = 'stepx_draft',
+            stepy = 'stepy_draft'
+        )
+
     def sv_init(self, context):
-        inp = self.inputs.new('SvStringsSocket', "Num X")
-        inp.prop_name = 'numx'
-        inp.prop_name_draft = 'numx_draft'
-        inp = self.inputs.new('SvStringsSocket', "Num Y")
-        inp.prop_name = 'numy'
-        inp.prop_name_draft = 'numy_draft'
-        inp = self.inputs.new('SvStringsSocket', "Step X")
-        inp.prop_name = 'stepx'
-        inp.prop_name_draft = 'stepx_draft'
-        inp = self.inputs.new('SvStringsSocket', "Step Y")
-        inp.prop_name = 'stepy'
-        inp.prop_name_draft = 'stepy_draft'
+        self.inputs.new('SvStringsSocket', "Num X").prop_name = 'numx'
+        self.inputs.new('SvStringsSocket', "Num Y").prop_name = 'numy'
+        self.inputs.new('SvStringsSocket', "Step X").prop_name = 'stepx'
+        self.inputs.new('SvStringsSocket', "Step Y").prop_name = 'stepy'
         self.outputs.new('SvVerticesSocket', "Vertices")
         self.outputs.new('SvStringsSocket', "Edges")
         self.outputs.new('SvStringsSocket', "Polygons")

--- a/nodes/number/numbers.py
+++ b/nodes/number/numbers.py
@@ -63,7 +63,7 @@ class SvNumberNode(bpy.types.Node, SverchCustomTreeNode):
         get=lambda s: uget(s, 'int_'),
         set=lambda s, val: uset(s, val, 'int_', 'int_min', 'int_max'))
     int_draft_ : IntProperty(
-        default=0, name="an int", update=updateNode,
+        default=0, name="[D] an int", update=updateNode,
         description = "Integer value (draft mode)",
         get=lambda s: uget(s, 'int_draft_'),
         set=lambda s, val: uset(s, val, 'int_draft_', 'int_min', 'int_max'))
@@ -71,7 +71,7 @@ class SvNumberNode(bpy.types.Node, SverchCustomTreeNode):
     int_max: IntProperty(default=1024, description='maximum')
 
     float_: FloatProperty(
-        default=0.0, name="a float", update=updateNode,
+        default=0.0, name="[D] a float", update=updateNode,
         description = "Floating-point value",
         get=lambda s: uget(s, 'float_'),
         set=lambda s, val: uset(s, val, 'float_', 'float_min', 'float_max'))
@@ -185,6 +185,9 @@ class SvNumberNode(bpy.types.Node, SverchCustomTreeNode):
             # same for float to int.
 
             self.outputs[0].sv_set(self.inputs[0].sv_get())
+
+    def does_support_draft_mode(self):
+        return True
 
 
 def register():

--- a/nodes/number/numbers.py
+++ b/nodes/number/numbers.py
@@ -52,9 +52,7 @@ class SvNumberNode(bpy.types.Node, SverchCustomTreeNode):
     def wrapped_update(self, context):
         kind = self.selected_mode
         prop_name = kind + '_'
-        inp = self.inputs[0].replace_socket('SvStringsSocket', kind.title())
-        inp.prop_name = prop_name
-        inp.prop_name_draft = prop_name + 'draft_'
+        self.inputs[0].replace_socket('SvStringsSocket', kind.title()).prop_name = prop_name
         self.outputs[0].replace_socket('SvStringsSocket', kind.title()).custom_draw = 'mode_custom_draw'
 
     int_: IntProperty(
@@ -92,14 +90,14 @@ class SvNumberNode(bpy.types.Node, SverchCustomTreeNode):
     show_limits: BoolProperty(default=False)
     to3d: BoolProperty(default=False, update=updateNode)
 
+    draft_properties_mapping = dict(float_ = 'float_draft_', int_ = 'int_draft_')
+
     def sv_init(self, context):
         self['float_'] = 0.0
         self['int_'] = 0
         self['float_draft_'] = 0.0
         self['int_draft_'] = 0
-        inp = self.inputs.new('SvStringsSocket', "Float")
-        inp.prop_name = 'float_'
-        inp.prop_name_draft = 'float_draft_'
+        self.inputs.new('SvStringsSocket', "Float").prop_name = 'float_'
         self.outputs.new('SvStringsSocket', "Float").custom_draw = 'mode_custom_draw'
 
     def mode_custom_draw(self, socket, context, layout):

--- a/nodes/number/numbers.py
+++ b/nodes/number/numbers.py
@@ -71,12 +71,12 @@ class SvNumberNode(bpy.types.Node, SverchCustomTreeNode):
     int_max: IntProperty(default=1024, description='maximum')
 
     float_: FloatProperty(
-        default=0.0, name="[D] a float", update=updateNode,
+        default=0.0, name="a float", update=updateNode,
         description = "Floating-point value",
         get=lambda s: uget(s, 'float_'),
         set=lambda s, val: uset(s, val, 'float_', 'float_min', 'float_max'))
     float_draft_: FloatProperty(
-        default=0.0, name="a float",
+        default=0.0, name="[D] a float",
         description = "Floating-point value (draft mode)",
         update=updateNode,
         get=lambda s: uget(s, 'float_draft_'),

--- a/ui/nodeview_keymaps.py
+++ b/ui/nodeview_keymaps.py
@@ -51,8 +51,24 @@ def add_keymap():
         kmi.properties.name = "NODEVIEW_MT_Dynamic_Menu"
         nodeview_keymaps.append((km, kmi))
 
-        # ctrl + Space  | enter extra search operator
+        # alt + Space  | enter extra search operator
         kmi = km.keymap_items.new('node.sv_extra_search', 'SPACE', 'PRESS', alt=True)
+        nodeview_keymaps.append((km, kmi))
+
+        # F5 | Trigger update of context node tree
+        kmi = km.keymap_items.new('node.sverchok_update_context', 'F5', 'PRESS')
+        nodeview_keymaps.append((km, kmi))
+
+        # Ctrl + F5 | Trigger update of context node tree, forced mode
+        kmi = km.keymap_items.new('node.sverchok_update_context_force', 'F5', 'PRESS', ctrl=True)
+        nodeview_keymaps.append((km, kmi))
+
+        # F6 | Toggle processing mode of the active node tree
+        kmi = km.keymap_items.new('node.sv_toggle_process', 'F6', 'PRESS')
+        nodeview_keymaps.append((km, kmi))
+
+        # F7 | Toggle draft mode for the active node tree
+        kmi = km.keymap_items.new('node.sv_toggle_draft', 'F7', 'PRESS')
         nodeview_keymaps.append((km, kmi))
 
         # Right Click   | show custom menu

--- a/ui/sv_panels.py
+++ b/ui/sv_panels.py
@@ -70,23 +70,7 @@ class SvToggleDraft(bpy.types.Operator):
         layout = self.layout
         node_tree = context.space_data.node_tree
         node_tree.sv_draft = not node_tree.sv_draft
-        node_tree.on_draft_mode_changed(node_tree.sv_draft)
-
-        # From the user perspective, some of node parameters
-        # got new parameter values, so the setup should be recalculated;
-        # but techically, node properties were not changed
-        # (only other properties were shown in UI), so enabling/disabling
-        # of draft mode does not automatically trigger tree update.
-        # Here we trigger it manually.
-
-        start_nodes = node_tree.get_nodes_supporting_draft_mode()
-        if start_nodes:
-            try:
-                bpy.context.window.cursor_set("WAIT")
-                node_tree.unfreeze(hard=True)
-                process_from_nodes(start_nodes)
-            finally:
-                bpy.context.window.cursor_set("DEFAULT")
+        #node_tree.on_draft_mode_changed(context)
 
         if node_tree.sv_draft:
             message = "Draft mode set for `%s'" % node_tree.name

--- a/ui/sv_panels.py
+++ b/ui/sv_panels.py
@@ -81,8 +81,12 @@ class SvToggleDraft(bpy.types.Operator):
 
         start_nodes = node_tree.get_nodes_supporting_draft_mode()
         if start_nodes:
-            node_tree.unfreeze(hard=True)
-            process_from_nodes(start_nodes)
+            try:
+                bpy.context.window.cursor_set("WAIT")
+                node_tree.unfreeze(hard=True)
+                process_from_nodes(start_nodes)
+            finally:
+                bpy.context.window.cursor_set("DEFAULT")
 
         if node_tree.sv_draft:
             message = "Draft mode set for `%s'" % node_tree.name

--- a/ui/sv_panels.py
+++ b/ui/sv_panels.py
@@ -33,7 +33,7 @@ def redraw_panels():
         for area in window.screen.areas:
             if area.type == 'NODE_EDITOR':
                 for region in area.regions:
-                    if region.type in {'HEADER', 'UI'}:
+                    if region.type in {'HEADER', 'UI', 'WINDOW'}:
                         region.tag_redraw()
 
 class SvToggleProcess(bpy.types.Operator):

--- a/ui/sv_panels.py
+++ b/ui/sv_panels.py
@@ -70,6 +70,7 @@ class SvToggleDraft(bpy.types.Operator):
         layout = self.layout
         node_tree = context.space_data.node_tree
         node_tree.sv_draft = not node_tree.sv_draft
+        node_tree.on_draft_mode_changed(node_tree.sv_draft)
 
         # From the user perspective, some of node parameters
         # got new parameter values, so the setup should be recalculated;
@@ -78,11 +79,7 @@ class SvToggleDraft(bpy.types.Operator):
         # of draft mode does not automatically trigger tree update.
         # Here we trigger it manually.
 
-        start_nodes = []
-        for node in node_tree.nodes:
-            if hasattr(node, 'does_support_draft_mode') and node.does_support_draft_mode():
-                start_nodes.append(node)
-
+        start_nodes = node_tree.get_nodes_supporting_draft_mode()
         if start_nodes:
             node_tree.unfreeze(hard=True)
             process_from_nodes(start_nodes)

--- a/ui/sv_panels.py
+++ b/ui/sv_panels.py
@@ -24,9 +24,59 @@ import sverchok
 from sverchok.core.update_system import process_from_nodes
 from sverchok.utils import profile
 from sverchok.utils.sv_update_utils import version_and_sha
+from sverchok.ui.development import displaying_sverchok_nodes
 
 objects_nodes_set = {'ObjectsNode', 'ObjectsNodeMK2', 'SvObjectsNodeMK3'}
 
+def redraw_panels():
+    for window in bpy.context.window_manager.windows:
+        for area in window.screen.areas:
+            if area.type == 'NODE_EDITOR':
+                for region in area.regions:
+                    if region.type in {'HEADER', 'UI'}:
+                        region.tag_redraw()
+
+class SvToggleProcess(bpy.types.Operator):
+    bl_idname = "node.sv_toggle_process"
+    bl_label = "Toggle processing of the current node tree"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    @classmethod
+    def poll(cls, context):
+        return displaying_sverchok_nodes(context)
+
+    def execute(self, context):
+        layout = self.layout
+        node_tree = context.space_data.node_tree
+        node_tree.sv_process = not node_tree.sv_process
+        if node_tree.sv_process:
+            message = "Processing enabled for `%s'" % node_tree.name
+        else:
+            message = "Processing disabled for `%s'" % node_tree.name
+        self.report({'INFO'}, message)
+        redraw_panels()
+        return {'FINISHED'}
+
+class SvToggleDraft(bpy.types.Operator):
+    bl_idname = "node.sv_toggle_draft"
+    bl_label = "Toggle draft mode of the current node tree"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    @classmethod
+    def poll(cls, context):
+        return displaying_sverchok_nodes(context)
+
+    def execute(self, context):
+        layout = self.layout
+        node_tree = context.space_data.node_tree
+        node_tree.sv_draft = not node_tree.sv_draft
+        if node_tree.sv_draft:
+            message = "Draft mode set for `%s'" % node_tree.name
+        else:
+            message = "Draft mode disabled for `%s'" % node_tree.name
+        self.report({'INFO'}, message)
+        redraw_panels()
+        return {'FINISHED'}
 
 class SvRemoveStaleDrawCallbacks(bpy.types.Operator):
 
@@ -185,6 +235,10 @@ class SV_PT_3DPanel(bpy.types.Panel):
 
                 split = row.column(align=True)
                 split.scale_x = little_width
+                split.prop(tree, "sv_draft", toggle=True, text="D")
+
+                split = row.column(align=True)
+                split.scale_x = little_width
                 split.prop(tree, 'use_fake_user', toggle=True, text='F')
 
                 # variables
@@ -259,9 +313,13 @@ class SV_PT_ToolsMenu(bpy.types.Panel):
         col3.scale_x = little_width
         col3.label(text='P')
 
-        col3 = row.column(align=True)
-        col3.scale_x = little_width
-        col3.label(text='F')
+        col4 = row.column(align=True)
+        col4.scale_x = little_width
+        col4.label(text='D')
+
+        col5 = row.column(align=True)
+        col5.scale_x = little_width
+        col5.label(text='F')
 
 
     def draw(self, context):
@@ -314,10 +372,13 @@ class SV_PT_ToolsMenu(bpy.types.Panel):
         col3.scale_x = little_width
         col3.label(text='P')
 
-        col3 = row.column(align=True)
-        col3.scale_x = little_width
-        col3.label(text='F')
+        col4 = row.column(align=True)
+        col4.scale_x = little_width
+        col4.label(text='D')
 
+        col5 = row.column(align=True)
+        col5.scale_x = little_width
+        col5.label(text='F')
 
         for name, tree in bpy.data.node_groups.items():
             if tree.bl_idname == 'SverchCustomTreeType':
@@ -351,6 +412,10 @@ class SV_PT_ToolsMenu(bpy.types.Panel):
 
                 split = row.column(align=True)
                 split.scale_x = little_width
+                split.prop(tree, "sv_draft", toggle=True, text="D")
+
+                split = row.column(align=True)
+                split.scale_x = little_width
                 split.prop(tree, 'use_fake_user', toggle=True, text='F')
 
         if context.scene.sv_new_version:
@@ -366,12 +431,30 @@ class SV_PT_ToolsMenu(bpy.types.Panel):
         layout.separator()
         layout.row().operator('node.remove_stale_draw_callbacks')
 
+def node_show_tree_mode(self, context):
+    if not displaying_sverchok_nodes(context):
+        return
+    layout = self.layout
+    node_tree = context.space_data.node_tree
+    if hasattr(node_tree, 'sv_draft') and hasattr(node_tree, 'sv_process'):
+        if not node_tree.sv_process:
+            message = "Disabled"
+            icon = 'X'
+        elif node_tree.sv_draft:
+            message = "DRAFT"
+            icon = 'CHECKBOX_DEHLT'
+        else:
+            message = "Processing"
+            icon = 'CHECKMARK'
+        layout.label(text=message, icon=icon)
 
 sv_tools_classes = [
     Sv3DViewObjInUpdater,
     SV_PT_ToolsMenu,
     SV_PT_3DPanel,
-    SvRemoveStaleDrawCallbacks
+    SvRemoveStaleDrawCallbacks,
+    SvToggleProcess,
+    SvToggleDraft
 ]
 
 
@@ -389,7 +472,7 @@ def register():
     for class_name in sv_tools_classes:
         bpy.utils.register_class(class_name)
 
-
+    bpy.types.NODE_HT_header.append(node_show_tree_mode)
 
 def unregister():
     for class_name in reversed(sv_tools_classes):
@@ -397,3 +480,5 @@ def unregister():
 
     del bpy.types.NodeTree.SvShowIn3D
     del bpy.types.Scene.SvShowIn3D_active
+    bpy.types.NODE_HT_header.remove(node_show_tree_mode)
+

--- a/utils/sv_panels_tools.py
+++ b/utils/sv_panels_tools.py
@@ -35,13 +35,16 @@ class SverchokUpdateAll(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     def execute(self, context):
-        sv_ngs = filter(lambda ng:ng.bl_idname == 'SverchCustomTreeType', bpy.data.node_groups)
-        for ng in sv_ngs:
-            ng.unfreeze(hard=True)
-        build_update_list()
-        process_tree()
+        try:
+            bpy.context.window.cursor_set("WAIT")
+            sv_ngs = filter(lambda ng:ng.bl_idname == 'SverchCustomTreeType', bpy.data.node_groups)
+            for ng in sv_ngs:
+                ng.unfreeze(hard=True)
+            build_update_list()
+            process_tree()
+        finally:
+            bpy.context.window.cursor_set("DEFAULT")
         return {'FINISHED'}
-
 
 class SverchokBakeAll(bpy.types.Operator):
     """Bake all nodes on this layout"""
@@ -77,11 +80,15 @@ class SverchokUpdateCurrent(bpy.types.Operator):
     node_group: StringProperty(default="")
 
     def execute(self, context):
-        ng = bpy.data.node_groups.get(self.node_group)
-        if ng:
-            ng.unfreeze(hard=True)
-            build_update_list(ng)
-            process_tree(ng)
+        try:
+            bpy.context.window.cursor_set("WAIT")
+            ng = bpy.data.node_groups.get(self.node_group)
+            if ng:
+                ng.unfreeze(hard=True)
+                build_update_list(ng)
+                process_tree(ng)
+        finally:
+            bpy.context.window.cursor_set("DEFAULT")
         return {'FINISHED'}
 
 class SverchokUpdateContext(bpy.types.Operator):
@@ -96,6 +103,7 @@ class SverchokUpdateContext(bpy.types.Operator):
 
     def execute(self, context):
         try:
+            bpy.context.window.cursor_set("WAIT")
             ng = context.space_data.node_tree
             if ng:
                 ng.unfreeze(hard=True)
@@ -103,6 +111,8 @@ class SverchokUpdateContext(bpy.types.Operator):
                 process_tree(ng)
         except:
             pass
+        finally:
+            bpy.context.window.cursor_set("DEFAULT")
 
         return {'FINISHED'}
 
@@ -118,6 +128,7 @@ class SverchokUpdateContextForced(bpy.types.Operator):
 
     def execute(self, context):
         try:
+            bpy.context.window.cursor_set("WAIT")
             ng = context.space_data.node_tree
             if ng:
                 try:
@@ -130,6 +141,8 @@ class SverchokUpdateContextForced(bpy.types.Operator):
                     ng.sv_process = prev_process_state
         except:
             pass
+        finally:
+            bpy.context.window.cursor_set("DEFAULT")
 
         return {'FINISHED'}
 


### PR DESCRIPTION
The initial idea was described in #2439 .

* Introduce draft mode
* Buttons for draft mode in UI
* Tree mode indicator in header
* Hotkeys:
** F5: trigger update of the current tree (the same as "Update   NodeTree" button in the panel)
** Ctrl+F5: the same as previous, but perform update even if "P" is      disabled for the node tree (enable it, process and then disable it      back).
** F6: toggle "P" (processing) of the current node tree.
** F7: toggle "D" (Draft) mode for the current node tree.

This, in fact, creates a new possible approach to working with complex node trees: to disable processing, play around with nodes and settings, and then trigger node tree recalculation only when you really want it (by Ctrl-F5).

For now, "draft" mode is supported in "A number" node, and in "Plane" node. I suggest to add support of this mode to other nodes on-demand.

@zeffii @Durman @vicdoval please review and test.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [ ] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [ ] Ready for merge.

