### PR TITLE
sv_first_run to False after reload event

### DIFF
--- a/core/links.py
+++ b/core/links.py
@@ -152,6 +152,8 @@ class SvLinks:
         before_sv_links = self.sv_links_cache[tree_id]
 
         if not self.sv_links_cache[tree_id]:
+            print('there was no links memory, creating it')
+            self.create_new_links(node_tree)
             return node_tree.nodes
 
         affected_nodes = []

--- a/core/update_system.py
+++ b/core/update_system.py
@@ -454,7 +454,13 @@ def process_from_nodes(nodes):
     if not nodes:
         return
 
-    node_names = [node.name for node in nodes]
+    node_names = []
+    for node in nodes:
+        if hasattr(node, "name"):
+            node_names.append(node.name)
+        else:
+            print("Something not very important happend in Blender memory", node, type(node))
+
     ng = nodes[0].id_data
     update_list = make_tree_from_nodes(node_names, ng)
     reset_error_some_nodes(ng, update_list)

--- a/menu.py
+++ b/menu.py
@@ -33,6 +33,7 @@ from sverchok.utils.sv_help import build_help_remap
 from sverchok.ui.sv_icons import node_icon, icon
 from sverchok.utils.context_managers import sv_preferences
 from sverchok.utils.extra_categories import get_extra_categories
+from sverchok.core.update_system import set_first_run
 
 class SverchNodeCategory(NodeCategory):
     @classmethod
@@ -560,6 +561,7 @@ def reload_menu():
     register_node_add_operators()
     
     build_help_remap(original_categories)
+    set_first_run(False)
     print("Reload complete, press update")
 
 def register_node_add_operators():


### PR DESCRIPTION
https://github.com/nortikin/sverchok/issues/3128#issuecomment-622388011
The flag sv_first_run had to be turned to False after reloading.

Also i notice something very strange, sometimes, very few times, when asking for node_tree.nodes after reloading it was returning a random panel data!! (or any other kind) really alien stuff but it happens so weirdly that it could not called or reported as a bug, I did as suggested here https://github.com/nortikin/sverchok/issues/3128#issuecomment-622402343  making a extra check for those cases so it does not report an error in stead reports the rejected data