### PR TITLE
add exception display in the nodeview

### DIFF
--- a/core/update_system.py
+++ b/core/update_system.py
@@ -31,7 +31,7 @@ from sverchok.utils.exception_drawing_with_bgl import clear_exception_drawing_wi
 
 import traceback
 import ast
-import sys
+# import sys
 
 graphs = []
 
@@ -357,9 +357,8 @@ def do_update_general(node_list, nodes, procesed_nodes=set()):
             exception("Node %s had exception: %s", node_name, err)
             
             if True:  # if ng.show_error_beside_node
-                tb = sys.exc_info()[2]
-                error_text = err.with_traceback(tb)
-                start_exception_drawing_with_bgl(ng, node_name, error_text)
+                error_text = traceback.format_exc()
+                start_exception_drawing_with_bgl(ng, node_name, error_text, err)
             
             return None
 

--- a/core/update_system.py
+++ b/core/update_system.py
@@ -31,7 +31,6 @@ from sverchok.utils.exception_drawing_with_bgl import clear_exception_drawing_wi
 
 import traceback
 import ast
-# import sys
 
 graphs = []
 
@@ -356,7 +355,7 @@ def do_update_general(node_list, nodes, procesed_nodes=set()):
             #traceback.print_tb(err.__traceback__)
             exception("Node %s had exception: %s", node_name, err)
             
-            if ng.sv_show_error_in_tree:  # if ng.show_error_beside_node
+            if ng.sv_show_error_in_tree:
                 error_text = traceback.format_exc()
                 start_exception_drawing_with_bgl(ng, node_name, error_text, err)
             

--- a/core/update_system.py
+++ b/core/update_system.py
@@ -328,6 +328,8 @@ def do_update_general(node_list, nodes, procesed_nodes=set()):
     total_time = 0
     done_nodes = set(procesed_nodes)
 
+    clear_exception_drawing_with_bgl(ng)
+
     for node_name in node_list:
         if node_name in done_nodes:
             continue
@@ -351,6 +353,7 @@ def do_update_general(node_list, nodes, procesed_nodes=set()):
             update_error_nodes(ng, node_name, err)
             #traceback.print_tb(err.__traceback__)
             exception("Node %s had exception: %s", node_name, err)
+            start_exception_drawing_with_bgl(ng, node_name, err)
             return None
 
     graphs.append(graph)

--- a/core/update_system.py
+++ b/core/update_system.py
@@ -27,9 +27,11 @@ from sverchok.core.socket_data import SvNoDataError, reset_socket_cache
 from sverchok.utils.logging import debug, info, warning, error, exception
 from sverchok.utils.profile import profile
 import sverchok
+from sverchok.utils.exception_drawing_with_bgl import clear_exception_drawing_with_bgl, start_exception_drawing_with_bgl
 
 import traceback
 import ast
+import sys
 
 graphs = []
 
@@ -328,7 +330,7 @@ def do_update_general(node_list, nodes, procesed_nodes=set()):
     total_time = 0
     done_nodes = set(procesed_nodes)
 
-    clear_exception_drawing_with_bgl(ng)
+    clear_exception_drawing_with_bgl(nodes)
 
     for node_name in node_list:
         if node_name in done_nodes:
@@ -353,7 +355,12 @@ def do_update_general(node_list, nodes, procesed_nodes=set()):
             update_error_nodes(ng, node_name, err)
             #traceback.print_tb(err.__traceback__)
             exception("Node %s had exception: %s", node_name, err)
-            start_exception_drawing_with_bgl(ng, node_name, err)
+            
+            if True:  # if ng.show_error_beside_node
+                tb = sys.exc_info()[2]
+                error_text = err.with_traceback(tb)
+                start_exception_drawing_with_bgl(ng, node_name, error_text)
+            
             return None
 
     graphs.append(graph)

--- a/core/update_system.py
+++ b/core/update_system.py
@@ -356,7 +356,7 @@ def do_update_general(node_list, nodes, procesed_nodes=set()):
             #traceback.print_tb(err.__traceback__)
             exception("Node %s had exception: %s", node_name, err)
             
