### PR TITLE
NURBS Curve / Surface Output

### DIFF
--- a/docs/nodes/viz/viewer_nurbs_curve.rst
+++ b/docs/nodes/viz/viewer_nurbs_curve.rst
@@ -1,0 +1,59 @@
+NURBS Curve Out Node
+====================
+
+Functionality
+-------------
+
+This node generates Blender's NURBS Curve objects from input data. It creates a new Curve object or updates existing on each update of input data or parameters.
+
+**NOTE**: Blender's functionality for NURBS is limited. For example, there is
+no way to specify explicit knot vector.
+For information about supported features and operations for NURBS Curve
+objects, please refer to Blender_ documentation.
+For more NURBS-related functions, it is possible to use the Sverchok-Extra_ addon.
+
+.. _Blender: https://docs.blender.org/manual/en/latest/modeling/curves/index.html
+.. _Sverchok-Extra: https://github.com/portnov/sverchok-extra
+
+Inputs
+------
+
+This node has the following inputs:
+
+* **ControlPoints**. Control points of the NURBS curve. This input is mandatory.
+* **Weights**. NURBS curve control point weights. This input is optional.
+* **Degree**. Degree of the curve. The default value is 3.
+
+Parameters
+----------
+
+This node has the following parameters:
+
+* **UPD**. The node will process data only if this button is enabled.
+* **Hide View** (eye icon). Toggle visibility of generated object in viewport.
+* **Hide Select** (pointer icon). Toggle ability to select for generated object.
+* **Hide Render** (render icon). Toggle renderability for generated object.
+* **Base name**. Base part of name for Curve object to create (or update).
+  Default is "Alpha".
+* **Select Toggle**. Select / deselect generated object.
+* **Material**. Material to be assigned to created object.
+* **Cyclic**. Defines whether the created curve should be cyclic (closed).
+  Unchecked by default.
+* **Endpoint**. Defines whether the created curve should touch it's end control
+  points. This parameter is not available when the **Cyclic** parameter is
+  checked. Checked by default.
+* **Resolution**. Curve subdivisions per segment. This parameter is available
+  in the N panel only.
+
+Outputs
+-------
+
+This node has the following output:
+
+* **Object**. Generated NURBS Curve objects.
+
+Examples of usage
+-----------------
+
+.. image:: https://user-images.githubusercontent.com/284644/75611529-16179b80-5b3d-11ea-99b8-5cfaafaa7c5b.png
+

