### PR TITLE
"Scalar field curvature" node

### DIFF
--- a/docs/nodes/field/field_index.rst
+++ b/docs/nodes/field/field_index.rst
@@ -19,6 +19,7 @@ Field
    scalar_field_math
    vector_field_math
    differential_operations
+   scalar_field_curvature
    merge_scalar_fields
    vector_field_graph
    vector_field_lines

--- a/docs/nodes/field/scalar_field_curvature.rst
+++ b/docs/nodes/field/scalar_field_curvature.rst
@@ -1,0 +1,73 @@
+Scalar Field Curvature
+======================
+
+Functionality
+-------------
+
+This node calculates several types of information about implicitly defined surface curvature:
+
+* Principal curvature values
+* Gauss Curvature
+* Mean Curvature
+
+You can refer to Wikipedia_ for more detailed information about these terms.
+
+.. _Wkikpedia: https://en.wikipedia.org/wiki/Differential_geometry_of_surfaces
+
+If we have a scalar field defined by `V = F(x,y,z)`, then at each point in space
+`(x,y,z)` it has a value of V; then through each point in space goes an
+iso-surface defined by `F(x,y,z) = V`. We can calculate curvature of that surface
+at that point. So, it appears that given one scalar field, we can define
+another one, defined by `K(x,y,z) = Curvature(F(x,y,z) = V at (x,y,z))`. We can
+simply evaluate that new scalar field at any point, for example at points of
+the surface `F(x,y,z) = V` itself; or we can do other strange things with this new
+scalar field...
+
+The most clearly useful this will be in combination with "Marching Cubes" node
+from Sverchok-Extra addon, but may give interesting effects by itself.
+
+Note that the calculation is done by numerical differentiation, so it may be not very precise in some cases.
+
+Inputs
+------
+
+This node has the following input:
+
+* **Field**. The scalar field, for which the curvature is to be calculated. This input is mandatory.
+
+Parameters
+----------
+
+This node has the following parameter:
+
+* **Step**. Grid step for numericall differentiation. Bigger values give more
+  smooth fields. The default value is `0.001`.
+
+Outputs
+-------
+
+This node has the following outputs:
+
+* **Gauss**. Scalar field, values of which are Gaussian curvature values of
+  iso-surfaces of the input scalar field.
+* **Mean**. Scalar field, values of which are mean curvature values of
+  iso-surfaces of the input scalar field.
+* **Curvature1**. Scalar field, values of which are first principal curvature
+  values of iso-surfaces of the input scalar field.
+* **Curvature2**. Scalar field, values of which are second principal curvature
+  values of iso-surfaces of the input scalar field.
+
+Examples of usage
+-----------------
+
+Build some scalar field by "Attractor Field" node, measure it's mean curvature
+and use that curvature values to color the vertices of a plane:
+
+.. image:: https://user-images.githubusercontent.com/284644/81438971-0e9cf000-9187-11ea-9d67-703b3550faf1.png
+
+Generate an iso-surface of the same scalar field, and use it's mean curvature
+values for coloring. Note: this example requires Sverchok-Extra addon for
+"Marching Cubes" node.
+
+.. image:: https://user-images.githubusercontent.com/284644/81438974-0fce1d00-9187-11ea-9583-1e8f4c6f8573.png
+

--- a/index.md
+++ b/index.md
@@ -112,6 +112,7 @@
      SvExAttractorFieldNode
      SvExImageFieldNode
      SvExScalarFieldMathNode
+     SvScalarFieldCurvatureNode
      SvExMergeScalarFieldsNode
      SvExScalarFieldEvaluateNode
      SvExVectorFieldEvaluateNode

--- a/nodes/field/scalar_field_curvature.py
+++ b/nodes/field/scalar_field_curvature.py
@@ -8,7 +8,7 @@ from sverchok.node_tree import SverchCustomTreeNode, throttled
 from sverchok.data_structure import updateNode, zip_long_repeat, match_long_repeat, ensure_nesting_level
 from sverchok.utils.logging import info, exception
 
