### PR TITLE
Matrix Apply understands NumPy

### DIFF
--- a/docs/nodes/matrix/apply_and_join.rst
+++ b/docs/nodes/matrix/apply_and_join.rst
@@ -32,9 +32,9 @@ Advanced Parameters
 
 In the N-Panel (and on the right-click menu) you can find:
 
-**Implementation**: 'NumPy' or 'Python'. As a general rule in this node the Numpy implementation will be faster if any input is a NumPy array or you want to get NumPy arrays from the outputs. If the surrounding nodes are using python list the performance of both implementations will depend on many factors. With a light geometry but many Matrixes the Python implementation will be faster, as heavier gets the input geometry and less the matrixes number the NumPy implementation will start being a better choice. Also if the incoming topology of polygons is regular the NumPy implementation will increase its performance while the Python implementation will not be affected by that parameter.
+**Implementation**: 'NumPy' or 'Python'. As a general rule in this node the Numpy implementation will be faster if any input is a NumPy array or you want to get NumPy arrays from the outputs. If the surrounding nodes are using python list the performance of both implementations will depend on many factors. With a light geometry but many matrices the Python implementation will be faster, as heavier gets the input geometry and less the matrices number the NumPy implementation will start being a better choice. Also if the incoming topology of polygons is regular the NumPy implementation will increase its performance while the Python implementation will not be affected by that parameter.
 
-**Output NumPy**: Get NumPy arrays in stead of regular lists (makes the node faster). Available for Vertices, Edges and Pols in the NumPy implementation
+**Output NumPy**: Get NumPy arrays in stead of regular lists (makes the node faster). Available for Vertices, Edges and Polygons in the NumPy implementation
 
 Outputs
 -------

--- a/docs/nodes/matrix/apply_and_join.rst
+++ b/docs/nodes/matrix/apply_and_join.rst
@@ -24,8 +24,17 @@ Parameters
 
 This node has the following parameter:
 
-**Join**. If set, then this node will join output meshes into one mesh, the same way as ``Mesh Join`` node does. 
+**Join**. If set, then this node will join output meshes into one mesh, the same way as ``Mesh Join`` node does.
 Otherwise, if N matrices are provided at the input, this node will produce N lists of vertices, N lists of edges and N lists of faces.
+
+Advanced Parameters
+-------------------
+
+In the N-Panel (and on the right-click menu) you can find:
+
+**Implementation**: 'NumPy' or 'Python'. As a general rule in this node the Numpy implementation will be faster if any input is a NumPy array or you want to get NumPy arrays from the outputs. If the surrounding nodes are using python list the performance of both implementations will depend on many factors. With a light geometry but many Matrixes the Python implementation will be faster, as heavier gets the input geometry and less the matrixes number the NumPy implementation will start being a better choice. Also if the incoming topology of polygons is regular the NumPy implementation will increase its performance while the Python implementation will not be affected by that parameter.
+
+**Output NumPy**: Get NumPy arrays in stead of regular lists (makes the node faster). Available for Vertices, Edges and Pols in the NumPy implementation
 
 Outputs
 -------
@@ -42,4 +51,3 @@ Examples
 .. image:: https://cloud.githubusercontent.com/assets/284644/6096652/ac13659e-afbf-11e4-83c9-e13b75c0e346.png
 
 .. image:: https://cloud.githubusercontent.com/assets/284644/6096654/b300fbfa-afbf-11e4-901b-1361a44238c2.png
-

--- a/nodes/generator/box_mk2.py
+++ b/nodes/generator/box_mk2.py
@@ -23,6 +23,7 @@ import numpy as np
 
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode, list_match_func, list_match_modes
+from sverchok.utils.modules.matrix_utils import matrix_apply_np
 
 def extend_lists(data, result):
     for d, r in zip(data, result):
@@ -48,13 +49,6 @@ def mesh_join_np(verts, edges, pols):
 
 def numpy_check(data, bool_list):
     return [lg if b else [l.tolist() for l in lg] for lg, b in zip(data, bool_list)]
