### PR TITLE
resolve init error

### DIFF
--- a/nodes/list_mutators/combinatorics.py
+++ b/nodes/list_mutators/combinatorics.py
@@ -76,6 +76,8 @@ class SvCombinatoricsNode(bpy.types.Node, SverchCustomTreeNode):
 
     def update(self):
         ''' Add/remove sockets as A-Z sockets are connected/disconnected '''
+        if not 'Result' in self.outputs:
+            return
 
         # not a multiple input operation ? => no need to update sockets
         if self.operation not in multiple_input_operations:


### PR DESCRIPTION
`node.update` is triggered many times before the node is entirely initialized, if you implement that update function, it must first be certain the node has completed `sv_init`, before it can be useful.

one way to do that is to check if the last output socket has been created.