### PR TITLE
Vectorize computations in some of *Formula nodes

### DIFF
--- a/docs/nodes/curve/curve_formula.rst
+++ b/docs/nodes/curve/curve_formula.rst
@@ -71,6 +71,15 @@ This node has the following parameters:
 
    The default mode is **Carthesian**.
 
+* **Vectorize**. This parameter is available in the N panel only. If enabled,
+  then to evaluate formulas for a series of input values, the node will use
+  NumPy functions to perform several computations at a time; otherwise, the
+  formulas will be evaluated separately for each input value. The use of
+  vectorization usually makes computations a lot faster (2x to 100x). The
+  parameter is enabled by default. If you experience some kind of troubles with
+  calculating some of functions (errors or not good enough precision), you can
+  disable this parameter.
+
 Outputs
 -------
 

--- a/docs/nodes/field/scalar_field_formula.rst
+++ b/docs/nodes/field/scalar_field_formula.rst
@@ -69,6 +69,14 @@ This node has the following parameters:
   value is **Carthesian**.
 * **Formula**. The formula which defines the scalar field. The default formula
   is `x*x + y*y + z*z`.
+* **Vectorize**. This parameter is available in the N panel only. If enabled,
+  then to evaluate formulas for a series of input values, the node will use
+  NumPy functions to perform several computations at a time; otherwise, the
+  formulas will be evaluated separately for each input value. The use of
+  vectorization usually makes computations a lot faster (2x to 100x). The
+  parameter is enabled by default. If you experience some kind of troubles with
+  calculating some of functions (errors or not good enough precision), you can
+  disable this parameter.
 
 Outputs
 -------

--- a/docs/nodes/field/vector_field_formula.rst
+++ b/docs/nodes/field/vector_field_formula.rst
@@ -76,6 +76,14 @@ This node has the following parameters:
 * **Output**. This defines the coordinate system in which the resulting vectors
   are expressed. The available values are **Carhtesian**, **Cylindrical** and
   **Spherical**. The default value is **Carthesian**.
+* **Vectorize**. This parameter is available in the N panel only. If enabled,
+  then to evaluate formulas for a series of input values, the node will use
+  NumPy functions to perform several computations at a time; otherwise, the
+  formulas will be evaluated separately for each input value. The use of
+  vectorization usually makes computations a lot faster (2x to 100x). The
+  parameter is enabled by default. If you experience some kind of troubles with
+  calculating some of functions (errors or not good enough precision), you can
+  disable this parameter.
 
 Outputs
 -------

--- a/docs/nodes/surface/surface_formula.rst
+++ b/docs/nodes/surface/surface_formula.rst
@@ -71,6 +71,15 @@ This node has the following parameters:
 
    The default mode is **Carthesian**.
 
+* **Vectorize**. This parameter is available in the N panel only. If enabled,
+  then to evaluate formulas for a series of input values, the node will use
+  NumPy functions to perform several computations at a time; otherwise, the
+  formulas will be evaluated separately for each input value. The use of
+  vectorization usually makes computations a lot faster (2x to 100x). The
+  parameter is enabled by default. If you experience some kind of troubles with
+  calculating some of functions (errors or not good enough precision), you can
+  disable this parameter.
+
 Outputs
 -------
 