--- a/docs/nodes/viz/viewer_nurbs_surface.rst
+++ b/docs/nodes/viz/viewer_nurbs_surface.rst
@@ -1,0 +1,100 @@
+NURBS Surface Out Node
+======================
+
+Functionality
+-------------
+
+This node generates Blender's NURBS Surface objects from input data. It creates
+a new Surface object or updates existing on each update of input data or
+parameters.
+
+**NOTE 1**: Blender's functionality for NURBS is limited. For example, there is
+no way to specify explicit knot vector.
+For information about supported features and operations for NURBS Surface
+objects, please refer to Blender_ documentation.
+For more NURBS-related functions, it is possible to use the Sverchok-Extra_ addon.
+
+.. _Blender: https://docs.blender.org/manual/en/latest/modeling/surfaces/introduction.html
+.. _Sverchok-Extra: https://github.com/portnov/sverchok-extra
+
+**NOTE 2**: In current implementation, this node does not create objects during
+scene update events. In many cases you will never even see this problem,
+because usually updates of node inputs or parameters happen more frequently. If
+at some moment there is no object created by this node in the scene, and you
+want it created, just press the **Update All** button in node editor's N panel.
+
+Inputs
+------
+
+This node has the following inputs:
+
+* **ControlPoints**. Control points of the NURBS surface. These points are
+  expected to form a "rectangular grid" MxN. If the **Input Mode** parameter is
+  set to **Single List** value, then this input expects one flat list of
+  vertices per surface (i.e., it expects a list of lists of vertices). That
+  single list will be split into rows by this node itself. If the **Input
+  Mode** parameter is set to **Separated lists** value, then this input expects
+  a list of lists of vertices per surface (i.e. it expects a list of lists of
+  lists of vertices). This input is mandatory.
+* **Weights**. NURBS surface control points weight. The shape of input data
+  should correspond to the shape of input data for the **ControlPoints** input:
+  it can be either list of lists of floats (in **Single List** mode), or list
+  of lists of lists of floats (in **Separated Lists** mode). This input is
+  optional.
+* **Degree U**. The degree of the surface in the U direction. The default value is 3.
+* **Degree V**. The degree of the surface in the V direction. The default value is 3.
+* **U Size**. Number of vertices per row. This is used to split the flat list
+  of control points into rows, when the **Input Mode** parameter is set to
+  **Single List**. Otherwise the input is not available. The default value is
+  5.
+
+Parameters
+----------
+
+This node has the following parameters:
+
+* **UPD**. The node will process data only if this button is enabled.
+* **Hide View** (eye icon). Toggle visibility of generated object in viewport.
+* **Hide Select** (pointer icon). Toggle ability to select for generated object.
+* **Hide Render** (render icon). Toggle renderability for generated object.
+* **Base name**. Base part of name for Surface object to create (or update).
+  Default is "Alpha".
+* **Select Toggle**. Select / deselect generated object.
+* **Material**. Material to be assigned to created object.
+* **Input mode**. This defines how control points and their weights are specified:
+
+  * **Single List**: it is expected that **ControlPoints** and **Weights**
+    inputs will be provided with one flat list of control points and weights.
+    The node will split that list into rows, using the value in the **U Size**
+    input.
+  * **Separated Lists**: it is expected that **ControlPoints** and **Weights**
+    inputs will be provided with lists of control points and their weights,
+    that were already split into rows.
+
+* **Cyclic U**. Whether the surface should be cyclic (closed) in the U
+  direction. Unchecked by default.
+* **Cyclic V**. Whether the surface should be cyclic (closed) in the V
+  direction. Unchecked by default.
+* **Endpoint U**. Whether the surface should touch it's end control points in
+  the U direction. This option is not available if **Cyclic U** is checked.
+  Checked by default.
+* **Endpoint V**. Whether the surface should touch it's end control points in
+  the V direction. This option is not available if **Cyclic V** is checked.
+  Checked by default.
+* **Smooth**. Whether the created surface should be in smoothed normals mode.
+  Checked by default. This parameter is available in the N panel only.
+* **Resolution U**, **Resolition V**. Surface subdivisions per segment. This
+  parameter is available in the N panel only.
+
+Outputs
+-------
+
+This node has the following output:
+
+* **Object**. Generated NURBS Surface objects.
+
+Examples of usage
+-----------------
+
+.. image:: https://user-images.githubusercontent.com/284644/75611527-144dd800-5b3d-11ea-81e0-5b2b1c8a50c0.png
+

--- a/docs/nodes/viz/viz_index.rst
+++ b/docs/nodes/viz/viz_index.rst
@@ -10,3 +10,6 @@ Viz
    viewer_waveform_output
    vd_draw_experimental
    empty_out
+   viewer_nurbs_curve
+   viewer_nurbs_surface
+

--- a/index.md
+++ b/index.md
@@ -317,6 +317,7 @@
     SvTypeViewerNodeV28
     SvSkinViewerNodeV28
     SvMetaballOutNode
+    SvNurbsCurveOutNode
     SvNurbsSurfaceOutNode
     ---
     SvEmptyOutNode

--- a/index.md
+++ b/index.md
@@ -317,6 +317,7 @@
     SvTypeViewerNodeV28
     SvSkinViewerNodeV28
     SvMetaballOutNode
+    SvNurbsSurfaceOutNode
     ---
     SvEmptyOutNode
     ---

