### PR TITLE
"Edge Boom" node.

### DIFF
--- a/docs/nodes/modifier_change/edge_boom.rst
+++ b/docs/nodes/modifier_change/edge_boom.rst
@@ -1,0 +1,70 @@
+Edge Boom
+=========
+
+Functionality
+-------------
+
+This node splits the input mesh object into separate edges objects; it can be
+used to create a separate object from each edge of the input mesh.
+
+Inputs
+------
+
+This node has the following inputs:
+
+- **Vertices**. Vertices of the input mesh. This input is mandatory.
+- **Edges**. Edges of the input mesh. This input is optional: if it is not
+  connected, **Faces** input will be used to determine object edges. But if you
+  want output objects to appear in certain order, you need to connect this.
+- **Faces**. Faces of the input mesh. This input is optional. This input must
+  be connected if **Edges** input is not connected.
+
+Parameters
+----------
+
+This node has the following parameters:
+
+- **Output mode**. The following modes are available:
+
+  * **Vertices**. For each edge of the input mesh, output the first vertex of
+    the edge to the **Vertex1** output and the second vertex of the edge to the
+    **Vertex2** output. This mode is the default one.
+  * **Objects**. Make a separate object from each edge of the input mesh, and
+    output the list of it's vertices (always 2 vertices) into **Vertices**
+    output, and the list of it's edges (always 1 edge) into **Edges** output.
+
+- **Separate**. This parameter is available only when **Output mode** is set to
+  **Objects**. If checked, output separate list of edge objects per each input
+  objects. Otherwise, output one flat list of edge objects for all input
+  objects. Unchecked by default.
+
+Outputs
+-------
+
+This node has the following outputs:
+
+- **Vertex1**. The first vertex of each edge. This output contains one vertex
+  for each edge of the input object. This output is only available when the
+  **Output mode** parameter is set to **Vertices**.
+- **Vertex2**. The second vertex of each edge. This output contains one vertex
+  for each edge of the input object. This output is only available when the
+  **Output mode** parameter is set to **Vertices**.
+- **Vertices**. Vertices of the objects into which the input mesh was split.
+  This output contains two vertices for each edge of the input mesh. This
+  output is only available when the **Output mode** parameter is set to
+  **Objects**.
+- **Edges**. Edges of the objects into which the input mesh was split. This
+  output contains one edge for each edge of the input mesh. This output is only
+  available when the **Output mode** parameter is set to **Objects**.
+
+Example of usage
+----------------
+
+Replace each edge of a square with a segment with subdivisions:
+
+.. image:: https://user-images.githubusercontent.com/284644/76330373-942f2b80-630f-11ea-95ee-0c1f5f398e72.png
+
+Move each edge of input objects randomly:
+
+.. image:: https://user-images.githubusercontent.com/284644/76344998-5dafdb80-6324-11ea-9ff3-12ce2bf496c5.png
+

--- a/docs/nodes/modifier_change/modifier_change_index.rst
+++ b/docs/nodes/modifier_change/modifier_change_index.rst
@@ -23,6 +23,7 @@ Modifier Change
    objects_along_edge
    offset
    polygons_boom
+   edge_boom
    polygons_to_edges
    recalc_normals
    remove_doubles

--- a/index.md
+++ b/index.md
@@ -125,6 +125,7 @@
     SvMakeMonotone
     ---
     PolygonBoomNode
+    SvEdgeBoomNode
     SvDissolveFaces2D
     Pols2EdgsNode
     SvMeshJoinNode

