### PR TITLE
Some new noises

### DIFF
--- a/data_structure.py
+++ b/data_structure.py
@@ -453,7 +453,7 @@ def levels_of_list_or_np(lst):
         return level
     return 0
 
-def get_data_nesting_level(data, data_types=(float, int, np.float64, str)):
+def get_data_nesting_level(data, data_types=(float, int, np.float64, np.int32, str)):
     """
     data: number, or list of numbers, or list of lists, etc.
     data_types: list or tuple of types.
@@ -477,7 +477,7 @@ def get_data_nesting_level(data, data_types=(float, int, np.float64, str)):
         """ Needed only for better error reporting. """
         if type(data) in data_types:
             return 0
-        elif type(data) in (list, tuple):
+        elif type(data) in (list, tuple, np.ndarray):
             if len(data) == 0:
                 return 1
             else:

--- a/docs/nodes/transforms/noise_displace.rst
+++ b/docs/nodes/transforms/noise_displace.rst
@@ -90,7 +90,7 @@ For the custom noises:
 
 .. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_8.png
 
-The custom noises will only allow one seed and matrix per object but the offer two different interpolations per noise to change the noise look
+The custom noises will only allow one seed and matrix per object but they offer two different interpolations per noise to change the noise look.
 
 .. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_9.png
 
@@ -98,7 +98,7 @@ Scale will be passed per vertex allowing different effects.
 
 .. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_10.png
 
-When interpolate is off there will be seams in the texture. The seems are placed every unit with the use of the matrix can be used to produce hard edges.
+When interpolate is off there will be seams in the texture. As the seems are placed every unit with the use of the matrix can be used to produce hard edges.
 
 
 .. _Noise: http://www.blender.org/documentation/blender_python_api_current/mathutils.noise.html

--- a/docs/nodes/transforms/noise_displace.rst
+++ b/docs/nodes/transforms/noise_displace.rst
@@ -49,9 +49,17 @@ Inputs & Parameters
 | Noise Matrix   | Matrix input to determinate noise origin, scale and rotation            |
 +----------------+-------------------------------------------------------------------------+
 
+Advanced Parameters
+-------------------
+
+In the N-Panel (and on the right-click menu) you can find:
+
+**List Match**: Define how list with different lengths should be matched
+
+**Output NumPy**: Get NumPy arrays in stead of regular lists (makes the node faster with  Custom noises slower with Mathutils noises).
+
 Examples
 --------
-
 
 
 .. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_1.png
@@ -71,9 +79,15 @@ In this example the scale output is used to blend with another oscillation textu
 
 The "Vector" Mode does not use vertex normals so it can be used just with vertices
 
+
 .. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_7.png
 
 The "Scale out" input can be used to mask the affected vertices
+
+
+.. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_11.png
+
+You can create many different outputs from one set of vertices if you input multiple seeds :
 
 For the Mathutils Noises:
 

--- a/docs/nodes/transforms/noise_displace.rst
+++ b/docs/nodes/transforms/noise_displace.rst
@@ -54,7 +54,7 @@ Advanced Parameters
 
 In the N-Panel (and on the right-click menu) you can find:
 
-**List Match**: Define how list with different lengths should be matched
+**List Match**: Define how list with different lengths should be matched.
 
 **Output NumPy**: Get NumPy arrays in stead of regular lists (makes the node faster with  Custom noises slower with Mathutils noises).
 
@@ -64,30 +64,33 @@ Examples
 
 .. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_1.png
 
-Basic example
+Basic examples
 
 
 .. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_3.png
 
-The node offers three ways of matching the list lengths "Repeat Last", "Cycle" and "Match Short" in this example "Cycle" is used to alternate the noise matrix
+The node offers three ways of matching the list lengths "Repeat Last", "Cycle" and "Match Short" in this example "Cycle" is used to alternate the noise matrix.
+
 
 .. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_5.png
 
-In this example the scale output is used to blend with another oscillation texture
+In this example the scale output is used to blend with another oscillation texture.
+
 
 .. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_6.png
 
-The "Vector" Mode does not use vertex normals so it can be used just with vertices
+The "Vector" Mode does not use vertex normals so it can be used just with vertices.
 
 
 .. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_7.png
 
-The "Scale out" input can be used to mask the affected vertices
+The "Scale out" input can be used to mask the affected vertices.
 
 
 .. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_11.png
 
-You can create many different outputs from one set of vertices if you input multiple seeds :
+You can create many different outputs from one set of vertices if you input multiple seeds.
+
 
 For the Mathutils Noises:
 
@@ -97,10 +100,10 @@ Seed and scale per vertex can be passed, in this example the seed is chosen by d
 
 .. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_4.png
 
-One matrix per point can be passed if the matrix list is wrapped, note that the "Flat Output" checkbox of the matrix in is un-checked
+One matrix per point can be passed if the matrix list is wrapped, note that the "Flat Output" checkbox of the matrix in is un-checked.
+
 
 For the custom noises:
-
 
 .. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_8.png
 

--- a/docs/nodes/transforms/noise_displace.rst
+++ b/docs/nodes/transforms/noise_displace.rst
@@ -12,6 +12,7 @@ Inputs & Parameters
 | Mode           | Pick between Scalar along Normal and Vector output                      |
 +----------------+-------------------------------------------------------------------------+
 | Noise Type     | Pick between several noise types                                        |
+|                | Mathutils noise:                                                        |
 |                |                                                                         |
 |                | - Blender                                                               |
 |                | - Cell Noise                                                            |
@@ -25,6 +26,18 @@ Inputs & Parameters
 |                | - Voronoi F4                                                            |
 |                |                                                                         |
 |                | See mathutils.noise docs ( Noise_ )                                     |
+|                | Custom noises:                                                          |
+|                |                                                                         |
+|                | - Random Cells                                                          |
+|                | - Random Gradients                                                      |
+|                | - Ortho Gradients                                                       |
+|                | - Numpy Perlin                                                          |
+|                |                                                                         |
+|                | (see examples)                                                          |
++----------------+-------------------------------------------------------------------------+
+| Smooth         | Smooth curvature (Only for custom noises)                               |
++----------------+-------------------------------------------------------------------------+
+| Interpolate    | Gradient interpolation (Hard noise when un-checked) (For custom noises) |
 +----------------+-------------------------------------------------------------------------+
 | Seed           | Accepts float values, they are hashed into *Integers* internally.       |
 |                | Seed values of 0 will internally be replaced with a randomly picked     |
@@ -45,13 +58,6 @@ Examples
 
 Basic example
 
-.. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_2.png
-
-Seed and scale per vertex can be passed, in this example the seed is chosen by determining the closest point of another mesh and the scale is based on the distance to that point
-
-.. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_4.png
-
-One matrix per point can be passed if the matrix list is wrapped, note that the "Flat Output" checkbox of the matrix in is un-checked
 
 .. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_3.png
 
@@ -69,6 +75,30 @@ The "Vector" Mode does not use vertex normals so it can be used just with vertic
 
 The "Scale out" input can be used to mask the affected vertices
 
+For the Mathutils Noises:
+
+.. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_2.png
+
+Seed and scale per vertex can be passed, in this example the seed is chosen by determining the closest point of another mesh and the scale is based on the distance to that point.
+
+.. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_4.png
+
+One matrix per point can be passed if the matrix list is wrapped, note that the "Flat Output" checkbox of the matrix in is un-checked
+
+For the custom noises:
+
+
+.. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_8.png
+
+The custom noises will only allow one seed and matrix per object but the offer two different interpolations per noise to change the noise look
+
+.. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_9.png
+
+Scale will be passed per vertex allowing different effects.
+
+.. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/transforms/noise_displace/noise_displace_blender_sverchok_example_10.png
+
+When interpolate is off there will be seams in the texture. The seems are placed every unit with the use of the matrix can be used to produce hard edges.
 
 
 .. _Noise: http://www.blender.org/documentation/blender_python_api_current/mathutils.noise.html

--- a/docs/nodes/vector/noise_mk2.rst
+++ b/docs/nodes/vector/noise_mk2.rst
@@ -25,12 +25,32 @@ Inputs & Parameters
 |                | - Voronoi F4                                                            |
 |                |                                                                         |
 |                | See mathutils.noise docs ( Noise_ )                                     |
+|                |                                                                         |
+|                | Custom noises:                                                          |
+|                |                                                                         |
+|                | - Random Cells                                                          |
+|                | - Random Gradients                                                      |
+|                | - Ortho Gradients                                                       |
+|                | - Numpy Perlin                                                          |
+|                |                                                                         |
+|                | (see examples)                                                          |
++----------------+-------------------------------------------------------------------------+
+| Smooth         | Smooth curvature (Only for custom noises)                               |
++----------------+-------------------------------------------------------------------------+
+| Interpolate    | Gradient interpolation (Hard noise when un-checked) (For custom noises) |
 +----------------+-------------------------------------------------------------------------+
 | Seed           | Accepts float values, they are hashed into *Integers* internally.       |
 |                | Seed values of 0 will internally be replaced with a randomly picked     |
 |                | constant to allow all seed input to generate repeatable output.         |
 |                | (Seed=0 would otherwise generate random values based on system time)    |
 +----------------+-------------------------------------------------------------------------+
+
+Advanced Parameters
+-------------------
+
+In the N-Panel (and on the right-click menu) you can find:
+
+**Output NumPy**: Get NumPy arrays in stead of regular lists (makes the node faster in Scalar mode and in Vector Mode with  Custom noises).
 
 Examples
 --------
@@ -47,6 +67,25 @@ Using noise to mask a mesh:
 Adding noise transformations:
 
 .. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/vector/noise/noise_sverchok_blender_example_4.png
+
+Using noise to filter a 3d grid:
+
+.. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/vector/noise/noise_sverchok_blender_example_6.png
+
+Custom noises:
+
+- Random Cells:
+.. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/vector/noise/noise_sverchok_blender_example_5.png
+
+- Random Gradients:
+.. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/vector/noise/noise_sverchok_blender_example_7.png
+
+-Ortho Gradients:
+.. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/vector/noise/noise_sverchok_blender_example_8.png
+
+- Numpy Perlin:
+
+.. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/vector/noise/noise_sverchok_blender_example_9.png
 
 Notes
 -----

--- a/docs/nodes/vector/noise_mk2.rst
+++ b/docs/nodes/vector/noise_mk2.rst
@@ -80,7 +80,7 @@ Custom noises:
 - Random Gradients:
 .. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/vector/noise/noise_sverchok_blender_example_7.png
 
--Ortho Gradients:
+- Ortho Gradients:
 .. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/vector/noise/noise_sverchok_blender_example_8.png
 
 - Numpy Perlin:

--- a/nodes/number/float_to_int.py
+++ b/nodes/number/float_to_int.py
@@ -19,7 +19,7 @@
 import bpy
 
 from sverchok.node_tree import SverchCustomTreeNode
-
+from numpy import ndarray
 
 class Float2IntNode(bpy.types.Node, SverchCustomTreeNode):
     ''' Float2Int '''
@@ -42,6 +42,8 @@ class Float2IntNode(bpy.types.Node, SverchCustomTreeNode):
     def inte(cls, l):
         if isinstance(l, (int, float)):
             return round(l)
+        elif isinstance(l, ndarray):
+            return l.astype(int)
         else:
             return [cls.inte(i) for i in l]
 

--- a/nodes/vector/noise_mk2.py
+++ b/nodes/vector/noise_mk2.py
@@ -16,33 +16,57 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
-import operator
-from math import sqrt
+
 
 import bpy
-from bpy.props import EnumProperty, IntProperty, FloatProperty
+from bpy.props import EnumProperty, IntProperty, BoolProperty
 from mathutils import noise
 
-from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import (updateNode, Vector_degenerate, match_long_repeat)
-from sverchok.utils.sv_noise_utils import noise_options, PERLIN_ORIGINAL
+from sverchok.node_tree import SverchCustomTreeNode, throttled
+from sverchok.data_structure import updateNode
+from sverchok.utils.sv_noise_utils import noise_options, PERLIN_ORIGINAL, noise_numpy_types
+import numpy as np
 
 
-def deepnoise(v, noise_basis=PERLIN_ORIGINAL):
-    u = noise.noise_vector(v, noise_basis=noise_basis)[:]
-    a = u[0], u[1], u[2]-1   # a = u minus (0,0,1)
-    return sqrt((a[0] * a[0]) + (a[1] * a[1]) + (a[2] * a[2])) * 0.5
+def numpy_noise(vecs, out, out_mode, seed, noise_function, smooth, output_numpy):
+    if out_mode == 'VECTOR':
+        obj = np.array(vecs)
+        r_noise = np.stack((
+            noise_function(obj, seed, smooth),
+            noise_function(obj, seed + 1, smooth),
+            noise_function(obj, seed + 2, smooth)
+            )).T
+        out.append((2 * r_noise - 1) if output_numpy else (2 * r_noise - 1).tolist())
+    else:
+        if output_numpy:
+            out.append(noise_function(np.array(vecs), seed, smooth))
+        else:
+            out.append(noise_function(np.array(vecs), seed, smooth).tolist())
+
+def mathulis_noise(vecs, out, out_mode, noise_type, noise_function, output_numpy):
+    if out_mode == 'VECTOR':
+        if output_numpy:
+            out.append(np.array([noise_function(v, noise_basis=noise_type)[:] for v in vecs]))
+        else:
+            out.append([noise_function(v, noise_basis=noise_type)[:] for v in vecs])
+    else:
+        vecs = np.array([noise_function(v, noise_basis=noise_type)[:] for v in vecs])
+        vecs -= [0, 0, 1]
+        n = np.linalg.norm(vecs, axis=1)*0.5
+        out.append(n if output_numpy else n.tolist())
 
 
-avail_noise = [(t[0], t[0].title(), t[0].title(), '', t[1]) for t in noise_options]
-noise_f = {'SCALAR': deepnoise, 'VECTOR': noise.noise_vector}
+avail_noise = [(t[0], t[0].title().replace('_', ' '), t[0].title(), '', t[1]) for t in noise_options]
+
+for idx, new_type in enumerate(noise_numpy_types.keys()):
+    avail_noise.append((new_type, new_type.title().replace('_', ' '), new_type.title(), '', 100 + idx))
 
 
 class SvNoiseNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     """
     Triggers: Vector Noise
     Tooltip: Affect input verts with a noise function.