--- a/nodes/viz/viewer_nurbs_curve.py
+++ b/nodes/viz/viewer_nurbs_curve.py
@@ -1,0 +1,128 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import numpy as np
+from itertools import zip_longest
+import traceback
+
+import bpy
+from mathutils import Matrix, Vector
+from bpy.props import StringProperty, BoolProperty, IntProperty, EnumProperty
+
+from sverchok.node_tree import SverchCustomTreeNode, throttled
+from sverchok.data_structure import Matrix_generate, match_long_repeat, updateNode, get_data_nesting_level, ensure_nesting_level, describe_data_shape, zip_long_repeat, fullList
+from sverchok.utils.sv_obj_helper import SvObjHelper
+
+class SvNurbsCurveOutNode(bpy.types.Node, SverchCustomTreeNode, SvObjHelper):
+    """
+    Triggers: Output NURBS Curve
+    Tooltip: Create Blender's NURBS Curve object
+    """
+
+    bl_idname = 'SvNurbsCurveOutNode'
+    bl_label = 'NURBS Curve Out'
+    bl_icon = 'META_BALL'
+    sv_icon = 'SV_METABALL'
+
+    data_kind: StringProperty(default='CURVE')
+
+    def get_curve_name(self, index):
+        return f'{self.basedata_name}.{index:04d}'
+
+    def create_curve(self, index):
+        object_name = self.get_curve_name(index)
+        surface_data = bpy.data.curves.new(object_name, 'CURVE')
+        surface_data.dimensions = '3D'
+        surface_object = bpy.data.objects.get(object_name)
+        if not surface_object:
+            surface_object = self.create_object(object_name, index, surface_data)
+        return surface_object
+
+    def find_curve(self, index):
+        object_name = self.get_curve_name(index)
+        return bpy.data.objects.get(object_name)
+
+    is_cyclic : BoolProperty(
+            name = "Cyclic",
+            default = False,
+            update = updateNode)
+
+    use_endpoint : BoolProperty(
+            name = "Endpoint",
+            default = True,
+            update = updateNode)
+
+    degree : IntProperty(
+            name = "Degree",
+            min = 2, max = 6,
+            default = 3,
+            update = updateNode)
+
+    def draw_buttons(self, context, layout):
+        self.draw_live_and_outliner(context, layout)
+        self.draw_object_buttons(context, layout)
+        layout.prop(self, 'is_cyclic', toggle=True)
+        row = layout.row(align=True)
+        row.prop(self, 'use_endpoint', toggle=True)
+        row.enabled = not self.is_cyclic
+
+    def sv_init(self, context):
+        self.inputs.new('SvVerticesSocket', 'ControlPoints')
+        self.inputs.new('SvStringsSocket', 'Weights')
+        self.inputs.new('SvStringsSocket', "Degree").prop_name = 'degree'
+        self.outputs.new('SvObjectSocket', "Objects")
+
+    def process(self):
+        if not self.activate:
+            return
+
+        vertices_s = self.inputs['ControlPoints'].sv_get()
+        has_weights = self.inputs['Weights'].is_linked
+        weights_s = self.inputs['Weights'].sv_get(default = [[1.0]])
+        degree_s = self.inputs['Degree'].sv_get()
+
+        vertices_s = ensure_nesting_level(vertices_s, 3)
+            
+        inputs = zip_long_repeat(vertices_s, weights_s, degree_s)
+        object_index = 0
+        for vertices, weights, degree in inputs:
+            if not vertices or not weights:
+                continue
+            object_index += 1
+            if isinstance(degree, (tuple, list)):
+                degree = degree[0]
+
+            fullList(weights, len(vertices))
+
+            curve_object = self.create_curve(object_index)
+            self.debug("Object: %s", curve_object)
+            if not curve_object:
+                continue
+
+            curve_object.data.splines.clear()
+            spline = curve_object.data.splines.new(type='NURBS')
+            spline.use_bezier_u = False
+            spline.use_bezier_v = False
+            spline.points.add(len(vertices)-1)
+
+            for p, new_co, new_weight in zip(spline.points, vertices, weights):
+                p.co = Vector(list(new_co) + [new_weight])
+                p.select = True
+
+            spline.use_cyclic_u = self.is_cyclic
+            spline.use_endpoint_u = not self.is_cyclic and self.use_endpoint
+            spline.order_u = degree + 1
+
+        self.remove_non_updated_objects(object_index)
+        self.set_corresponding_materials()
+        objects = self.get_children()
+
+        self.outputs['Objects'].sv_set(objects)
+
+classes = [SvNurbsCurveOutNode]
+register, unregister = bpy.utils.register_classes_factory(classes)
+