--- a/nodes/modifier_change/edge_boom.py
+++ b/nodes/modifier_change/edge_boom.py
@@ -1,0 +1,110 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import bpy
+from bpy.props import EnumProperty
+
+from sverchok.node_tree import SverchCustomTreeNode, throttled
+from sverchok.data_structure import zip_long_repeat, updateNode
+from sverchok.utils.sv_mesh_utils import polygons_to_edges
+
+class SvEdgeBoomNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: Edge Boom
+    Tooltip: decompose a mesh into list of edge objects
+    """
+    bl_idname = 'SvEdgeBoomNode'
+    bl_label = 'Edge Boom'
+    bl_icon = 'OUTLINER_OB_EMPTY'
+    sv_icon = 'SV_EXPLODE'
+
+    modes = [
+        ('VER', "Vertices", "Output list of first vertices and list of second vertices of each edge", 0),
+        ('OBJ', "Objects", "Output list of objects, each consisting of a single edge", 1)
+    ]
+
+    @throttled
+    def update_sockets(self, context):
+        self.outputs['Vertex1'].hide_safe = self.out_mode != 'VER'
+        self.outputs['Vertex2'].hide_safe = self.out_mode != 'VER'
+        self.outputs['Vertices'].hide_safe = self.out_mode != 'OBJ'
+        self.outputs['Edges'].hide_safe = self.out_mode != 'OBJ'
+
+    out_mode : EnumProperty(
+        name = "Output mode",
+        description = "Output mode",
+        default = 'VER',
+        items = modes,
+        update = update_sockets)
+
+    def sv_init(self, context):
+        self.inputs.new('SvVerticesSocket', "Vertices")
+        self.inputs.new('SvStringsSocket', 'Edges')
+        self.inputs.new('SvStringsSocket', 'Faces')
+        self.outputs.new('SvVerticesSocket', 'Vertex1')
+        self.outputs.new('SvVerticesSocket', 'Vertex2')
+        self.outputs.new('SvVerticesSocket', 'Vertices')
+        self.outputs.new('SvStringsSocket', 'Edges')
+        self.update_sockets(context)
+
+    def draw_buttons(self, context, layout):
+        layout.label(text="Output mode:")
+        layout.prop(self, "out_mode", text="")
+
+    def process(self):
+        vertices_s = self.inputs['Vertices'].sv_get()
+        edges_s = self.inputs['Edges'].sv_get(default=[[]])
+        faces_s = self.inputs['Faces'].sv_get()
+
+        verts1_out = []
+        verts2_out = []
+        verts_out = []
+        edges_out = []
+        for vertices, edges, faces in zip_long_repeat(vertices_s, edges_s, faces_s):
+            new_verts1 = []
+            new_verts2 = []
+            if not edges:
+                edges = polygons_to_edges([faces], unique_edges=True)[0]
+            for i1, i2 in edges:
+                new_verts = []
+                new_edges = []
+                if i1 > i2:
+                    i1, i2 = i2, i1
+                v1, v2 = vertices[i1], vertices[i2]
+                new_verts1.append(v1)
+                new_verts2.append(v2)
+                new_verts.append(v1)
+                new_verts.append(v2)
+                new_edges.append([0,1])
+                verts_out.append(new_verts)
+                edges_out.append(new_edges)
+
+            verts1_out.append(new_verts1)
+            verts2_out.append(new_verts2)
+
+        self.outputs['Vertex1'].sv_set(verts1_out)
+        self.outputs['Vertex2'].sv_set(verts2_out)
+        self.outputs['Vertices'].sv_set(verts_out)
+        self.outputs['Edges'].sv_set(edges_out)
+
+def register():
+    bpy.utils.register_class(SvEdgeBoomNode)
+
+def unregister():
+    bpy.utils.unregister_class(SvEdgeBoomNode)
+


### PR DESCRIPTION
This node is similar to "polygon boom". It takes a mesh and outputs a separate object for each edge of input mesh.
The node has two modes of output:
* "Object mode": output list of vertices (always two) and list of edges (always one) for each edge of the mesh;
* "Vertices mode": for each edge of the mesh, output it's first vertex into one socket, and the second vertex into another socket.

![Screenshot_20200309_232049](https://user-images.githubusercontent.com/284644/76330373-942f2b80-630f-11ea-95ee-0c1f5f398e72.png)

![Screenshot_20200310_231030](https://user-images.githubusercontent.com/284644/76344998-5dafdb80-6324-11ea-9ff3-12ce2bf496c5.png)


## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

