### PR TITLE
Animatable nodes

### DIFF
--- a/node_tree.py
+++ b/node_tree.py
@@ -239,6 +239,14 @@ class SvNodeTreeCommon(object):
         else:
             process_from_nodes(self.get_groups())
 
+    def animation_update(self):
+        animated_nodes = []
+        for node in self.nodes:
+            if hasattr(node, 'is_animatable'):
+                if node.is_animatable:
+                    animated_nodes.append(node)
+        process_from_nodes(animated_nodes)
+
 class SvGenericUITooltipOperator(bpy.types.Operator):
     arg: StringProperty()
     bl_idname = "node.sv_generic_ui_tooltip"
@@ -367,7 +375,8 @@ class SverchCustomTree(NodeTree, SvNodeTreeCommon):
         For animation callback/handler
         """
         if self.sv_animate:
-            process_tree(self)
+            self.animation_update()
+            # process_tree(self)
 
     def process(self):
         """

--- a/nodes/analyzer/object_insolation.py
+++ b/nodes/analyzer/object_insolation.py
@@ -24,6 +24,7 @@ from mathutils.bvhtree import BVHTree
 
 from bpy.props import BoolProperty, IntProperty
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.data_structure import (updateNode, match_long_repeat, match_cross)
 from sverchok.utils.logging import debug, info, error
 
@@ -56,7 +57,7 @@ class FakeObj(object):
 
 
 
-class SvOBJInsolationNode(bpy.types.Node, SverchCustomTreeNode):
+class SvOBJInsolationNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     ''' Insolation by RayCast Object '''
     bl_idname = 'SvOBJInsolationNode'
     bl_label = 'Object ID Insolation'
@@ -80,7 +81,11 @@ class SvOBJInsolationNode(bpy.types.Node, SverchCustomTreeNode):
         so('SvStringsSocket',  "Hours")
         # self.inputs[2].prop[2] = -1  # z down   # <--- mayybe?
 
+    def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
+
     def draw_buttons_ext(self, context, layout):
+        self.animatable_buttons(layout)
         row = layout.row(align=True)
         row.prop(self,    "mode",   text="In Mode")
         row.prop(self,    "sort_critical",text="Limit")

--- a/nodes/analyzer/object_insolation.py
+++ b/nodes/analyzer/object_insolation.py
@@ -82,10 +82,10 @@ class SvOBJInsolationNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode
         # self.inputs[2].prop[2] = -1  # z down   # <--- mayybe?
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
 
     def draw_buttons_ext(self, context, layout):
-        self.animatable_buttons(layout)
+        self.draw_animatable_buttons(layout)
         row = layout.row(align=True)
         row.prop(self,    "mode",   text="In Mode")
         row.prop(self,    "sort_critical",text="Limit")

--- a/nodes/generator/script1_lite.py
+++ b/nodes/generator/script1_lite.py
@@ -33,6 +33,7 @@ from sverchok.utils.snlite_importhelper import (
 from sverchok.utils.snlite_utils import vectorize, ddir
 from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata, pydata_from_bmesh
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.data_structure import updateNode
 
 
@@ -105,7 +106,7 @@ class SvScriptNodeLiteTextImport(bpy.types.Operator):
         return {'FINISHED'}
 
 
-class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode):
+class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     ''' snl SN Lite /// a lite version of SN '''
 
     bl_idname = 'SvScriptNodeLite'
@@ -459,13 +460,15 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode):
     def draw_buttons(self, context, layout):
         sn_callback = 'node.scriptlite_ui_callback'
 
-        col = layout.column(align=True)
-        row = col.row()
-
         if not self.script_str:
+            col = layout.column(align=True)
+            row = col.row()
             row.prop_search(self, 'script_name', bpy.data, 'texts', text='', icon='TEXT')
             row.operator(sn_callback, text='', icon='PLUGIN').fn_name = 'load'
         else:
+            self.animatable_buttons(layout, icon_only=True)
+            col = layout.column(align=True)
+            row = col.row()
             row.operator(sn_callback, text='Reload').fn_name = 'load'
             row.operator(sn_callback, text='Clear').fn_name = 'nuke_me'
 

--- a/nodes/generator/script1_lite.py
+++ b/nodes/generator/script1_lite.py
@@ -466,7 +466,7 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
             row.prop_search(self, 'script_name', bpy.data, 'texts', text='', icon='TEXT')
             row.operator(sn_callback, text='', icon='PLUGIN').fn_name = 'load'
         else:
-            self.animatable_buttons(layout, icon_only=True)
+            self.draw_animatable_buttons(layout, icon_only=True)
             col = layout.column(align=True)
             row = col.row()
             row.operator(sn_callback, text='Reload').fn_name = 'load'

--- a/nodes/generators_extended/mesh_eval.py
+++ b/nodes/generators_extended/mesh_eval.py
@@ -292,7 +292,7 @@ class SvMeshEvalNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
                     update=updateNode)
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         row = layout.row()
         row.prop_search(self, 'filename', bpy.data, 'texts', text='', icon='TEXT')
         row = layout.row()

--- a/nodes/generators_extended/mesh_eval.py
+++ b/nodes/generators_extended/mesh_eval.py
@@ -28,6 +28,7 @@ import json
 import io
 
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.data_structure import fullList, updateNode, dataCorrect, match_long_repeat
 from sverchok.utils.script_importhelper import safe_names
 from sverchok.utils.logging import exception, info
@@ -265,7 +266,7 @@ class SvJsonFromMesh(bpy.types.Operator):
         bpy.data.texts[text].clear()
         bpy.data.texts[text].write(values)
 
-class SvMeshEvalNode(bpy.types.Node, SverchCustomTreeNode):
+class SvMeshEvalNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     """
     Triggers: mesh JSON eval expression
     Tooltip: Generate mesh from parametric JSON expression
@@ -291,6 +292,7 @@ class SvMeshEvalNode(bpy.types.Node, SverchCustomTreeNode):
                     update=updateNode)
 
     def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
         row = layout.row()
         row.prop_search(self, 'filename', bpy.data, 'texts', text='', icon='TEXT')
         row = layout.row()

--- a/nodes/generators_extended/profile_mk3.py
+++ b/nodes/generators_extended/profile_mk3.py
@@ -23,6 +23,7 @@ from bpy.props import BoolProperty, StringProperty, EnumProperty, FloatProperty,
 from mathutils import Vector
 
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.core.socket_data import SvNoDataError
 from sverchok.data_structure import updateNode, match_long_repeat
 from sverchok.utils.logging import info, debug, warning
@@ -395,7 +396,7 @@ class SvProfileImportOperator(bpy.types.Operator):
 # Node class
 #################################
 
-class SvProfileNodeMK3(bpy.types.Node, SverchCustomTreeNode):
+class SvProfileNodeMK3(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     '''
     Triggers: svg-like 2d profiles
     Tooltip: Generate multiple parameteric 2d profiles using SVG like syntax
@@ -444,6 +445,7 @@ class SvProfileNodeMK3(bpy.types.Node, SverchCustomTreeNode):
         description="If distance between first and last point is less than this, X command will remove the last point")
 
     def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
         layout.prop(self, 'selected_axis', expand=True)
         layout.prop_search(self, 'filename', bpy.data, 'texts', text='', icon='TEXT')
 

--- a/nodes/generators_extended/profile_mk3.py
+++ b/nodes/generators_extended/profile_mk3.py
@@ -445,7 +445,7 @@ class SvProfileNodeMK3(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
         description="If distance between first and last point is less than this, X command will remove the last point")
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         layout.prop(self, 'selected_axis', expand=True)
         layout.prop_search(self, 'filename', bpy.data, 'texts', text='', icon='TEXT')
 

--- a/nodes/logic/neuro_elman.py
+++ b/nodes/logic/neuro_elman.py
@@ -195,7 +195,7 @@ class SvNeuroElman1LNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode)
         self.outputs.new('SvStringsSocket', "result")
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         handle_name = self.name + self.id_data.name
         layout.prop(self, "k_learning", text="koeff learning")
         layout.prop(self, "gisterezis", text="gisterezis")

--- a/nodes/logic/neuro_elman.py
+++ b/nodes/logic/neuro_elman.py
@@ -22,6 +22,7 @@ import bpy
 from bpy.props import BoolProperty, IntProperty, StringProperty, FloatProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.data_structure import updateNode
 from sverchok.data_structure import handle_read, handle_write
 
@@ -167,7 +168,7 @@ class SvNeuro_Elman:
 
 
 
-class SvNeuroElman1LNode(bpy.types.Node, SverchCustomTreeNode):
+class SvNeuroElman1LNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     ''' Neuro Elman 1 Layer '''
     bl_idname = 'SvNeuroElman1LNode'
     bl_label = '*Neuro Elman 1 Layer'
@@ -194,6 +195,7 @@ class SvNeuroElman1LNode(bpy.types.Node, SverchCustomTreeNode):
         self.outputs.new('SvStringsSocket', "result")
 
     def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
         handle_name = self.name + self.id_data.name
         layout.prop(self, "k_learning", text="koeff learning")
         layout.prop(self, "gisterezis", text="gisterezis")

--- a/nodes/modifier_change/pulga_physics.py
+++ b/nodes/modifier_change/pulga_physics.py
@@ -21,6 +21,7 @@ from numpy import array
 import bpy
 from bpy.props import IntProperty, StringProperty, BoolProperty, FloatProperty, FloatVectorProperty
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.data_structure import updateNode, node_id, match_long_repeat
 from sverchok.utils.pulga_physics_core import pulga_system_init
 
@@ -45,7 +46,7 @@ def fill_past_file(p, location):
     text.clear()
     text.write(''.join(str(p)))
 
-class SvPulgaPhysicsNode(bpy.types.Node, SverchCustomTreeNode):
+class SvPulgaPhysicsNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     '''
     Triggers: Springs, Cloth
     Tooltip: Physics Engine
@@ -151,6 +152,9 @@ class SvPulgaPhysicsNode(bpy.types.Node, SverchCustomTreeNode):
             for i in range(len(data)):
                 self.accumulativity_set_data([], i)
             self.accumulative_parse = False
+            self.is_animatable =False
+        else:
+            self.is_animatable =True
 
         if not data:
             self.node_cache[0] = {}
@@ -399,6 +403,7 @@ class SvPulgaPhysicsNode(bpy.types.Node, SverchCustomTreeNode):
         so(vs, 'Pins Reactions')
 
         self.update_sockets(context)
+        self.is_animatable = False
 
     def draw_buttons(self, context, layout):
         '''draw buttons on the node'''

--- a/nodes/modifier_make/sweep_modulator.py
+++ b/nodes/modifier_make/sweep_modulator.py
@@ -50,7 +50,7 @@ class SvSweepModulator(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
         onew("SvStringsSocket", "Faces")
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         row = layout.row(align=True)
         row.prop(self, "active", text="ACTIVATE")
         row = layout.row(align=True)

--- a/nodes/modifier_make/sweep_modulator.py
+++ b/nodes/modifier_make/sweep_modulator.py
@@ -9,6 +9,7 @@ import numpy as np
 
 import bpy
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.data_structure import updateNode
 from sverchok.core.handlers import get_sv_depsgraph, set_sv_depsgraph_need
 
@@ -20,7 +21,7 @@ def interp_v3l_v3v3(a, b, t):
     else: return ((1.0 - t) * a) + (t * b)
 
 
-class SvSweepModulator(bpy.types.Node, SverchCustomTreeNode):
+class SvSweepModulator(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
 
     """
     Triggers: SvSweepModulator