--- a/nodes/viz/viewer_nurbs_curve.py
+++ b/nodes/viz/viewer_nurbs_curve.py
@@ -47,16 +47,19 @@ class SvNurbsCurveOutNode(bpy.types.Node, SverchCustomTreeNode, SvObjHelper):
 
     is_cyclic : BoolProperty(
             name = "Cyclic",
+            description = "Whether to make cyclic curve",
             default = False,
             update = updateNode)
 
     use_endpoint : BoolProperty(
             name = "Endpoint",
+            description = "Whether should the curve touch it's end points",
             default = True,
             update = updateNode)
 
     degree : IntProperty(
             name = "Degree",
+            description = "Degree of the curve",
             min = 2, max = 6,
             default = 3,
             update = updateNode)

--- a/nodes/viz/viewer_nurbs_curve.py
+++ b/nodes/viz/viewer_nurbs_curve.py
@@ -64,6 +64,13 @@ class SvNurbsCurveOutNode(bpy.types.Node, SverchCustomTreeNode, SvObjHelper):
             default = 3,
             update = updateNode)
 
+    resolution : IntProperty(
+            name = "Resolution",
+            description = "Curve subdivisions per segment",
+            min = 1, max = 1024,
+            default = 10,
+            update = updateNode)
+
     def draw_buttons(self, context, layout):
         self.draw_live_and_outliner(context, layout)
         self.draw_object_buttons(context, layout)
@@ -71,6 +78,10 @@ class SvNurbsCurveOutNode(bpy.types.Node, SverchCustomTreeNode, SvObjHelper):
         row = layout.row(align=True)
         row.prop(self, 'use_endpoint', toggle=True)
         row.enabled = not self.is_cyclic
+
+    def draw_buttons_ext(self, context, layout):
+        self.draw_buttons(context, layout)
+        layout.prop(self, 'resolution')
 
     def draw_label(self):
         return f"NURBS Curve {self.basedata_name}"
@@ -123,6 +134,7 @@ class SvNurbsCurveOutNode(bpy.types.Node, SverchCustomTreeNode, SvObjHelper):
                 spline.use_cyclic_u = self.is_cyclic
                 spline.use_endpoint_u = not self.is_cyclic and self.use_endpoint
                 spline.order_u = degree + 1
+                spline.resolution_u = self.resolution
 
             self.remove_non_updated_objects(object_index)
             self.set_corresponding_materials()

--- a/nodes/viz/viewer_nurbs_curve.py
+++ b/nodes/viz/viewer_nurbs_curve.py
@@ -25,8 +25,7 @@ class SvNurbsCurveOutNode(bpy.types.Node, SverchCustomTreeNode, SvObjHelper):
 
     bl_idname = 'SvNurbsCurveOutNode'
     bl_label = 'NURBS Curve Out'
-    bl_icon = 'META_BALL'
-    sv_icon = 'SV_METABALL'
+    bl_icon = 'CURVE_NCURVE'
 
     data_kind: StringProperty(default='CURVE')
 

--- a/nodes/viz/viewer_nurbs_curve.py
+++ b/nodes/viz/viewer_nurbs_curve.py
@@ -70,6 +70,9 @@ class SvNurbsCurveOutNode(bpy.types.Node, SverchCustomTreeNode, SvObjHelper):
         row.prop(self, 'use_endpoint', toggle=True)
         row.enabled = not self.is_cyclic
 
+    def draw_label(self):
+        return f"NURBS Curve {self.basedata_name}"
+
     def sv_init(self, context):
         self.inputs.new('SvVerticesSocket', 'ControlPoints')
         self.inputs.new('SvStringsSocket', 'Weights')

--- a/nodes/viz/viewer_nurbs_surface.py
+++ b/nodes/viz/viewer_nurbs_surface.py
@@ -134,6 +134,26 @@ class SvNurbsSurfaceOutNode(bpy.types.Node, SverchCustomTreeNode, SvObjHelper):
             default = 3,
             update = updateNode)
 
