### PR TITLE
Bugfix to the formula node

### DIFF
--- a/nodes/number/formula3.py
+++ b/nodes/number/formula3.py
@@ -184,7 +184,7 @@ class SvFormulaNodeMk3(bpy.types.Node, SverchCustomTreeNode):
             input_values = [inputs.get(name, [[0]]) for name in var_names]
             parameters = match_long_repeat(input_values)
         else:
-            parameters = [[[]]]
+            parameters = [[[None]]]
         for objects in zip(*parameters):
             object_results = []
             for values in zip_long_repeat(*objects):


### PR DESCRIPTION
Hi! I have spotted what I think is a bug.
I am quite of a noob; hopefully, I am doing the right thing creating this pull request...

## Addressed problem description

I've noticed that the Formula Node does not work when inputting an expression that lacks any variable. For example, typing x + 3 (given the default value for x of 0), it does correctly evaluate outputting 3. Typing 3 + 1 gives no result, as the for loop https://github.com/nortikin/sverchok/blob/e9cfe0c77f07844564a9121ba5821cad96701edf/nodes/number/formula3.py#L190 never runs if var_names == false

## Solution description

`zip_long_repeat(*objects)` returns an empty iterator if `objects` is `([],)`.
My proposed fix is aimed to make `objects` equal to `([None],)` when there are no variables in the expression. Thus `list(zip_long_repeat(*objects)) = (None,)` and the for loop runs once.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Manual testing done. 
- [x] Ready for merge.

