### PR TITLE
Viewer Layer node

### DIFF
--- a/core/update_system.py
+++ b/core/update_system.py
@@ -198,7 +198,7 @@ def separate_nodes(ng, links=None):
             node_set_list[-1].add(n)
 
     found_node_sets = [ns for ns in node_set_list if len(ns) > 1]
-  
+
     if hasattr(ng, "sv_subtree_evaluation_order"):
         sorting_type = ng.sv_subtree_evaluation_order
         if sorting_type in {'X', 'Y'}:
@@ -357,7 +357,7 @@ def do_update_general(node_list, nodes, procesed_nodes=set()):
     timings = []
     graph = []
     gather = graph.append
-    
+
     total_time = 0
     done_nodes = set(procesed_nodes)
 
@@ -387,19 +387,19 @@ def do_update_general(node_list, nodes, procesed_nodes=set()):
             update_error_nodes(ng, node_name, err)
             #traceback.print_tb(err.__traceback__)
             exception("Node %s had exception: %s", node_name, err)
-            
+
             if hasattr(ng, "sv_show_error_in_tree"):
                 # not yet supported in monad trees..
                 if ng.sv_show_error_in_tree:
                     error_text = traceback.format_exc()
                     start_exception_drawing_with_bgl(ng, node_name, error_text, err)
-            
+
             return None
 
     graphs.append(graph)
     if data_structure.DEBUG_MODE:
         debug("Node set updated in: %.4f seconds", total_time)
-    
+
     return timings
 
 
@@ -522,7 +522,7 @@ def process_tree(ng=None):
 def reload_sverchok():
     data_structure.RELOAD_EVENT = False
     from sverchok.core import handlers