+    resolution_u : IntProperty(
+            name = "Resolution U",
+            description = "Surface subdivisions per segment",
+            min = 1, max = 1024,
+            default = 10,
+            update = updateNode)
+
+    resolution_v : IntProperty(
+            name = "Resolution V",
+            description = "Surface subdivisions per segment",
+            min = 1, max = 1024,
+            default = 10,
+            update = updateNode)
+
+    smooth : BoolProperty(
+            name = "Smooth",
+            description = "Smooth the normals of the surface",
+            default = True,
+            update = updateNode)
+
     def draw_buttons(self, context, layout):
         self.draw_live_and_outliner(context, layout)
         self.draw_object_buttons(context, layout)
@@ -151,6 +171,12 @@ class SvNurbsSurfaceOutNode(bpy.types.Node, SverchCustomTreeNode, SvObjHelper):
         s2 = row.split()
         row.prop(self, 'use_endpoint_v', toggle=True)
         s2.enabled = not self.is_cyclic_v
+
+    def draw_buttons_ext(self, context, layout):
+        self.draw_buttons(context, layout)
+        layout.prop(self, 'smooth')
+        layout.prop(self, 'resolution_u')
+        layout.prop(self, 'resolution_v')
 
     def sv_init(self, context):
         self.inputs.new('SvVerticesSocket', 'ControlPoints')
@@ -239,6 +265,9 @@ class SvNurbsSurfaceOutNode(bpy.types.Node, SverchCustomTreeNode, SvObjHelper):
                 spline = surface_object.data.splines[0]
                 spline.order_u = degree_u + 1
                 spline.order_v = degree_v + 1
+                spline.resolution_u = self.resolution_v
+                spline.resolution_v = self.resolution_u
+                spline.use_smooth = self.smooth
 
             self.remove_non_updated_objects(object_index)
             self.set_corresponding_materials()

--- a/nodes/viz/viewer_nurbs_surface.py
+++ b/nodes/viz/viewer_nurbs_surface.py
@@ -219,15 +219,16 @@ class SvNurbsSurfaceOutNode(bpy.types.Node, SverchCustomTreeNode, SvObjHelper):
                 spline.use_cyclic_u = self.is_cyclic_v
                 spline.use_endpoint_u = not self.is_cyclic_v and self.use_endpoint_v
                 spline.use_endpoint_v = not self.is_cyclic_u and self.use_endpoint_u
-                spline.order_u = degree_u# + 1
-                spline.order_v = degree_v# + 1
-                self.info("DU: %s, DV: %s", degree_u, degree_v)
-                self.info("OU: %s, OV: %s", spline.order_u, spline.order_v)
 
             bpy.context.view_layer.objects.active = surface_object
             bpy.ops.object.mode_set(mode = 'EDIT')
             bpy.ops.curve.make_segment()
             bpy.ops.object.mode_set(mode = 'OBJECT')
+            spline = surface_object.data.splines[0]
+            spline.order_u = degree_u + 1
+            spline.order_v = degree_v + 1
+            self.info("DU: %s, DV: %s", degree_u, degree_v)
+            self.info("OU: %s, OV: %s", spline.order_u, spline.order_v)
 
         self.remove_non_updated_objects(object_index)
         self.set_corresponding_materials()

--- a/nodes/viz/viewer_nurbs_surface.py
+++ b/nodes/viz/viewer_nurbs_surface.py
@@ -43,8 +43,7 @@ class SvNurbsSurfaceOutNode(bpy.types.Node, SverchCustomTreeNode, SvObjHelper):
 
     bl_idname = 'SvNurbsSurfaceOutNode'
     bl_label = 'NURBS Surface Out'
-    bl_icon = 'META_BALL'
-    sv_icon = 'SV_METABALL'
+    bl_icon = 'SURFACE_NSURFACE'
 
     data_kind: StringProperty(default='SURFACE')
 