--- a/nodes/field/scalar_field_formula.py
+++ b/nodes/field/scalar_field_formula.py
@@ -11,7 +11,6 @@ from sverchok.utils.script_importhelper import safe_names_np
 from sverchok.utils.logging import info, exception
 from sverchok.utils.math import (
         from_cylindrical, from_spherical,
-        from_cylindrical_np, from_spherical_np,
         to_cylindrical, to_spherical,
         to_cylindrical_np, to_spherical_np,
         coordinate_modes
@@ -67,17 +66,26 @@ class SvScalarFieldFormulaNode(bpy.types.Node, SverchCustomTreeNode):
 
         def carthesian(x, y, z, V):
             variables.update(dict(x=x, y=y, z=z, V=V))
-            return safe_eval_compiled(compiled, variables)
+            r = safe_eval_compiled(compiled, variables)
+            if not isinstance(r, np.ndarray):
+                r = np.full_like(x, r)
+            return r
 
         def cylindrical(x, y, z, V):
             rho, phi, z = to_cylindrical((x, y, z), mode='radians')
             variables.update(dict(rho=rho, phi=phi, z=z, V=V))
-            return safe_eval_compiled(compiled, variables)
+            r = safe_eval_compiled(compiled, variables)
+            if not isinstance(r, np.ndarray):
+                r = np.full_like(x, r)
+            return r
 
         def spherical(x, y, z, V):
             rho, phi, theta = to_spherical((x, y, z), mode='radians')
             variables.update(dict(rho=rho, phi=phi, theta=theta, V=V))
-            return safe_eval_compiled(compiled, variables)
+            r = safe_eval_compiled(compiled, variables)
+            if not isinstance(r, np.ndarray):
+                r = np.full_like(x, r)
+            return r
 
         if self.input_mode == 'XYZ':
             function = carthesian

--- a/nodes/field/vector_field_formula.py
+++ b/nodes/field/vector_field_formula.py
@@ -7,10 +7,15 @@ from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty, St
 from sverchok.node_tree import SverchCustomTreeNode, throttled
 from sverchok.data_structure import updateNode, zip_long_repeat, fullList, match_long_repeat
 from sverchok.utils.modules.eval_formula import get_variables, sv_compile, safe_eval_compiled
+from sverchok.utils.script_importhelper import safe_names_np
 from sverchok.utils.logging import info, exception
-from sverchok.utils.math import from_cylindrical, from_spherical, to_cylindrical, to_spherical
-
-from sverchok.utils.math import coordinate_modes
+from sverchok.utils.math import (
+        from_cylindrical, from_spherical,
+        from_cylindrical_np, from_spherical_np,
+        to_cylindrical, to_spherical,
+        to_cylindrical_np, to_spherical_np,
+        coordinate_modes
+    )
 from sverchok.utils.field.vector import SvVectorFieldLambda
 
 class SvVectorFieldFormulaNode(bpy.types.Node, SverchCustomTreeNode):
@@ -54,6 +59,12 @@ class SvVectorFieldFormulaNode(bpy.types.Node, SverchCustomTreeNode):
         default = 'XYZ',
         update = updateNode)
 
+    use_numpy_function : BoolProperty(
+        name = "Vectorize",
+        description = "Vectorize formula computations; disable this if you have troubles with some functions",
+        default = True,
+        update = updateNode)
+
     def sv_init(self, context):
         self.inputs.new('SvVectorFieldSocket', "Field")
         self.outputs.new('SvVectorFieldSocket', "Field")
@@ -66,6 +77,10 @@ class SvVectorFieldFormulaNode(bpy.types.Node, SverchCustomTreeNode):
         layout.prop(self, "formula3", text="")
         layout.label(text="Output:")
         layout.prop(self, "output_mode", expand=True)
+
+    def draw_buttons_ext(self, context, layout):
+        self.draw_buttons(context, layout)
+        layout.prop(self, 'use_numpy_function')
 
     def make_function(self, variables):
         compiled1 = sv_compile(self.formula1)
@@ -103,6 +118,71 @@ class SvVectorFieldFormulaNode(bpy.types.Node, SverchCustomTreeNode):
             v1 = safe_eval_compiled(compiled1, variables)
             v2 = safe_eval_compiled(compiled2, variables)
             v3 = safe_eval_compiled(compiled3, variables)