-    handlers.sv_post_load([])
+    handlers.sv_handler_load_post([])
 
 def get_update_lists(ng):
     """

--- a/docs/nodes/scene/scene_index.rst
+++ b/docs/nodes/scene/scene_index.rst
@@ -21,3 +21,4 @@ Scene
    particles_MK2
    node_remote
    selection_grabber_lite
+   viewer_layer

--- a/docs/nodes/scene/viewer_layer.rst
+++ b/docs/nodes/scene/viewer_layer.rst
@@ -1,0 +1,77 @@
+Viewer Layer
+============
+
+Functionality
+-------------
+
+This node helps you manage multiple viewer nodes in a centralized way.
+
+It allows you to create multiple layers (groups) to which you can add any of the supported viewer nodes [1] available in the node tree. Once the viewer nodes are added to the ViewerLayer node you can change their attributes (ON/OFF status, vert/edge/face display status and colors etc) directly from within the ViewerLayer node without having to navigate to each viewer node in the node tree to adjust those settings. Additionally, the ViewerLayer node also allows for various operations to be applied to all layers or all viewers in a layer at once (e.g. hide/show all, turn ON/OFF vert/edge/face display for all, collapse viewers in a layer or collapse all layers).
+
+Notes:
+[1] : Currently the supported viewer nodes are the "Viewer Draw" and the "Viewer Index" nodes.
+
+One usefulness of this node is that you can group together various viewer nodes that belong together in rendering some information in the viewport and you can easily turn ON/OFF all those viewers at once with miminal interaction (sometimes with just one click).
+
+
+Node Operations
+---------------
+The node level operations that apply to all layers in the node are:
+* Collapse/Expand all layers (via mix-status toggle button)
+* Turn ON/OFF vert/edge/face display (via corresponding mix-status toggle buttons)
+* Turn ON/OFF visibility of layers/viewers (via corresponding mix-status toggle buttons)
+* Add Layer to node (via "Add Layer" (plus list) button at the bottom of the node)
+
+
+Layer Operations
+----------------
+The layer level operations that apply to all viewers in the layer are:
+* Remove Layer from node (via "Remove Layer" (minus) button following the layer name)
+* Rename Layer (layers are allowed to have same name)
+* Collapse/Expand Layer (via "Expand" button in front of the layer name)
+* Turn ON/OFF (visibility status) of all viewers in Layer
+* Add Viewer to Layer (via "Add Viewer" (plus) button at the bottom of the layer)
+
+Notes:
+- There are no limitations on the number of layers a ViewerLayer node can create.
+- Once a layer is created, a "Add Viewer" (plus) button is shown at the bottom of the layer to allow viewer entries to be created for each layer. Once the number of viewer entries is the same as the number of available viewer nodes in the node tree, the "Add Viewer" button is hidden.
+
+
+Viewer Operations
+-----------------
+The viewer level operations that apply to each viewer in the layer are:
+* Remove Viewer (via "Remove Viewer" (minus) button next to the viewer entry)
+* Select Viewer (from drop down of avaialable viewer nodes)
+* Update ON/OFF status and vert/edge/face display status and colors (via corresponding UI)
+
+Notes:
+- The "Remove Viewer" button is only displayed when the viewer entry is empty.
+- The viewer selection options (viewer name drop down list) of a viewer entry is the list of the names of all the available viewer nodes in the node tree, excluding the viewer nodes already added to the layer. This is to ensure no duplicate viewers are added to a layer, and also to facilitate selection by providing a shorter list with only those viewers that have not yet been selected yet for a layer.
+
+
+ON, OFF and MIX status
+----------------------
+When the layers in the node or the viewers in a layer have an ON status, the corresponding ON/OFF toggle button will show the "Eye Open" icon, indicating the overall status of its descendants. Tapping on the toggle button will turn all its descendants status to OFF.
+
+When the layers in the node or the viewers in a layer have an OFF status, the ON/OFF toggle button will show the "Eye Close" icon indicating the overall status of its descendants. Tapping on the toggle button will turn all its descendants status to ON.
+
+When the layers in the node or the viewers in a layer have a MIX (ON and OFF) status, the ON/OF toggle button  will show a "Dot" icon, indicating the overall status of its descendants (layers or viewers). Tapping on the toggle button will turn all its descendants status to ON.
+
+Note: If a parent level (node or layer) has a MIX status and you want to turn all descendants OFF, you need to tap the ON/OFF toggle button twice: once to turn all ON and second to turn all OFF.
+
+Similar ON/OFF/MIX behavior holds true for the for the vert/edge/face display toggle buttons, except that the icons stays the same (vert/edge/face icon).
+
+
+Renaming viewer nodes externally
+--------------------------------
+When a viewer node is renamed externally the ViewerLayer node will capture the name change and will invalidate all the viewer entries in all layers that reference the older names (those entries will be highlighted in RED, assuming the default Blender color theme). In this case you can either chose to remove that viewer entry from the layers or reselect a new viewer for those entries from the latest list of viewers.
+
+Note: Once SV provides a feature to have a fixed, unique ID assigned to every node created (and saved with the blend file), which could be used as a reference, instead of the viewer nodes name, the ViewerLayer node would be able to capture the external changes to the viewer node names and automatically update the names in the layer entries without needing to invalidate viewer entries. Until then, the manual removal / update of the invalidated viewer entries is necessary. So, keep this in mind when you change the viewer node names externally. For this reason it's best to rename the viewer nodes before adding them to the ViewerLayer nodes, and then resist the temptation to change their names. :)
+
+
+Extra Viewer settings
+---------------------
+Based on the width of the ViewerLayer node additional settings for the viewers are shown/hidden. For narrow width, the viewer name and visibility toggle button are shown. For larger (>300px) width the vert/edge/face colors are also shown. And for even larger width (>400px) the vert/edge/face display status toggle buttons are also shown.
+
+
+

--- a/index.md
+++ b/index.md
@@ -438,6 +438,8 @@
     SvFCurveInNodeMK1
     SvCollectionPicker
     SvSelectionGrabberLite
+    ---
+    SvViewerLayerNode
 
 ## Objects
     SvVertexGroupNodeMK2
@@ -482,6 +484,7 @@
     ---
     SvCombinatoricsNode
 
+
 ## Alpha Nodes
     SvBManalyzinNode
     SvBMObjinputNode
@@ -505,3 +508,4 @@
     ---
     SvGetPropNodeMK2
     SvSetPropNodeMK2
+

--- a/nodes/scene/viewer_layer.py
+++ b/nodes/scene/viewer_layer.py
@@ -1,0 +1,497 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+
+import bpy
+from bpy.props import FloatProperty, BoolProperty, StringProperty, CollectionProperty, IntProperty
+
+import sverchok
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode
+from sverchok.core.handlers import subscribe_to_changes, sverchok_trees
+from sverchok.utils.logging import debug
+
+
+layer_names = [
+    "Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta", "Eta", "Theta",
+    "Iota", "Kappa", "Lambda", "Mu", "Nu", "Xi", "Omicron", "Pi", "Rho",
+    "Sigma", "Tau", "Upsilon", "Phi", "Chi", "Psi", "Omega"]
+
+# set of supported viewer nodes + mapping of their various respective attributes
+viewer_dict = {
+    'SvVDExperimental': {
+        'display': {
+            'vert': "display_verts",
+            'edge': "display_edges",
+            'face': "display_faces"
+        },
+        'colors': {
+            'vert': "vert_color",
+            'edge': "edge_color",
+            'face': "face_color"
+        }
+    },
+    'SvIDXViewer28': {
+        'display': {
+            'vert': "display_vert_index",
+            'edge': "display_edge_index",
+            'face': "display_face_index"
+        },
+        'colors': {
+            'vert': "numid_verts_col",
+            'edge': "numid_edges_col",
+            'face': "numid_faces_col"
+        }
+    }
+}
+
+elements = {'vert': 'UV_VERTEXSEL', 'edge': 'UV_EDGESEL', 'face': 'UV_FACESEL'}
+
+
+def viewer_name_change_callback(self):
+    ''' Subscription callback for viewer node name change (calls from handlers.py) '''
+    debug("* VLN: viewer_name_change_callback")
+    # propagate the name change callback to all Viewer Layer nodes
+    for node_tree in sverchok_trees():
+        layer_nodes = [n for n in node_tree.nodes if n.bl_idname == "SvViewerLayerNode"]
+        for node in layer_nodes:
+            debug("VLN: propagate name change callback to: %s", node.bl_idname)
+            node.viewer_changed_name()
+
+
+def subscribe_to_viewer_nodes_name_changes():
+    ''' Subscribe to name change of various viewer nodes (calls to handlers.py) '''
+    debug("* VLN: layer_nodes_subscribe_to_viewer_changes")
+    VIZ_NODE1 = sverchok.nodes.viz.vd_draw_experimental.SvVDExperimental
+    VIZ_NODE2 = sverchok.nodes.viz.viewer_idx28.SvIDXViewer28
+
+    subscribe_to_list = [(VIZ_NODE1, "name"), (VIZ_NODE2, "name")]
+
+    for subscribe_to in subscribe_to_list:
+        subscribe_to_changes(subscribe_to, "Viewer node name changed", viewer_name_change_callback)
+
+
+def update_viewer_list(self, context):
+    ''' Update callback (wrapper) when a viewer entry name changes in the layer node '''
+    debug("* VLN: SvViewerGroup: update_viewer_list")
+    viewer_name_change_callback(None)
+
+
+class SvLayerOperatorCallback(bpy.types.Operator):
+    ''' Delegate layer changes to the layer node '''
+    bl_idname = "nodes.sv_viewer_layer_callback"
+    bl_label = "Sv Ops Layer callback"
+
+    function_name: StringProperty()  # what function to call
+    layer_name: StringProperty()  # layer name
+    layer_id: IntProperty() # unique id to find layer in the node
+    element_type: StringProperty()  # "vert", "edge" or "face"
+
+    def execute(self, context):
+        n = context.node
+        getattr(n, self.function_name)(self)
+        return {"FINISHED"}
+
+
+class SvViewerOperatorCallback(bpy.types.Operator):
+    ''' Delegate viewer changes to the layer node '''
+    bl_idname = "nodes.sv_viewer_callback"
+    bl_label = "Sv Ops Viewer callback"
+
+    function_name: StringProperty()  # what function to call
+    layer_name: StringProperty()  # layer name
+    layer_id: IntProperty()  # unique id to find layer in the node
+    viewer_id: IntProperty()  # unique id to find viewer in the layer
+
+    def execute(self, context):
+        n = context.node
+        getattr(n, self.function_name)(self.layer_id, self.viewer_id)
+        return {"FINISHED"}
+
+
+class SvViewerGroup(bpy.types.PropertyGroup):
+    ''' Property group for the viewer entries '''
+    collection_name: CollectionProperty(name="List of Viewers", type=bpy.types.PropertyGroup)
+    node_name: StringProperty(update=update_viewer_list)
+    viewer_id: IntProperty(name="Viewer ID", description="ID of the viewer's entry in the layer")
+
+
+class SvViewerLayerGroup(bpy.types.PropertyGroup):
+    ''' Property group for the layer entries '''
+    collection_name: CollectionProperty(name="List of Layers", type=bpy.types.PropertyGroup)
+    viewers: CollectionProperty(name="Viewers", type=SvViewerGroup)
+    expand: BoolProperty(name="Expand Layer", default=True)
+    layer_id: IntProperty(name="Layer ID", description="ID of the layer's entry in the node")
+
+
+class SvViewerLayerNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: Layer, Viewer
+    Tooltip: Group viewer nodes into layers to easily manipulate their settings
+    """
+    bl_idname = 'SvViewerLayerNode'
+    bl_label = 'Viewer Layers'
+    bl_icon = 'HIDE_OFF'
+
+    layers: CollectionProperty(name="Layers", type=SvViewerLayerGroup)
+    layer_id: IntProperty(name="Layer ID", default=0)
+    viewer_id: IntProperty(name="Viewer ID", default=0)
+
+    def viewer_changed_name(self):
+        ''' Callback used when external viewer nodes name changed '''
+        debug("* VLN: SvViewerLayerNode: viewer_changed_name")
+        self.update_layers_viewers_lists()
+
+    def number_of_viewer_nodes(self):
+        ''' Total number of viewer nodes in the tree '''
+        count = 0
+        for node in self.id_data.nodes:
+            if node.bl_idname in viewer_dict.keys():
+                count += 1
+        return count
+
+    def get_next_default_layer_name(self):
+        return layer_names[len(self.layers)-1]
+
+    def get_next_layer_id(self):
+        self.layer_id += 1
+        return self.layer_id
+
+    def get_next_viewer_id(self):
+        self.viewer_id += 1
+        return self.viewer_id
+
+    def status_icon(self, status):
+        #  status all ON                 status all OFF               status MIX
+        return "HIDE_OFF" if status == 1 else "HIDE_ON" if status == 2 else "DOT"
+
+    def new_status(self, status):
+        if status == 1:  # all ON => next will make all OFF
+            new_status = False
+        elif status == 2:  # all OFF => next will make all ON
+            new_status = True
+        else:  # a MIX => next will make all ON
+            new_status = True
+
+        return new_status
+
+    def layer_visibility_status(self, layer):
+        """
+        Return the layer's cummulative viewer [ON/OFF/MIX] status: [1, 2 or 3]
+        status = (hidden bit) | (visible bit)
+        1 = 0x01 : status all ON (visible)
+        2 = 0x10 : status all OFF (hidden)
+        3 = 0x11 : status MIX (both visible & hidden)
+        """
+        tree_nodes = self.id_data.nodes
+        status = 0
+        for viewer in layer.viewers:
+            viewer_node = tree_nodes.get(viewer.node_name)
+            if viewer_node:
+                if viewer_node.activate:  # mark that the layer has active viewers
+                    status = status | 1
+                else:  # mark that the layer has inactive viewers
+                    status = status | 2
+
+        return status
+
+    def all_layer_visibility_status(self):
+        ''' Return the cummulative visibility status of all layers '''
+        status = 0
+        for layer in self.layers:
+            status = status | self.layer_visibility_status(layer)
+
+        return status
+
+    def setup_subscriptions(self):
+        """
+        Setup node/attribute subscriptions
+
+        This is called from the handlers.py after loading blender file to allow
+        existing viewer layer node to subscribe to viewer node name changes.
+        """
+        debug("* setup_subscriptions in class: %s", self.bl_idname)
+        subscribe_to_viewer_nodes_name_changes()
+        # also, update all layers viewers lists (if any exist)
+        self.update_layers_viewers_lists()
+
+    def update_layers_viewers_lists(self):
+        ''' Update the viewer name lists for viwers in all layers '''
+        debug("* update_layers_viewers_lists")
+
+        all_viewer_names = [n.name for n in self.id_data.nodes if n.bl_idname in viewer_dict.keys()]
+        debug("all viewer names = {}".format(all_viewer_names))
+
+        if self.layers:
+            debug("update node ({0} layers)".format(len(self.layers)))
+            for layer in self.layers:
+                debug(" update layer \"{0}\" ({1} viewers): ".format(layer.name, len(layer.viewers)))
+
+                layer_viewer_names = list(set([v.node_name for v in layer.viewers if v.node_name != ""]))
+                debug("layer viewer names = {}".format(layer_viewer_names))
+
+                unused_names = [name for name in all_viewer_names if name not in layer_viewer_names]
+                debug("unused names = {}".format(unused_names))
+
+                if layer.viewers:
+                    for viewer in layer.viewers:
+                        debug("  update viewer: %s", viewer.name)
+
+                        viewer.collection_name.clear()
+
+                        for name in unused_names:
+                            debug("   adding viewer %s to the list", name)
+                            viewer.collection_name.add().name = name
+
+                        if viewer.node_name in all_viewer_names and viewer.node_name not in unused_names:
+                            viewer.collection_name.add().name = viewer.node_name
+                else:
+                    debug("layer \"{0}\" has no viewers".format(layer.name))
+        else:
+            debug("node has no layers")
+
+    def draw_buttons(self, context, layout):
+        lcb = SvLayerOperatorCallback.bl_idname  # LAYER callback
+        vcb = SvViewerOperatorCallback.bl_idname  # VIEWER callback
+
+        tree_nodes = self.id_data.nodes
+
+        if self.layers:
+            # overall controls
+            box = layout.box()
+            row = box.row(align=True)
+            split = row.split(factor=0.5)
+
+            all_expand = split.operator(lcb, text='', icon='COLLAPSEMENU')
+            all_expand.function_name = 'ops_toggle_all_layer_expansion'
+
+            for element in elements:
+                toggle_element = split.operator(lcb, text='', icon=elements[element])
+                toggle_element.function_name = "ops_toggle_element_visibility"
+                toggle_element.element_type = element
+
+            status = self.all_layer_visibility_status()
+            all_toggle = split.operator(lcb, text='', icon=self.status_icon(status))
+            all_toggle.function_name = 'ops_toggle_all_layer_visibility'
+
+        for layer in self.layers:
+            row = layout.row(align=True)
+            split = row.split(factor=0.1)
+
+            split.prop(layer, "expand", icon="COLLAPSEMENU", text="")
+            split = split.split(factor=0.6)
+            row = split.row(align=True)
+            row.prop(layer, "name", text="")
+
+            # show the REMOVE LAYER button
+            rm_button = row.operator(lcb, text='', icon='REMOVE')
+            rm_button.function_name = "ops_remove_layer"
+            rm_button.layer_name = layer.name
+            rm_button.layer_id = layer.layer_id
+
+            # show the LAYER VISIBILITY button
+            status = self.layer_visibility_status(layer)
+            viz_button = split.operator(lcb, text='', icon=self.status_icon(status))
+            viz_button.function_name = "ops_toggle_layer_visibility"
+            viz_button.layer_name = layer.name
+            viz_button.layer_id = layer.layer_id
+
+            if layer.expand:
+                # show entries for all the viewers in the layer
+                box = layout.box()
+                for viewer in layer.viewers:
+                    row = box.row(align=True)
+                    part1 = row.split(factor=0.7 if self.width < 300 else 0.5 if self.width < 400 else 0.4)
+                    part1.prop_search(viewer, "node_name", viewer, 'collection_name', icon='NODE', text='')
+
+                    viewer_node = tree_nodes.get(viewer.node_name)
+                    if viewer_node:
+                        display = viewer_dict[viewer_node.bl_idname]['display']
+                        color = viewer_dict[viewer_node.bl_idname]['colors']
+
+                        part2 = part1.split(align=True)
+                        if self.width > 400:
+                            for element in elements:
+                                part2.prop(viewer_node, display[element], text='', icon=elements[element])
+
+                        if self.width > 300:
+                            for element in elements:
+                                part2.prop(viewer_node, color[element], text='')
+
+                        if viewer_node.bl_idname == "SvIDXViewer28":
+                            if self.width > 400:
+                                part2.prop(viewer_node, "draw_bface", text='', icon="GHOST_ENABLED")
+
+                        icon_name = "HIDE_OFF" if viewer_node.activate else "HIDE_ON"
+                        part2.prop(viewer_node, "activate", toggle=True, icon=icon_name, text='')
+
+                    else:  # no viewer node for viewer entry => show remove option
+                        part2 = part1.split(align=True)
+                        # add the REMOVE VIEWER button
+                        rm_button = part2.operator(vcb, text='', icon='REMOVE')
+                        rm_button.function_name = "ops_remove_viewer"
+                        rm_button.layer_name = layer.name
+                        rm_button.layer_id = layer.layer_id
+                        rm_button.viewer_id = viewer.viewer_id
+
+                # show the ADD NEW VIEWER to layer button
+                # max number of viewer enties <= number of available viewers
+                if len(layer.viewers) < self.number_of_viewer_nodes():
+                    add_button = box.row().operator(lcb, text='', icon='PLUS')
+                    add_button.function_name = "ops_add_new_viewer"
+                    add_button.layer_name = layer.name
+                    add_button.layer_id = layer.layer_id
+
+        # show the ADD NEW LAYER button
+        layout.row().operator(lcb, text='', icon='COLLECTION_NEW').function_name = "ops_add_new_layer"
+
+    def ops_add_new_viewer(self, op):
+        debug("* VLN: SvViewerLayerNode: ops_add_new_viewer")
+        layer_name = op.layer_name
+        layer_id = op.layer_id
+        debug("add new viewer to layer: %s", layer_name)
+        debug("number of layers: %d", len(self.layers))
+        for layer in self.layers:
+            if layer.layer_id == layer_id:
+                viewer_id = self.get_next_viewer_id()
+                debug("creating viewer with entry id: %d", viewer_id)
+                viewer = layer.viewers.add()
+                viewer.name = str(viewer_id)
+                viewer.viewer_id = viewer_id
+                debug("mark viewer name empty")
+                viewer.node_name = ''  # trigger a list update
+
+        self.update_layers_viewers_lists()
+
+    def ops_remove_viewer(self, layer_id, viewer_id):
+        debug("* VLN: SvViewerLayerNode: ops_remove_viewer")
+        debug("remove viewer in layer_id: %d with viewer_id: %d", layer_id, viewer_id)
+        for layer in self.layers:
+            if layer.layer_id == layer_id:
+                for index, viewer in enumerate(layer.viewers):
+                    if viewer.viewer_id == viewer_id:
+                        debug("removing viewer from index: %d with viewer_id: %d", index, viewer_id)
+                        debug("viewer name: %s", viewer.node_name)
+                        layer.viewers.remove(index)
+                        self.update_layers_viewers_lists()
+                        return
+
+    def ops_add_new_layer(self, dummy):
+        debug("* VLN: SvViewerLayerNode: ops_add_new_layer")
+        layer = self.layers.add()
+        layer.name = self.get_next_default_layer_name()
+        layer.layer_id = self.get_next_layer_id()
+        debug("add new layer: %s", layer.name)
+
+    def ops_remove_layer(self, op):
+        debug("* VLN: SvViewerLayerNode: ops_remove_layer")
+        layer_name = op.layer_name
+        layer_id = op.layer_id
+        debug("remove layer: %s", layer_name)
+        for index, layer in enumerate(self.layers):
+            if layer.layer_id == layer_id:
+                debug("removing layer from index: %d", index)
+                self.layers.remove(index)
+                return
+
+    def ops_toggle_layer_visibility(self, op):
+        debug("* VLN: SvViewerLayerNode: ops_toggle_layer_visibility")
+        layer_name = op.layer_name
+        layer_id = op.layer_id
+        debug("toggle layer: %s", layer_name)
+        tree_nodes = self.id_data.nodes
+        for layer in self.layers:
+            if layer.layer_id == layer_id:
+                # check layer's viewers active state
+                status = self.layer_visibility_status(layer)
+
+                new_status = self.new_status(status)
+
+                for viewer in layer.viewers:
+                    viewer_node = tree_nodes.get(viewer.node_name)
+                    if viewer_node:
+                        viewer_node.activate = new_status
+
+    def ops_toggle_all_layer_visibility(self, dummy):
+        debug("* VLN: SvViewerLayerNode: ops_toggle_all_layer_visibility")
+        status = 0
+        for layer in self.layers:
+            status = status | self.layer_visibility_status(layer)
+
+        new_status = self.new_status(status)
+
+        tree_nodes = self.id_data.nodes
+        for layer in self.layers:
+            for viewer in layer.viewers:
+                viewer_node = tree_nodes.get(viewer.node_name)
+                if viewer_node:
+                    viewer_node.activate = new_status
+
+    def ops_toggle_all_layer_expansion(self, dummy):
+        debug("* VLN: SvViewerLayerNode: ops_toggle_all_layer_expansion")
+        status = 0
+        for layer in self.layers:
+            if layer.expand:
+                status = status | 1
+            else:
+                status = status | 2
+
+        new_status = self.new_status(status)
+
+        for layer in self.layers:
+            layer.expand = new_status
+
+    def ops_toggle_element_visibility(self, op):
+        ''' Toggle visibility for vert, edge or face elements '''
+        debug("* VLN: ops_toggle_element_visibility")
+
+        element = op.element_type  # vert, edge or face
+
+        tree_nodes = self.id_data.nodes
+
+        status = 0
+        for layer in self.layers:
+            for viewer in layer.viewers:
+                viewer_node = tree_nodes.get(viewer.node_name)
+
+                if viewer_node:
+                    attribute = viewer_dict[viewer_node.bl_idname]['display'][element]
+                    viewer_status = getattr(viewer_node, attribute)
+
+                    if viewer_status:  # accumulate visible and invisible status
+                        status = status | 1
+                    else:
+                        status = status | 2
+
+        new_status = self.new_status(status)
+
+        for layer in self.layers:
+            for viewer in layer.viewers:
+                viewer_node = tree_nodes.get(viewer.node_name)
+                if viewer_node:
+                    attribute = viewer_dict[viewer_node.bl_idname]['display'][element]
+                    setattr(viewer_node, attribute, new_status)
+
+    def sv_init(self, context):
+        self.width = 432
+
+    def process(self):
+        ...
+
+
+classes = SvLayerOperatorCallback, SvViewerOperatorCallback, SvViewerGroup, SvViewerLayerGroup, SvViewerLayerNode
+
+
+def register():
+    debug("* VLN: REGISTER the SvViewerLayerNode classes")
+    _ = [bpy.utils.register_class(cls) for cls in classes]
+    # setup subscriptions (useful when reloading the addon)
+    subscribe_to_viewer_nodes_name_changes()
+
+
+def unregister():
+    _ = [bpy.utils.unregister_class(cls) for cls in reversed(classes)]