--- a/nodes/viz/viewer_nurbs_surface.py
+++ b/nodes/viz/viewer_nurbs_surface.py
@@ -1,0 +1,240 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import numpy as np
+from itertools import zip_longest
+import traceback
+
+import bpy
+from mathutils import Matrix, Vector
+from bpy.props import StringProperty, BoolProperty, IntProperty, EnumProperty
+
+from sverchok.node_tree import SverchCustomTreeNode, throttled
+from sverchok.data_structure import Matrix_generate, match_long_repeat, updateNode, get_data_nesting_level, ensure_nesting_level, describe_data_shape, zip_long_repeat, fullList
+from sverchok.utils.sv_obj_helper import SvObjHelper
+
+# from python 3.5 docs https://docs.python.org/3.5/library/itertools.html recipes
+def grouper(iterable, n, fillvalue=None):
+    "Collect data into fixed-length chunks or blocks"
+    # grouper('ABCDEFG', 3, 'x') --> ABC DEF Gxx"
+    args = [iter(iterable)] * n
+    return list(map(list, zip_longest(*args, fillvalue=fillvalue)))
+
+def is_scene_event():
+    stack = traceback.extract_stack()
+    if not stack:
+        return False
+    file, line, method, text = stack[0]
+    # During any scene event, the root of Python stack will
+    # point at SvNodeTreeCommon.update().
+    if "node_tree.py" in file and method == "update":
+        return True
+    return False
+
+
+class SvNurbsSurfaceOutNode(bpy.types.Node, SverchCustomTreeNode, SvObjHelper):
+    """
+    Triggers: Output NURBS Surface
+    Tooltip: Create Blender's NURBS Surface object
+    """
+
+    bl_idname = 'SvNurbsSurfaceOutNode'
+    bl_label = 'NURBS Surface Out'
+    bl_icon = 'META_BALL'
+    sv_icon = 'SV_METABALL'
+
+    data_kind: StringProperty(default='SURFACE')
+
+    def get_surface_name(self, index):
+        return f'{self.basedata_name}.{index:04d}'
+
+    def create_surface(self, index):
+        object_name = self.get_surface_name(index)
+        surface_data = bpy.data.curves.new(object_name, 'SURFACE')
+        surface_data.dimensions = '3D'
+        surface_object = self.get_or_create_object(object_name, index, surface_data)
+        return surface_object
+
+    def find_surface(self, index):
+        object_name = self.get_surface_name(index)
+        return bpy.data.objects.get(object_name)
+
+    input_modes = [
+            ('1D', "Single list", "List of all control points (concatenated)", 1),
+            ('2D', "Separated lists", "List of lists of control points", 2)
+        ]
+
+    @throttled
+    def update_sockets(self, context):
+        self.inputs['USize'].hide_safe = self.input_mode == '2D'
+
+    input_mode : EnumProperty(
+            name = "Input mode",
+            default = '1D',
+            items = input_modes,
+            update = update_sockets)
+
+    u_size : IntProperty(
+            name = "U Size",
+            default = 5,
+            min = 3,
+            update = updateNode)
+
+    is_cyclic_u : BoolProperty(
+            name = "Cyclic U",
+            default = False,
+            update = updateNode)
+
+    is_cyclic_v : BoolProperty(
+            name = "Cyclic V",
+            default = False,
+            update = updateNode)
+
+    use_endpoint_u : BoolProperty(
+            name = "Endpoint U",
+            default = True,
+            update = updateNode)
+
+    use_endpoint_v : BoolProperty(
+            name = "Endpoint V",
+            default = True,
+            update = updateNode)
+
+    degree_u : IntProperty(
+            name = "Degree U",
+            min = 2, max = 6,
+            default = 3,
+            update = updateNode)
+
+    degree_v : IntProperty(
+            name = "Degree V",
+            min = 2, max = 6,
+            default = 3,
+            update = updateNode)
+
+    def draw_buttons(self, context, layout):
+        self.draw_live_and_outliner(context, layout)
+        self.draw_object_buttons(context, layout)
+
+        layout.prop(self, "input_mode")
+
+        row = layout.row(align=True)
+        row.prop(self, 'is_cyclic_u', toggle=True)
+        row.prop(self, 'is_cyclic_v', toggle=True)
+
+        row = layout.row(align=True)
+        s1 = row.split()
+        s1.prop(self, 'use_endpoint_u', toggle=True)
+        s1.enabled = not self.is_cyclic_u
+        s2 = row.split()
+        row.prop(self, 'use_endpoint_v', toggle=True)
+        s2.enabled = not self.is_cyclic_v
+
+    def sv_init(self, context):
+        self.inputs.new('SvVerticesSocket', 'ControlPoints')
+        self.inputs.new('SvStringsSocket', 'Weights')
+        self.inputs.new('SvStringsSocket', "DegreeU").prop_name = 'degree_u'
+        self.inputs.new('SvStringsSocket', "DegreeV").prop_name = 'degree_v'
+        self.inputs.new('SvStringsSocket', "USize").prop_name = 'u_size'
+        self.outputs.new('SvObjectSocket', "Objects")
+
+    def draw_label(self):
+        return f"NURBS Surface {self.basedata_name}"
+
+    def process(self):
+        if not self.activate:
+            return
+        # FIXME: HACK:
+        # during scene load event, Blender is currently returning None
+        # when checking for bpy.data.objects.get('Alpha'); however,
+        # the object may actually exist, and if we create a new object
+        # with the same name, we will get Blender crash when trying to
+        # switch the object to EDIT mode. So, let's check call stack
+        # and do not do anything when processing scene events.
+        if is_scene_event():
+            self.info("Will not process during scene event")
+            return
+
+        vertices_s = self.inputs['ControlPoints'].sv_get()
+        has_weights = self.inputs['Weights'].is_linked
+        weights_s = self.inputs['Weights'].sv_get(default = [[1.0]])
+        u_size_s = self.inputs['USize'].sv_get()
+        degree_u_s = self.inputs['DegreeU'].sv_get()
+        degree_v_s = self.inputs['DegreeV'].sv_get()
+
+        if self.input_mode == '1D':
+            vertices_s = ensure_nesting_level(vertices_s, 3)
+        else:
+            vertices_s = ensure_nesting_level(vertices_s, 4)
+            
+        inputs = zip_long_repeat(vertices_s, weights_s, u_size_s, degree_u_s, degree_v_s)
+        object_index = 0
+        objects = []
+        for vertices, weights, u_size, degree_u, degree_v in inputs:
+            if not vertices or not weights:
+                continue
+            object_index += 1
+
+            if isinstance(u_size, (list, tuple)):
+                u_size = u_size[0]
+            if isinstance(degree_u, (tuple, list)):
+                degree_u = degree_u[0]
+            if isinstance(degree_v, (tuple, list)):
+                degree_v = degree_v[0]
+            if self.input_mode == '1D':
+                fullList(weights, len(vertices))
+            else:
+                if isinstance(weights[0], (int, float)):
+                    weights = [weights]
+                fullList(weights, len(vertices))
+                for verts_u, weights_u in zip(vertices, weights):
+                    fullList(weights_u, len(verts_u))
+
+            surface_object = self.create_surface(object_index)
+            self.debug("Object: %s", surface_object)
+
+            if self.input_mode == '1D':
+                n_v = u_size
+                n_u = len(vertices) // n_v
+
+                vertices = grouper(vertices, n_u)
+                weights = grouper(weights, n_u)
+
+            surface_object.data.splines.clear()
+            for vertices_row, weights_row in zip(vertices, weights):
+                spline = surface_object.data.splines.new(type='NURBS')
+                spline.use_bezier_u = False
+                spline.use_bezier_v = False
+                spline.points.add(n_u - 1)
+
+                for p, new_co, new_weight in zip(spline.points, vertices_row, weights_row):
+                    p.co = Vector(list(new_co) + [new_weight])
+                    p.select = True
+
+                spline.use_cyclic_v = self.is_cyclic_u
+                spline.use_cyclic_u = self.is_cyclic_v
+                spline.use_endpoint_u = not self.is_cyclic_v and self.use_endpoint_v
+                spline.use_endpoint_v = not self.is_cyclic_u and self.use_endpoint_u
+                spline.order_u = degree_u# + 1
+                spline.order_v = degree_v# + 1
+                self.info("DU: %s, DV: %s", degree_u, degree_v)
+                self.info("OU: %s, OV: %s", spline.order_u, spline.order_v)
+
+            bpy.context.view_layer.objects.active = surface_object
+            bpy.ops.object.mode_set(mode = 'EDIT')
+            bpy.ops.curve.make_segment()
+            bpy.ops.object.mode_set(mode = 'OBJECT')
+
+        self.remove_non_updated_objects(object_index)
+        self.set_corresponding_materials()
+        objects = self.get_children()
+
+        self.outputs['Objects'].sv_set(objects)
+
+classes = [SvNurbsSurfaceOutNode]
+register, unregister = bpy.utils.register_classes_factory(classes)
+

