### PR TITLE
strip obj_ref - temporary fix

### DIFF
--- a/core/sockets.py
+++ b/core/sockets.py
@@ -295,7 +295,7 @@ class SvObjectSocket(NodeSocket, SvSocketCommon):
         if self.is_linked and not self.is_output:
             return self.convert_data(SvGetSocket(self, deepcopy), implicit_conversions)
         elif self.object_ref:
-            obj_ref = bpy.data.objects.get(self.object_ref)
+            obj_ref = bpy.data.objects.get(self.object_ref.strip())
             if not obj_ref:
                 raise SvNoDataError(self)
             return [obj_ref]

--- a/nodes/scene/instancer_MK2.py
+++ b/nodes/scene/instancer_MK2.py
@@ -105,10 +105,6 @@ class SvInstancerNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         row = col.row(align=True)
         row.prop(self, "basedata_name", text="", icon='FILE_CACHE')
         
-    def get_objects(self):
-        if self.inputs['objects'].is_linked:
-            return dataCorrect(self.inputs['objects'].sv_get())
-        return []
 
     def get_matrices(self):
         if self.inputs['matrix'].is_linked:
@@ -124,7 +120,7 @@ class SvInstancerNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         if not matrices:
             return
 
-        objects = self.get_objects()
+        objects = self.inputs['objects'].sv_get()
         if not objects:
             return
         


### PR DESCRIPTION
prop_search in the SvObjectSocket will now return not the object.name, but an IDProperty or some not super useful thing for us at the moment.

i've implemented a simple fix, but probably ...an alternative to `prop_search` is needed