### PR TITLE
Polygons to edges to numpy

### DIFF
--- a/docs/nodes/modifier_change/polygons_to_edges.rst
+++ b/docs/nodes/modifier_change/polygons_to_edges.rst
@@ -12,18 +12,31 @@ Input & Output
 
 +--------+-------+-------------------------------------------+
 | socket | name  | Description                               |
-+========+=======+===========================================+    
++========+=======+===========================================+
 | input  | pols  | Polygons                                  |
 +--------+-------+-------------------------------------------+
 | output | edges | The edges from which the polygon is built |
 +--------+-------+-------------------------------------------+
 
+Parameters
+----------
+
+- **Regular Polygons: Activate when the incoming list of polygons has constant number of sides to make the node faster.
+
+- **Unique Edges** : When active the node will remove the doubled edges
+
+Advanced Parameters
+-------------------
+
+In the N-Panel (and on the right-click menu) you can find:
+
+**Output NumPy**: Get NumPy arrays in stead of regular lists (makes the node faster with regular polygon list or when the polygon lists are NumPy arrays)
 
 Examples
 --------
 
-.. image:: https://cloud.githubusercontent.com/assets/619340/4186197/c89fefae-375e-11e4-8224-14d47b5f9dd8.PNG
-  :alt: Polygon2EdgeDemo1.PNG
+.. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/modifier_change/polygons_to_edges/blender_sverchok_parametric_polygons_to_edges.png
+  :alt: Polygon_to_Edges_example
 
 Notes
 -------

--- a/nodes/modifier_change/polygons_to_edges.py
+++ b/nodes/modifier_change/polygons_to_edges.py
@@ -18,28 +18,99 @@
 
 import bpy
 from bpy.props import BoolProperty
+from numpy import array, empty, concatenate, unique, sort, int32, ndarray
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import dataCorrect
+from sverchok.data_structure import dataCorrect_np, updateNode
 from sverchok.utils.sv_mesh_utils import polygons_to_edges
 from sverchok.utils.decorators import deprecated
+
 
 @deprecated("Please use sverchok.utils.sv_mesh_utils.polygons_to_edges instead")
 def pols_edges(obj, unique_edges=False):
     return polygons_to_edges(obj, unique_edges)
 
+def pol_to_edges(pol):
+
+    edges = empty([len(pol), 2], 'i')
+    edges[:, 0] = pol
+    edges[1:, 1] = pol[:-1]
+    edges[0, 1] = pol[-1]
+
+    return edges
+
+def polygons_to_edges_np(obj, unique_edges=False, output_numpy=False):
+    result = []
+
+    for pols in obj:
+        regular_mesh = True
+        try:
+            np_pols = array(pols, dtype=int32)
+        except ValueError:
+            regular_mesh = False
+
+        if not regular_mesh:
+            if output_numpy:
+                result.append(concatenate([pol_to_edges(p) for p in pols]))
+            else:
+                result.append(polygons_to_edges([pols], unique_edges)[0])
+        else:
+
+            edges = empty(list(np_pols.shape)+[2], 'i')
+            edges[:, :, 0] = np_pols
+            edges[:, 1:, 1] = np_pols[:, :-1]
+            edges[:, 0, 1] = np_pols[:, -1]
+
+            edges = edges.reshape(-1, 2)
+            if output_numpy:
+                if unique_edges:
+                    result.append(unique(sort(edges), axis=0))
+                else:
+                    result.append(edges)
+            else:
+                if unique_edges:
+                    result.append(unique(sort(edges), axis=0).tolist())
+                else:
+                    result.append(edges.tolist())
+    return result
+
 class Pols2EdgsNode(bpy.types.Node, SverchCustomTreeNode):
-    ''' take polygon and to edges '''
+    """
+    Triggers: Edges from Faces
+    Tooltip: Get edges lists from polygons lists.
+    """
+
     bl_idname = 'Pols2EdgsNode'
     bl_label = 'Polygons to Edges'
-    bl_icon = 'OUTLINER_OB_EMPTY'
+    bl_icon = 'EDGESEL'
     sv_icon = 'SV_POLYGONS_TO_EDGES'
 
     unique_edges: BoolProperty(
-        name="Unique Edges", default=False, update=SverchCustomTreeNode.process_node)
+        name="Unique Edges", default=False, update=updateNode)
+
+    regular_pols: BoolProperty(
+        name='Regular polygons',
+        description='Makes the node faster if all the incoming polygons have the same number of sides',
+        default=False, update=updateNode)
+
+    output_numpy: BoolProperty(
+        name='Output NumPy',
+        description='Output NumPy arrays',
+        default=False, update=updateNode)
 
     def draw_buttons(self, context, layout):
+        layout.prop(self, "regular_pols")
         layout.prop(self, "unique_edges")
+
+    def draw_buttons_ext(self, context, layout):
+        '''draw buttons on the N-panel'''
+        self.draw_buttons(context, layout)
+        layout.prop(self, 'output_numpy')
+
+    def rclick_menu(self, context, layout):
+        '''right click sv_menu items'''
+        self.draw_buttons(context, layout)
+        layout.prop(self, "output_numpy")
 
     def sv_init(self, context):
         self.inputs.new('SvStringsSocket', "pols")
@@ -48,9 +119,15 @@ class Pols2EdgsNode(bpy.types.Node, SverchCustomTreeNode):
     def process(self):
         if not self.outputs[0].is_linked:
             return
-        X_ = self.inputs['pols'].sv_get()
-        X = dataCorrect(X_)
-        result = polygons_to_edges(X, self.unique_edges)
+
+        polygons_ = self.inputs['pols'].sv_get(deepcopy=False)
+        polygons = dataCorrect_np(polygons_)
+
+        if self.output_numpy or isinstance(polygons[0], ndarray) or self.regular_pols:
+            result = polygons_to_edges_np(polygons, self.unique_edges, self.output_numpy)
+        else:
+            result = polygons_to_edges(polygons, self.unique_edges)
+
         self.outputs['edgs'].sv_set(result)
 
     def draw_label(self):


### PR DESCRIPTION
Alternative algorithm that improves the performance in some cases:
When the polygon list has all polygons with the same number of sides.
When the polygon list is a numpy array
When outputting numpy array of edges
![image](https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/modifier_change/polygons_to_edges/blender_sverchok_parametric_polygons_to_edges.png)

Getting unique edges form the polygons of a 100x100x100 box (120.000 edges)
Classical 0.250 s
With Regular Polygons checked 0.204 s
With Regular Polygons and Output numpy 0.123 s
With Regular Polygons and Output numpy and numpy input 0.99s


- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