-from sverchok.utils.field.scalar import SvScalarField, SvScalarFieldGaussCurvature
+from sverchok.utils.field.scalar import SvScalarField, SvScalarFieldGaussCurvature, SvScalarFieldMeanCurvature, SvScalarFieldPrincipalCurvature, ScalarFieldCurvatureCalculator
 
 class SvScalarFieldCurvatureNode(bpy.types.Node, SverchCustomTreeNode):
     """
@@ -23,6 +23,18 @@ class SvScalarFieldCurvatureNode(bpy.types.Node, SverchCustomTreeNode):
     def sv_init(self, context):
         self.inputs.new('SvScalarFieldSocket', "Field")
         self.outputs.new('SvScalarFieldSocket', "Gauss")
+        self.outputs.new('SvScalarFieldSocket', "Mean")
+        self.outputs.new('SvScalarFieldSocket', "Curvature1")
+        self.outputs.new('SvScalarFieldSocket', "Curvature2")
+
+    step : FloatProperty(
+            name = "Step",
+            default = 0.001,
+            precision = 4,
+            update = updateNode)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'step')
 
     def process(self):
         if not any(socket.is_linked for socket in self.outputs):
@@ -30,15 +42,29 @@ class SvScalarFieldCurvatureNode(bpy.types.Node, SverchCustomTreeNode):
 
         field_s = self.inputs['Field'].sv_get()
         field_s = ensure_nesting_level(field_s, 2, data_types=(SvScalarField,))
+        step = self.step
 
-        fields_out = []
+        gauss_out = []
+        mean_out = []
+        k1_out = []
+        k2_out = []
         for fields in field_s:
             for field in fields:
-                step = 0.001
-                new_field = SvScalarFieldGaussCurvature(field, step)
-                fields_out.append(new_field)
+                calculator = ScalarFieldCurvatureCalculator(field, step)
+                new_gauss = SvScalarFieldGaussCurvature(field, calculator)
+                new_mean = SvScalarFieldMeanCurvature(field, calculator)
+                new_k1 = SvScalarFieldPrincipalCurvature(field, calculator, 1)
+                new_k2 = SvScalarFieldPrincipalCurvature(field, calculator, 2)
 
-        self.outputs['Gauss'].sv_set(fields_out)
+                gauss_out.append(new_gauss)
+                mean_out.append(new_mean)
+                k1_out.append(new_k1)
+                k2_out.append(new_k2)
+
+        self.outputs['Gauss'].sv_set(gauss_out)
+        self.outputs['Mean'].sv_set(mean_out)
+        self.outputs['Curvature1'].sv_set(k1_out)
+        self.outputs['Curvature2'].sv_set(k2_out)
 
 def register():
     bpy.utils.register_class(SvScalarFieldCurvatureNode)

--- a/nodes/field/scalar_field_curvature.py
+++ b/nodes/field/scalar_field_curvature.py
@@ -1,0 +1,48 @@
+
+import numpy as np
+
+import bpy
+from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty, StringProperty
+
+from sverchok.node_tree import SverchCustomTreeNode, throttled
+from sverchok.data_structure import updateNode, zip_long_repeat, match_long_repeat, ensure_nesting_level
+from sverchok.utils.logging import info, exception
+
+from sverchok.utils.field.scalar import SvScalarField, SvScalarFieldGaussCurvature
+
+class SvScalarFieldCurvatureNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: Scalar Field Curvature
+    Tooltip: Scalar Field Curvature
+    """
+    bl_idname = 'SvScalarFieldCurvatureNode'
+    bl_label = 'Scalar Field Curvature'
+    bl_icon = 'OUTLINER_OB_EMPTY'
+    sv_icon = 'SV_SCALAR_FIELD_MATH'
+
+    def sv_init(self, context):
+        self.inputs.new('SvScalarFieldSocket', "Field")
+        self.outputs.new('SvScalarFieldSocket', "Gauss")
+
+    def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+
+        field_s = self.inputs['Field'].sv_get()
+        field_s = ensure_nesting_level(field_s, 2, data_types=(SvScalarField,))
+
+        fields_out = []
+        for fields in field_s:
+            for field in fields:
+                step = 0.001
+                new_field = SvScalarFieldGaussCurvature(field, step)
+                fields_out.append(new_field)
+
+        self.outputs['Gauss'].sv_set(fields_out)
+
+def register():
+    bpy.utils.register_class(SvScalarFieldCurvatureNode)
+
+def unregister():
+    bpy.utils.unregister_class(SvScalarFieldCurvatureNode)
+


### PR DESCRIPTION
This node calculates surface curvatures for surfaces defined by scalar field iso-surfaces - a.k.a. implicit surfaces, `F(x,y,z) = C`. The most clearly useful this will be in combination with "marching cubes" from sverchok-extra, but may give interesting effects by itself.

If we have a scalar field defined by `V = F(x,y,z)`, then at each point in space `(x,y,z)` it has a value of `V`, then through each point in space goes an iso-surface defined by `F(x,y,z) = V`. We can calculate curvature of that surface at that point. So, it appears that given one scalar field, we can define another one, defined by `K(x,y,z) = Curvature(F(x,y,z) =V at (x,y,z))`. We can simply evaluate that new scalar field at any point, for example at points of the surface `F(x,y,z)=V` itself; or we can do other strange things with this new scalar field...

![Screenshot_20200508_234500](https://user-images.githubusercontent.com/284644/81438971-0e9cf000-9187-11ea-9d67-703b3550faf1.png)
![Screenshot_20200508_234800](https://user-images.githubusercontent.com/284644/81438974-0fce1d00-9187-11ea-9583-1e8f4c6f8573.png)


## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