-
-def matrix_apply_np(verts, matrix):
-    '''taken from https://blender.stackexchange.com/a/139517'''
-
-    verts_co_4d = np.ones(shape=(verts.shape[0], 4), dtype=np.float)
-    verts_co_4d[:, :-1] = verts  # cos v (x,y,z,1) - point,   v(x,y,z,0)- vector
-    return np.einsum('ij,aj->ai', matrix, verts_co_4d)[:, :-1]
 
 def numpy_cube(params, origin, flags):
     '''

--- a/nodes/generator/plane_mk3.py
+++ b/nodes/generator/plane_mk3.py
@@ -23,6 +23,8 @@ import numpy as np
 
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode, list_match_func, list_match_modes
+from sverchok.utils.modules.matrix_utils import matrix_apply_np
+
 
 directionItems = [("XY", "XY", ""), ("YZ", "YZ", ""), ("ZX", "ZX", "")]
 dimensionsItems = [
@@ -56,13 +58,6 @@ def mesh_join_np(verts, edges, pols):
 def numpy_check(data, bool_list):
     return [lg if b else [l.tolist() for l in lg] for lg, b in zip(data, bool_list)]
 
-
-def matrix_apply_np(verts, matrix):
-    '''taken from https://blender.stackexchange.com/a/139517'''
-
-    verts_co_4d = np.ones(shape=(verts.shape[0], 4), dtype=np.float)
-    verts_co_4d[:, :-1] = verts  # cos v (x,y,z,1) - point,   v(x,y,z,0)- vector
-    return np.einsum('ij,aj->ai', matrix, verts_co_4d)[:, :-1]
 
 def planes_size_number(params, ops, flags):
     list_match = ops[1]

--- a/nodes/matrix/apply_and_join.py
+++ b/nodes/matrix/apply_and_join.py
@@ -40,7 +40,6 @@ def mesh_join_np(verts, edges, pols, out_np_pols):
     accum_vert_lens = np.add.accumulate([len(v) for v in chain([[]], verts)])
 
     v_out = np.concatenate(verts)
-    e_out, p_out = np.array([]), np.array([])
 
     # just checking the first object to detect presence of edges and Polygons
     # this would fail if the first object does not have edges/pols and there
@@ -50,10 +49,11 @@ def mesh_join_np(verts, edges, pols, out_np_pols):
 
     if are_some_edges:
         e_out = np.concatenate([edg + l for edg, l in zip(edges, accum_vert_lens)])
+    else:
+        e_out = np.array([])
 
     if are_some_pols:
         if out_np_pols:
-
             is_array_of_lists = pols[0].dtype == object
             if is_array_of_lists:
                 p_out = [np.array(p) + l  for pol, l in zip(pols, accum_vert_lens) for p in pol]
@@ -62,6 +62,8 @@ def mesh_join_np(verts, edges, pols, out_np_pols):
                 p_out = np.concatenate([pol + l for pol, l in zip(pols, accum_vert_lens)])
         else:
             p_out = [[v + l for v in p]  for pol, l in zip(pols, accum_vert_lens) for p in pol]
+    else:
+        p_out = np.array([])
 
     return v_out, e_out, p_out
 
@@ -131,9 +133,7 @@ def apply_and_join_python(vertices, edges, faces, matrices, do_join):
 class SvMatrixApplyJoinNode(bpy.types.Node, SverchCustomTreeNode):
     """
     Triggers: Mat * Mesh (& Join)
-    Tooltip: Multiply vectors on matrices with several objects in output,
-    and process edges & faces too. It can also join the output meshes in to a
-    single one.
+    Tooltip: Multiply vectors on matrices with several objects in output, processes edges & faces too. It can also join the output meshes in to a single one
     """
 
     bl_idname = 'SvMatrixApplyJoinNode'

--- a/nodes/matrix/apply_and_join.py
+++ b/nodes/matrix/apply_and_join.py
@@ -17,26 +17,89 @@
 # ##### END GPL LICENSE BLOCK #####
 
 import bpy
-from bpy.props import BoolProperty
-from mathutils import Matrix, Vector
+from bpy.props import BoolProperty, EnumProperty, BoolVectorProperty
+from mathutils import Vector
+import numpy as np
+
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import (Matrix_generate, updateNode) #, fullList_deep_copy)
+from sverchok.data_structure import updateNode
 from sverchok.utils.sv_mesh_utils import mesh_join