### PR DESCRIPTION
Continue the developing of a **viewer layer node** (based on the #2111 conversation) and get a firsts incarnation of such node out there. This is an early stage developing (nothing much as been added since the issue was raised) and will need more brainstorming and playing around to get it to a polished state. 

Considering that since this issue was originally started (2.79) Blender 2.8x has revamped its layering/collection system we might think differently about how we can implement such a viewer layer node in SV. Can (should) we tap into the hierarchical collection system B28 offers? Let’s start the conversation :)

![SV-ViewerLayerNode-Example1-loress](https://user-images.githubusercontent.com/2083719/80288923-46c51d00-8709-11ea-988c-02e2d84ff66d.jpg)


<details>
<summary>Live Demo</summary>

![SV-ViewerLayersNode-demo1](https://user-images.githubusercontent.com/2083719/79697128-e5a3d200-824e-11ea-896d-7acdcf307dc7.gif)

</details>

ToDo (Feature List):

- [x] Make Layer names editable
- [x] Toggle visibility icon (“show/hide” eye icon)
- [x] Add option to remove viewers within layers
- [x] Add option to remove layers
- [ ] Update layer viewer lists when viewer nodes are removed from the node tree
- [x] Update layer viewer lists when viewer nodes are renamed
- [x] Make layers collapse/expand (add toggle to show/hide the list of viewers in a layer)
- [ ] Add option to add a layer to another layer (hierarchical layers, similar to BL collections)
- [x] Update layer visibility icon (status) based on its children status
- [x] Add option to avoid duplicate viewers in a layer