### PR TITLE
Factorizing the angle units code into a helper class

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -66,7 +66,7 @@ class SverchokPreferences(AddonPreferences):
             color_def.apply_theme()
 
     tab_modes = data_structure.enum_item_4(["General", "Node Defaults", "Theme"])
-    
+
     selected_tab: bpy.props.EnumProperty(
         items=tab_modes,
         description="pick viewing mode",
@@ -195,7 +195,7 @@ class SverchokPreferences(AddonPreferences):
 
     over_sized_buttons: BoolProperty(
         default=False, name="Big buttons", description="Very big buttons")
-    
+
     node_panel_modes = [
             ("X", "Do not show", "Do not show node buttons", 0),
             ("T", "T panel", "Show node buttons under the T panel", 1),
@@ -207,7 +207,7 @@ class SverchokPreferences(AddonPreferences):
         name = "Display node buttons",
         description = "Where to show node insertion buttons. Restart Blender to apply changes.",
         default = "X")
-    
+
     node_panels_icons_only : BoolProperty(
             name = "Display icons only",
             description = "Show node icon only when icon has an icon, otherwise show it's name",
@@ -235,9 +235,13 @@ class SverchokPreferences(AddonPreferences):
 
     stethoscope_view_scale: FloatProperty(
         default=1.0, min=0.01, step=0.01, description='default stethoscope scale')
-    
+
     index_viewer_scale: FloatProperty(
         default=1.0, min=0.01, step=0.01, description='default index viewer scale')
+
+    auto_update_angle_values: BoolProperty(
+        default=True,
+        description="Auto update angle values when angle units are changed to preserve the angle")
 
     def set_nodeview_render_params(self, context):
         # i think these are both the same..
@@ -262,7 +266,7 @@ class SverchokPreferences(AddonPreferences):
     def update_log_level(self, context):
         logging.info("Setting log level to %s", self.log_level)
         logging.setLevel(self.log_level)
-    
+
     log_levels = [
             ("DEBUG", "Debug", "Debug output", 0),
             ("INFO", "Information", "Informational output", 1),
@@ -367,18 +371,23 @@ class SverchokPreferences(AddonPreferences):
             row_sub1 = col.row().split(factor=0.5)
             box_sub1 = row_sub1.box()
             box_sub1_col = box_sub1.column(align=True)
-            
+
             box_sub1_col.label(text='Render Scale & Location')
             # box_sub1_col.prop(self, 'render_location_xy_multiplier', text='xy multiplier')
             # box_sub1_col.prop(self, 'render_scale', text='scale')
             box_sub1_col.label(text=f'xy multiplier: {self.render_location_xy_multiplier}')
             box_sub1_col.label(text=f'render_scale : {self.render_scale}')
-            
+
             box_sub1_col.label(text='Stethoscope')
             box_sub1_col.prop(self, 'stethoscope_view_scale', text='scale')
 
             box_sub1_col.label(text='Index Viewer')
-            box_sub1_col.prop(self, 'index_viewer_scale', text='scale')           
+            box_sub1_col.prop(self, 'index_viewer_scale', text='scale')
+
+            box_sub2 = box_sub1.box()
+            box_sub2_col = box_sub2.column(align=True)
+            box_sub2_col.label(text='Angle Units')
+            box_sub2_col.prop(self, 'auto_update_angle_values', text="Auto Update Angle Values")
 
             col3 = row_sub1.split().column()
             col3.label(text='Location of custom defaults')

--- a/utils/sv_transform_helper.py
+++ b/utils/sv_transform_helper.py
@@ -1,0 +1,146 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import bpy
+from bpy.props import (EnumProperty, BoolProperty)
+
+from sverchok.data_structure import updateNode
+from sverchok.settings import get_params
+
+from math import pi
+
+euler_order_items = [
+    ('XYZ', 'XYZ', "", 0),
+    ('XZY', 'XZY', "", 1),
+    ('YXZ', 'YXZ', "", 2),
+    ('YZX', 'YZX', "", 3),
+    ('ZXY', 'ZXY', "", 4),
+    ('ZYX', 'ZYX', "", 5)
+]
+
+
+class AngleUnits:
+    RADIANS = "RAD"
+    DEGREES = "DEG"
+    UNITIES = "UNI"
+
+    @classmethod
+    def get_blender_enum(cls):
+        return [
+            (AngleUnits.RADIANS, "Rad", "Radians", "", 0),
+            (AngleUnits.DEGREES, "Deg", "Degrees", "", 1),
+            (AngleUnits.UNITIES, "Uni", "Unities", "", 2)
+        ]
+
+
+angle_remap_options = {
+    # from               to
+    (AngleUnits.RADIANS, AngleUnits.DEGREES): 180/pi,
+    (AngleUnits.RADIANS, AngleUnits.UNITIES): 1/(2*pi),
+    (AngleUnits.DEGREES, AngleUnits.RADIANS): pi/180,
+    (AngleUnits.DEGREES, AngleUnits.UNITIES): 1/360,
+    (AngleUnits.UNITIES, AngleUnits.RADIANS): 2*pi,
+    (AngleUnits.UNITIES, AngleUnits.DEGREES): 360
+}
+
+
+class SvAngleHelper():
+
+    def get_preferences(self):
+        props = get_params({
+            'auto_update_angle_values': False,
+        })
+        return props.auto_update_angle_values
+
+    def angle_conversion_factor(self, from_angle_units, to_angle_units):
+        if from_angle_units == to_angle_units:
+            return 1
+
+        multiplier = angle_remap_options.get((from_angle_units, to_angle_units))
+
+        if not multiplier:
+            raise Error(f"node {self.name} failure to map angle units, {from_angle_units}->{to_angle_units}")
+
+        return multiplier
+
+    def radians_conversion_factor(self):
+        return self.angle_conversion_factor(self.angle_units, AngleUnits.RADIANS)
+
+    def degrees_conversion_factor(self):
+        return self.angle_conversion_factor(self.angle_units, AngleUnits.DEGREES)
+
+    def unities_conversion_factor(self):
+        return self.angle_conversion_factor(self.angle_units, AngleUnits.UNITIES)
+
+    def update_angle(self, context):
+        ''' Wrapper to inhibit angle updates when units are changed '''
+        if self.inhibit_updates:
+            return
+
+        updateNode(self, context)
+
+    def update_angles(self, context, acf):
+        ''' Override this in the derived class to update specific angle values'''
+        # print("SvAngleHelper update_angles called")
+
+    def update_angle_units(self, context):
+        ''' Update all the angles to preserve their values in the new units '''
+        if self.angle_units == self.last_angle_units:
+            return
+
+        auto_update_angle_values = self.get_preferences()
+
+        if auto_update_angle_values:
+            acf = self.angle_conversion_factor(self.last_angle_units, self.angle_units)
+
+            self.inhibit_updates = True  # deactivate updates
+            self.update_angles(context, acf)
+            self.inhibit_updates = False  # reactivate updates
+
+        self.last_angle_units = self.angle_units  # keep track of the last units
+
+        updateNode(self, context)
+
+    def angle_unit_conversion_factor(self, new_angle_units):
+        return self.angle_conversion_factor(self.angle_units, new_angle_units)
+
+    euler_order: EnumProperty(
+        name="Euler Order", description="Order of the Euler rotations",
+        default="XYZ", items=euler_order_items, update=updateNode)
+
+    angle_units: EnumProperty(
+        name="Angle Units", description="Angle units (Radians/Degrees/Unities)",
+        default=AngleUnits.DEGREES, items=AngleUnits.get_blender_enum(),
+        update=update_angle_units)
+
+    last_angle_units: EnumProperty(
+        name="Last Angle Units", description="Angle units (Radians/Degrees/Unities)",
+        default=AngleUnits.DEGREES, items=AngleUnits.get_blender_enum())
+
+    inhibit_updates: BoolProperty(
+        name='Inhibit Update', description='Flag to inhibit update calls', default=False)
+
+    def draw_angle_euler_buttons(self, context, layout):
+        col = layout.column(align=True)
+        col.prop(self, "euler_order", text="")
+
+    def draw_angle_units_buttons(self, context, layout):
+        box = layout.box()
+        box.label(text="Angle Units")
+        row = box.row(align=True)
+        row.prop(self, "angle_units", expand=True)


### PR DESCRIPTION
Factorizing the angle unit / conversion code into a helper class so that nodes that use angles that want to select the angle units (RAD, DEG, UNI) can have a way to create the the angle unit UI elements and conversions performed. 

Note: this PR will focus on the SvAngleHelper class/file but for the sake of illustrating how this is going to be used by various nodes that could adopt it I started to integrate it into some nodes (the changes to these nodes could be added in a separate PR) .

- [x] Code changes complete.
- [ ] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