+            return out_coordinates(v1, v2, v3)
+
+        if self.input_mode == 'XYZ':
+            function = carthesian_in
+        elif self.input_mode == 'CYL':
+            function = cylindrical_in
+        else: # SPH
+            function = spherical_in
+
+        return function
+
+    def make_function_vector(self, variables):
+        compiled1 = sv_compile(self.formula1)
+        compiled2 = sv_compile(self.formula2)
+        compiled3 = sv_compile(self.formula3)
+
+        if self.output_mode == 'XYZ':
+            def out_coordinates(x, y, z):
+                return x, y, z
+        elif self.output_mode == 'CYL':
+            def out_coordinates(rho, phi, z):
+                return from_cylindrical_np(rho, phi, z, mode='radians')
+        else: # SPH
+            def out_coordinates(rho, phi, theta):
+                return from_spherical_np(rho, phi, theta, mode='radians')
+
+        def carthesian_in(x, y, z, V):
+            variables.update(dict(x=x, y=y, z=z, V=V))
+            v1 = safe_eval_compiled(compiled1, variables, allowed_names = safe_names_np)
+            v2 = safe_eval_compiled(compiled2, variables, allowed_names = safe_names_np)
+            v3 = safe_eval_compiled(compiled3, variables, allowed_names = safe_names_np)
+            if not isinstance(v1, np.ndarray):
+                v1 = np.full_like(x, v1)
+            if not isinstance(v2, np.ndarray):
+                v2 = np.full_like(x, v2)
+            if not isinstance(v3, np.ndarray):
+                v3 = np.full_like(x, v3)
+            return out_coordinates(v1, v2, v3)
+
+        def cylindrical_in(x, y, z, V):
+            rho, phi, z = to_cylindrical((x, y, z), mode='radians')
+            variables.update(dict(rho=rho, phi=phi, z=z, V=V))
+            v1 = safe_eval_compiled(compiled1, variables, allowed_names = safe_names_np)
+            v2 = safe_eval_compiled(compiled2, variables, allowed_names = safe_names_np)
+            v3 = safe_eval_compiled(compiled3, variables, allowed_names = safe_names_np)
+            if not isinstance(v1, np.ndarray):
+                v1 = np.full_like(x, v1)
+            if not isinstance(v2, np.ndarray):
+                v2 = np.full_like(x, v2)
+            if not isinstance(v3, np.ndarray):
+                v3 = np.full_like(x, v3)
+            return out_coordinates(v1, v2, v3)
+
+        def spherical_in(x, y, z, V):
+            rho, phi, theta = to_spherical((x, y, z), mode='radians')
+            variables.update(dict(rho=rho, phi=phi, theta=theta, V=V))
+            v1 = safe_eval_compiled(compiled1, variables, allowed_names = safe_names_np)
+            v2 = safe_eval_compiled(compiled2, variables, allowed_names = safe_names_np)
+            v3 = safe_eval_compiled(compiled3, variables, allowed_names = safe_names_np)
+            if not isinstance(v1, np.ndarray):
+                v1 = np.full_like(x, v1)
+            if not isinstance(v2, np.ndarray):
+                v2 = np.full_like(x, v2)
+            if not isinstance(v3, np.ndarray):
+                v3 = np.full_like(x, v3)
             return out_coordinates(v1, v2, v3)
 
         if self.input_mode == 'XYZ':
@@ -177,8 +257,12 @@ class SvVectorFieldFormulaNode(bpy.types.Node, SverchCustomTreeNode):
                 var_values_s = [[]]
             for var_values in var_values_s:
                 variables = dict(zip(var_names, var_values))
-                function = self.make_function(variables.copy())
-                new_field = SvVectorFieldLambda(function, variables, field_in)
+                function = self.make_function(variables)
+                if self.use_numpy_function:
+                    function_vector = self.make_function_vector(variables)
+                else:
+                    function_vector = None
+                new_field = SvVectorFieldLambda(function, variables, field_in, function_vector)
                 fields_out.append(new_field)
 
         self.outputs['Field'].sv_set(fields_out)

--- a/nodes/surface/surface_formula.py
+++ b/nodes/surface/surface_formula.py
@@ -13,7 +13,6 @@ from sverchok.utils.logging import info, exception
 from sverchok.utils.math import (
             from_cylindrical, from_spherical,
             from_cylindrical_np, from_spherical_np,
-            to_cylindrical, to_spherical,
             coordinate_modes
         )
 from sverchok.utils.surface import SvLambdaSurface
