### PR TITLE
"Adaptive tessellate" node

### DIFF
--- a/docs/nodes/surface/adaptive_tessellate.rst
+++ b/docs/nodes/surface/adaptive_tessellate.rst
@@ -46,6 +46,36 @@ the surface's U/V coordinates frame.
 Since the node uses Delaunay triangulation, it is enough to just apply "Dual
 Mesh" node after it to have a Voronoi subdivision.
 
+**Assumptions and Limitations**:
+
+This node uses a relatively simple algorithm without any "AI" or too complex
+computations involved. Thus, the node can not handle all cases. Especially,
+
+* The node can not generate very good subdivision if the surface has places
+  where it is much more stretched along one direction compared to another. For
+  example, if at some place a `[0; 1] x [0; 1]` square of U/V space is mapped
+  onto a rectangular part of the surface with side lengths of 10 and 100 - the
+  generated faces will appear stretched in one direction. However,
+
+   * It will be okay if the rectangle will have sides of 100 and 130.
+   * It will be okay if not only one part of the surface, but the whole surface
+     is much more stretched in one direction than in another.
+
+* The node may not generate too good subdivision near the edges of the surface.
+  Especially this is noticeable when the surface is supposed to be closed.
+* The node can not automatically detect where the surface is supposed to have
+  "shar edges" (if any). If you happen to know where such edges should be (in
+  terms of surface's U/V coordinates), use the "AddUVPoints" input.
+* When surface curvature values are used, the node may not handle very well
+  so-called "signular points" of the surface (if it happens to have any) -
+  places where different values of U/V coordinates are mapped into one point in
+  space. For example, a sphere with usual polar parametrisation has such points
+  at the poles.
+* Surface curvature values are calculated numerically, so they can be not very
+  precise, especially with very "noisy" surfaces.
+* With high number of points to be generated, the node may be slow, especially
+  when surface curvature values are considered.
+
 Inputs
 ------
 

--- a/docs/nodes/surface/adaptive_tessellate.rst
+++ b/docs/nodes/surface/adaptive_tessellate.rst
@@ -65,7 +65,7 @@ computations involved. Thus, the node can not handle all cases. Especially,
 * The node may not generate too good subdivision near the edges of the surface.
   Especially this is noticeable when the surface is supposed to be closed.
 * The node can not automatically detect where the surface is supposed to have
-  "shar edges" (if any). If you happen to know where such edges should be (in
+  "sharp edges" (if any). If you happen to know where such edges should be (in
   terms of surface's U/V coordinates), use the "AddUVPoints" input.
 * When surface curvature values are used, the node may not handle very well
   so-called "signular points" of the surface (if it happens to have any) -
@@ -124,7 +124,7 @@ This node has the following parameters:
    * **Gauss**. Use the absolute value of Gaussian curvature.
    * **Mean**. Use the absolute value of mean curvature.
 
-   Please refer to Wikipedia_ for more information about these terms.
+  Please refer to Wikipedia_ for more information about these terms.
 
 * **Trimming mode**. This defines which part of the surface will be generated,
   when the trimming curve is used. The available options are **Inner** and
@@ -141,7 +141,7 @@ This node has the following parameters:
   This defines the precision of the trimming operation. The default value is 5.
   Usually you do not have to change this value.
 
-.. _Wkikpedia: https://en.wikipedia.org/wiki/Differential_geometry_of_surfaces
+.. _Wikipedia: https://en.wikipedia.org/wiki/Differential_geometry_of_surfaces
 
 Outputs
 -------

--- a/docs/nodes/surface/adaptive_tessellate.rst
+++ b/docs/nodes/surface/adaptive_tessellate.rst
@@ -1,0 +1,170 @@
+Adaptive Tessellate Surface
+===========================
+
+Functionality
+-------------
+
+This node generates an adaptive tessellation for the given surface, i.e. the
+mesh which represents the surface, and has smaller amount of subdivisions in
+places where the mesh is nearly flat and more subdivisions where the surface
+behaivour is more interesting.
+
+In most cases, one converts a Surface object into a mesh by use of "Evaluate
+Surface" node. That node generates a subdivision by cartesian (rectangular)
+grid. 
+However, in some cases a cartesian grid is not suitable. When the surface has
+some "almost flat" places and others, that are much more "bent" or even
+"sharp", a naive cartesian grid approach:
+
+*   generates too many points on flat areas
+*   and generates too few points in the curvy areas.
+
+This node generates points on the surface by following algorithm:
+
+*   Start with a cartesian grid.
+*   Then add more points into "most interesting" grid cells. "Interesting" cells may be defined as:
+
+   *    Having larger area (more precisely, area stretching factor)
+   *    Having bigger curvature value. Curvature may be defined as Gaussian
+     curvature, mean curvature or as bigger one of the principal curvatures.
+
+    Number of vertices, which is to be added into each cell of the grid, is calculated proportionally to this "subdivision factor".
+
+*   Make a Delaunay triangulation of all these points
+    And then map this triangluated thing onto the surface.
+
+This approach can not automatically handle cases where the surface should have
+sharp edges. However, if we just happen to know where these sharp edges are, we
+can manually add points on these edges before building a Delaunay
+triangluation.
+
+Also, this node can trim (cut) the surface by a trimming curve, similar to
+"Tessellate & Trim Surface" node.
+The provided trimming curve is supposed to be planar (flat), and be defined in
+the surface's U/V coordinates frame.
+
+Since the node uses Delaunay triangulation, it is enough to just apply "Dual
+Mesh" node after it to have a Voronoi subdivision.
+
+Inputs
+------
+
+This node has the following inputs:
+
+* **Surface**. The surface to be tessellated. This input is mandatory.
+* **TrimCurve**. The curve used to trim the surface. The curve is supposed to
+  be flat and lying in the XOY plane. This input is optional.
+* **SamplesU**, **SamplesV**. Number of initial subdivisions in U and V
+  directions (for the first step of the algorithm). The default value is 25.
+* **SamplesT**. The number of points to evaluate the trimming curve at. The default value is 100.
+* **Min per cell**. Minimal number of additional vertices, which is to be added
+  into grid cells which have the least value of subdivision factor (area and/or
+  curvature). The default value is 0 - do not add any vertices to such cells.
+* **Max per cell**. Maximum number of additional vertices, which is to be added
+  into grid cells which have the greatest value of subdivision factor (area
+  and/or curvature). The default value is 5.
+* **Seed**. Random seed value. The default value is 0.
+* **AddUVPoints**. Additional points in the surface's UV space, which are to be
+  added into subdivision before calculating Delaunay triangulation. For
+  example, this may be useful to explicitly add vertices in places where the
+  surface should have sharp edges. Only X and Y coordinates of provided
+  vertices will be used. This input is optional.
+
+Parameters
+----------
+
+This node has the following parameters:
+
+* **By Curvature**. Use surface curvature value to distribute additional points
+  on the surface: places with greater curvatuer value will receive more points.
+  The exact meaning of "curvature" is defined by **Curvature** parameter.
+  Checked by default.
+* **By Area**. Use area stretching factor to distribute additional points on
+  the surface. Area stretching factor is defined as area of rectangular grid
+  cell mapped onto the surface divided by area of that cell in surface's UV
+  space. I.e., places where the surface is more stretched, will receive more
+  vertices.
+* **Curvature type**. This parameter is available only when **By Curvature**
+  parameter is enabled. This defines which exactly curvature value of the
+  surface will be used. The available options are:
+
+   * **Maximum**. Use the greater of absolute values of two principal curvature
+     values. This option is the default one.
+   * **Gauss**. Use the absolute value of Gaussian curvature.
+   * **Mean**. Use the absolute value of mean curvature.
+
+   Please refer to Wikipedia_ for more information about these terms.
+
+* **Trimming mode**. This defines which part of the surface will be generated,
+  when the trimming curve is used. The available options are **Inner** and
+  **Outer**. The default value is **Inner**.
+* **Curvature Clip**. This parameter is available only in the N panel of the
+  node, only when the **By Curvature** parameter is enabled. The calculated
+  values of surface curvature will be restricted to do not exceed this number.
+  This is used to ignore places on the surface where it has too high values of
+  curvature (sharp points) - otherwise the algorithm would be placing all the
+  additional points to such places. The default value is 100. Usually you do
+  not have to change this value. Set the parameter to 0 (zero) to disable this
+  part of the algorithm.
+* **Trim Accuracy**. This parameter is available in the node's N panel only.
+  This defines the precision of the trimming operation. The default value is 5.
+  Usually you do not have to change this value.
+
+.. _Wkikpedia: https://en.wikipedia.org/wiki/Differential_geometry_of_surfaces
+
+Outputs
+-------
+
+This node has the following outputs:
+
+* **Vertices**. Generated vertices on the surface.
+* **Faces**. Generated faces (they are all triangles).
+* **UVPoints**. Points represenging U/V coordinates of all generated vertices
+  on the surface. Z coordinates of these points is always zero.
+
+Examples of Usage
+-----------------
+
+Motivating example. Let's consider a surface which is made out of plane with
+several bumps. On the left: a surface evaluated with cartesian grid; on the
+right: the same surface with adaptive tessellation. Each of these meshes has
+(nearly) the same count of triangles - 41K.
+
+.. image:: https://user-images.githubusercontent.com/284644/80983371-eb500900-8e45-11ea-93ad-50ccee371bb3.png
+
+Notice how much smoother the bumps are on the right mesh. Also notice the sharp
+edges around the bumps - they are made by explicitly defining the points where
+they should be (by use of **AddUVPoints** input).
+
+The same pictue with wireframe display enabled:
+
+.. image:: https://user-images.githubusercontent.com/284644/80921813-14af5d00-8d92-11ea-9038-b504a176b7fe.png
+
+Notice that on the left, the mesh has a lot of subdivisions in the flat part,
+where they are not at all necessary. The right mesh has much less subdivisions
+in flat parts, and much more on the bumps.
+
+A simpler example, with one bump and no additional points used:
+
+.. image:: https://user-images.githubusercontent.com/284644/80983350-e68b5500-8e45-11ea-8c91-50f56adbc0fe.png
+
+Use of the node with formula-defined surface, with only **By Curvature**
+parameter enabled. Notice that there are more subdivisions in the places where
+the surface is bent:
+
+.. image:: https://user-images.githubusercontent.com/284644/80983355-e7bc8200-8e45-11ea-8007-d3b6469d4f61.png
+
+The same surface with only **By Area** parameter enabled. Here there are more
+subdivisions in places where the surface is stretched (but it is almost flat at
+these places):
+
+.. image:: https://user-images.githubusercontent.com/284644/80983357-e8551880-8e45-11ea-8f2c-881beebe8d39.png
+
+And with both parameters enabled at the same time:
+
+.. image:: https://user-images.githubusercontent.com/284644/80983360-e8edaf00-8e45-11ea-8af5-8f86334ef066.png
+
+An example of the **TrimCurve** input usage:
+
+.. image:: https://user-images.githubusercontent.com/284644/80983363-e9864580-8e45-11ea-8dc9-f656108177a4.png
+

--- a/docs/nodes/surface/adaptive_tessellate.rst
+++ b/docs/nodes/surface/adaptive_tessellate.rst
@@ -16,22 +16,23 @@ However, in some cases a cartesian grid is not suitable. When the surface has
 some "almost flat" places and others, that are much more "bent" or even
 "sharp", a naive cartesian grid approach:
 
-*   generates too many points on flat areas
-*   and generates too few points in the curvy areas.
+* generates too many points on flat areas
+* and generates too few points in the curvy areas.
 
 This node generates points on the surface by following algorithm:
 
-*   Start with a cartesian grid.
-*   Then add more points into "most interesting" grid cells. "Interesting" cells may be defined as:
+* Start with a cartesian grid.
+* Then add more points into "most interesting" grid cells. "Interesting" cells may be defined as:
 
-   *    Having larger area (more precisely, area stretching factor)
-   *    Having bigger curvature value. Curvature may be defined as Gaussian
-     curvature, mean curvature or as bigger one of the principal curvatures.
+  * Having larger area (more precisely, area stretching factor)
+  * Having bigger curvature value. Curvature may be defined as Gaussian
+    curvature, mean curvature or as bigger one of the principal curvatures.
 
-    Number of vertices, which is to be added into each cell of the grid, is calculated proportionally to this "subdivision factor".
+   Number of vertices, which is to be added into each cell of the grid, is
+   calculated proportionally to this "subdivision factor".
 
-*   Make a Delaunay triangulation of all these points
-    And then map this triangluated thing onto the surface.
+* Make a Delaunay triangulation of all these points.
+* And then map this triangluated thing onto the surface.
 
 This approach can not automatically handle cases where the surface should have
 sharp edges. However, if we just happen to know where these sharp edges are, we

--- a/docs/nodes/surface/surface_index.rst
+++ b/docs/nodes/surface/surface_index.rst
@@ -23,6 +23,7 @@ Surface
    swap
    curvatures
    gauss_curvature
+   adaptive_tessellate
    tessellate_trim
    evaluate_surface
 

--- a/index.md
+++ b/index.md
@@ -99,6 +99,7 @@
      SvSurfaceCurvaturesNode
      SvExApplyFieldToSurfaceNode
      SvExTessellateTrimSurfaceNode
+     SvAdaptiveTessellateNode
      SvExEvalSurfaceNode
 
 ## Fields

--- a/nodes/surface/adaptive_tessellate.py
+++ b/nodes/surface/adaptive_tessellate.py
@@ -35,14 +35,14 @@ class SvAdaptiveTessellateNode(bpy.types.Node, SverchCustomTreeNode):
             update = updateNode)
 
     min_ppf : IntProperty(
-            name = "Min per face",
-            description = "Minimum number of new points per rectangular grid face",
+            name = "Min per cell",
+            description = "Minimum number of new points per rectangular grid cell",
             min = 0, default = 0,
             update = updateNode)
 
     max_ppf : IntProperty(
-            name = "Max per face",
-            description = "Minimum number of new points per rectangular grid face",
+            name = "Max per cell",
+            description = "Minimum number of new points per rectangular grid cell",
             min = 1, default = 5,
             update = updateNode)
 
@@ -93,7 +93,7 @@ class SvAdaptiveTessellateNode(bpy.types.Node, SverchCustomTreeNode):
     crop_mode: bpy.props.EnumProperty(
         items=mode_items,
         default = 'inner',
-        name='Mode of cropping mesh',
+        name="Trimming mode",
         update=updateNode,
         description='Switch between creating holes and fitting mesh into another mesh')
 

--- a/nodes/surface/adaptive_tessellate.py
+++ b/nodes/surface/adaptive_tessellate.py
@@ -1,0 +1,124 @@
+
+import numpy as np
+
+import bpy
+from bpy.props import EnumProperty, IntProperty, BoolProperty
+
+import sverchok
+from sverchok.node_tree import SverchCustomTreeNode, throttled
+from sverchok.data_structure import updateNode, zip_long_repeat, ensure_nesting_level, get_data_nesting_level
+from sverchok.utils.logging import info, exception
+from sverchok.utils.geom_2d.merge_mesh import crop_mesh_delaunay
+
+from sverchok.utils.curve import SvCurve
+from sverchok.utils.surface import SvSurface
+from sverchok.utils.adaptive_surface import adaptive_subdivide
+
+class SvAdaptiveTessellateNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: Adaptive Tessellate Surface
+    Tooltip: Adaptively tessellate surface
+    """
+    bl_idname = 'SvAdaptiveTessellateNode'
+    bl_label = 'Adaptive Tessellate Surface'
+    bl_icon = 'OUTLINER_OB_EMPTY'
+    sv_icon = 'SV_TRIM_TESSELLATE'
+
+    samples_u : IntProperty(
+            name = "Samples U",
+            default = 25, min = 3,
+            update = updateNode)
+
+    samples_v : IntProperty(
+            name = "Samples V",
+            default = 25, min = 3,
+            update = updateNode)
+
+    min_ppf : IntProperty(
+            name = "Min per face",
+            description = "Minimum number of new points per rectangular grid face",
+            min = 0, default = 0,
+            update = updateNode)
+
+    max_ppf : IntProperty(
+            name = "Max per face",
+            description = "Minimum number of new points per rectangular grid face",
+            min = 1, default = 5,
+            update = updateNode)
+
+    seed : IntProperty(
+            name = "Seed",
+            description = "Random Seed value",
+            default = 0,
+            update = updateNode)
+
+    by_curvature : BoolProperty(
+            name = "By Curvature",
+            default = True,
+            update = updateNode)
+
+    by_area : BoolProperty(
+            name = "By Area",
+            default = False,
+            update = updateNode)
+
+    def draw_buttons(self, context, layout):
+        row = layout.row(align=True)
+        row.prop(self, 'by_curvature', toggle=True)
+        row.prop(self, 'by_area', toggle=True)
+
+    def sv_init(self, context):
+        self.inputs.new('SvSurfaceSocket', "Surface")
+        self.inputs.new('SvStringsSocket', "SamplesU").prop_name = 'samples_u'
+        self.inputs.new('SvStringsSocket', "SamplesV").prop_name = 'samples_v'
+        self.inputs.new('SvStringsSocket', "MinPpf").prop_name = 'min_ppf'
+        self.inputs.new('SvStringsSocket', "MaxPpf").prop_name = 'max_ppf'
+        self.inputs.new('SvStringsSocket', "Seed").prop_name = 'seed'
+        self.inputs.new('SvVerticesSocket', "AddUVPoints")
+        self.outputs.new('SvVerticesSocket', "Vertices")
+        self.outputs.new('SvStringsSocket', "Faces")
+
+    def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+
+        surfaces_s = self.inputs['Surface'].sv_get()
+        samples_u_s = self.inputs['SamplesU'].sv_get()
+        samples_v_s = self.inputs['SamplesV'].sv_get()
+        min_ppf_s = self.inputs['MinPpf'].sv_get()
+        max_ppf_s = self.inputs['MaxPpf'].sv_get()
+        seed_s = self.inputs['Seed'].sv_get()
+        add_points_s = self.inputs['AddUVPoints'].sv_get(default=[[]])
+
+        surfaces_s = ensure_nesting_level(surfaces_s, 2, data_types=(SvSurface,))
+        samples_u_s = ensure_nesting_level(samples_u_s, 2)
+        samples_v_s = ensure_nesting_level(samples_v_s, 2)
+        min_ppf_s = ensure_nesting_level(min_ppf_s, 2)
+        max_ppf_s = ensure_nesting_level(max_ppf_s, 2)
+        seed_s = ensure_nesting_level(seed_s, 2)
+        add_points_s = ensure_nesting_level(add_points_s, 4)
+
+        verts_out = []
+        faces_out = []
+        inputs = zip_long_repeat(surfaces_s, samples_u_s, samples_v_s, min_ppf_s, max_ppf_s, seed_s, add_points_s)
+        for surfaces, samples_u_i, samples_v_i, min_ppf_i, max_ppf_i, seed_i, add_points_i in inputs:
+            objects = zip_long_repeat(surfaces, samples_u_i, samples_v_i, min_ppf_i, max_ppf_i, seed_i, add_points_i)
+            for surface, samples_u, samples_v, min_ppf, max_ppf, seed, add_points in objects:
+                us, vs, new_faces = adaptive_subdivide(surface,
+                                        samples_u, samples_v,
+                                        self.by_curvature, self.by_area,
+                                        add_points,
+                                        min_ppf, max_ppf, seed)
+                new_verts = surface.evaluate_array(us, vs).tolist()
+                verts_out.append(new_verts)
+                faces_out.append(new_faces)
+
+        self.outputs['Vertices'].sv_set(verts_out)
+        self.outputs['Faces'].sv_set(faces_out)
+
+def register():
+    bpy.utils.register_class(SvAdaptiveTessellateNode)
+
+def unregister():
+    bpy.utils.unregister_class(SvAdaptiveTessellateNode)
+

--- a/nodes/surface/adaptive_tessellate.py
+++ b/nodes/surface/adaptive_tessellate.py
@@ -114,6 +114,7 @@ class SvAdaptiveTessellateNode(bpy.types.Node, SverchCustomTreeNode):
         self.inputs.new('SvVerticesSocket', "AddUVPoints")
         self.outputs.new('SvVerticesSocket', "Vertices")
         self.outputs.new('SvStringsSocket', "Faces")
+        self.outputs.new('SvVerticesSocket', "UVPoints")
 
     def draw_buttons_ext(self, context, layout):
         self.draw_buttons(context, layout)
@@ -147,6 +148,7 @@ class SvAdaptiveTessellateNode(bpy.types.Node, SverchCustomTreeNode):
 
         verts_out = []
         faces_out = []
+        uv_out = []
         inputs = zip_long_repeat(surfaces_s, curves_s, samples_u_s, samples_v_s, samples_t_s, min_ppf_s, max_ppf_s, seed_s, add_points_s)
         for surfaces, curves, samples_u_i, samples_v_i, samples_t_i, min_ppf_i, max_ppf_i, seed_i, add_points_i in inputs:
             objects = zip_long_repeat(surfaces, curves, samples_u_i, samples_v_i, samples_t_i, min_ppf_i, max_ppf_i, seed_i, add_points_i)
@@ -163,11 +165,14 @@ class SvAdaptiveTessellateNode(bpy.types.Node, SverchCustomTreeNode):
                                         add_points = add_points,
                                         min_ppf = min_ppf, max_ppf = max_ppf, seed = seed)
                 new_verts = surface.evaluate_array(us, vs).tolist()
+                new_uv = [(u,v,0) for u, v in zip(us, vs)]
+                uv_out.append(new_uv)
                 verts_out.append(new_verts)
                 faces_out.append(new_faces)
 
         self.outputs['Vertices'].sv_set(verts_out)
         self.outputs['Faces'].sv_set(faces_out)
+        self.outputs['UVPoints'].sv_set(uv_out)
 
 def register():
     bpy.utils.register_class(SvAdaptiveTessellateNode)

--- a/nodes/surface/adaptive_tessellate.py
+++ b/nodes/surface/adaptive_tessellate.py
@@ -75,17 +75,39 @@ class SvAdaptiveTessellateNode(bpy.types.Node, SverchCustomTreeNode):
             default = MAXIMUM,
             update = updateNode)
 
+    samples_t : IntProperty(
+            name = "Curve Samples",
+            default = 100, min = 3,
+            update = updateNode)
+
+    mode_items = [('inner', 'Inner', 'Fit mesh', 'SELECT_INTERSECT', 0),
+                  ('outer', 'Outer', 'Make hole', 'SELECT_SUBTRACT', 1)]
+
+    crop_mode: bpy.props.EnumProperty(
+        items=mode_items,
+        default = 'inner',
+        name='Mode of cropping mesh',
+        update=updateNode,
+        description='Switch between creating holes and fitting mesh into another mesh')
+
+    accuracy: bpy.props.IntProperty(
+        name='Accuracy', update=updateNode, default=5, min=3, max=12,
+        description='Some errors of the node can be fixed by changing this value')
+
     def draw_buttons(self, context, layout):
         row = layout.row(align=True)
         row.prop(self, 'by_curvature', toggle=True)
         row.prop(self, 'by_area', toggle=True)
         if self.by_curvature:
             layout.prop(self, 'curvature_type')
+        layout.prop(self, 'crop_mode', expand=True)
 
     def sv_init(self, context):
         self.inputs.new('SvSurfaceSocket', "Surface")
+        self.inputs.new('SvCurveSocket', "TrimCurve")
         self.inputs.new('SvStringsSocket', "SamplesU").prop_name = 'samples_u'
         self.inputs.new('SvStringsSocket', "SamplesV").prop_name = 'samples_v'
+        self.inputs.new('SvStringsSocket', "SamplesT").prop_name = 'samples_t'
         self.inputs.new('SvStringsSocket', "MinPpf").prop_name = 'min_ppf'
         self.inputs.new('SvStringsSocket', "MaxPpf").prop_name = 'max_ppf'
         self.inputs.new('SvStringsSocket', "Seed").prop_name = 'seed'
@@ -93,34 +115,48 @@ class SvAdaptiveTessellateNode(bpy.types.Node, SverchCustomTreeNode):
         self.outputs.new('SvVerticesSocket', "Vertices")
         self.outputs.new('SvStringsSocket', "Faces")
 
+    def draw_buttons_ext(self, context, layout):
+        self.draw_buttons(context, layout)
+        layout.prop(self, 'accuracy')
+
     def process(self):
         if not any(socket.is_linked for socket in self.outputs):
             return
 
         surfaces_s = self.inputs['Surface'].sv_get()
+        curves_s = self.inputs['TrimCurve'].sv_get(default = [[None]])
         samples_u_s = self.inputs['SamplesU'].sv_get()
         samples_v_s = self.inputs['SamplesV'].sv_get()
+        samples_t_s = self.inputs['SamplesT'].sv_get()
         min_ppf_s = self.inputs['MinPpf'].sv_get()
         max_ppf_s = self.inputs['MaxPpf'].sv_get()
         seed_s = self.inputs['Seed'].sv_get()
         add_points_s = self.inputs['AddUVPoints'].sv_get(default=[[]])
 
         surfaces_s = ensure_nesting_level(surfaces_s, 2, data_types=(SvSurface,))
+        curves_s = ensure_nesting_level(curves_s, 2, data_types = (SvCurve,type(None)))
         samples_u_s = ensure_nesting_level(samples_u_s, 2)
         samples_v_s = ensure_nesting_level(samples_v_s, 2)
+        samples_t_s = ensure_nesting_level(samples_t_s, 2)
         min_ppf_s = ensure_nesting_level(min_ppf_s, 2)
         max_ppf_s = ensure_nesting_level(max_ppf_s, 2)
         seed_s = ensure_nesting_level(seed_s, 2)
         add_points_s = ensure_nesting_level(add_points_s, 4)
 
+        epsilon = 1.0 / 10**self.accuracy
+
         verts_out = []
         faces_out = []
-        inputs = zip_long_repeat(surfaces_s, samples_u_s, samples_v_s, min_ppf_s, max_ppf_s, seed_s, add_points_s)
-        for surfaces, samples_u_i, samples_v_i, min_ppf_i, max_ppf_i, seed_i, add_points_i in inputs:
-            objects = zip_long_repeat(surfaces, samples_u_i, samples_v_i, min_ppf_i, max_ppf_i, seed_i, add_points_i)
-            for surface, samples_u, samples_v, min_ppf, max_ppf, seed, add_points in objects:
+        inputs = zip_long_repeat(surfaces_s, curves_s, samples_u_s, samples_v_s, samples_t_s, min_ppf_s, max_ppf_s, seed_s, add_points_s)
+        for surfaces, curves, samples_u_i, samples_v_i, samples_t_i, min_ppf_i, max_ppf_i, seed_i, add_points_i in inputs:
+            objects = zip_long_repeat(surfaces, curves, samples_u_i, samples_v_i, samples_t_i, min_ppf_i, max_ppf_i, seed_i, add_points_i)
+            for surface, curve, samples_u, samples_v, samples_t, min_ppf, max_ppf, seed, add_points in objects:
                 us, vs, new_faces = adaptive_subdivide(surface,
                                         samples_u, samples_v,
+                                        trim_curve = curve,
+                                        samples_t = samples_t,
+                                        trim_mode = self.crop_mode,
+                                        epsilon = epsilon,
                                         by_curvature = self.by_curvature,
                                         curvature_type = self.curvature_type,
                                         by_area = self.by_area,

--- a/utils/adaptive_surface.py
+++ b/utils/adaptive_surface.py
@@ -1,0 +1,125 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import numpy as np
+import random
+from math import ceil
+
+from sverchok.utils.logging import info, exception
+from sverchok.utils.surface import SvSurface
+from sverchok.utils.geom_2d.merge_mesh import crop_mesh_delaunay
+from sverchok.utils.voronoi import computeDelaunayTriangulation, Site
+
+def populate_surface_uv(surface, samples_u, samples_v, by_curvature=True, by_area=True, min_ppf=1, max_ppf=5, seed=1):
+    u_min, u_max = surface.get_u_min(), surface.get_u_max()
+    v_min, v_max = surface.get_v_min(), surface.get_v_max()
+    us_range = np.linspace(u_min, u_max, num=samples_u)
+    vs_range = np.linspace(v_min, v_max, num=samples_v)
+    us, vs = np.meshgrid(us_range, vs_range)
+    us = us.flatten()
+    vs = vs.flatten()
+
+    if by_curvature:
+        curvatures = abs(surface.gauss_curvature_array(us, vs)).clip(0, 100)
+        curvatures = curvatures.reshape((samples_u, samples_v))
+
+        curvatures_0 = curvatures[:-1, :-1]
+        curvatures_du = curvatures[1:, :-1]
+        curvatures_dv = curvatures[:-1, 1:]
+        curvatures_du_dv = curvatures[1:, 1:]
+
+        max_curvatures = np.max([curvatures_0, curvatures_du, curvatures_dv, curvatures_du_dv], axis=0)
+        max_curvature = max_curvatures.max()
+        min_curvature = max_curvatures.min()
+        curvatures_range = max_curvature - min_curvature
+        info("Curvature range: %s - %s", min_curvature, max_curvature)
+        if curvatures_range == 0:
+            max_curvatures = np.zeros((samples_u-1, samples_v-1))
+        else:
+            max_curvatures = (max_curvatures - min_curvature) / curvatures_range
+    else:
+        max_curvatures = np.zeros((samples_u-1, samples_v-1))
+        curvatures_range = 0
+
+    if by_area:
+        surface_points = surface.evaluate_array(us, vs)
+        surface_points = surface_points.reshape((samples_u, samples_v, 3))
+
+        points_0 = surface_points[:-1, :-1,:]
+        points_du = surface_points[1:, :-1,:]
+        points_dv = surface_points[:-1, 1:,:]
+        points_du_dv = surface_points[1:, 1:,:]
+
+        areas_1 = np.linalg.norm(np.cross(points_du_dv - points_0, points_du - points_0), axis=2)/6.0
+        areas_2 = np.linalg.norm(np.cross(points_dv - points_0, points_du_dv - points_0), axis=2)/6.0
+        areas = areas_1 + areas_2
+        min_area = areas.min()
+        max_area = areas.max()
+        areas_range = max_area - min_area
+        info("Areas range: %s - %s", min_area, max_area)
+        if areas_range == 0:
+            areas = np.zeros((samples_u-1, samples_v-1))
+        else:
+            areas = (areas - min_area) / areas_range
+    else:
+        areas = np.zeros((samples_u-1, samples_v-1))
+        areas_range = 0
+
+    factors = max_curvatures + areas
+    factor_range = areas_range + curvatures_range
+    if by_area and by_curvature:
+        factors = factors / 2.0
+        factor_range = factor_range / 2.0
+    max_factor = factors.max()
+    if max_factor != 0:
+        factors = factors / max_factor
+    info("Factors: %s - %s (%s)", factors.min(), factors.max(), factor_range)
+    info("Areas: %s - %s", areas.min(), areas.max())
+    info("Curvatures: %s - %s", max_curvatures.min(), max_curvatures.max())
+
+    ppf_range = max_ppf - min_ppf
+
+    if not seed:
+        seed = 12345
+    random.seed(seed)
+    new_u = []
+    new_v = []
+    for i in range(samples_u-1):
+        u1 = us_range[i]
+        u2 = us_range[i+1]
+        for j in range(samples_v-1):
+            v1 = vs_range[j]
+            v2 = vs_range[j+1]
+            factor = factors[i,j]
+            if factor_range == 0:
+                ppf = (min_ppf + max_ppf)/2
+            else:
+                ppf = min_ppf + ppf_range * factor
+            #ppf = int(round(ppf))
+            ppf = ceil(ppf)
+#             if ppf > 1:
+#                 info("I %s, J %s, factor %s, PPF %s", i, j, factor, ppf)
+#                 info("U %s - %s, V %s - %s", u1, u2, v1, v2)
+            for k in range(ppf):
+                u = random.uniform(u1, u2)
+                v = random.uniform(v1, v2)
+                new_u.append(u)
+                new_v.append(v)
+
+    return us, vs, new_u, new_v
+
+def adaptive_subdivide(surface, samples_u, samples_v, by_curvature=True, by_area=True, add_points=None, min_ppf=1, max_ppf=5, seed=1):
+    us, vs, new_u, new_v = populate_surface_uv(surface, samples_u, samples_v, by_curvature, by_area, min_ppf, max_ppf, seed)
+    us_list = list(us) + new_u
+    vs_list = list(vs) + new_v
+    if add_points and len(add_points[0]) > 0:
+        us_list.extend([p[0] for p in add_points])
+        vs_list.extend([p[1] for p in add_points])
+    points_uv = [Site(u, v) for u, v in zip(us_list, vs_list)]
+    faces = computeDelaunayTriangulation(points_uv)
+    return np.array(us_list), np.array(vs_list), faces
+

--- a/utils/adaptive_surface.py
+++ b/utils/adaptive_surface.py
@@ -57,7 +57,8 @@ def populate_surface_uv(surface, samples_u, samples_v, by_curvature=True, curvat
         if curvature_type == GAUSS:
             curvatures = abs(surface.gauss_curvature_array(us, vs)).clip(0, 100)
         elif curvature_type == MAXIMUM:
-            curvatures = abs(surface.principal_curvature_values_array(us, vs)[1])
+            curvatures_1, curvatures_2 = surface.principal_curvature_values_array(us, vs, order=False)
+            curvatures = abs(np.vstack((curvatures_1, curvatures_2))).max(axis=0)
         elif curvature_type == MEAN:
             curvatures = abs(surface.mean_curvature_array(us, vs))
         else:

--- a/utils/adaptive_surface.py
+++ b/utils/adaptive_surface.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 import random
-from math import ceil
+from math import ceil, isnan
 
 from sverchok.utils.logging import info, exception
 from sverchok.utils.surface import SvSurface
@@ -98,7 +98,7 @@ def populate_surface_uv(surface, samples_u, samples_v, by_curvature=True, by_are
             v1 = vs_range[j]
             v2 = vs_range[j+1]
             factor = factors[i,j]
-            if factor_range == 0:
+            if factor_range == 0 or isnan(factor):
                 ppf = (min_ppf + max_ppf)/2
             else:
                 ppf = min_ppf + ppf_range * factor

--- a/utils/adaptive_surface.py
+++ b/utils/adaptive_surface.py
@@ -194,10 +194,11 @@ def calc_sizes(surface_points, samples_u, samples_v):
 
     return target_u_length, target_v_length
 
-def adaptive_subdivide(surface, samples_u, samples_v, by_curvature=True, curvature_type = MAXIMUM, by_area=True, add_points=None, min_ppf=1, max_ppf=5, trim_curve = None, samples_t = 100, trim_mode = 'inner', epsilon = 1e-4, seed=1):
+def adaptive_subdivide(surface, samples_u, samples_v, by_curvature=True, curvature_type = MAXIMUM, curvature_clip = 100, by_area=True, add_points=None, min_ppf=1, max_ppf=5, trim_curve = None, samples_t = 100, trim_mode = 'inner', epsilon = 1e-4, seed=1):
     data = populate_surface_uv(surface, samples_u, samples_v,
                             by_curvature = by_curvature,
                             curvature_type = curvature_type,
+                            curvature_clip = curvature_clip,
                             by_area = by_area,
                             min_ppf = min_ppf, max_ppf = max_ppf, seed =seed)
     us, vs, new_u, new_v = data.us, data.vs, data.new_us, data.new_vs

--- a/utils/adaptive_surface.py
+++ b/utils/adaptive_surface.py
@@ -57,6 +57,9 @@ def populate_surface_uv(surface, samples_u, samples_v, by_curvature=True, by_are
         areas_1 = np.linalg.norm(np.cross(points_du_dv - points_0, points_du - points_0), axis=2)/6.0
         areas_2 = np.linalg.norm(np.cross(points_dv - points_0, points_du_dv - points_0), axis=2)/6.0
         areas = areas_1 + areas_2
+        h_u = us_range[1] - us_range[0]
+        h_v = vs_range[1] - vs_range[0]
+        areas = areas / (h_u * h_v)
         min_area = areas.min()
         max_area = areas.max()
         areas_range = max_area - min_area

--- a/utils/adaptive_surface.py
+++ b/utils/adaptive_surface.py
@@ -19,7 +19,7 @@ def populate_surface_uv(surface, samples_u, samples_v, by_curvature=True, by_are
     v_min, v_max = surface.get_v_min(), surface.get_v_max()
     us_range = np.linspace(u_min, u_max, num=samples_u)
     vs_range = np.linspace(v_min, v_max, num=samples_v)
-    us, vs = np.meshgrid(us_range, vs_range)
+    us, vs = np.meshgrid(us_range, vs_range, indexing='ij')
     us = us.flatten()
     vs = vs.flatten()
 
@@ -77,9 +77,9 @@ def populate_surface_uv(surface, samples_u, samples_v, by_curvature=True, by_are
     max_factor = factors.max()
     if max_factor != 0:
         factors = factors / max_factor
-    info("Factors: %s - %s (%s)", factors.min(), factors.max(), factor_range)
-    info("Areas: %s - %s", areas.min(), areas.max())
-    info("Curvatures: %s - %s", max_curvatures.min(), max_curvatures.max())
+    #info("Factors: %s - %s (%s)", factors.min(), factors.max(), factor_range)
+    #info("Areas: %s - %s", areas.min(), areas.max())
+    #info("Curvatures: %s - %s", max_curvatures.min(), max_curvatures.max())
 
     ppf_range = max_ppf - min_ppf
 

--- a/utils/surface.py
+++ b/utils/surface.py
@@ -326,8 +326,8 @@ class SvSurface(object):
         calc = self.curvature_calculator(us, vs)
         return calc.mean()
 
-    def principal_curvature_values_array(self, us, vs):
-        calc = self.curvature_calculator(us, vs)
+    def principal_curvature_values_array(self, us, vs, order=True):
+        calc = self.curvature_calculator(us, vs, order=order)
         return calc.values()
 
     def principal_curvatures_array(self, us, vs):

--- a/utils/surface.py
+++ b/utils/surface.py
@@ -113,6 +113,9 @@ class SurfaceCurvatureCalculator(object):
         c1 = (-B - np.sqrt(D))/(2*A)
         c2 = (-B + np.sqrt(D))/(2*A)
 
+        c1[np.isnan(c1)] = 0
+        c2[np.isnan(c2)] = 0
+
         c1mask = (c1 < c2)
         c2mask = np.logical_not(c1mask)
 
@@ -534,10 +537,10 @@ class SvPlane(SvSurface):
         return self._normal
 
     def normal_array(self, us, vs):
-        normal = self.normal
+        normal = self._normal[np.newaxis].T
         n = np.linalg.norm(normal)
         normal = normal / n
-        return np.tile(normal, len(us))
+        return np.tile(normal, len(us)).T
 
 class SvEquirectSphere(SvSurface):
     __description__ = "Equirectangular Sphere"


### PR DESCRIPTION
## Addressed problem description

Given a Surface object, it is easy to convert it to mesh by evaluating it on a cartesian grid, by use of "Evaluate Surface" node. However, in some cases a cartesian grid is not suitable. When the surface has some "almost flat" places and others, that are much more "bent" or even "sharp", a naive cartesian grid approach:

* generates too many points on flat areas
* and generates too few points in the curvy areas.

## Solution description

* Start with a cartesian grid.
* Then add more points into "most interesting" grid cells. "Interesting" cells may be defined as:
  * Having larger area (more precisely, area stretching factor)
  * Having bigger curvature value. Curvature may be defined as Gaussian curvature, mean curvature or as bigger one of the principal curvatures.
* Make a Delaunay triangulation of all these points
* And then map this triangluated thing onto the surface.

This approach can not automatically handle cases where the surface should have sharp edges. However, if we just happen to know where these sharp edges are, we can manually add points on these edges before building a Delaunay triangluation.

On the left: a surface evaluated with cartesian grid; on the right: the same surface with adaptive tessellation. Each of these meshes has (nearly) the same count of triangles - 41K.
![Screenshot_20200503_224620](https://user-images.githubusercontent.com/284644/80921809-137e3000-8d92-11ea-8a66-d3714a2b795c.png)
The same with wireframe enabled.
![Screenshot_20200503_224647](https://user-images.githubusercontent.com/284644/80921813-14af5d00-8d92-11ea-9038-b504a176b7fe.png)


## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