-            if True:  # if ng.show_error_beside_node
+            if ng.sv_show_error_in_tree:  # if ng.show_error_beside_node
                 error_text = traceback.format_exc()
                 start_exception_drawing_with_bgl(ng, node_name, error_text, err)
             

--- a/node_tree.py
+++ b/node_tree.py
@@ -206,7 +206,6 @@ class SverchCustomTree(NodeTree, SvNodeTreeCommon):
 
     def turn_off_ng(self, context):
         process_tree(self)
-
         # should turn off tree. for now it does by updating it whole
         # should work something like this
         # outputs = filter(lambda n: isinstance(n,SvOutput), self.nodes)

--- a/node_tree.py
+++ b/node_tree.py
@@ -212,11 +212,18 @@ class SverchCustomTree(NodeTree, SvNodeTreeCommon):
         # for node in outputs:
         #   node.disable()
 
+    def show_error_update(self, context):
+        process_tree(self)    
+
     sv_animate: BoolProperty(name="Animate", default=True, description='Animate this layout')
     sv_show: BoolProperty(name="Show", default=True, description='Show this layout', update=turn_off_ng)
     sv_bake: BoolProperty(name="Bake", default=True, description='Bake this layout')
     sv_process: BoolProperty(name="Process", default=True, description='Process layout')
     sv_user_colors: StringProperty(default="")
+
+    sv_show_error_in_tree: BoolProperty(
+        description="use bgl to draw the error to the nodeview",
+        name="Show error in tree", default=False, update=show_error_update)
 
     def on_draft_mode_changed(self, context):
         """

--- a/node_tree.py
+++ b/node_tree.py
@@ -352,7 +352,7 @@ class SverchCustomTreeNode:
         return self.n_id
 
     @property
-    def asbolute_location(self):
+    def absolute_location(self):
         """ does not return a vactor, it returns a:  tuple(x, y) """
         return recursive_framed_location_finder(self, self.location[:])
 

--- a/node_tree.py
+++ b/node_tree.py
@@ -351,6 +351,12 @@ class SverchCustomTreeNode:
             self.n_id = str(hash(self) ^ hash(time.monotonic()))
         return self.n_id
 
+    @property
+    def asbolute_location(self):
+        """ does not return a vactor, it returns a:  tuple(x, y) """
+        return recursive_framed_location_finder(node, node.location[:])
+
+
     def ensure_enums_have_no_space(self, enums=None):
         """
         enums: a list of property names to check. like  self.current_op  

--- a/node_tree.py
+++ b/node_tree.py
@@ -354,7 +354,7 @@ class SverchCustomTreeNode:
     @property
     def asbolute_location(self):
         """ does not return a vactor, it returns a:  tuple(x, y) """
-        return recursive_framed_location_finder(node, node.location[:])
+        return recursive_framed_location_finder(self, self.location[:])
 
 
     def ensure_enums_have_no_space(self, enums=None):

--- a/ui/development.py
+++ b/ui/development.py
@@ -237,6 +237,13 @@ def idname_draw(self, context):
     op.old_node_name = node.name
     op.new_bl_idname = bl_idname
 
+    col.separator()
+
+    box = col.box()
+    box.alert = True
+    box.label(text="common node features")
+    box.prop(node.id_data, "sv_show_error_in_tree", icon="CONSOLE")
+
 
 def register():
     branch = get_branch()

--- a/ui/sv_panels.py
+++ b/ui/sv_panels.py
@@ -432,6 +432,7 @@ class SV_PT_ToolsMenu(bpy.types.Panel):
         layout.row().operator('node.sv_show_latest_commits')
         layout.separator()
         layout.row().operator('node.remove_stale_draw_callbacks')
+        # layout.row().prop(addon, "sv_display_error_in_nodeview")
 
 def node_show_tree_mode(self, context):
     if not displaying_sverchok_nodes(context):

--- a/ui/sv_panels.py
+++ b/ui/sv_panels.py
@@ -432,7 +432,6 @@ class SV_PT_ToolsMenu(bpy.types.Panel):
         layout.row().operator('node.sv_show_latest_commits')
         layout.separator()
         layout.row().operator('node.remove_stale_draw_callbacks')
