### PR TITLE
needed for monad

### DIFF
--- a/core/update_system.py
+++ b/core/update_system.py
@@ -187,11 +187,12 @@ def separate_nodes(ng, links=None):
 
     found_node_sets = [ns for ns in node_set_list if len(ns) > 1]
   
-    sorting_type = ng.sv_subtree_evaluation_order  
-    if sorting_type in {'X', 'Y'}:
-        sort_index = 0 if sorting_type == "X" else 1
-        find_lowest = lambda ns: min(ng.nodes[n].absolute_location[sort_index] for n in ns)
-        found_node_sets = sorted(found_node_sets, key=find_lowest)
+    if hasattr(ng, "sv_subtree_evaluation_order"):
+        sorting_type = ng.sv_subtree_evaluation_order  
+        if sorting_type in {'X', 'Y'}:
+            sort_index = 0 if sorting_type == "X" else 1
+            find_lowest = lambda ns: min(ng.nodes[n].absolute_location[sort_index] for n in ns)
+            found_node_sets = sorted(found_node_sets, key=find_lowest)
 
     return found_node_sets
 


### PR DESCRIPTION
monad tree node type doesn't support `sv_subtree_evaluation_order` (it makes no sense to have disjoint sets in a monad... at all. )