### PR TITLE
Snlite consolemode

### DIFF
--- a/nodes/script/console_node.py
+++ b/nodes/script/console_node.py
@@ -76,7 +76,11 @@ fragment_shader = '''
     }
 '''
 
-lexed_colors = ['stringColor', 'numberColor', 'name1Color', 'errorColor', 'name2Color', 'name3Color']
+lexed_colors = [
+    'stringColor', 'numberColor', 'name1Color',
+    'parenColor', 'braceColor', 'bracketColor',
+    'opColor', 'commentColor', 'name2Color', 'name3Color'
+]
 
 lexed_fragment_shader = '''
     in float v_lexer;
@@ -88,7 +92,11 @@ lexed_fragment_shader = '''
     uniform vec4 stringColor;
     uniform vec4 numberColor;
     uniform vec4 name1Color;
-    uniform vec4 errorColor;
+    uniform vec4 parenColor;
+    uniform vec4 braceColor;
+    uniform vec4 bracketColor;
+    uniform vec4 opColor;
+    uniform vec4 commentColor;
     uniform vec4 name2Color;
     uniform vec4 name3Color;
     
@@ -98,8 +106,12 @@ lexed_fragment_shader = '''
         int cIndex = int(v_lexer);
         if (cIndex == 3) { test_tint = stringColor; }
         if (cIndex == 2) { test_tint = numberColor; }
-        if (cIndex == 1) { test_tint = name1Color; } 
-        if (cIndex == 53) { test_tint = errorColor; }
+        if (cIndex == 1) { test_tint = name1Color; }
+        if (cIndex == 7 || cIndex == 8) { test_tint = parenColor; }
+        if (cIndex == 25 || cIndex == 26) { test_tint = braceColor; }
+        if (cIndex == 9 || cIndex == 10) { test_tint = bracketColor; }
+        if (cIndex == 53) { test_tint = opColor; }
+        if (cIndex == 55) { test_tint = commentColor; }
         if (cIndex == 90) { test_tint = name2Color; }
         if (cIndex == 91) { test_tint = name3Color; }
         fragColor = texture(image, texCoord_interp) * test_tint;
@@ -149,8 +161,9 @@ def syntax_highlight_basic(node):
                 continue
             if not token.string or (token.start == token.end):
                 continue
-            
+
             token_type = token.type
+            
             if token.type == 1:
                 if token.string in {
                         'print', 'def', 'class', 'break', 'continue', 'return', 'while', 'or', 'and',
@@ -158,6 +171,14 @@ def syntax_highlight_basic(node):
                     token_type = 90
                 elif token.string in {'False', 'True', 'yield', 'repr', 'range', 'enumerate'}:
                     token_type = 91
+
+            elif token.type == 53:
+                # OPS
+                # 7: 'LPAR', 8: 'RPAR
+                # 9: 'LSQB', 10: 'RSQB'
+                # 25: 'LBRACE', 26: 'RBRACE'
+                if token.exact_type in {7, 8, 9, 10, 25, 26}:
+                    token_type = token.exact_type
 
             # print(token)
             #  start = (line number, 1 indexed) , (char index, 0 indexed)
@@ -384,9 +405,13 @@ class SvConsoleNode(bpy.types.Node, SverchCustomTreeNode, SvNodeViewDrawMixin):
     stringColor: make_color("string color", (0.148, 0.447, 0.040, 1.0))  # 3
     numberColor: make_color("number color", (0.9, 0.9, 1.0, 1.0))  # 2
     name1Color: make_color("name1 color", (0.4, 0.9, 0.8, 1.0))  # 1
-    errorColor: make_color("error color", (1.0, 0.3, 0.7, 1.0))  # 53
+    parenColor: make_color("parenthesis color", (0.4, 0.3, 0.7, 1.0))  # 53     7/8
+    bracketColor: make_color("brackets color", (0.5, 0.7, 0.7, 1.0))  # 53      9/10
+    braceColor: make_color("braces color", (0.4, 0.5, 0.7, 1.0))  # 53         25/26
+    opColor: make_color("op color", (1.0, 0.3, 0.7, 1.0))  # 53
     name2Color: make_color("name2 color", (0.7, 0.9, 0.3, 1.0))  # 90
     name3Color: make_color("name3 color", (0.3, 0.9, 0.4, 1.0))  # 91
+    commentColor: make_color("comment color", (0.2, 0.2, 0.2, 1.0))
 
     def prepare_for_grid(self):
         char_width = int(15 * self.local_scale)

--- a/nodes/script/console_node.py
+++ b/nodes/script/console_node.py
@@ -413,6 +413,9 @@ class SvConsoleNode(bpy.types.Node, SverchCustomTreeNode, SvNodeViewDrawMixin):
     name3Color: make_color("name3 color", (0.3, 0.9, 0.4, 1.0))  # 91
     commentColor: make_color("comment color", (0.2, 0.2, 0.2, 1.0))
 
+    def get_lexed_colors(self):
+        return [(lex_name, getattr(self, lex_name)[:]) for lex_name in lexed_colors]
+
     def prepare_for_grid(self):
         char_width = int(15 * self.local_scale)
         char_height = int(32 * self.local_scale)


### PR DESCRIPTION
more token theme options.

![image](https://user-images.githubusercontent.com/619340/77747094-4fe5a000-701e-11ea-967c-cde25c8ed849.png)

```
import bpy

nt = bpy.data.node_groups['NodeTree']
n = nt.nodes['Console Node']
print(n.get_lexed_colors())

[('stringColor', (0.198512047, 0.60381627, 0.2609070, 1.0)), 
('numberColor', (1.0, 0.71175, 0.64198547, 1.0)), 
('name1Color', (0.024261888, 0.50130575, 0.6382718, 1.0)), 
('parenColor', (0.366933584, 0.9712737, 1.0, 1.0)), 
('braceColor', (0.656979084, 0.6999999, 0.57874518, 1.0)), 
('bracketColor', (0.71199423, 1.0, 1.0, 1.0)), 
('opColor', (1.0, 0.3000000, 0.6999999, 1.0)), 
('commentColor', (0.4385440, 0.438544, 0.4385440, 1.0)), 
('name2Color', (0.6999999, 0.8999999, 0.3000000, 1.0)), 
('name3Color', (0.3000000, 0.8999999, 0.40000000, 1.0))]
```
the   
![image](https://user-images.githubusercontent.com/619340/77747130-63910680-701e-11ea-8e88-fcb76b5c319e.png)  mode is specifically for the ScriptNode, then console node will not read the socket data, but rather the `node.script_str` from the connected SNLite node