+from sverchok.utils.modules.matrix_utils import matrix_apply_np
+
+
+socket_names = ['Vertices', 'Edges', 'Polygons']
+
+def mesh_join_np(verts, edges, pols, out_np):
+
+    lens = [0]
+    for v in verts:
+        lens.append(lens[-1] + v.shape[0])
+
+    v_out = np.concatenate(verts)
+    e_out, p_out = np.array([]), np.array([])
+
+    if len(edges[0]) > 0:
+        e_out = np.concatenate([edg + l for edg, l in zip(edges, lens)])
+
+    if len(pols[0]) > 0 and out_np[2]:
+
+        if pols[0].dtype == object:
+            p_out = [np.array(p) + l  for pol, l in zip(pols, lens) for p in pol]
+
+        else:
+            p_out = np.concatenate([pol + l for pol, l in zip(pols, lens)])
+    else:
+        p_out = [[v + l for v in p]  for pol, l in zip(pols, lens) for p in pol]
+
+    return v_out, e_out, p_out
+
+def apply_matrix_to_vectors(vertices, matrices, out_verts):
+    max_v = len(vertices) - 1
+    for i, m in enumerate(matrices):
+        vert_id = min(i, max_v)
+        out_verts.append([(m @ Vector(v))[:] for v in vertices[vert_id]])
+
+def apply_matrix_to_vectors_np(vertices, matrices,out_verts):
+    r_vertices = [np.array(v) for v in vertices]
+    max_v = len(vertices) - 1
+    for i, m in enumerate(matrices):
+        vert_id = min(i, max_v)
+        out_verts.append(matrix_apply_np(r_vertices[vert_id], m))
 
 
 class SvMatrixApplyJoinNode(bpy.types.Node, SverchCustomTreeNode):
-    '''
-    M * verts (optional join)  ///
+    """
+    Triggers: Mat * Mesh (& Join)
+    Tooltip: Multiply vectors on matrices with several objects in output,
+    and process edges & faces too. It can also join the output meshes in to a
+    single one.
+    """
 
-    Multiply vectors on matrices with several objects in output,
-    and process edges & faces too
-    '''
     bl_idname = 'SvMatrixApplyJoinNode'
     bl_label = 'Matrix Apply'
     bl_icon = 'OUTLINER_OB_EMPTY'
     sv_icon = 'SV_MATRIX_APPLY_JOIN'
 
     do_join: BoolProperty(name='Join', default=True, update=updateNode)
+
+    implementation_modes = [
+        ("NumPy", "NumPy", "NumPy", 0),
+        ("Python", "Python", "Python", 1)]
+
+    implementation: EnumProperty(
+        name='Implementation', items=implementation_modes,
+        description='Choose calculation method (See Documentation)',
+        default="Python", update=updateNode)
+
+    output_numpy: BoolProperty(
+        name='Output NumPy',
+        description='Output NumPy arrays',
+        default=False, update=updateNode)
+    out_np: BoolVectorProperty(
+        name="Ouput Numpy",
+        description="Output NumPy arrays",
+        default=(False, False, False),
+        size=3, update=updateNode)
 
     def sv_init(self, context):
         self.inputs.new('SvVerticesSocket', "Vertices")
@@ -51,29 +114,85 @@ class SvMatrixApplyJoinNode(bpy.types.Node, SverchCustomTreeNode):
     def draw_buttons(self, context, layout):
         layout.prop(self, "do_join")
 
+    def draw_buttons_ext(self, context, layout):
+        layout.prop(self, "do_join")
+        layout.label(text="Implementation:")
+        layout.prop(self, "implementation", expand=True)
+        if self.implementation == 'NumPy':
+            layout.label(text="Ouput Numpy:")
+            r = layout.row()
+            for i in range(3):
+                r.prop(self, "out_np", index=i, text=socket_names[i], toggle=True)
+
+    def rclick_menu(self, context, layout):
+        layout.prop(self, "do_join")
+        layout.prop_menu_enum(self, "implementation", text="Implementation")
+        if self.implementation == 'NumPy':
+            layout.label(text="Ouput Numpy:")
+
+            for i in range(3):
+                layout.prop(self, "out_np", index=i, text=socket_names[i], toggle=True)
+
     def process(self):
-        if not self.inputs['Matrices'].is_linked:
+        if not (self.inputs['Matrices'].is_linked and any(s.is_linked for s in self.outputs)):
             return
-        vertices = self.inputs['Vertices'].sv_get()
-        matrices = self.inputs['Matrices'].sv_get()
+        vertices = self.inputs['Vertices'].sv_get(deepcopy=False)
 