@@ -49,8 +50,9 @@ class SvSweepModulator(bpy.types.Node, SverchCustomTreeNode):
         onew("SvStringsSocket", "Faces")
 
     def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
         row = layout.row(align=True)
-        row.prop(self, "active", text="UPDATE")
+        row.prop(self, "active", text="ACTIVATE")
         row = layout.row(align=True)
         row.prop(self, "construct_name", text="", icon="EXPERIMENTAL")
         row = layout.row(align=True)

--- a/nodes/network/udp_client.py
+++ b/nodes/network/udp_client.py
@@ -64,7 +64,7 @@ class UdpClientNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     active: BoolProperty(default=False, name='Active')
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         layout.prop(self, 'active', text='Active')
         layout.prop(self, 'ip', text='IP')
         layout.prop(self, 'port', text='Port')

--- a/nodes/network/udp_client.py
+++ b/nodes/network/udp_client.py
@@ -21,11 +21,12 @@ import socket
 import bpy
 from bpy.props import IntProperty, FloatProperty, EnumProperty, StringProperty, BoolProperty
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.utils.profile import profile
 from sverchok.data_structure import updateNode
 
 
-class UdpClientNode(bpy.types.Node, SverchCustomTreeNode):
+class UdpClientNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
 
     bl_idname = 'UdpClientNode'
     bl_label = 'UDP Client'
@@ -63,6 +64,7 @@ class UdpClientNode(bpy.types.Node, SverchCustomTreeNode):
     active: BoolProperty(default=False, name='Active')
 
     def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
         layout.prop(self, 'active', text='Active')
         layout.prop(self, 'ip', text='IP')
         layout.prop(self, 'port', text='Port')

--- a/nodes/number/curve_mapper.py
+++ b/nodes/number/curve_mapper.py
@@ -20,6 +20,8 @@ import bpy
 from bpy.props import BoolProperty, FloatProperty, EnumProperty, StringProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
+
 from sverchok.data_structure import updateNode, list_match_func, numpy_list_match_modes, numpy_list_match_func
 from sverchok.utils.sv_itertools import recurse_f_level_control
 from sverchok.utils.sv_manual_curves_utils import get_valid_evaluate_function_legacy, get_valid_evaluate_function, get_valid_curve
@@ -39,7 +41,7 @@ def curve_mapper(params, constant, matching_f):
 
     return result
 
-class SvCurveMapperNode(bpy.types.Node, SverchCustomTreeNode):
+class SvCurveMapperNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     """
     Triggers: Manual Curve remap
     Tooltip:  Map input list using a manually defined curve
@@ -49,56 +51,10 @@ class SvCurveMapperNode(bpy.types.Node, SverchCustomTreeNode):
     bl_label = 'Curve Mapper'
     bl_icon = 'NORMALIZE_FCURVES'
 
-    def update_sockets(self, context):
-        if not self.inputs["Old Min"].is_linked:
-            self.inputs["Old Min"].hide_safe = self.auto_limits
-        if not self.inputs["Old Max"].is_linked:
-            self.inputs["Old Max"].hide_safe = self.auto_limits
-        updateNode(self, context)
-
-    old_min: FloatProperty(
-        name='Old Min', description='Old Min',
-        default=0, update=updateNode)
-
-    old_max: FloatProperty(
-        name='Old Max', description='Old Max',
-        default=1, update=updateNode)
-
-    new_min: FloatProperty(
-        name='New Min', description='New Min',
-        default=0, update=updateNode)
-
-    new_max: FloatProperty(
-        name='New Max', description='New Max',
-        default=10, update=updateNode)
-
     value: FloatProperty(
         name='Value', description='New Max',
         default=.5, update=updateNode)
 
-    def update_mapper(self, context):
-        if self.update_curve:
-            self.update_curve = False
-            updateNode(self,context)
-
-    update_curve: BoolProperty(
-        name='Update', description='Update Node with updated curve',
-        default=False, update=update_mapper)
-
-    auto_limits: BoolProperty(
-        name='List limits', description='Use old min and old max from list',
-        default=False, update=update_sockets)
-
-    list_match: EnumProperty(
-        name="List Match",
-        description="Behavior on different list lengths",
-        items=numpy_list_match_modes, default="REPEAT",
-        update=updateNode)
-
-    output_numpy: BoolProperty(
-        name='Output NumPy',
-        description='Output NumPy arrays',
-        default=False, update=updateNode)
     n_id: StringProperty(default='')
 
     def sv_init(self, context):
@@ -116,13 +72,14 @@ class SvCurveMapperNode(bpy.types.Node, SverchCustomTreeNode):
             layout.label(text="Connect input to activate")
             return
         try:
+            self.animatable_buttons(layout, icon_only=True)
             n_id = self.node_id
             tnode = m.nodes['RGB Curves' + n_id]
             if not tnode:
                 layout.label(text="Connect input to activate")
                 return
             layout.template_curve_mapping(tnode, "mapping", type="NONE")
-            layout.prop(self, "update_curve", toggle=True)
+
         except AttributeError:
             layout.label(text="Connect input to activate")
             return
@@ -141,11 +98,10 @@ class SvCurveMapperNode(bpy.types.Node, SverchCustomTreeNode):
         outputs = self.outputs
         n_id = self.node_id
         evaluate = get_evaluator(node_group_name, 'RGB Curves'+n_id)
-        # no outputs, end early.
+
         if not outputs['Value'].is_linked:
             return
         result = []
-
         floats_in = inputs[0].sv_get(default=[[]], deepcopy=False)
 
         desired_levels = [2]

--- a/nodes/number/curve_mapper.py
+++ b/nodes/number/curve_mapper.py
@@ -82,7 +82,7 @@ class SvCurveMapperNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
             layout.label(text="Connect input to activate")
             return
         try:
-            self.animatable_buttons(layout, icon_only=True)
+            self.draw_animatable_buttons(layout, icon_only=True)
             tnode = m.nodes[self._get_curve_node_name()]
             if not tnode:
                 layout.label(text="Connect input to activate")

--- a/nodes/object_nodes/armature_analyzer.py
+++ b/nodes/object_nodes/armature_analyzer.py
@@ -18,10 +18,12 @@
 
 import bpy
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
+
 from sverchok.data_structure import match_long_cycle as mlc, updateNode
 
 
-class SvArmaturePropsNode(bpy.types.Node, SverchCustomTreeNode):
+class SvArmaturePropsNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     '''Armature object props'''
     bl_idname = 'SvArmaturePropsNode'
     bl_label = 'Armature Props'
@@ -37,6 +39,9 @@ class SvArmaturePropsNode(bpy.types.Node, SverchCustomTreeNode):
         self.outputs.new('SvStringsSocket', 'Length of bone')
         self.outputs.new('SvMatrixSocket', "local bone matrix")
         self.outputs.new('SvObjectSocket', "Armature Object")
+        
+    def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
 
     def process(self):
         armobj, selm = self.inputs

--- a/nodes/object_nodes/armature_analyzer.py
+++ b/nodes/object_nodes/armature_analyzer.py
@@ -41,7 +41,7 @@ class SvArmaturePropsNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode
         self.outputs.new('SvObjectSocket', "Armature Object")
         
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
 
     def process(self):
         armobj, selm = self.inputs

--- a/nodes/object_nodes/assign_materials.py
+++ b/nodes/object_nodes/assign_materials.py
@@ -141,7 +141,7 @@ class SvAssignMaterialListNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatabl
         self.outputs.new('SvObjectSocket', 'Object')
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         layout.template_list("UI_UL_SvMaterialUiList", "materials", self, "materials", self, "selected")
         row = layout.row(align=True)
 

--- a/nodes/object_nodes/assign_materials.py
+++ b/nodes/object_nodes/assign_materials.py
@@ -22,6 +22,8 @@ import bpy
 from bpy.props import StringProperty, IntProperty, CollectionProperty, PointerProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
+
 from sverchok.data_structure import updateNode, match_long_repeat, fullList
 from sverchok.utils.logging import info, debug
 
@@ -118,7 +120,7 @@ class SvMoveMaterial(bpy.types.Operator):
             updateNode(node, context)
         return {'FINISHED'}
 
-class SvAssignMaterialListNode(bpy.types.Node, SverchCustomTreeNode):
+class SvAssignMaterialListNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     """
     Triggers: material list
     Tooltip: Assign the list of materials to the object