--- a/nodes/viz/viewer_nurbs_surface.py
+++ b/nodes/viz/viewer_nurbs_surface.py
@@ -84,44 +84,52 @@ class SvNurbsSurfaceOutNode(bpy.types.Node, SverchCustomTreeNode, SvObjHelper):
 
     input_mode : EnumProperty(
             name = "Input mode",
+            description = "What to expect in ControlPoints and Weights inputs: either single list (and subdivide it into rows in the node), or pre-subdivided list of lists",
             default = '1D',
             items = input_modes,
             update = update_sockets)
 
     u_size : IntProperty(
             name = "U Size",
+            description = "Number of control points in one row",
             default = 5,
             min = 3,
             update = updateNode)
 
     is_cyclic_u : BoolProperty(
             name = "Cyclic U",
+            description = "Whether to make surface cyclic in the U direction",
             default = False,
             update = updateNode)
 
     is_cyclic_v : BoolProperty(
             name = "Cyclic V",
+            description = "Whether to make surface cyclic in the V direction",
             default = False,
             update = updateNode)
 
     use_endpoint_u : BoolProperty(
             name = "Endpoint U",
+            description = "Whether the surface should touch it's end points in the U direction",
             default = True,
             update = updateNode)
 
     use_endpoint_v : BoolProperty(
             name = "Endpoint V",
+            description = "Whether the surface should touch it's end points in the V direction",
             default = True,
             update = updateNode)
 
     degree_u : IntProperty(
             name = "Degree U",
+            description = "Degree of the surface in the U direction",
             min = 2, max = 6,
             default = 3,
             update = updateNode)
 
     degree_v : IntProperty(
             name = "Degree V",
+            description = "Degree of the surface in the V direction",
             min = 2, max = 6,
             default = 3,
             update = updateNode)