+        edges = self.inputs['Edges'].sv_get(default=[[]], deepcopy=False)
+        faces = self.inputs['Faces'].sv_get(default=[[]], deepcopy=False)
+        matrices = self.inputs['Matrices'].sv_get(deepcopy=False)
+
+        out_verts = []
         n = len(matrices)
-        result_vertices = (vertices*n)[:n]
 
-        outV = []
-        for i, i2 in zip(matrices, result_vertices):
-            outV.append([(i @ Vector(v))[:] for v in i2])
+        if self.implementation == 'NumPy':
 
-        edges = self.inputs['Edges'].sv_get(default=[[]])
-        faces = self.inputs['Faces'].sv_get(default=[[]])
-        result_edges = (edges * n)[:n]
-        result_faces = (faces * n)[:n]
-        if self.do_join:
-            outV, result_edges, result_faces = mesh_join(outV, result_edges, result_faces)
-            outV, result_edges, result_faces = [outV], [result_edges], [result_faces]
-        self.outputs['Edges'].sv_set(result_edges)
-        self.outputs['Faces'].sv_set(result_faces)
-        self.outputs['Vertices'].sv_set(outV)
+            apply_matrix_to_vectors_np(vertices, matrices, out_verts)
+
+            if self.do_join:
+                #prepare data for joining
+                out_edges = ([np.array(e) for e in edges] * n)[:n]
+                if self.out_np[2]:
+                    out_faces = ([np.array(f) for f in faces] * n)[:n]
+                else:
+                    out_faces = (faces * n)[:n]
+
+                out_verts, out_edges, out_faces = mesh_join_np(out_verts, out_edges, out_faces, self.out_np)
+
+                out_verts, out_faces = [out_verts], [out_faces]
+
+                if self.out_np[1]:
+                    out_edges = [out_edges]
+                else:
+                    out_edges = [out_edges.tolist()]
+            else:
+                out_edges = (edges * n)[:n]
+                out_faces = (faces * n)[:n]
+
+            if not self.out_np[0]:
+                out_verts = [v.tolist() for v in out_verts]
+
+        else:
+            if isinstance(vertices[0], np.ndarray):
+                py_verts = [v.tolist() for v in vertices]
+            else:
+                py_verts = vertices
+            apply_matrix_to_vectors(py_verts, matrices, out_verts)
+
+            if self.do_join:
+                out_edges = (edges * n)[:n]
+                out_faces = (faces * n)[:n]
+                out_verts, out_edges, out_faces = mesh_join(out_verts, out_edges, out_faces)
+                out_verts, out_edges, out_faces = [out_verts], [out_edges], [out_faces]
+            else:
+                out_edges = (edges * n)[:n]
+                out_faces = (faces * n)[:n]
+
+
+
+        self.outputs['Edges'].sv_set(out_edges)
+        self.outputs['Faces'].sv_set(out_faces)
+        self.outputs['Vertices'].sv_set(out_verts)
 
 
 def register():

--- a/nodes/transforms/apply.py
+++ b/nodes/transforms/apply.py
@@ -22,14 +22,9 @@ from bpy.props import BoolProperty
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import (Vector_generate, Vector_degenerate,
                                      Matrix_generate, updateNode)
+from sverchok.utils.modules.matrix_utils import matrix_apply_np
+
 import numpy as np
-
-def matrix_apply_np(verts, matrix):
-    '''taken from https://blender.stackexchange.com/a/139517'''
-
-    verts_co_4d = np.ones(shape=(verts.shape[0], 4), dtype=np.float)
-    verts_co_4d[:, :-1] = verts  # cos v (x,y,z,1) - point,   v(x,y,z,0)- vector
-    return np.einsum('ij,aj->ai', matrix, verts_co_4d)[:, :-1]
 
 class MatrixApplyNode(bpy.types.Node, SverchCustomTreeNode):
     ''' Multiply vectors on matrixes with several objects in output '''
@@ -58,7 +53,7 @@ class MatrixApplyNode(bpy.types.Node, SverchCustomTreeNode):
     def process(self):
         if not self.outputs['Vectors'].is_linked:
             return
-            
+
         vecs_ = self.inputs['Vectors'].sv_get(deepcopy=False)
         mats = self.inputs['Matrixes'].sv_get(deepcopy=False)
 