@@ -139,6 +141,7 @@ class SvAssignMaterialListNode(bpy.types.Node, SverchCustomTreeNode):
         self.outputs.new('SvObjectSocket', 'Object')
 
     def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
         layout.template_list("UI_UL_SvMaterialUiList", "materials", self, "materials", self, "selected")
         row = layout.row(align=True)
 

--- a/nodes/object_nodes/closest_point_on_mesh2.py
+++ b/nodes/object_nodes/closest_point_on_mesh2.py
@@ -49,9 +49,9 @@ class SvPointOnMeshNodeMK2(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNod
         so('SvStringsSocket', "FaceINDEX")
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
     def draw_buttons_ext(self, context, layout):
-        self.animatable_buttons(layout)
+        self.draw_animatable_buttons(layout)
         row = layout.row(align=True)
         row.prop(self, "mode", text="In Mode")
         row.prop(self, "mode2", text="Out Mode")

--- a/nodes/object_nodes/closest_point_on_mesh2.py
+++ b/nodes/object_nodes/closest_point_on_mesh2.py
@@ -21,10 +21,12 @@ import mathutils
 from mathutils import Vector
 from bpy.props import FloatProperty, BoolProperty
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
+
 from sverchok.data_structure import (updateNode, second_as_first_cycle)
 
 
-class SvPointOnMeshNodeMK2(bpy.types.Node, SverchCustomTreeNode):
+class SvPointOnMeshNodeMK2(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     ''' Point on Mesh '''
     bl_idname = 'SvPointOnMeshNodeMK2'
     bl_label = 'Object ID Point on Mesh MK2' #new is pointless name
@@ -46,7 +48,10 @@ class SvPointOnMeshNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         so('SvVerticesSocket', "Normal_on_mesh")
         so('SvStringsSocket', "FaceINDEX")
 
+    def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
     def draw_buttons_ext(self, context, layout):
+        self.animatable_buttons(layout)
         row = layout.row(align=True)
         row.prop(self, "mode", text="In Mode")
         row.prop(self, "mode2", text="Out Mode")

--- a/nodes/object_nodes/color_uv_texture.py
+++ b/nodes/object_nodes/color_uv_texture.py
@@ -22,10 +22,12 @@ from mathutils.geometry import barycentric_transform
 import numpy as np
 from bpy.props import BoolProperty, StringProperty, FloatVectorProperty
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
+
 from sverchok.data_structure import (updateNode, second_as_first_cycle as safc)
 
 
-class SvMeshUVColorNode(bpy.types.Node, SverchCustomTreeNode):
+class SvMeshUVColorNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     ''' Find pixel on UV texture from surface'''
     bl_idname = 'SvMeshUVColorNode'
     bl_label = 'Set UV Color'
@@ -39,6 +41,7 @@ class SvMeshUVColorNode(bpy.types.Node, SverchCustomTreeNode):
         size=4, min=0.0, max=1.0, subtype='COLOR', update=updateNode)
 
     def draw_buttons(self, context,   layout):
+        self.animatable_buttons(layout, icon_only=True)
         layout.prop_search(self, 'object_ref', bpy.data, 'objects')
         ob = bpy.data.objects.get(self.object_ref)
         if ob and ob.type == 'MESH':

--- a/nodes/object_nodes/color_uv_texture.py
+++ b/nodes/object_nodes/color_uv_texture.py
@@ -41,7 +41,7 @@ class SvMeshUVColorNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
         size=4, min=0.0, max=1.0, subtype='COLOR', update=updateNode)
 
     def draw_buttons(self, context,   layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         layout.prop_search(self, 'object_ref', bpy.data, 'objects')
         ob = bpy.data.objects.get(self.object_ref)
         if ob and ob.type == 'MESH':

--- a/nodes/object_nodes/custom_mesh_normals.py
+++ b/nodes/object_nodes/custom_mesh_normals.py
@@ -40,7 +40,7 @@ class SvSetCustomMeshNormals(bpy.types.Node, SverchCustomTreeNode, SvAnimatableN
     mode: EnumProperty(items=modes, default='per_Vert', update=updateNode)
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         layout.prop(self, "mode", expand=True)
 
     def sv_init(self, context):

--- a/nodes/object_nodes/custom_mesh_normals.py
+++ b/nodes/object_nodes/custom_mesh_normals.py
@@ -20,10 +20,12 @@
 import bpy
 from bpy.props import EnumProperty
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
+
 from sverchok.data_structure import (updateNode, second_as_first_cycle as safc)
 
 
-class SvSetCustomMeshNormals(bpy.types.Node, SverchCustomTreeNode):
+class SvSetCustomMeshNormals(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     ''' Set custom normals for verts or loops '''
     bl_idname = 'SvSetCustomMeshNormals'
     bl_label = 'Set Custom Normals'
@@ -38,6 +40,7 @@ class SvSetCustomMeshNormals(bpy.types.Node, SverchCustomTreeNode):
     mode: EnumProperty(items=modes, default='per_Vert', update=updateNode)
 
     def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
         layout.prop(self, "mode", expand=True)
 
     def sv_init(self, context):

--- a/nodes/object_nodes/get_asset_properties.py
+++ b/nodes/object_nodes/get_asset_properties.py
@@ -19,6 +19,7 @@
 import bpy
 from bpy.props import EnumProperty
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.data_structure import (updateNode, no_space, enum_item as e)
 
 # class SvGenericCallbackWithParams() mixin  <- refresh
@@ -61,7 +62,7 @@ def frame_from_available2(current_frame, layer):
     return inp_to_index.get(tval, 0)
 
 
-class SvGetAssetProperties(bpy.types.Node, SverchCustomTreeNode):
+class SvGetAssetProperties(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     ''' Get Asset Props '''
     bl_idname = 'SvGetAssetProperties'
     bl_label = 'Object ID Selector'
@@ -159,7 +160,7 @@ class SvGetAssetProperties(bpy.types.Node, SverchCustomTreeNode):
 
     def draw_buttons(self, context, layout):
         # layout.operator('node.'   ,text='refresh from scene')
-
+        self.animatable_buttons(layout, icon_only=True)
         layout.row().prop(self, "Mode", text="data")
 
         if self.Mode == 'objects':

--- a/nodes/object_nodes/get_asset_properties.py
+++ b/nodes/object_nodes/get_asset_properties.py
@@ -160,7 +160,7 @@ class SvGetAssetProperties(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNod
 
     def draw_buttons(self, context, layout):
         # layout.operator('node.'   ,text='refresh from scene')
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         layout.row().prop(self, "Mode", text="data")
 
         if self.Mode == 'objects':

--- a/nodes/object_nodes/getsetprop.py
+++ b/nodes/object_nodes/getsetprop.py
@@ -202,7 +202,7 @@ class SvGetPropNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     def draw_buttons(self, context, layout):
         layout.alert = self.bad_prop
         if len(self.outputs) > 0:
-            self.animatable_buttons(layout, icon_only=True)
+            self.draw_animatable_buttons(layout, icon_only=True)
         layout.prop(self, "prop_name", text="")
 
     def process(self):

--- a/nodes/object_nodes/getsetprop.py
+++ b/nodes/object_nodes/getsetprop.py
@@ -26,6 +26,8 @@ import mathutils
 from mathutils import Matrix, Vector, Euler, Quaternion, Color
 
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
+
 from sverchok.data_structure import Matrix_generate, updateNode, node_id
 
 def parse_to_path(p):
@@ -156,7 +158,7 @@ def secondary_type_assesment(item):
             return "SvColorSocket"
     return None
 
-class SvGetPropNode(bpy.types.Node, SverchCustomTreeNode):
+class SvGetPropNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     ''' Get property '''
     bl_idname = 'SvGetPropNode'
     bl_label = 'Get property'
@@ -199,6 +201,8 @@ class SvGetPropNode(bpy.types.Node, SverchCustomTreeNode):
     
     def draw_buttons(self, context, layout):
         layout.alert = self.bad_prop
+        if len(self.outputs) > 0:
+            self.animatable_buttons(layout, icon_only=True)
         layout.prop(self, "prop_name", text="")
 
     def process(self):

--- a/nodes/object_nodes/getsetprop_mk2.py
+++ b/nodes/object_nodes/getsetprop_mk2.py
@@ -220,7 +220,7 @@ class SvGetPropNodeMK2(bpy.types.Node, SverchCustomTreeNode, SvPropNodeMixin, Sv
             outputs.new(s_type, "Data")
     
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         layout.alert = self.bad_prop
         layout.prop(self, "prop_name", text="")
 

--- a/nodes/object_nodes/getsetprop_mk2.py
+++ b/nodes/object_nodes/getsetprop_mk2.py
@@ -26,6 +26,7 @@ import mathutils
 from mathutils import Matrix, Vector, Euler, Quaternion, Color
 
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.data_structure import Matrix_generate, updateNode, node_id
 
 
@@ -202,7 +203,7 @@ class SvPropNodeMixin():
     prop_name: StringProperty(name='', update=verify_prop)
 
 
-class SvGetPropNodeMK2(bpy.types.Node, SverchCustomTreeNode, SvPropNodeMixin):
+class SvGetPropNodeMK2(bpy.types.Node, SverchCustomTreeNode, SvPropNodeMixin, SvAnimatableNode):
     ''' Get property '''
     bl_idname = 'SvGetPropNodeMK2'
     bl_label = 'Get property MK2'
@@ -219,6 +220,7 @@ class SvGetPropNodeMK2(bpy.types.Node, SverchCustomTreeNode, SvPropNodeMixin):
             outputs.new(s_type, "Data")
     
     def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
         layout.alert = self.bad_prop
         layout.prop(self, "prop_name", text="")
 

--- a/nodes/object_nodes/lattice_analyzer.py
+++ b/nodes/object_nodes/lattice_analyzer.py
@@ -18,10 +18,12 @@
 
 import bpy
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
+
 from sverchok.data_structure import updateNode
 
 
-class SvLatticePropsNode(bpy.types.Node, SverchCustomTreeNode):
+class SvLatticePropsNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     '''Lattice object props'''
     bl_idname = 'SvLatticePropsNode'
     bl_label = 'Lattice Props'
@@ -34,6 +36,9 @@ class SvLatticePropsNode(bpy.types.Node, SverchCustomTreeNode):
         self.outputs.new('SvVerticesSocket', 'init points')
         self.outputs.new('SvVerticesSocket', 'deformed points')
         self.outputs.new('SvObjectSocket', "Lattice Object")
+
+    def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
 
     def process(self):
         lattobj, dep, selm = self.inputs

--- a/nodes/object_nodes/lattice_analyzer.py
+++ b/nodes/object_nodes/lattice_analyzer.py
@@ -38,7 +38,7 @@ class SvLatticePropsNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode)
         self.outputs.new('SvObjectSocket', "Lattice Object")
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
 
     def process(self):
         lattobj, dep, selm = self.inputs

--- a/nodes/object_nodes/material_index.py
+++ b/nodes/object_nodes/material_index.py
@@ -22,9 +22,11 @@ import bpy
 from bpy.props import IntProperty, BoolProperty, EnumProperty
 
 from sverchok.node_tree import SverchCustomTreeNode, throttled
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
+
 from sverchok.data_structure import updateNode, match_long_repeat, fullList, get_data_nesting_level, describe_data_shape
 
-class SvMaterialIndexNode(bpy.types.Node, SverchCustomTreeNode):
+class SvMaterialIndexNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     '''
     Triggers: material index
     Tooltip: Set material index per object face
@@ -67,6 +69,7 @@ class SvMaterialIndexNode(bpy.types.Node, SverchCustomTreeNode):
             update = updateNode)
 
     def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
         layout.prop(self, "all_faces", toggle=True)
         if self.all_faces:
             layout.prop(self, "matching_mode", text='')

--- a/nodes/object_nodes/material_index.py
+++ b/nodes/object_nodes/material_index.py
@@ -69,7 +69,7 @@ class SvMaterialIndexNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode
             update = updateNode)
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         layout.prop(self, "all_faces", toggle=True)
         if self.all_faces:
             layout.prop(self, "matching_mode", text='')

--- a/nodes/object_nodes/object_raycast2.py
+++ b/nodes/object_nodes/object_raycast2.py
@@ -71,13 +71,13 @@ class SvOBJRayCastNodeMK2(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode
         # self.inputs[2].prop[2] = -1  # z down   # <--- mayybe?
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         
     def draw_buttons_ext(self, context, layout):
         row = layout.row(align=True)
         row.prop(self,    "mode",   text="In Mode")
         row.prop(self,    "mode2",   text="Out Mode")
-        self.animatable_buttons(layout)
+        self.draw_animatable_buttons(layout)
 
     def process(self):
         o,s,e = self.inputs

--- a/nodes/object_nodes/object_raycast2.py
+++ b/nodes/object_nodes/object_raycast2.py
@@ -22,6 +22,8 @@ from mathutils import Vector
 from mathutils.bvhtree import BVHTree
 from bpy.props import BoolProperty
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
+
 from sverchok.data_structure import (updateNode, match_long_repeat)
 
 
@@ -47,7 +49,7 @@ class FakeObj(object):
             return [True, tv[0], tv[1], tv[2]]
 
 
-class SvOBJRayCastNodeMK2(bpy.types.Node, SverchCustomTreeNode):
+class SvOBJRayCastNodeMK2(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     ''' RayCast Object '''
     bl_idname = 'SvOBJRayCastNodeMK2'
     bl_label = 'Object ID Raycast MK2'  # new is nonsense name
@@ -68,10 +70,14 @@ class SvOBJRayCastNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         so('SvStringsSocket', "FaceINDEX")
         # self.inputs[2].prop[2] = -1  # z down   # <--- mayybe?
 
+    def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
+        
     def draw_buttons_ext(self, context, layout):
         row = layout.row(align=True)
         row.prop(self,    "mode",   text="In Mode")
         row.prop(self,    "mode2",   text="Out Mode")
+        self.animatable_buttons(layout)
 
     def process(self):
         o,s,e = self.inputs

--- a/nodes/object_nodes/points_from_uv_to_mesh.py
+++ b/nodes/object_nodes/points_from_uv_to_mesh.py
@@ -23,6 +23,8 @@ from mathutils.geometry import barycentric_transform
 import numpy as np
 from bpy.props import BoolProperty, StringProperty, FloatVectorProperty
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
+
 from sverchok.data_structure import (updateNode)
 
 
@@ -50,7 +52,7 @@ def UV(self, object):
     return [vertices_new, polygons_new]
 
 
-class SvUVPointonMeshNode(bpy.types.Node, SverchCustomTreeNode):
+class SvUVPointonMeshNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     ''' Transform vectors from UV space to Object space '''
     bl_idname = 'SvUVPointonMeshNode'
     bl_label = 'Find UV Coord on Surface'
@@ -59,6 +61,7 @@ class SvUVPointonMeshNode(bpy.types.Node, SverchCustomTreeNode):
     object_ref: StringProperty(default='', update=updateNode)
 
     def draw_buttons(self, context,   layout):
+        self.animatable_buttons(layout, icon_only=True)
         layout.prop_search(self, 'object_ref', bpy.data, 'objects')
         ob = bpy.data.objects.get(self.object_ref)
 

--- a/nodes/object_nodes/points_from_uv_to_mesh.py
+++ b/nodes/object_nodes/points_from_uv_to_mesh.py
@@ -61,7 +61,7 @@ class SvUVPointonMeshNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode
     object_ref: StringProperty(default='', update=updateNode)
 
     def draw_buttons(self, context,   layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         layout.prop_search(self, 'object_ref', bpy.data, 'objects')
         ob = bpy.data.objects.get(self.object_ref)
 

--- a/nodes/object_nodes/sample_uv_color.py
+++ b/nodes/object_nodes/sample_uv_color.py
@@ -37,7 +37,7 @@ class SvSampleUVColorNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode
     object_ref: StringProperty(default='', update=updateNode)
 
     def draw_buttons(self, context,   layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         layout.prop_search(self, 'object_ref', bpy.data, 'objects')
         ob = bpy.data.objects.get(self.object_ref)
         if ob and ob.type == 'MESH':

--- a/nodes/object_nodes/sample_uv_color.py
+++ b/nodes/object_nodes/sample_uv_color.py
@@ -22,10 +22,12 @@ from mathutils.geometry import barycentric_transform
 import numpy as np
 from bpy.props import BoolProperty, StringProperty
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
+
 from sverchok.data_structure import (updateNode)
 
 
-class SvSampleUVColorNode(bpy.types.Node, SverchCustomTreeNode):
+class SvSampleUVColorNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     ''' Sample pixel color on UV texture from surface'''
     bl_idname = 'SvSampleUVColorNode'
     bl_label = 'Sample UV Color'
@@ -35,6 +37,7 @@ class SvSampleUVColorNode(bpy.types.Node, SverchCustomTreeNode):
     object_ref: StringProperty(default='', update=updateNode)
 
     def draw_buttons(self, context,   layout):
+        self.animatable_buttons(layout, icon_only=True)
         layout.prop_search(self, 'object_ref', bpy.data, 'objects')
         ob = bpy.data.objects.get(self.object_ref)
         if ob and ob.type == 'MESH':

--- a/nodes/object_nodes/scene_raycast2.py
+++ b/nodes/object_nodes/scene_raycast2.py
@@ -41,7 +41,7 @@ class SvSCNRayCastNodeMK2(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode
         so("SvMatrixSocket", "hited object matrix")
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
 
     def process(self):
         P,N,S,I,O,M = self.outputs

--- a/nodes/object_nodes/scene_raycast2.py
+++ b/nodes/object_nodes/scene_raycast2.py
@@ -18,10 +18,11 @@
 
 import bpy
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.data_structure import (updateNode, match_long_repeat)
 
 
-class SvSCNRayCastNodeMK2(bpy.types.Node, SverchCustomTreeNode):
+class SvSCNRayCastNodeMK2(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     ''' RayCast Scene '''
     bl_idname = 'SvSCNRayCastNodeMK2'
     bl_label = 'Scene Raycast MK2' #new is nonsense name
@@ -38,6 +39,9 @@ class SvSCNRayCastNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         so('SvStringsSocket', "FaceIndex")
         so("SvObjectSocket", "Objects")
         so("SvMatrixSocket", "hited object matrix")
+
+    def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
 
     def process(self):
         P,N,S,I,O,M = self.outputs

--- a/nodes/object_nodes/select_mesh_verts.py
+++ b/nodes/object_nodes/select_mesh_verts.py
@@ -21,10 +21,11 @@ import bpy
 import numpy as np
 from bpy.props import StringProperty, BoolProperty, EnumProperty
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.data_structure import (updateNode, second_as_first_cycle as safc)
 
 
-class SvSelectMeshVerts(bpy.types.Node, SverchCustomTreeNode):
+class SvSelectMeshVerts(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     ''' Select vertices of mesh objects '''
     bl_idname = 'SvSelectMeshVerts'
     bl_label = 'Select Object Vertices'
@@ -41,6 +42,7 @@ class SvSelectMeshVerts(bpy.types.Node, SverchCustomTreeNode):
     mode: EnumProperty(items=modes, default='vertices', update=updateNode)
 
     def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
         layout.prop(self, "deselect_all", text="clear selection")
         layout.prop(self, "mode", expand=True)
         if self.inputs[4].is_linked:

--- a/nodes/object_nodes/select_mesh_verts.py
+++ b/nodes/object_nodes/select_mesh_verts.py
@@ -42,7 +42,7 @@ class SvSelectMeshVerts(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     mode: EnumProperty(items=modes, default='vertices', update=updateNode)
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         layout.prop(self, "deselect_all", text="clear selection")
         layout.prop(self, "mode", expand=True)
         if self.inputs[4].is_linked:

--- a/nodes/object_nodes/set_blenddata2.py
+++ b/nodes/object_nodes/set_blenddata2.py
@@ -21,6 +21,8 @@ import bpy
 from mathutils import Matrix
 from bpy.props import StringProperty
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
+
 from sverchok.data_structure import (updateNode, second_as_first_cycle as safc)
 
 # pylint: disable=w0122
@@ -28,7 +30,7 @@ from sverchok.data_structure import (updateNode, second_as_first_cycle as safc)
 # pylint: disable=w0613
 
 
-class SvSetDataObjectNodeMK2(bpy.types.Node, SverchCustomTreeNode):
+class SvSetDataObjectNodeMK2(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     ''' Set Object Props '''
     bl_idname = 'SvSetDataObjectNodeMK2'
     bl_label = 'Object ID Set MK2'
@@ -38,6 +40,7 @@ class SvSetDataObjectNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     formula: StringProperty(name='formula', default='delta_location', update=updateNode)
 
     def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
         layout.prop(self, "formula", text="")
 
     def sv_init(self, context):

--- a/nodes/object_nodes/set_blenddata2.py
+++ b/nodes/object_nodes/set_blenddata2.py
@@ -40,7 +40,7 @@ class SvSetDataObjectNodeMK2(bpy.types.Node, SverchCustomTreeNode, SvAnimatableN
     formula: StringProperty(name='formula', default='delta_location', update=updateNode)
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         layout.prop(self, "formula", text="")
 
     def sv_init(self, context):

--- a/nodes/object_nodes/set_custom_uv_map.py
+++ b/nodes/object_nodes/set_custom_uv_map.py
@@ -13,7 +13,7 @@ import bpy
 from mathutils import Vector
 
 from sverchok.node_tree import SverchCustomTreeNode
-
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.data_structure import updateNode
 
 
@@ -43,7 +43,7 @@ def set_uv(verts, faces, obj, uv_name, matrix=None):
     obj.data.uv_layers[uv_name].data.foreach_set("uv", unpack_uv)
 
 
-class SvSetCustomUVMap(bpy.types.Node, SverchCustomTreeNode):
+class SvSetCustomUVMap(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     """
     Triggers: Set custom UV map to Blender mesh
 
@@ -58,6 +58,7 @@ class SvSetCustomUVMap(bpy.types.Node, SverchCustomTreeNode):
                                       update=updateNode)
 
     def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
         layout.prop(self, 'uv_name', text='', icon='GROUP_UVS')
 
     def sv_init(self, context):

--- a/nodes/object_nodes/set_custom_uv_map.py
+++ b/nodes/object_nodes/set_custom_uv_map.py
@@ -58,7 +58,7 @@ class SvSetCustomUVMap(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
                                       update=updateNode)
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         layout.prop(self, 'uv_name', text='', icon='GROUP_UVS')
 
     def sv_init(self, context):

--- a/nodes/object_nodes/weightsmk2.py
+++ b/nodes/object_nodes/weightsmk2.py
@@ -19,10 +19,12 @@
 import bpy
 from bpy.props import StringProperty, BoolProperty, FloatProperty
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
+
 from sverchok.data_structure import (updateNode, second_as_first_cycle)
 
 
-class SvVertexGroupNodeMK2(bpy.types.Node, SverchCustomTreeNode):
+class SvVertexGroupNodeMK2(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     ''' Vertex Group mk2'''
     bl_idname = 'SvVertexGroupNodeMK2'
     bl_label = 'Vertex group weights'
@@ -34,6 +36,7 @@ class SvVertexGroupNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     group_name: StringProperty(default='Sv_VGroup', update=updateNode)
 
     def draw_buttons(self, context,   layout):
+        self.animatable_buttons(layout, icon_only=True)
         layout.prop(self, "group_name", text="")
 
     def draw_buttons_ext(self, context, layout):

--- a/nodes/object_nodes/weightsmk2.py
+++ b/nodes/object_nodes/weightsmk2.py
@@ -36,7 +36,7 @@ class SvVertexGroupNodeMK2(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNod
     group_name: StringProperty(default='Sv_VGroup', update=updateNode)
 
     def draw_buttons(self, context,   layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         layout.prop(self, "group_name", text="")
 
     def draw_buttons_ext(self, context, layout):

--- a/nodes/scene/blenddata_to_svdata2.py
+++ b/nodes/scene/blenddata_to_svdata2.py
@@ -20,10 +20,11 @@
 import bpy
 from bpy.props import BoolProperty
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.data_structure import (updateNode)
 from sverchok.core.handlers import get_sv_depsgraph, set_sv_depsgraph_need
 
-class SvObjectToMeshNodeMK2(bpy.types.Node, SverchCustomTreeNode):
+class SvObjectToMeshNodeMK2(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     '''Get Object Data'''
     bl_idname = 'SvObjectToMeshNodeMK2'
     bl_label = 'Object ID Out MK2'
@@ -48,6 +49,7 @@ class SvObjectToMeshNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         self.outputs.new('SvMatrixSocket', "Matrices")
 
     def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
         row = layout.row()
         row.prop(self, "modifiers", text="Post modifiers")
 

--- a/nodes/scene/blenddata_to_svdata2.py
+++ b/nodes/scene/blenddata_to_svdata2.py
@@ -49,7 +49,7 @@ class SvObjectToMeshNodeMK2(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNo
         self.outputs.new('SvMatrixSocket', "Matrices")
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         row = layout.row()
         row.prop(self, "modifiers", text="Post modifiers")
 

--- a/nodes/scene/collection_picker_mk1.py
+++ b/nodes/scene/collection_picker_mk1.py
@@ -8,13 +8,14 @@
 import bpy
 
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.data_structure import updateNode
 
 # pylint: disable=w0613
 # pylint: disable=c0111
 # pylint: disable=c0103
 
-class SvCollectionPicker(bpy.types.Node, SverchCustomTreeNode):
+class SvCollectionPicker(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     
     """
     Triggers: SvCollectionPicker
@@ -40,6 +41,7 @@ class SvCollectionPicker(bpy.types.Node, SverchCustomTreeNode):
         self.outputs.new("SvObjectSocket", "Objects")
 
     def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
         col = layout.column()
         col.prop_search(self, 'collection', bpy.data, 'collections', text='', icon='GROUP')
 

--- a/nodes/scene/collection_picker_mk1.py
+++ b/nodes/scene/collection_picker_mk1.py
@@ -41,7 +41,7 @@ class SvCollectionPicker(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode)
         self.outputs.new("SvObjectSocket", "Objects")
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         col = layout.column()
         col.prop_search(self, 'collection', bpy.data, 'collections', text='', icon='GROUP')
 

--- a/nodes/scene/curve_in.py
+++ b/nodes/scene/curve_in.py
@@ -21,6 +21,7 @@ import mathutils
 
 # from bpy.props import FloatProperty, BoolProperty
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.data_structure import updateNode
 from sverchok.utils.sv_extended_curve_utils import get_points_bezier, get_points_nurbs, offset
 from sverchok.utils.modules.range_utils import frange_count
@@ -133,7 +134,7 @@ def interpolate_radii(spline, segments, interpolation_type='LINEAR'):
     return radii
 
 
-class SvCurveInputNode(bpy.types.Node, SverchCustomTreeNode):
+class SvCurveInputNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     ''' Curve data in '''
     bl_idname = 'SvCurveInputNode'
     bl_label = 'Curve Input'
@@ -158,6 +159,7 @@ class SvCurveInputNode(bpy.types.Node, SverchCustomTreeNode):
         new_o_put("SvMatrixSocket", "matrices")
 
     def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
         layout.prop(self, 'selected_mode', expand=True)
 
     def get_objects(self):

--- a/nodes/scene/curve_in.py
+++ b/nodes/scene/curve_in.py
@@ -159,7 +159,7 @@ class SvCurveInputNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
         new_o_put("SvMatrixSocket", "matrices")
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         layout.prop(self, 'selected_mode', expand=True)
 
     def get_objects(self):

--- a/nodes/scene/frame_info_mk2.py
+++ b/nodes/scene/frame_info_mk2.py
@@ -64,7 +64,7 @@ class SvFrameInfoNodeMK2(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode)
 
     def draw_buttons_ext(self, context, layout):
         self.draw_buttons(context, layout)
-        self.animatable_buttons(layout)
+        self.draw_animatable_buttons(layout)
 
     def process(self):
         scene = bpy.context.scene

--- a/nodes/scene/frame_info_mk2.py
+++ b/nodes/scene/frame_info_mk2.py
@@ -19,9 +19,10 @@
 import bpy
 
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 
 
-class SvFrameInfoNodeMK2(bpy.types.Node, SverchCustomTreeNode):
+class SvFrameInfoNodeMK2(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     ''' Frame Info '''
     bl_idname = 'SvFrameInfoNodeMK2'
     bl_label = 'Frame info'
@@ -60,6 +61,10 @@ class SvFrameInfoNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         # row.operator("screen.keyframe_jump", text="", icon='NEXT_KEYFRAME').next = True
         row.operator("screen.frame_jump", text="", icon='FF').end = True
         row.prop(scene, "frame_current", text="")
+
+    def draw_buttons_ext(self, context, layout):
+        self.draw_buttons(context, layout)
+        layout.prop(self, 'is_animatable')
 
     def process(self):
         scene = bpy.context.scene

--- a/nodes/scene/frame_info_mk2.py
+++ b/nodes/scene/frame_info_mk2.py
@@ -64,7 +64,7 @@ class SvFrameInfoNodeMK2(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode)
 
     def draw_buttons_ext(self, context, layout):
         self.draw_buttons(context, layout)
-        layout.prop(self, 'is_animatable')
+        self.animatable_buttons(layout)
 
     def process(self):
         scene = bpy.context.scene

--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -162,7 +162,7 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
             layout.label(text='--None--')
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         col = layout.column(align=True)
         row = col.row(align=True)
         # row.prop_search(self, 'groupname', bpy.data, 'groups', text='', icon='HAND')
@@ -195,7 +195,7 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
 
     def draw_buttons_ext(self, context, layout):
         layout.prop(self, 'to3d', text="To Control panel")
-        self.animatable_buttons(layout)
+        self.draw_animatable_buttons(layout)
 
     @property
     def draw_3dpanel(self):

--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -162,7 +162,7 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
             layout.label(text='--None--')
 
     def draw_buttons(self, context, layout):
-
+        self.animatable_buttons(layout, icon_only=True)
         col = layout.column(align=True)
         row = col.row(align=True)
         # row.prop_search(self, 'groupname', bpy.data, 'groups', text='', icon='HAND')
@@ -195,7 +195,7 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
 
     def draw_buttons_ext(self, context, layout):
         layout.prop(self, 'to3d', text="To Control panel")
-        layout.prop(self, 'is_animatable')
+        self.animatable_buttons(layout)
 
     @property
     def draw_3dpanel(self):

--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -22,6 +22,7 @@ import bmesh
 
 import sverchok
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.data_structure import updateNode
 from sverchok.utils.sv_bmesh_utils import pydata_from_bmesh
 from sverchok.core.handlers import get_sv_depsgraph, set_sv_depsgraph_need
@@ -52,7 +53,7 @@ class SvOB3Callback(bpy.types.Operator):
 
 
 
-class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
+class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     """
     Triggers: Input Scene Objects
     Tooltip: Get Scene Objects into Sverchok Tree
@@ -95,7 +96,10 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
         default=True, update=updateNode)
 
     object_names: bpy.props.CollectionProperty(type=bpy.types.PropertyGroup)
-    to3d: BoolProperty(default=False, update=updateNode)
+    to3d: BoolProperty(
+        default=False, 
+        description="Show in Sverchok control panel",
+        update=updateNode)
 
 
     def sv_init(self, context):
@@ -190,7 +194,8 @@ class SvObjectsNodeMK3(bpy.types.Node, SverchCustomTreeNode):
         self.draw_obj_names(layout)
 
     def draw_buttons_ext(self, context, layout):
-        layout.prop(self, 'to3d')
+        layout.prop(self, 'to3d', text="To Control panel")
+        layout.prop(self, 'is_animatable')
 
     @property
     def draw_3dpanel(self):

--- a/nodes/scene/particles_MK2.py
+++ b/nodes/scene/particles_MK2.py
@@ -34,10 +34,10 @@ class SvParticlesMK2Node(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode)
     Filt_D: BoolProperty(default=True, update=updateNode)
     
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         
     def draw_buttons_ext(self, context, layout):
-        self.animatable_buttons(layout)
+        self.draw_animatable_buttons(layout)
         layout.prop(self, "Filt_D", text="filter death")
 
     def sv_init(self, context):

--- a/nodes/scene/particles_MK2.py
+++ b/nodes/scene/particles_MK2.py
@@ -20,29 +20,33 @@ import bpy
 import numpy as np
 from bpy.props import BoolProperty
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.data_structure import updateNode, second_as_first_cycle as safc
 from sverchok.core.handlers import get_sv_depsgraph, set_sv_depsgraph_need
 
 
-class SvParticlesMK2Node(bpy.types.Node, SverchCustomTreeNode):
+class SvParticlesMK2Node(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     ''' Particles input node new '''
     bl_idname = 'SvParticlesMK2Node'
     bl_label = 'ParticlesMK2'
     bl_icon = 'PARTICLES'
 
     Filt_D: BoolProperty(default=True, update=updateNode)
-
-    def draw_buttons_ext(self, context,   layout):
+    
+    def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
+        
+    def draw_buttons_ext(self, context, layout):
+        self.animatable_buttons(layout)
         layout.prop(self, "Filt_D", text="filter death")
 
     def sv_init(self, context):
         self.inputs.new('SvObjectSocket', "Object")
         self.inputs.new('SvVerticesSocket', "Velocity")
         self.inputs.new('SvVerticesSocket', "Location")
-        self.inputs.new('SvStringsSocket',  "Size")
+        self.inputs.new('SvStringsSocket', "Size")
         self.outputs.new('SvVerticesSocket', "outLocation")
         self.outputs.new('SvVerticesSocket', "outVelocity")
-        set_sv_depsgraph_need()
 
     def process(self):
         O, V, L, S = self.inputs

--- a/nodes/scene/uv_texture.py
+++ b/nodes/scene/uv_texture.py
@@ -58,7 +58,7 @@ class SvUVtextureNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
         description="Choose UV to load", update=updateNode)
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         layout.prop(self, 'uv', text='uv')
 
     def UV(self, object, uv):

--- a/nodes/scene/uv_texture.py
+++ b/nodes/scene/uv_texture.py
@@ -23,9 +23,10 @@ from sverchok.utils.sv_bmesh_utils import *
 import numpy as np
 
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.data_structure import updateNode
 
-class SvUVtextureNode(bpy.types.Node, SverchCustomTreeNode):
+class SvUVtextureNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     ''' UV texture node '''
     bl_idname = 'SvUVtextureNode'
     bl_label = 'UVtextures'
@@ -57,6 +58,7 @@ class SvUVtextureNode(bpy.types.Node, SverchCustomTreeNode):
         description="Choose UV to load", update=updateNode)
 
     def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
         layout.prop(self, 'uv', text='uv')
 
     def UV(self, object, uv):

--- a/nodes/script/multi_exec.py
+++ b/nodes/script/multi_exec.py
@@ -79,7 +79,7 @@ class SvExecNodeMod(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     dynamic_strings: bpy.props.CollectionProperty(type=SvExecNodeDynaStringItem)
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         row = layout.row(align=True)
         # add() remove() clear() move()
         row.operator(callback_id, text='', icon='ZOOM_IN').cmd = 'add_new_line'
@@ -116,7 +116,7 @@ class SvExecNodeMod(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
 
 
     def draw_buttons_ext(self, context, layout):
-        self.animatable_buttons(layout)
+        self.draw_animatable_buttons(layout)
         col = layout.column(align=True)
         col.operator(callback_id, text='copy to node').cmd = 'copy_from_text'
         col.prop_search(self, 'text', bpy.data, "texts", text="")

--- a/nodes/script/multi_exec.py
+++ b/nodes/script/multi_exec.py
@@ -23,6 +23,7 @@ import bmesh as bm
 import numpy as np
 from bpy.props import StringProperty
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.data_structure import updateNode
 
 callback_id = 'node.callback_execnodemod'
@@ -68,7 +69,7 @@ class SvExecNodeModCallback(bpy.types.Operator):
         return {'FINISHED'}
 
 
-class SvExecNodeMod(bpy.types.Node, SverchCustomTreeNode):
+class SvExecNodeMod(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     '''Execute small script'''
     bl_idname = 'SvExecNodeMod'
     bl_label = 'Exec Node Mod'
@@ -78,6 +79,7 @@ class SvExecNodeMod(bpy.types.Node, SverchCustomTreeNode):
     dynamic_strings: bpy.props.CollectionProperty(type=SvExecNodeDynaStringItem)
 
     def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
         row = layout.row(align=True)
         # add() remove() clear() move()
         row.operator(callback_id, text='', icon='ZOOM_IN').cmd = 'add_new_line'
@@ -114,6 +116,7 @@ class SvExecNodeMod(bpy.types.Node, SverchCustomTreeNode):
 
 
     def draw_buttons_ext(self, context, layout):
+        self.animatable_buttons(layout)
         col = layout.column(align=True)
         col.operator(callback_id, text='copy to node').cmd = 'copy_from_text'
         col.prop_search(self, 'text', bpy.data, "texts", text="")

--- a/nodes/script/sn_functor_b.py
+++ b/nodes/script/sn_functor_b.py
@@ -17,6 +17,7 @@ from mathutils import Matrix, Vector
 from bpy.props import FloatProperty, IntProperty, StringProperty, BoolProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.data_structure import updateNode, node_id
 from sverchok.utils.sv_operator_mixins import SvGenericCallbackWithParams
 from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata, pydata_from_bmesh
@@ -52,7 +53,7 @@ class SvSNPropsFunctor:
         self.inputs.clear()
         self.outputs.clear()
 
-class SvSNFunctorB(bpy.types.Node, SverchCustomTreeNode, SvSNPropsFunctor):
+class SvSNFunctorB(bpy.types.Node, SverchCustomTreeNode, SvSNPropsFunctor, SvAnimatableNode):
     """
     Triggers:  functorB
     Tooltip:  use a simpler nodescript style
@@ -105,12 +106,12 @@ class SvSNFunctorB(bpy.types.Node, SverchCustomTreeNode, SvSNPropsFunctor):
             print('code:', exec_info.tb_frame.f_code)
 
     def draw_buttons(self, context, layout):
-
+        self.animatable_buttons(layout, icon_only=True)
         if not self.loaded:
             row = layout.row()
             row.prop_search(self, 'script_name', bpy.data, 'texts', text='')
             row.operator(sn_callback, text='', icon='PLUGIN').fn_name = 'load'
-
+        
         row = layout.row()
         row.operator(sn_callback, text='Load').fn_name='load'
         row.operator(sn_callback, text='Reset').fn_name='reset'

--- a/nodes/script/sn_functor_b.py
+++ b/nodes/script/sn_functor_b.py
@@ -106,7 +106,7 @@ class SvSNFunctorB(bpy.types.Node, SverchCustomTreeNode, SvSNPropsFunctor, SvAni
             print('code:', exec_info.tb_frame.f_code)
 
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         if not self.loaded:
             row = layout.row()
             row.prop_search(self, 'script_name', bpy.data, 'texts', text='')

--- a/nodes/text/text_in_mk2.py
+++ b/nodes/text/text_in_mk2.py
@@ -32,6 +32,7 @@ import bpy
 from bpy.props import BoolProperty, EnumProperty, StringProperty, IntProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.data_structure import node_id, multi_socket, updateNode
 
 from sverchok.utils.sv_text_io_common import (
@@ -84,7 +85,7 @@ def pop_all_data(node, n_id):
     node.json_data.pop(n_id, None)
 
 
-class SvTextInNodeMK2(bpy.types.Node, SverchCustomTreeNode, CommonTextMixinIO):
+class SvTextInNodeMK2(bpy.types.Node, SverchCustomTreeNode, CommonTextMixinIO, SvAnimatableNode):
     """
     Triggers: Text in from datablock
     Tooltip: Quickly load text from datablock into NodeView
@@ -155,13 +156,17 @@ class SvTextInNodeMK2(bpy.types.Node, SverchCustomTreeNode, CommonTextMixinIO):
     # Sverchok list options
     # choose which socket to interpret data as
     socket_type: EnumProperty(items=socket_types, default='s')
-
+    
+    def set_animatable(self, context):
+        self.is_animatable = self.autoreload
     #interesting but dangerous, TODO
-    autoreload: BoolProperty(default=False, description="Reload text file on every update", name='auto reload')
+    autoreload: BoolProperty(default=False, description="Reload text file on every update", name='auto reload', update=set_animatable)
 
     # to have one socket output
     one_sock: BoolProperty(name='one socket', default=False)
-
+    def sv_init(self, context):
+        self.is_animatable = False
+        
     def draw_buttons_ext(self, context, layout):
         if self.textmode == 'CSV':
             layout.prop(self, 'force_input')

--- a/nodes/transforms/texture_displace.py
+++ b/nodes/transforms/texture_displace.py
@@ -313,7 +313,7 @@ class SvDisplaceNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
             layout.label(text=socket.name+ '. ' + SvGetSocketInfo(socket))
     def draw_buttons(self, context, layout):
         is_vector = self.out_mode in ['RGB to XYZ', 'HSV to XYZ', 'HLS to XYZ']
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         c = layout.split(factor=0.5, align=False)
         r = c.column(align=False)
         r.label(text='Direction'+ ':')

--- a/nodes/transforms/texture_displace.py
+++ b/nodes/transforms/texture_displace.py
@@ -22,6 +22,7 @@ from bpy.props import EnumProperty, FloatProperty, FloatVectorProperty, StringPr
 from mathutils import Vector, Matrix, Color
 
 from sverchok.node_tree import SverchCustomTreeNode, throttled
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.core.socket_data import SvGetSocketInfo
 from sverchok.data_structure import updateNode, list_match_func, numpy_list_match_modes, iter_list_match_func
 from sverchok.utils.sv_itertools import recurse_f_level_control
@@ -179,7 +180,7 @@ mapper_funcs = {
     'Texture Matrix': lambda v, m: m @ v
 }
 
-class SvDisplaceNode(bpy.types.Node, SverchCustomTreeNode):
+class SvDisplaceNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     """
     Triggers: Add texture to verts
     Tooltip: Affect input verts/mesh with a scene texture. Mimics Blender Displace modifier
@@ -312,7 +313,7 @@ class SvDisplaceNode(bpy.types.Node, SverchCustomTreeNode):
             layout.label(text=socket.name+ '. ' + SvGetSocketInfo(socket))
     def draw_buttons(self, context, layout):
         is_vector = self.out_mode in ['RGB to XYZ', 'HSV to XYZ', 'HLS to XYZ']
-
+        self.animatable_buttons(layout, icon_only=True)
         c = layout.split(factor=0.5, align=False)
         r = c.column(align=False)
         r.label(text='Direction'+ ':')

--- a/nodes/vector/texture_evaluate.py
+++ b/nodes/vector/texture_evaluate.py
@@ -22,6 +22,7 @@ from bpy.props import EnumProperty, FloatProperty, FloatVectorProperty, StringPr
 from mathutils import Vector, Matrix, Color
 
 from sverchok.node_tree import SverchCustomTreeNode, throttled
+from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
 from sverchok.core.socket_data import SvGetSocketInfo
 from sverchok.data_structure import updateNode, list_match_func, numpy_list_match_modes, iter_list_match_func, no_space
 from sverchok.utils.sv_itertools import recurse_f_level_control
@@ -73,7 +74,7 @@ mapper_funcs = {
     'Object': lambda v: Vector(v),
 }
 
-class SvTextureEvaluateNode(bpy.types.Node, SverchCustomTreeNode):
+class SvTextureEvaluateNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     """
     Triggers: Scence Texture In
     Tooltip: Evaluate Scene texture at input coordinates
@@ -150,6 +151,7 @@ class SvTextureEvaluateNode(bpy.types.Node, SverchCustomTreeNode):
         else:
             layout.label(text=socket.name+ '. ' + SvGetSocketInfo(socket))
     def draw_buttons(self, context, layout):
+        self.animatable_buttons(layout, icon_only=True)
         b = layout.split(factor=0.33, align=True)
         b.label(text='Mapping:')
         b.prop(self, 'tex_coord_type', expand=False, text='')
@@ -161,6 +163,7 @@ class SvTextureEvaluateNode(bpy.types.Node, SverchCustomTreeNode):
 
     def draw_buttons_ext(self, context, layout):
         '''draw buttons on the N-panel'''
+        self.animatable_buttons(layout)
         self.draw_buttons(context, layout)
         layout.prop(self, 'list_match', expand=False)
 

--- a/nodes/vector/texture_evaluate.py
+++ b/nodes/vector/texture_evaluate.py
@@ -151,7 +151,7 @@ class SvTextureEvaluateNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNo
         else:
             layout.label(text=socket.name+ '. ' + SvGetSocketInfo(socket))
     def draw_buttons(self, context, layout):
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
         b = layout.split(factor=0.33, align=True)
         b.label(text='Mapping:')
         b.prop(self, 'tex_coord_type', expand=False, text='')
@@ -163,7 +163,7 @@ class SvTextureEvaluateNode(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNo
 
     def draw_buttons_ext(self, context, layout):
         '''draw buttons on the N-panel'''
-        self.animatable_buttons(layout)
+        self.draw_animatable_buttons(layout)
         self.draw_buttons(context, layout)
         layout.prop(self, 'list_match', expand=False)
 

--- a/utils/nodes_mixins/sv_animatable_nodes.py
+++ b/utils/nodes_mixins/sv_animatable_nodes.py
@@ -1,0 +1,27 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+from bpy.props import BoolProperty
+
+
+# pylint: disable=c0111
+# pylint: disable=c0103
+
+
+class SvAnimatableNode():
+    '''
+    This mixin is used to add is_animatable property to the node.
+    This property is used on frame change to determine which nodes should be updated
+    
+    To allow the user to control it just add layout.prop(self, 'is_animatable')
+    probably in the draw_buttons_ext function
+    '''
+    is_animatable = BoolProperty(
+        name="Animate Node",
+        description="Update Node on frame change",
+        default=True
+    )

--- a/utils/nodes_mixins/sv_animatable_nodes.py
+++ b/utils/nodes_mixins/sv_animatable_nodes.py
@@ -23,9 +23,9 @@ class SvAnimatableNode():
     And the node class will need to inherit this class.
     
     To allow the user to control it just add in draw buttons function:
-        self.animatable_buttons(layout, icon_only=True)
+        self.draw_animatable_buttons(layout, icon_only=True)
     or/and in the draw_buttons_ext function
-        self.animatable_buttons(layout)
+        self.draw_animatable_buttons(layout)
 
     '''
     is_animatable = BoolProperty(
@@ -46,7 +46,7 @@ class SvAnimatableNode():
         update=refresh_node
     )
     
-    def animatable_buttons(self, layout, icon_only=False):
+    def draw_animatable_buttons(self, layout, icon_only=False):
         row = layout.row(align=True)
         row.prop(self, 'is_animatable', icon='ANIM', icon_only=icon_only)
         row.prop(self, 'refresh', icon='FILE_REFRESH', icon_only=icon_only)

--- a/utils/nodes_mixins/sv_animatable_nodes.py
+++ b/utils/nodes_mixins/sv_animatable_nodes.py
@@ -6,7 +6,7 @@
 # License-Filename: LICENSE
 
 from bpy.props import BoolProperty
-
+from sverchok.data_structure import updateNode
 
 # pylint: disable=c0111
 # pylint: disable=c0103
@@ -25,3 +25,19 @@ class SvAnimatableNode():
         description="Update Node on frame change",
         default=True
     )
+    def refresh_node(self, context):
+        if self.refresh:
+            self.refresh = False
+            updateNode(self, context)
+
+    refresh = BoolProperty(
+        name="Update Node",
+        description="Update Node",
+        default=False,
+        update=refresh_node
+    )
+    
+    def animatable_buttons(self, layout, icon_only=False):
+        row = layout.row(align=True)
+        row.prop(self, 'is_animatable', icon='ANIM', icon_only=icon_only)
+        row.prop(self, 'refresh', icon='FILE_REFRESH', icon_only=icon_only)

--- a/utils/nodes_mixins/sv_animatable_nodes.py
+++ b/utils/nodes_mixins/sv_animatable_nodes.py
@@ -16,7 +16,12 @@ class SvAnimatableNode():
     '''
     This mixin is used to add is_animatable property to the node.
     This property is used on frame change to determine which nodes should be updated
+    The node file will need to have this code line:
 
+    from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
+
+    And the node class will need to inherit this class.
+    
     To allow the user to control it just add in draw buttons function:
         self.animatable_buttons(layout, icon_only=True)
     or/and in the draw_buttons_ext function
@@ -28,6 +33,7 @@ class SvAnimatableNode():
         description="Update Node on frame change",
         default=True
     )
+    
     def refresh_node(self, context):
         if self.refresh:
             self.refresh = False

--- a/utils/nodes_mixins/sv_animatable_nodes.py
+++ b/utils/nodes_mixins/sv_animatable_nodes.py
@@ -16,9 +16,12 @@ class SvAnimatableNode():
     '''
     This mixin is used to add is_animatable property to the node.
     This property is used on frame change to determine which nodes should be updated
-    
-    To allow the user to control it just add layout.prop(self, 'is_animatable')
-    probably in the draw_buttons_ext function
+
+    To allow the user to control it just add in draw buttons function:
+        self.animatable_buttons(layout, icon_only=True)
+    or/and in the draw_buttons_ext function
+        self.animatable_buttons(layout)
+
     '''
     is_animatable = BoolProperty(
         name="Animate Node",


### PR DESCRIPTION
#3128

> Right now when the frame changes a global update is performed which is bad idea because many parts of the node tree may not change during the animation.
> I propose to add a is_animatable property to the nodes that can be affected by a scene change, (Objects in, F-Curve, Objects Id selector...) so when the frame change is done the system calls process_from_animatable in stead of a global process.

Added a mixin SvAnimatableNode with a couple of properties:
`is_animatable`: determine if should be called on frame change
`refresh`:  update the node
and a function to draw the icons on the node:
`self.animatable_buttons(layout, icon_only=True)
`
This are the actual Animatable nodes if you miss any please inform:
![image](https://user-images.githubusercontent.com/10011941/80485696-2c35b280-895a-11ea-9ac7-930bf0cd902d.png)