@@ -141,6 +140,14 @@ class SvSurfaceFormulaNode(bpy.types.Node, SverchCustomTreeNode):
             v1 = safe_eval_compiled(compiled1, variables, allowed_names = safe_names_np)
             v2 = safe_eval_compiled(compiled2, variables, allowed_names = safe_names_np)
             v3 = safe_eval_compiled(compiled3, variables, allowed_names = safe_names_np)
+
+            if not isinstance(v1, np.ndarray):
+                v1 = np.full_like(u, v1)
+            if not isinstance(v2, np.ndarray):
+                v2 = np.full_like(u, v2)
+            if not isinstance(v3, np.ndarray):
+                v3 = np.full_like(u, v3)
+
             return np.array(out_coordinates(v1, v2, v3)).T
 
         return function

--- a/utils/curve.py
+++ b/utils/curve.py
@@ -558,8 +558,9 @@ class SvCircle(SvCurve):
 class SvLambdaCurve(SvCurve):
     __description__ = "Formula"
 
-    def __init__(self, function):
+    def __init__(self, function, function_numpy = None):
         self.function = function
+        self.function_numpy = function_numpy
         self.u_bounds = (0.0, 1.0)
         self.tangent_delta = 0.001
 
@@ -570,7 +571,10 @@ class SvLambdaCurve(SvCurve):
         return self.function(t)
 
     def evaluate_array(self, ts):
-        return np.vectorize(self.function, signature='()->(3)')(ts)
+        if self.function_numpy is not None:
+            return self.function_numpy(ts)
+        else:
+            return np.vectorize(self.function, signature='()->(3)')(ts)
 
     def tangent(self, t):
         point = self.function(t)

--- a/utils/field/scalar.py
+++ b/utils/field/scalar.py
@@ -81,8 +81,9 @@ class SvVectorFieldDecomposed(SvScalarField):
 class SvScalarFieldLambda(SvScalarField):
     __description__ = "Formula"
 
-    def __init__(self, function, variables, in_field):
+    def __init__(self, function, variables, in_field, function_numpy = None):
         self.function = function
+        self.function_numpy = function_numpy
         self.variables = variables
         self.in_field = in_field
 
@@ -91,7 +92,10 @@ class SvScalarFieldLambda(SvScalarField):
             Vs = np.zeros(xs.shape[0])
         else:
             Vs = self.in_field.evaluate_grid(xs, ys, zs)
-        return np.vectorize(self.function)(xs, ys, zs, Vs)
+        if self.function_numpy is not None:
+            return self.function_numpy(xs, ys, zs, Vs)
+        else:
+            return np.vectorize(self.function)(xs, ys, zs, Vs)
 
     def evaluate(self, x, y, z):
         if self.in_field is None:

--- a/utils/field/vector.py
+++ b/utils/field/vector.py
@@ -135,8 +135,9 @@ class SvVectorFieldLambda(SvVectorField):
 
     __description__ = "Formula"
 
-    def __init__(self, function, variables, in_field):
+    def __init__(self, function, variables, in_field, function_numpy = None):
         self.function = function
+        self.function_numpy = function_numpy
         self.variables = variables
         self.in_field = in_field
 
@@ -146,8 +147,11 @@ class SvVectorFieldLambda(SvVectorField):
         else:
             vx, vy, vz = self.in_field.evaluate_grid(xs, ys, zs)
             Vs = np.stack((vx, vy, vz)).T
-        return np.vectorize(self.function,
-                    signature = "(),(),(),(3)->(),(),()")(xs, ys, zs, Vs)
+        if self.function_numpy is None:
+            return np.vectorize(self.function,
+                        signature = "(),(),(),(3)->(),(),()")(xs, ys, zs, Vs)
+        else:
+            return self.function_numpy(xs, ys, zs, Vs)
 
     def evaluate(self, x, y, z):
         if self.in_field is None:

--- a/utils/math.py
+++ b/utils/math.py
@@ -196,6 +196,14 @@ def to_cylindrical(v, mode="degrees"):
         phi = degrees(phi)
     return rho, phi, z
 
+def to_cylindrical_np(v, mode="degrees"):
+    x,y,z = v
+    rho = np.sqrt(x*x + y*y)
+    phi = np.arctan2(y,x)
+    if mode == "degrees":
+        phi = np.degrees(phi)
+    return rho, phi, z
+
 def to_spherical(v, mode="degrees"):
     x,y,z = v
     rho = sqrt(x*x + y*y + z*z)
@@ -206,5 +214,17 @@ def to_spherical(v, mode="degrees"):
     if mode == "degrees":
         phi = degrees(phi)
         theta = degrees(theta)
+    return rho, phi, theta
+
+def to_spherical_np(v, mode="degrees"):
+    x,y,z = v
+    rho = np.sqrt(x*x + y*y + z*z)
+    if rho == 0.0:
+        return 0.0, 0.0, 0.0
+    theta = np.arccos(z/rho)
+    phi = np.arctan2(y,x)
+    if mode == "degrees":
+        phi = np.degrees(phi)
+        theta = np.degrees(theta)
     return rho, phi, theta
 

--- a/utils/math.py
+++ b/utils/math.py
@@ -163,6 +163,13 @@ def from_cylindrical(rho, phi, z, mode="degrees"):
     y = rho*sin(phi)
     return x, y, z
 
+def from_cylindrical_np(rho, phi, z, mode='degrees'):
+    if mode == "degrees":
+        phi = np.radians(phi)
+    x = rho*np.cos(phi)
+    y = rho*np.sin(phi)
+    return x, y, z
+
 def from_spherical(rho, phi, theta, mode="degrees"):
     if mode == "degrees":
         phi = radians(phi)
@@ -170,6 +177,15 @@ def from_spherical(rho, phi, theta, mode="degrees"):
     x = rho * sin(theta) * cos(phi)
     y = rho * sin(theta) * sin(phi)
     z = rho * cos(theta)
+    return x, y, z
+
+def from_spherical_np(rho, phi, theta, mode="degrees"):
+    if mode == "degrees":
+        phi = np.radians(phi)
+        theta = np.radians(theta)
+    x = rho * np.sin(theta) * np.cos(phi)
+    y = rho * np.sin(theta) * np.sin(phi)
+    z = rho * np.cos(theta)
     return x, y, z
 
 def to_cylindrical(v, mode="degrees"):

--- a/utils/math.py
+++ b/utils/math.py
@@ -219,10 +219,17 @@ def to_spherical(v, mode="degrees"):
 def to_spherical_np(v, mode="degrees"):
     x,y,z = v
     rho = np.sqrt(x*x + y*y + z*z)
-    if rho == 0.0:
-        return 0.0, 0.0, 0.0
-    theta = np.arccos(z/rho)
-    phi = np.arctan2(y,x)
+    bad = (rho == 0)
+    good = np.logical_not(bad)
+
+    theta = np.empty_like(x)
+    theta[good] = np.arccos(z[good]/rho[good])
+    theta[bad] = 0.0
+
+    phi = np.empty_like(x)
+    phi[good] = np.arctan2(y[good], x[good])
+    phi[bad] = 0.0
+
     if mode == "degrees":
         phi = np.degrees(phi)
         theta = np.degrees(theta)

--- a/utils/modules/eval_formula.py
+++ b/utils/modules/eval_formula.py
@@ -119,14 +119,16 @@ def sv_compile(string):
         logging.exception(e)
         raise Exception("Invalid expression syntax: " + str(e))
 
-def safe_eval_compiled(compiled, variables):
+def safe_eval_compiled(compiled, variables, allowed_names = None):
     """
     Evaluate expression, allowing only functions known to be "safe"
     to be used.
     """