--- a/nodes/transforms/noise_displace.py
+++ b/nodes/transforms/noise_displace.py
@@ -28,16 +28,9 @@ from sverchok.data_structure import (updateNode, list_match_func, numpy_list_mat
 from sverchok.utils.sv_noise_utils import noise_options, noise_numpy_types
 from sverchok.utils.sv_itertools import recurse_f_level_control
 from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata
+from sverchok.utils.modules.matrix_utils import matrix_apply_np
+
 import numpy as np
-
-
-def matrix_apply_np(verts, matrix):
-    '''taken from https://blender.stackexchange.com/a/139517'''
-
-    verts_co_4d = np.ones(shape=(verts.shape[0], 4), dtype=np.float)
-    verts_co_4d[:, :-1] = verts  # cos v (x,y,z,1) - point,   v(x,y,z,0)- vector
-    return np.einsum('ij,aj->ai', matrix, verts_co_4d)[:, :-1]
-
 
 def deepnoise(vert, noise_basis='PERLIN_ORIGINAL'):
     noise_v = noise.noise_vector(vert, noise_basis=noise_basis)[:]

--- a/nodes/transforms/rotate_mk3.py
+++ b/nodes/transforms/rotate_mk3.py
@@ -25,13 +25,7 @@ import numpy as np
 from sverchok.node_tree import SverchCustomTreeNode, throttled
 from sverchok.data_structure import updateNode, list_match_func, numpy_list_match_modes, numpy_list_match_func
 from sverchok.utils.sv_itertools import recurse_f_level_control
-
-def matrix_apply_np(verts, matrix):
-    '''taken from https://blender.stackexchange.com/a/139517'''
-
-    verts_co_4d = np.ones(shape=(verts.shape[0], 4), dtype=np.float)
-    verts_co_4d[:, :-1] = verts  # cos v (x,y,z,1) - point,   v(x,y,z,0)- vector
-    return np.einsum('ij,aj->ai', matrix, verts_co_4d)[:, :-1]
+from sverchok.utils.modules.matrix_utils import matrix_apply_np
 
 def np_rotate_many_centers(props, mat, np_local_match):
     verts, centers = np_local_match([np.array(p) for p in props[:2]])

--- a/ui/icons/svg/sv_matrix_apply_join.svg
+++ b/ui/icons/svg/sv_matrix_apply_join.svg
@@ -1,0 +1,242 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg32983"
+   version="1.1"
+   viewBox="0 0 4.2333332 4.2333335"
+   height="16"
+   width="16"
+   sodipodi:docname="sv_matrix_apply_join.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1360"
+     inkscape:window-height="705"
+     id="namedview10"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="-0.71186441"
+     inkscape:cy="8"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg32983" />
+  <defs
+     id="defs32977" />
+  <metadata
+     id="metadata32980">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     style="display:inline;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.87371045;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     d="M 2.9789706,2.1454887 0.97266153,3.5833881"
+     id="path4474"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cc"
+     inkscape:export-xdpi="6.5963187"
+     inkscape:export-ydpi="6.5963187"
+     inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_matrix_apply_join.png" />
+  <path
+     inkscape:export-ydpi="6.5963187"
+     inkscape:export-xdpi="6.5963187"
+     sodipodi:nodetypes="cc"
+     inkscape:connector-curvature="0"
+     id="path4476"
+     d="M 3.0070693,2.1243882 0.97266153,2.5858877"
+     style="display:inline;fill:#ffff00;stroke:#000000;stroke-width:0.87371045;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_matrix_apply_join.png" />
+  <path
+     inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_matrix_apply_join.png"
+     inkscape:export-ydpi="6.5963187"
+     inkscape:export-xdpi="6.5963187"
+     sodipodi:nodetypes="cc"
+     inkscape:connector-curvature="0"
+     id="path4478"
+     d="M 2.9775683,2.1343894 0.97125923,0.69648484"
+     style="display:inline;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.87371045;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+  <path
+     inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_matrix_apply_join.png"
+     style="display:inline;fill:#ffff00;stroke:#000000;stroke-width:0.87371045;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     d="M 3.005667,2.1554873 0.97125923,1.6939852"
+     id="path4480"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cc"
+     inkscape:export-xdpi="6.5963187"
+     inkscape:export-ydpi="6.5963187" />
+  <path
+     style="display:inline;fill:#000000;fill-opacity:0;stroke:#666666;stroke-width:0.34136632;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     d="M 2.9775683,2.1343894 0.97125923,0.69648484"
+     id="path4482"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cc"
+     inkscape:export-xdpi="6.5963187"
+     inkscape:export-ydpi="6.5963187"
+     inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_matrix_apply_join.png" />
+  <path
+     inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_matrix_apply_join.png"
+     inkscape:export-ydpi="6.5963187"
+     inkscape:export-xdpi="6.5963187"
+     sodipodi:nodetypes="cc"
+     inkscape:connector-curvature="0"
+     id="path4484"
+     d="M 3.012652,2.1413877 0.90246753,1.5563833"
+     style="display:inline;fill:#000000;fill-opacity:0;stroke:#666666;stroke-width:0.34136632;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+  <path
+     inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_matrix_apply_join.png"
+     inkscape:export-ydpi="6.5963187"
+     inkscape:export-xdpi="6.5963187"
+     sodipodi:nodetypes="cc"
+     inkscape:connector-curvature="0"
+     id="path4486"
+     d="M 2.9789706,2.1454887 0.97266153,3.5833881"
+     style="display:inline;fill:#333333;fill-opacity:1;stroke:#666666;stroke-width:0.34136632;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+  <rect
+     inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_matrix_apply_join.png"
+     inkscape:export-ydpi="6.5963187"
+     inkscape:export-xdpi="6.5963187"
+     y="-1.3109161e-06"
+     x="0"
+     height="4.233336"
+     width="4.233336"
+     id="rect4488"
+     style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.00343558;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:13.03029823;stroke-opacity:1;enable-background:new" />
+  <path
+     style="display:inline;fill:#000000;fill-opacity:0;stroke:#666666;stroke-width:0.34136632;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     d="M 3.0140543,2.1384878 0.92106773,2.5170881"
+     id="path4490"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cc"
+     inkscape:export-xdpi="6.5963187"
+     inkscape:export-ydpi="6.5963187"
+     inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_matrix_apply_join.png" />
+  <g
+     style="display:inline;enable-background:new"
+     id="g4504"
+     transform="matrix(0.03716968,0,0,0.03716968,77.42555,-8.7436156)"
+     inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_matrix_apply_join.png"
+     inkscape:export-xdpi="6.5963187"
+     inkscape:export-ydpi="6.5963187">
+    <circle
+       r="12.078945"
+       cy="251.18491"
+       cx="-2058.9282"
+       id="circle4492"
+       style="opacity:1;fill:#e59933;fill-opacity:1;stroke:#000000;stroke-width:4.61219978;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:export-xdpi="6.5963187"
+       inkscape:export-ydpi="6.5963187"
+       inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_list_item.png" />
+    <circle
+       inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_list_item.png"
+       inkscape:export-ydpi="6.5963187"
+       inkscape:export-xdpi="6.5963187"
+       style="opacity:1;fill:#99ff99;fill-opacity:1;stroke:#000000;stroke-width:4.61202765;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="circle4494"
+       cx="-2058.9282"
+       cy="276.68262"
+       r="12.078945" />
+    <g
+       id="g4502"
+       transform="matrix(0.77772407,0,0,0.77772407,-455.62097,49.191448)"
+       style="fill:#858500;fill-opacity:1"
+       inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_list_item.png"
+       inkscape:export-xdpi="6.5963187"
+       inkscape:export-ydpi="6.5963187">
+      <circle
+         r="15.531145"
+         cy="325.29395"
+         cx="-2061.5376"
+         id="circle4500"
+         style="opacity:1;fill:#99ff99;fill-opacity:1;stroke:#000000;stroke-width:5.93015909;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         inkscape:export-xdpi="6.5963187"
+         inkscape:export-ydpi="6.5963187"
+         inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_linked_verts.png" />
+    </g>
+    <g
+       transform="matrix(0.8183286,0,0,0.8183286,-371.16218,66.225474)"
+       id="g4498"
+       inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_list_item.png"
+       inkscape:export-xdpi="6.5963187"
+       inkscape:export-ydpi="6.5963187">
+      <circle
+         r="19.224251"
+         cy="322.30551"
+         cx="-2061.5376"
+         id="circle4496"
+         style="opacity:1;fill:#33cccc;fill-opacity:1;stroke:#000000;stroke-width:7.34027433;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         inkscape:export-xdpi="6.5963187"
+         inkscape:export-ydpi="6.5963187"
+         inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_linked_verts.png" />
+    </g>
+  </g>
+  <g
+     style="display:inline;enable-background:new"
+     id="g4520"
+     transform="matrix(0.04905175,0,0,0.04905175,104.26345,-12.831116)"
+     inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_matrix_apply_join.png"
+     inkscape:export-xdpi="6.5963187"
+     inkscape:export-ydpi="6.5963187">
+    <circle
+       inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_list_item.png"
+       inkscape:export-ydpi="6.5963187"
+       inkscape:export-xdpi="6.5963187"
+       style="opacity:1;fill:#e59933;fill-opacity:1;stroke:#000000;stroke-width:4.85281897;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="circle4510"
+       cx="-2058.1772"
+       cy="278.76486"
+       r="12.70958" />
+    <g
+       transform="matrix(0.8183286,0,0,0.8183286,-371.16218,66.225474)"
+       id="g4514"
+       inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_list_item.png"
+       inkscape:export-xdpi="6.5963187"
+       inkscape:export-ydpi="6.5963187">
+      <circle
+         r="15.531145"
+         cy="325.29395"
+         cx="-2061.5376"
+         id="circle4512"
+         style="opacity:1;fill:#99ff99;fill-opacity:1;stroke:#000000;stroke-width:5.93015909;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         inkscape:export-xdpi="6.5963187"
+         inkscape:export-ydpi="6.5963187"
+         inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_linked_verts.png" />
+    </g>
+    <g
+       id="g4518"
+       transform="matrix(0.8183286,0,0,0.8183286,-371.16218,39.39652)"
+       style="fill:#858500;fill-opacity:1"
+       inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_list_item.png"
+       inkscape:export-xdpi="6.5963187"
+       inkscape:export-ydpi="6.5963187">
+      <circle
+         r="15.531145"
+         cy="325.29395"
+         cx="-2061.5376"
+         id="circle4516"
+         style="opacity:1;fill:#99ff99;fill-opacity:1;stroke:#000000;stroke-width:5.93015909;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         inkscape:export-xdpi="6.5963187"
+         inkscape:export-ydpi="6.5963187"
+         inkscape:export-filename="C:\Users\PcCom\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\sverchok\ui\icons\sv_linked_verts.png" />
+    </g>
+  </g>
+</svg>

--- a/utils/modules/matrix_utils.py
+++ b/utils/modules/matrix_utils.py
@@ -7,7 +7,7 @@
 
 from mathutils import Vector, Matrix
 from sverchok.data_structure import match_long_repeat
-
+import numpy as np
 def vectors_to_matrix(centrs, normals, p0_xdirs):
     mat_collect = []
 
@@ -45,3 +45,13 @@ def matrix_normal(params, T, U):
         m = Matrix.Translation(V) @ n.to_matrix().to_4x4()
         out.append(m)
     return out
+
+def matrix_apply_np(verts, matrix):
+    '''
+    taken from https://blender.stackexchange.com/a/139517
+    verts should be a numpy array with shape (n,3)
+    matrix can be a regular mathultis matrix'''
+
+    verts_co_4d = np.ones(shape=(verts.shape[0], 4), dtype=np.float)
+    verts_co_4d[:, :-1] = verts  # cos v (x,y,z,1) - point,   v(x,y,z,0)- vector
+    return np.einsum('ij,aj->ai', matrix, verts_co_4d)[:, :-1]


### PR DESCRIPTION
Added a Numpy implementation of the node, after coding the performance results are:
As a general rule in this node the new Numpy implementation will be faster if any input is a NumPy array or you want to get NumPy arrays from the outputs. If the surrounding nodes are using python list the performance of both implementations will depend on many factors. With a light geometry but many Matrices the Python implementation will be faster, as heavier gets the input geometry and less the matrices number the NumPy implementation will start being a better choice. Also if the incoming topology of polygons is regular the NumPy implementation will increase its performance while the Python implementation will not be affected by that parameter.

So the default will be the previous Python implementation at this point in time.
 
- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [x] Unit-tests implemented.
- [x] Ready for merge.

