### PR TITLE
Fix framed node location nvdrawing

### DIFF
--- a/nodes/number/easing.py
+++ b/nodes/number/easing.py
@@ -127,7 +127,7 @@ class SvEasingNode(bpy.types.Node, SverchCustomTreeNode):
         """
         adjust render location based on preference multiplier setting
         """
-        x, y = [int(j) for j in (self.location + Vector((self.width + 20, 0)))[:]]
+        x, y = [int(j) for j in (Vector(self.absolute_location) + Vector((self.width + 20, 0)))[:]]
 
         try:
             with sv_preferences() as prefs:

--- a/nodes/viz/viewer_texture.py
+++ b/nodes/viz/viewer_texture.py
@@ -262,7 +262,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
 
     @property
     def xy_offset(self):
-        a = self.location[:]
+        a = self.absolute_location
         b = int(self.width) + 20
         return int(a[0] + b), int(a[1])
 

--- a/nodes/viz/viewer_texture_lite.py
+++ b/nodes/viz/viewer_texture_lite.py
@@ -58,7 +58,7 @@ class SvTextureViewerNodeLite(bpy.types.Node, SverchCustomTreeNode):
 
     @property
     def xy_offset(self):
-        a = self.location[:]
+        a = self.absolute_location
         b = int(self.width) + 20
         return int(a[0] + b), int(a[1])
 

--- a/nodes/viz/viewer_waveform_output.py
+++ b/nodes/viz/viewer_waveform_output.py
@@ -218,7 +218,7 @@ class SvWaveformViewer(bpy.types.Node, SverchCustomTreeNode):
         """
         adjust render location based on preference multiplier setting
         """
-        x, y = [int(j) for j in (self.location + Vector((self.width + 20, 0)))[:]]
+        x, y = [int(j) for j in (Vector(self.absolute_location) + Vector((self.width + 20, 0)))[:]]
 
         try:
             with sv_preferences() as prefs:

--- a/utils/sv_nodeview_draw_helper.py
+++ b/utils/sv_nodeview_draw_helper.py
@@ -18,7 +18,7 @@ class SvNodeViewDrawMixin():
 
     @property
     def xy_offset(self):
-        a = self.location[:]
+        a = self.absolute_location
         b = int(self.width) + 20
         return int(a[0] + b), int(a[1])
 


### PR DESCRIPTION
implement obvious fixes using `node.absolute_location` as an abstraction of `recursive lookup `

```python
    @property
    def absolute_location(self):
        """ does not return a vactor, it returns a:  tuple(x, y) """
        return recursive_framed_location_finder(self, self.location[:])
```