-        # layout.row().prop(addon, "sv_display_error_in_nodeview")
 
 def node_show_tree_mode(self, context):
     if not displaying_sverchok_nodes(context):

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -125,7 +125,7 @@ utils_modules = [
     "csg_core", "csg_geom", "geom", "sv_easing_functions", "sv_text_io_common", "sv_obj_baker",
     "snlite_utils", "snlite_importhelper", "context_managers", "sv_node_utils", "sv_noise_utils",
     "profile", "logging", "testing", "sv_prefs", "sv_requests", "sv_examples_utils", "sv_shader_sources",
-    "avl_tree", "sv_nodeview_draw_helper", "sv_font_xml_parser",
+    "avl_tree", "sv_nodeview_draw_helper", "sv_font_xml_parser", "exception_drawing_with_bgl"
     # UI text editor ui
     "text_editor_submenu", "text_editor_plugins",
     # UI operators and tools

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -125,7 +125,7 @@ utils_modules = [
     "csg_core", "csg_geom", "geom", "sv_easing_functions", "sv_text_io_common", "sv_obj_baker",
     "snlite_utils", "snlite_importhelper", "context_managers", "sv_node_utils", "sv_noise_utils",
     "profile", "logging", "testing", "sv_prefs", "sv_requests", "sv_examples_utils", "sv_shader_sources",
-    "avl_tree", "sv_nodeview_draw_helper", "sv_font_xml_parser", "exception_drawing_with_bgl"
+    "avl_tree", "sv_nodeview_draw_helper", "sv_font_xml_parser", "exception_drawing_with_bgl",
     # UI text editor ui
     "text_editor_submenu", "text_editor_plugins",
     # UI operators and tools

--- a/utils/exception_drawing_with_bgl.py
+++ b/utils/exception_drawing_with_bgl.py
@@ -1,0 +1,14 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+
+def clear_exception_drawing_with_bgl(ng):
+    pass
+
+
+def start_exception_drawing_with_bgl(ng, node_name, err):
+    pass

--- a/utils/exception_drawing_with_bgl.py
+++ b/utils/exception_drawing_with_bgl.py
@@ -5,10 +5,71 @@
 # SPDX-License-Identifier: GPL3
 # License-Filename: LICENSE
 
+# pylint: disable=c0103
+# pylint: disable=w0612
+# pylint: disable=w0613
+
+import time
+from sverchok.ui import bgl_callback_nodeview as nvBGL2
+from sverchok.settings import get_params
+
+
+def exception_nodetree_id(ng):
+    """ only one node per ng will have an exception """
+    return str(hash(ng) ^ hash(time.monotonic())) + "_exception"
+
+
+def get_preferences():
+    """ obtain the dpi adjusted xy and scale factors """
+    props = get_params({
+        'render_scale': 1.0,
+        'render_location_xy_multiplier': 1.0})
+    return props.render_scale, props.render_location_xy_multiplier
+
+
+def adjust_position_and_dimensions(node, loc):
+    """ further adjustement is needed, not done yet in the code below Frames, nested 
+        node param is used for this.
+    """
+    x, y = loc
+    scale, multiplier = get_preferences()
+    x, y = [x * multiplier, y * multiplier]
+    # maybe we do something independant of scale.
+    return x, y
+
+
+def xyoffset(node):
+    """ what is the location, offset to draw to """
+    a = node.location[:]
+    b = int(node.width) + 20
+    return int(a[0] + b), int(a[1])
+
 
 def clear_exception_drawing_with_bgl(ng):
-    pass
+    """ remove the previously drawn exception if needed """
+    ng_id = exception_nodetree_id(ng)
+    nvBGL2.callback_disable(ng_id)
 
 
 def start_exception_drawing_with_bgl(ng, node_name, err):
-    pass
+    """ start drawing the exception data beside the node """
+    node = ng.nodes[node_name]
+    text = lambda: None
+    text.body = err
+    config = lambda: None
+    config.loc = adjust_position_and_dimensions(node, xyoffset(node))
+
+    ng_id = exception_nodetree_id(ng)
+    draw_data = {
+        'tree_name': ng.name[:],
+        'mode': 'custom_function_context', 
+        'custom_function': simple_exception_display,
+        'args': (text, config)
+    }
+    nvBGL2.callback_enable(ng_id, draw_data)
+
+def simple_exception_display(context, args):
+    """
+    a simple bgl/blf exception showing tool for nodeview
+    """
+    ...

--- a/utils/exception_drawing_with_bgl.py
+++ b/utils/exception_drawing_with_bgl.py
@@ -14,7 +14,6 @@ import time
 
 import sverchok
 from sverchok.ui import bgl_callback_nodeview as nvBGL2
-from sverchok.utils.sv_node_utils import recursive_framed_location_finder
 
 def exception_nodetree_id(ng):
     """ only one node per ng will have an exception """
@@ -44,7 +43,7 @@ def adjust_position_and_dimensions(node, loc):
 def xyoffset(node):
     """ what is the location, offset to draw to """
     loc_xy = node.location[:]
-    a = recursive_framed_location_finder(node, loc_xy)
+    a = node.absolute_location
     b = int(node.width) + 20
     return int(a[0] + b), int(a[1])
 

--- a/utils/exception_drawing_with_bgl.py
+++ b/utils/exception_drawing_with_bgl.py
@@ -42,7 +42,6 @@ def adjust_position_and_dimensions(node, loc):
 
 def xyoffset(node):
     """ what is the location, offset to draw to """
-    loc_xy = node.location[:]
     a = node.absolute_location
     b = int(node.width) + 20
     return int(a[0] + b), int(a[1])

--- a/utils/exception_drawing_with_bgl.py
+++ b/utils/exception_drawing_with_bgl.py
@@ -56,12 +56,18 @@ def clear_exception_drawing_with_bgl(nodes):
     nvBGL2.callback_disable(ng_id)
 
 
-def start_exception_drawing_with_bgl(ng, node_name, err):
+def start_exception_drawing_with_bgl(ng, node_name, error_text, err):
     """ start drawing the exception data beside the node """
     node = ng.nodes[node_name]
-    text = lambda: None
-    text.body = err
     config = lambda: None
+    text = lambda: None
+    text.final_error_message = str(err)
+    
+    if "\n" in error_text:
+        text.body = error_text.splitlines()
+    else:
+        text.body = error_text
+
     x, y, scale = adjust_position_and_dimensions(node, xyoffset(node))
     config.loc = x, y
     config.scale = scale
@@ -81,9 +87,6 @@ def simple_exception_display(context, args):
     """
     text, config = args
 
-    # print(dir(text.body))
-    line = str(text.body)
-    
     x, y = config.loc
     x, y = int(x), int(y)
     r, g, b = (1.0, 1.0, 1.0)
@@ -97,7 +100,17 @@ def simple_exception_display(context, args):
     blf.color(font_id, r, g, b, 1.0)
     ypos = y
 
-    # for line in lines:
+    if isinstance(text.body, list):
+        for line in text.body:
+            blf.position(0, x, ypos, 0)
+            blf.draw(font_id, line)
+            ypos -= int(line_height * 1.3)
+    
+    elif isinstance(text.body, str):
+        blf.position(0, x, ypos, 0)
+        blf.draw(font_id, text.body)
+        ypos -= int(line_height * 1.3)
+
+    blf.color(font_id, 0.911393, 0.090249, 0.257536, 1.0)
     blf.position(0, x, ypos, 0)
-    blf.draw(font_id, line)
-    ypos -= int(line_height * 1.3)
+    blf.draw(font_id, text.final_error_message)


### PR DESCRIPTION
this addresses a longstanding pain-in-the-butt issue with distance between the error and the node where the error occurs.

first a simple implementation, with as little overhead as humanly possible.

![image](https://user-images.githubusercontent.com/619340/76163742-19b4af00-6149-11ea-9f1e-78d0bda8ec82.png)

![image](https://user-images.githubusercontent.com/619340/76163795-8e87e900-6149-11ea-8233-1984da37ee9f.png)

![image](https://user-images.githubusercontent.com/619340/76164609-939c6680-6150-11ea-8861-9d83a9b68de8.png)

