### PR TITLE
fix curve template mapping evaluate

### DIFF
--- a/node_scripts/SNLite_templates/UI_curves_manual.py
+++ b/node_scripts/SNLite_templates/UI_curves_manual.py
@@ -4,7 +4,7 @@ out floats_out s
 ui = my_temp_material2, RGB Curves2
 """
 
-from sverchok.utils.snlite_utils import get_valid_evaluate_function as get_evaluator
+from sverchok.utils.snlite_utils import get_valid_evaluate_function2 as get_evaluator
 
 # currently the node noame (here 'RGB Curves') must be uniqe per material.
 # copying nodes within the same nodetree  does not automatically 'bump' the nodename

--- a/utils/snlite_utils.py
+++ b/utils/snlite_utils.py
@@ -71,7 +71,7 @@ def get_valid_evaluate_function2(mat_name, node_name):
     node = get_valid_node(mat_name, node_name, 'ShaderNodeRGBCurve')
 
     curve = node.mapping.curves[3]
-    try: curve.evaluate(0.0)
+    try:  node.mapping.evaluate(curve, 0.0)
     except: node.mapping.initialize()
 
     evaluate = lambda val: node.mapping.evaluate(curve, val)

--- a/utils/snlite_utils.py
+++ b/utils/snlite_utils.py
@@ -60,6 +60,23 @@ def get_valid_evaluate_function(mat_name, node_name):
 
     return curve.evaluate
 
+def get_valid_evaluate_function2(mat_name, node_name):
+    ''' 
+    Takes a material name (cycles) and a Node name it expects to find.
+    The node will be of type ShaderNodeRGBCurve and this function
+    will force its existence, then return the evaluate function for the last
+    component of RGBA - allowing us to use this as a float modifier.
+    '''
+
+    node = get_valid_node(mat_name, node_name, 'ShaderNodeRGBCurve')
+
+    curve = node.mapping.curves[3]
+    try: curve.evaluate(0.0)
+    except: node.mapping.initialize()
+
+    evaluate = lambda val: node.mapping.evaluate(curve, val)
+    return evaluate
+
 
 def vectorize(all_data):
 


### PR DESCRIPTION
fixes curve evaluate

![image](https://user-images.githubusercontent.com/619340/76687056-c0ed8680-6620-11ea-99ed-bac1d0e0fd22.png)

using
```python
def get_valid_evaluate_function2(mat_name, node_name):
    ''' 
    Takes a material name (cycles) and a Node name it expects to find.
    The node will be of type ShaderNodeRGBCurve and this function
    will force its existence, then return the evaluate function for the last
    component of RGBA - allowing us to use this as a float modifier.
    '''

    node = get_valid_node(mat_name, node_name, 'ShaderNodeRGBCurve')

    curve = node.mapping.curves[3]
    try:  node.mapping.evaluate(curve, 0.0)
    except: node.mapping.initialize()

    evaluate = lambda val: node.mapping.evaluate(curve, val)
    return evaluate
```