### PR TITLE
console_node line width limits

### DIFF
--- a/nodes/script/console_node.py
+++ b/nodes/script/console_node.py
@@ -170,7 +170,7 @@ def ensure_line_padding(text, filler=" ", max_line_length=200):
         elif line_length < longest_line: 
             new_line(line.ljust(longest_line, filler))
         else:
-            new_line(line[:line_length+1])  # trimming
+            new_line(line[:line_length])  # trimming
 
     return new_lines, longest_line
         

--- a/nodes/script/console_node.py
+++ b/nodes/script/console_node.py
@@ -165,12 +165,10 @@ def ensure_line_padding(text, filler=" ", max_line_length=200):
     # this may produce untokenizable lines when trimming
     for line in lines:
         line_length = len(line)
-        if line_length == longest_line:
-            new_line(line)
-        elif line_length < longest_line: 
+        if line_length <= longest_line: 
             new_line(line.ljust(longest_line, filler))
         else:
-            new_line(line[:line_length])  # trimming
+            new_line(line[:longest_line])  # trimming
 
     return new_lines, longest_line
         
@@ -200,7 +198,7 @@ def text_decompose(content, last_n_lines, max_line_length):
         if last_n_lines > 0:
             content = get_last_n_lines(content, last_n_lines)
 
-        return_str, width = ensure_line_padding(content, max_line_length=200)
+        return_str, width = ensure_line_padding(content, " ", max_line_length)
     else:
         return_str, width = ensure_line_padding("no valid text found\nfeed it multiline\ntext")
 

--- a/nodes/script/console_node.py
+++ b/nodes/script/console_node.py
@@ -162,7 +162,7 @@ def ensure_line_padding(text, filler=" ", max_line_length=200):
     new_lines = []
     new_line = new_lines.append
 
-    # this may produce untokenizable linesm when trimming
+    # this may produce untokenizable lines when trimming
     for line in lines:
         line_length = len(line)
         if line_length == longest_line:
@@ -375,6 +375,7 @@ class SvConsoleNode(bpy.types.Node, SverchCustomTreeNode, SvNodeViewDrawMixin):
                 socket_data = socket_data[0]
                 if isinstance(socket_data, list) and len(socket_data) and isinstance(socket_data[0], str):
 
+                    # if max_line_length passed, it mst math terminal_width (chars_x)
                     multiline, (chars_x, chars_y) = text_decompose('\n'.join(socket_data), self.last_n_lines, self.max_line_length)
                     valid_multiline = '\n'.join(multiline)
                     self.terminal_text = valid_multiline


### PR DESCRIPTION
## an explanation of the current implementation:

- The console node interprets the incoming text data, and depending on the color mode does full
1. code tokenizing
2. random char colors (why?.. as tests..)
3. no color.
- The incoming text longest line is found, and this is used to set the terminal_width. The longest line is also used to pad all shorter lines with whitespace. The new padded text is stored as a multiline string in `node.terminal_text`.
- Then it makes a grid of `x * y` character cells, each cell is 2 triangles. 
     - So for example 2 lines, of 5 chars is 10 cells, that makes a total of 20 triangles.

The issue is when you load a json of a stored sverchok layout, and the json contains a monad, the `"groups"` key will contain one or more very long lines (because it describes a nodetree but as a flat string ) . This will then push the longest line length to a considerable length, and as a conseqence the total amount of triangles produced by the drawing callback is going to cause considerable slow down in drawing.

-----

the solution in this implementation is to automatically trim the longest line, the problem however is exactly what to do with that line.
   1. simply trim it and break lexing?
   2. trim it by replacing the line with a placeholder to indicate `# this line is trimmed`, and make it parsable as a code comment. (not breaking lexer)
   3. replace it with spaces
   4. completely skip the long line, and display a warning.