--- a/nodes/viz/viewer_nurbs_surface.py
+++ b/nodes/viz/viewer_nurbs_surface.py
@@ -174,7 +174,6 @@ class SvNurbsSurfaceOutNode(bpy.types.Node, SverchCustomTreeNode, SvObjHelper):
             
         inputs = zip_long_repeat(vertices_s, weights_s, u_size_s, degree_u_s, degree_v_s)
         object_index = 0
-        objects = []
         for vertices, weights, u_size, degree_u, degree_v in inputs:
             if not vertices or not weights:
                 continue

--- a/utils/sv_obj_helper.py
+++ b/utils/sv_obj_helper.py
@@ -383,7 +383,6 @@ class SvObjHelper():
         obj = bpy.data.objects.get(object_name)
         if not obj:
             obj = self.create_object(object_name, obj_index, data)
-            print("Creating object")
         return obj
 
     def get_obj_curve(self, obj_index):

--- a/utils/sv_obj_helper.py
+++ b/utils/sv_obj_helper.py
@@ -383,6 +383,7 @@ class SvObjHelper():
         obj = bpy.data.objects.get(object_name)
         if not obj:
             obj = self.create_object(object_name, obj_index, data)
+            print("Creating object")
         return obj
 
     def get_obj_curve(self, obj_index):


### PR DESCRIPTION
This adds two nodes:

* NURBS Curve Output
* NURBS Surface Output

The nodes create Blender's NURBS objects. Note that NURBS support in Blender is limited; for example, there is no way to specify the knot vector explicitly.

Also there is some problem in Blender (to be reported later, I think), due to which I have to avoid creating an object during scene update events. Updating existing object works fine.

![Screenshot_20200229_113920](https://user-images.githubusercontent.com/284644/75611527-144dd800-5b3d-11ea-81e0-5b2b1c8a50c0.png)
![Screenshot_20200229_214359](https://user-images.githubusercontent.com/284644/75611529-16179b80-5b3d-11ea-99b8-5cfaafaa7c5b.png)


## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [ ] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [ ] Ready for merge.

