### PR TITLE
only apply generated uv if objects have that property

### DIFF
--- a/nodes/viz/viewer_polyline.py
+++ b/nodes/viz/viewer_polyline.py
@@ -98,7 +98,10 @@ def live_curve(obj_index, node, verts, radii, twist):
 def make_curve_geometry(obj_index, node, verts, matrix, radii, twist):
     sv_object = live_curve(obj_index, node, verts, radii, twist)
     sv_object.hide_select = False
-    node.set_auto_uv(sv_object)
+
+    if hasattr(sv_object.data, "use_uv_as_generated"):
+        node.set_auto_uv(sv_object)
+
     node.push_custom_matrix_if_present(sv_object, matrix)
     return sv_object
 


### PR DESCRIPTION
addresses #2872 .

only apply generated uv if objects have that property. this will allow you to transition. but that property is gone in new version of Blender so i think a shadernode solution is necessary.