-    
+
     A short description for reader of node code
     """
 
@@ -50,7 +74,8 @@ class SvNoiseNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     bl_label = 'Vector Noise'
     bl_icon = 'FORCE_TURBULENCE'
     sv_icon = 'SV_VECTOR_NOISE'
-
+    
+    @throttled
     def changeMode(self, context):
         outputs = self.outputs
         if self.out_mode == 'SCALAR':
@@ -80,6 +105,21 @@ class SvNoiseNodeMK2(bpy.types.Node, SverchCustomTreeNode):
 
     seed: IntProperty(default=0, name='Seed', update=updateNode)
 
+    smooth: BoolProperty(
+        name='Smooth',
+        description='Smooth noise',
+        default=True, update=updateNode)
+
+    interpolate: BoolProperty(
+        name='Interpolate',
+        description='Interpolate gradients',
+        default=True, update=updateNode)
+
+    output_numpy: BoolProperty(
+        name='Output NumPy',
+        description='Output NumPy arrays',
+        default=False, update=updateNode)
+
     def sv_init(self, context):
         self.inputs.new('SvVerticesSocket', 'Vertices')
         self.inputs.new('SvStringsSocket', 'Seed').prop_name = 'seed'
@@ -88,35 +128,63 @@ class SvNoiseNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     def draw_buttons(self, context, layout):
         layout.prop(self, 'out_mode', expand=True)
         layout.prop(self, 'noise_type', text="Type")
+        if self.noise_type in noise_numpy_types.keys():
+            row = layout.row(align=True)
+            row.prop(self, 'smooth', toggle=True)
+            row.prop(self, 'interpolate', toggle=True)
+
+
+    def draw_buttons_ext(self, ctx, layout):
+        self.draw_buttons(ctx, layout)
+        layout.prop(self, "output_numpy", toggle=False)
+
+    def rclick_menu(self, context, layout):
+        layout.prop_menu_enum(self, "out_mode")
+        layout.prop_menu_enum(self, "noise_type")
+        if self.noise_type in noise_numpy_types.keys():
+            layout.prop(self, 'smooth', toggle=True)
+            layout.prop(self, 'interpolate', toggle=True)
+        layout.prop(self, "output_numpy", toggle=True)
 
     def process(self):
         inputs, outputs = self.inputs, self.outputs
 
-        if not outputs[0].is_linked:
+        if not (outputs[0].is_linked and inputs[0].is_linked):
             return
 
         out = []
         verts = inputs['Vertices'].sv_get(deepcopy=False)
         seeds = inputs['Seed'].sv_get()[0]
 
-        noise_function = noise_f[self.out_mode]
+        max_len = max(map(len, (seeds, verts)))
+        noise_type = self.noise_type
 
+        out_mode = self.out_mode
+        output_numpy = self.output_numpy
 
-        for idx, (seed, obj) in enumerate(zip(*match_long_repeat([seeds, verts]))):
-            # multi-pass, make sure seed_val is a number and it isn't 0.
-            # 0 unsets the seed and generates unreproducable output based on system time
-            # We force the seed to a non 0 value.
-            # See https://github.com/nortikin/sverchok/issues/1095#issuecomment-271261600
-            seed_val = seed if isinstance(seed, (int, float)) else 0
-            seed_val = int(round(seed_val)) or 140230
+        if noise_type in noise_numpy_types.keys():
 
-            noise.seed_set(seed_val)
-            out.append([noise_function(v, noise_basis=self.noise_type) for v in obj])
+            noise_function = noise_numpy_types[noise_type][self.interpolate]
+            smooth = self.smooth
+            for i in range(max_len):
+                seed = seeds[min(i, len(seeds)-1)]
+                obj_id = min(i, len(verts)-1)
+                numpy_noise(verts[obj_id], out, out_mode, seed, noise_function, smooth, output_numpy)
 
-        if 'Noise V' in outputs:
-            outputs['Noise V'].sv_set(Vector_degenerate(out))
         else:
-            outputs['Noise S'].sv_set(out)
+
+            noise_function = noise.noise_vector
+
+            for i in range(max_len):
+                seed = seeds[min(i, len(seeds)-1)]
+                obj_id = min(i, len(verts)-1)
+                # 0 unsets the seed and generates unreproducable output based on system time
+                seed_val = int(round(seed)) or 140230
+                noise.seed_set(seed_val)
+                mathulis_noise(verts[obj_id], out, out_mode, noise_type, noise_function, output_numpy)
+
+        outputs[0].sv_set(out)
+
 
     def draw_label(self):
         if self.hide:
@@ -130,4 +198,3 @@ class SvNoiseNodeMK2(bpy.types.Node, SverchCustomTreeNode):
 
 classes = [SvNoiseNodeMK2]
 register, unregister = bpy.utils.register_classes_factory(classes)
-

--- a/nodes/vector/noise_mk2.py
+++ b/nodes/vector/noise_mk2.py
@@ -52,8 +52,8 @@ def mathulis_noise(vecs, out, out_mode, noise_type, noise_function, output_numpy
     else:
         vecs = np.array([noise_function(v, noise_basis=noise_type)[:] for v in vecs])
         vecs -= [0, 0, 1]
-        n = np.linalg.norm(vecs, axis=1)*0.5
-        out.append(n if output_numpy else n.tolist())
+        noise_output = np.linalg.norm(vecs, axis=1)*0.5
+        out.append(noise_output if output_numpy else noise_output.tolist())
 
 
 avail_noise = [(t[0], t[0].title().replace('_', ' '), t[0].title(), '', t[1]) for t in noise_options]
@@ -74,7 +74,7 @@ class SvNoiseNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     bl_label = 'Vector Noise'
     bl_icon = 'FORCE_TURBULENCE'
     sv_icon = 'SV_VECTOR_NOISE'
-    
+
     @throttled
     def changeMode(self, context):
         outputs = self.outputs

--- a/nodes/viz/viewer_skin.py
+++ b/nodes/viz/viewer_skin.py
@@ -24,7 +24,7 @@ import bpy
 from bpy.props import (BoolProperty, FloatProperty, IntProperty)
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import updateNode, match_long_repeat, fullList, fullList_np, numpy_full_list
+from sverchok.data_structure import updateNode, fullList_np, numpy_full_list
 from sverchok.utils.sv_obj_helper import SvObjHelper
 from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata, pydata_from_bmesh
 
@@ -59,7 +59,7 @@ def process_mesh_into_features(skin_vertices, edge_keys, assume_unique=True):
         ndA[highest].add(lowest)
 
     ndB = defaultdict(set)
-    ndC = {k: len(ndA[k]) for k in sorted(ndA.keys()) if len(ndA[k]) == 1 or len(ndA[k]) >=3}
+    ndC = {k: len(ndA[k]) for k in sorted(ndA.keys()) if len(ndA[k]) == 1 or len(ndA[k]) >= 3}
     for k, v in ndC.items():
         ndB[v].add(k)
 
@@ -89,7 +89,7 @@ def shrink_geometry(bm, dist, layers):
     bmesh.ops.remove_doubles(bm, verts=bm.verts[:], dist=dist)
     bm.verts.ensure_lookup_table()
 
-    verts, edges, faces = pydata_from_bmesh(bm)
+    verts, edges, _ = pydata_from_bmesh(bm)
     data_out = [verts, edges]
     for layer_name in made_layers:
         data_out.append([bm.verts[i][layer_name] for i in range(len(bm.verts))])
@@ -251,7 +251,7 @@ class SvSkinViewerNodeV28(bpy.types.Node, SverchCustomTreeNode, SvObjHelper):
         fullList_np(geometry_full[2], maxlen)
         fullList_np(geometry_full[3], maxlen)
         fullList_np(geometry_full[4], maxlen)
-        print(geometry_full[1])
+
         catch_idx = 0
         for idx, (geometry) in enumerate(zip(*geometry_full)):
             catch_idx = idx

--- a/utils/sv_noise_utils.py
+++ b/utils/sv_noise_utils.py
@@ -1,10 +1,11 @@
 # This file is part of project Sverchok. It's copyrighted by the contributors
 # recorded in the version control history of the file, available from
 # its original location https://github.com/nortikin/sverchok/commit/master
-#  
+#
 # SPDX-License-Identifier: GPL3
 # License-Filename: LICENSE
 
+import numpy as np
 
 noise_options = [
     ('BLENDER', 0),
@@ -25,3 +26,221 @@ def get_noise_type(name):
 for name, value in noise_options:
     locals()[name] = name
 
+#### #Numpy noises
+
+PERLIN_VECS = np.array([
+    [1, 1, 0], [-1, 1, 0], [1, -1, 0], [-1, -1, 0],
+    [1, 0, 1], [-1, 0, 1], [1, 0, -1], [-1, 0, -1],
+    [0, 1, 1], [0, -1, 1], [0, 1, -1], [0, -1, -1],
+    ])/np.sqrt(2)
+
+ORTHO_VECS = np.array([
+    [1, 0, 0], [0, 1, 0], [0, 0, 1],
+    [-1, 0, 0], [0, -1, 0], [0, 0, -1]
+    ])
+OFFSET_VECS = np.array([
+    [1, 0, 0],
+    [0, 1, 0], [1, 1, 0],
+    [0, 0, 1], [1, 0, 1],
+    [0, 1, 1], [1, 1, 1]])
+
+def rand(scalar_array, seed):
+    ''' pseudo random from scalar. Returns the fractional part of the sin formula'''
+    return np.modf(seed*np.sin(scalar_array))[0]
+
+def rand_v(vector_array, seed_vals):
+    '''
+    pseudo random from vector.
+    Returns the fractional part of the sin formula
+    seed_vals is an array with 7 random numbers'''
+    c = seed_vals
+    s = np.sum(vector_array * c[:3], axis=1)
+    return 0.5 + 0.5 * np.modf(c[3] * np.sin(c[4] * rand(s, c[5]) + c[6]))[0]
+
+def rand_vector_from_v(vector_array, seed_vals):
+    '''
+    pseudo random from vector.
+    Returns the fractional part of the sin formula
+    seed_vals is an array with 7 random numbers'''
+    c = seed_vals
+    s = np.sum(vector_array * c[:3], axis=1)
+    return np.stack((
+        np.modf(c[3] * np.sin(c[4] * rand(s, c[5]) + c[6]))[0],
+        np.modf(c[4] * np.sin(c[5] * rand(s, c[6]) + c[3]))[0],
+        np.modf(c[5] * np.sin(c[6] * rand(s, c[3]) + c[4]))[0])
+        ).T
+
+def perlin_ease(v):
+    '''array easing from perlin noise'''
+    return 6 * np.power(v, 5) - 15 * np.power(v, 4)+ 10 * np.power(v, 3)
+
+def interp(v1, v2, fac):
+    '''array interpolation'''
+    return v1 + (v2 - v1) * fac
+
+def multi_interpolation(gradients, v_frac):
+    '''interpolate between 8 gradients using x,y and z values '''
+    return interp(
+                interp(
+                    interp(gradients[0], gradients[1], v_frac[:, 0]),
+                    interp(gradients[2], gradients[3], v_frac[:, 0]),
+                    v_frac[:, 1]
+                    ),
+                interp(
+                    interp(gradients[4], gradients[5], v_frac[:, 0]),
+                    interp(gradients[6], gradients[7], v_frac[:, 0]),
+                    v_frac[:, 1]
+                    ),
+                v_frac[:, 2]
+                )
+
+def choose_vector(rand_vecs, v_int, seed_vals):
+    return rand_vecs[(rand_vecs.shape[0] * rand_v(v_int, seed_vals)).astype(int)]
+
+def random_vector(rand_vecs, v_int, seed_vals):
+    return rand_vecs[(rand_vecs.shape[0] * rand_v(v_int, seed_vals)).astype(int)]
+
+def gradient_noise_random(vecs, seed, smooth):
+    '''sets random seed and passes random vectors to the noise gradients func'''
+    np.random.seed(seed)
+    rand_vecs = np.random.uniform(-1, 1, (64, 3))
+    rand_vecs /= np.linalg.norm(rand_vecs, axis=1)[:, np.newaxis]
+    return noise_gradients(vecs, smooth, rand_vecs)
+
+def gradient_noise_ortho(vecs, seed, smooth):
+    '''sets random seed and passes ortho vectors to the noise gradients func'''
+
+    np.random.seed(seed)
+    rand_vecs = np.repeat(ORTHO_VECS, 2, axis=0)
+    rand_vecs = ORTHO_VECS
+    return noise_gradients(vecs, smooth, rand_vecs)
+
+def gradient_noise_perlin(vecs, seed, smooth):
+    '''sets random seed and passes perlin vectors to the noise gradients func'''
+
+    np.random.seed(seed)
+    return noise_gradients(vecs, smooth, PERLIN_VECS)
+
+
+def noise_gradients(vecs, smooth, rand_vecs):
+    '''the gradient is a dot product between a random vector and the fractional part of the vector'''
+    seed_vals = np.random.uniform(10, 10000, 7)
+    v_int = np.floor(vecs)
+    if smooth:
+        v_frac = perlin_ease(vecs - v_int)
+    else:
+        v_frac = vecs - v_int
+
+    gradient = np.sum(choose_vector(rand_vecs, v_int, seed_vals) * v_frac, axis=1)
+
+    return (1 + gradient)*.5
+
+
+
+def interpolation_noise_random(vecs, seed, smooth):
+    '''sets random seed and passes random vectors to the noise noise_interpolator func'''
+    np.random.seed(seed)
+    rand_vecs = np.random.uniform(-1, 1, (12, 3))
+    rand_vecs /= np.linalg.norm(rand_vecs, axis=1)[:, np.newaxis]
+    return random_gradient_interpolator(vecs, smooth, rand_vecs)
+
+def interpolation_noise_ortho(vecs, seed, smooth):
+    '''sets random seed and passes ortho vectors to the noise noise_interpolator func'''
+
+    np.random.seed(seed)
+    rand_vecs = np.repeat(ORTHO_VECS, 2, axis=0)
+    return noise_interpolator(vecs, smooth, rand_vecs)
+
+def numpy_perlin_noise(vecs, seed, smooth):
+    '''sets random seed and passes  Perlin vectors to the noise noise_interpolator func'''
+    np.random.seed(seed)
+    return noise_interpolator(vecs, smooth, PERLIN_VECS)
+
+
+def noise_interpolator(vecs, smooth, rand_vecs):
+    '''
+    Interpolate between gradients.
+    The gradient is a dot product between a random vector
+    and the fractional part of the vector
+    rand_vecs in one array with 12 vectors
+    '''
+    seed_vals = np.random.uniform(10, 10000, 7)
+    offset = OFFSET_VECS
+    v_int = np.floor(vecs)
+    v_frac = vecs - v_int
+    gradients = [np.sum(choose_vector(rand_vecs, v_int, seed_vals) * v_frac, axis=1)]
+    for off in offset:
+        gradients.append(
+            np.sum(choose_vector(rand_vecs, v_int + off, seed_vals) *  (v_frac- off), axis=1)
+        )
+
+    if smooth:
+        r_total = 0.5 + multi_interpolation(gradients, perlin_ease(v_frac))
+    else:
+        r_total = 0.5 + multi_interpolation(gradients, v_frac)
+
+    return r_total
+
+def random_gradient_interpolator(vecs, smooth, rand_vecs):
+    '''
+    Interpolate between gradients.
+    The gradient is a dot product between a random vector
+    and the fractional part of the vector
+    rand_vecs in one array with 12 vectors
+    '''
+    seed_vals = np.random.uniform(10, 10000, 7)
+    offset = OFFSET_VECS
+    v_int = np.floor(vecs)
+    v_frac = vecs - v_int
+
+    gradients = [np.sum(choose_vector(rand_vecs, v_int, seed_vals) * v_frac, axis=1)]
+
+    for off in offset:
+        gradients.append(
+            np.sum(choose_vector(rand_vecs, v_int + off, seed_vals) *  (v_frac- off), axis=1)
+        )
+
+    if smooth:
+        r_total = 0.5 + multi_interpolation(gradients, perlin_ease(v_frac))
+    else:
+        r_total = 0.5 + multi_interpolation(gradients, v_frac)
+
+    return r_total
+
+
+def random_interpolator(vecs, seed, smooth):
+    '''
+    Interpolate between values.
+    The value is random value at each integer
+    the fractional part of the vector is used to make the interpolation.
+    rand_vecs in one array with 12 vectors
+    '''
+    np.random.seed(seed)
+    seed_vals = np.random.uniform(10, 10000, 7)
+    offset = OFFSET_VECS
+    v_int = np.floor(vecs)
+    v_frac = vecs - v_int
+
+    gradients = [rand_v(v_int, seed_vals)]
+    for off in offset:
+        gradients.append(rand_v(v_int + off, seed_vals))
+    if smooth:
+        r_total = multi_interpolation(gradients, perlin_ease(v_frac))
+    else:
+        r_total = multi_interpolation(gradients, v_frac)
+
+    return r_total
+
+def random_cells(vecs, seed, smooth):
+    '''The value is random value at each integer'''
+    np.random.seed(seed)
+    seed_vals = np.random.uniform(10, 10000, 7)
+
+    return rand_v(np.floor(vecs), seed_vals)
+
+noise_numpy_types = {
+    'RANDOM_CELLS': (random_cells, random_interpolator),
+    'RANDOM_GRADIENTS': (gradient_noise_random, interpolation_noise_random),
+    'ORTHO_GRADIENTS': (gradient_noise_ortho, interpolation_noise_ortho),
+    'NUMPY_PERLIN': (gradient_noise_perlin, numpy_perlin_noise),
+     }


### PR DESCRIPTION
I optimized the code of the 'Vector Noise', then I thought: A Numpy implementation sure is faster.  
After digging inside of the Perlin magic my implementation was slower than the previous optimised code.... but opened up some control over the Noise generation so I added 4 types of noise with some options :)
Random Cells:
![noise_sverchok_blender_example_5](https://user-images.githubusercontent.com/10011941/77473744-307c2680-6e16-11ea-8482-1bfb8d364de9.png)
Ortho Gradients
![noise_displace_blender_sverchok_example_8](https://user-images.githubusercontent.com/10011941/77473642-0e82a400-6e16-11ea-95c9-6b73acfe7041.png)
Random Gradients:
![noise_sverchok_blender_example_7](https://user-images.githubusercontent.com/10011941/77473895-75a05880-6e16-11ea-850b-487b839a1ca3.png)
And Numpy Perlin
![noise_sverchok_blender_example_9](https://user-images.githubusercontent.com/10011941/77473928-8224b100-6e16-11ea-930d-21d448c76323.png)

The are available in the Vector Noise node and on the Noise Displace node

Also on this PR:
- Float to Int node will ouput Numpy arrays if has a numpy input
- get_nesting_level of data_structure.py  accepts numpy



- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

