### PR TITLE
Node update decorator

### DIFF
--- a/node_tree.py
+++ b/node_tree.py
@@ -136,7 +136,7 @@ def throttled(func):
     return wrapper_update
 
 
-def throttle_node(func):
+def throttle_node_update(func):
     """
     this function is used to reject calls to node.update
 
@@ -153,7 +153,7 @@ def throttle_node(func):
                 ... usually something like :   
                 ...      if 'last_output' in self.outputs: return True
 
-            @throttle_node
+            @throttle_node_update
             def update(self):
                 ... stuff you do with a highly dynamic ui node
 

--- a/node_tree.py
+++ b/node_tree.py
@@ -136,31 +136,31 @@ def throttled(func):
     return wrapper_update
 
 
-def throttle_node_update(func):
+def poll_node(func):
     """
     this function is used to reject calls to node.update
 
     use as a decorator:
 
-        from sverchok.node_tree import SverchCustomTreeNode, throttle_node
+        from sverchok.node_tree import SverchCustomTreeNode, poll_node
 
         class node:
 
 
-            def hold_check(self):
+            def sv_poll(self):
                 ... test here to return True, if you want to avoid executing the update
                 ... function too early.
                 ... usually something like :   
                 ...      if 'last_output' in self.outputs: return True
 
-            @throttle_node_update
+            @poll_node
             def update(self):
                 ... stuff you do with a highly dynamic ui node
 
 
     """
     def wrapper_node_update(self):
-        if not self.hold_check():
+        if not self.sv_poll():
             func(self)
 
     return wrapper_node_update

--- a/node_tree.py
+++ b/node_tree.py
@@ -82,6 +82,10 @@ class SvLinkNewNodeInput(bpy.types.Operator):
         return {'FINISHED'}
 
 
+
+
+
+
 @contextmanager
 def throttle_tree_update(node):
     """ usage
@@ -131,6 +135,35 @@ def throttled(func):
 
     return wrapper_update
 
+
+def throttle_node(func):
+    """
+    this function is used to reject calls to node.update
+
+    use as a decorator:
+
+        from sverchok.node_tree import SverchCustomTreeNode, throttle_node
+
+        class node:
+
+
+            def hold_check(self):
+                ... test here to return True, if you want to avoid executing the update
+                ... function too early.
+                ... usually something like :   
+                ...      if 'last_output' in self.outputs: return True
+
+            @throttle_node
+            def update(self):
+                ... stuff you do with a highly dynamic ui node
+
+
+    """
+    def wrapper_node_update(self):
+        if not self.hold_check():
+            func(self)
+
+    return wrapper_node_update
 
 
 class SvNodeTreeCommon(object):

--- a/nodes/list_mutators/combinatorics.py
+++ b/nodes/list_mutators/combinatorics.py
@@ -19,10 +19,10 @@
 import bpy
 from bpy.props import IntProperty, EnumProperty
 
-from sverchok.node_tree import SverchCustomTreeNode, throttle_node_update
-from sverchok.data_structure import (match_long_repeat, updateNode)
+from sverchok.node_tree import SverchCustomTreeNode, poll_node
+from sverchok.data_structure import match_long_repeat, updateNode
 
-from itertools import (product, permutations, combinations)
+from itertools import product, permutations, combinations
 
 operations = {
     "PRODUCT":      (10, lambda s, r: product(*s, repeat=r)),
@@ -74,7 +74,7 @@ class SvCombinatoricsNode(bpy.types.Node, SverchCustomTreeNode):
 
         self.update_operation(context)
     
-    def hold_check(self):
+    def sv_poll(self):
         if not 'Result' in self.outputs:
             return True
 
@@ -82,7 +82,7 @@ class SvCombinatoricsNode(bpy.types.Node, SverchCustomTreeNode):
         if self.operation not in multiple_input_operations:
             return True
 
-    @throttle_node_update
+    @poll_node
     def update(self):
         ''' Add/remove sockets as A-Z sockets are connected/disconnected '''
 

--- a/nodes/list_mutators/combinatorics.py
+++ b/nodes/list_mutators/combinatorics.py
@@ -19,7 +19,7 @@
 import bpy
 from bpy.props import IntProperty, EnumProperty
 
-from sverchok.node_tree import SverchCustomTreeNode, throttle_node
+from sverchok.node_tree import SverchCustomTreeNode, throttle_node_update
 from sverchok.data_structure import (match_long_repeat, updateNode)
 
 from itertools import (product, permutations, combinations)
@@ -82,7 +82,7 @@ class SvCombinatoricsNode(bpy.types.Node, SverchCustomTreeNode):
         if self.operation not in multiple_input_operations:
             return True
 
-    @throttle_node
+    @throttle_node_update
     def update(self):
         ''' Add/remove sockets as A-Z sockets are connected/disconnected '''
 


### PR DESCRIPTION
i don't know if this is needed, or if it's just extra complexity.

it's a decorator for the node's `update` function. For most nodes we don't need to implement the update function, only for nodes which change their ui according to user interaction with sockets.

When we do implement the `update` function, we have a few checks at the top of the function that must be done before any real dynamic UI code can be run.

Usually the code in the update function consists out of testing to see if the last output was generated, and perhaps if certain sockets are connected. The example i'll use is the `combinatorics` node This PR contains the `poll_node` decorator, which wraps the update function, the decorator will call a function called "sv_poll", which will return true is you want to avoid calling update. (in that sense it is in reverse to to normal operator poll)