+    if allowed_names is None:
+        allowed_names = safe_names
     try:
         env = dict()
-        env.update(safe_names)
+        env.update(allowed_names)
         env.update(variables)
         env["__builtins__"] = {}
         return eval(compiled, env)

--- a/utils/script_importhelper.py
+++ b/utils/script_importhelper.py
@@ -18,6 +18,7 @@
 
 import inspect
 from math import *
+import numpy as np
 
 from mathutils import Vector, Matrix
 
@@ -87,4 +88,35 @@ safe_names['pi'] = pi
 # Blender modules
 # Consider this not safe for now
 # safe_names["bpy"] = bpy
+
+def _add_numpy_exact(r, names):
+    for name in names:
+        r[name] = getattr(np, name)
+
+safe_names_np = safe_names.copy()
+_add_numpy_exact(safe_names_np, [
+        'ceil', 'copysign', 'cos', 'sin',
+        'cosh', 'sinh', 'degrees', 'radians',
+        'exp', 'expm1', 'fabs', 'floor', 'fmod',
+        'frexp', 'hypot', 'isfinite', 'isinf',
+        'isnan', 'ldexp', 'log', 'log10', 'log1p', 'log2',
+        'modf', 'sqrt', 'tan', 'tanh', 'trunc'
+    ])
+
+def _numpy_wrapper(f):
+    return lambda a: np.array([f(x) for x in a])
+
+safe_names_np.update({
+        'acos': np.arccos,
+        'acosh': np.arccosh,
+        'asin': np.arcsin,
+        'asinh': np.arcsinh,
+        'atan2': np.arctan2,
+        'atanh': np.arctanh,
+        'erf': _numpy_wrapper(erf),
+        'erfc': _numpy_wrapper(erfc),
+        'gamma': _numpy_wrapper(gamma),
+        'lgamma': _numpy_wrapper(lgamma),
+        'factorial': _numpy_wrapper(factorial)
+    })
 

--- a/utils/surface.py
+++ b/utils/surface.py
@@ -803,8 +803,9 @@ class SvDefaultSphere(SvSurface):
 class SvLambdaSurface(SvSurface):
     __description__ = "Formula"
 
-    def __init__(self, function):
+    def __init__(self, function, function_numpy = None):
         self.function = function
+        self.function_numpy = function_numpy
         self.u_bounds = (0.0, 1.0)
         self.v_bounds = (0.0, 1.0)
         self.normal_delta = 0.001
@@ -833,7 +834,10 @@ class SvLambdaSurface(SvSurface):
         return self.function(u, v)
 
     def evaluate_array(self, us, vs):
-        return np.vectorize(self.function, signature='(),()->(3)')(us, vs)
+        if self.function_numpy is None:
+            return np.vectorize(self.function, signature='(),()->(3)')(us, vs)
+        else:
+            return self.function_numpy(us, vs)
 
     def normal(self, u, v):
         return self.normal_array(np.array([u]), np.array([v]))[0]


### PR DESCRIPTION
For the following nodes:
* Curve Formula
* Surface Formula
* Scalar Field Formula
* Vector Field Formula

allow to perform vectorized computations via numpy. Without vectorization, the formulas are evaluated for each input value separately. With vectorization, when the subsequent node calls something like `surface.evaluate_array()` to calculate values at a series of points, the formula is evaluated one time for the whole array. Calls to usual `math` module functions are automatically replaced with corresponding `numpy` calls.

In my experiments, I have speedups from 2x to 100x. As usual with vectorization, the more values you compute at the time, the bigger speedup you will have. So, the biggest speedup there will be for use, for example, of "scalar field formula" + "Marching Cubes" with high samples, or "Surface Formula" + "Evaluate Surface" with a lot of samples.

I suspect there might be either bugs or precision-related troubles when `math` functions are replaced with their `numpy` counterparts, though I've not experienced such. So I made this vectorization mode optional, but enabled by default. It may be disabled in the node's N panel.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

