### PR TITLE
Presets functionality upgrade

### DIFF
--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -115,6 +115,12 @@ Preset is a named set of stored settings of one of several nodes. You can:
 Each preset belongs to some preset category. By default, all presets are in
 special category named "General".
 
+There are special categories for presets of settings of nodes of specific
+types; such categories can store only settings of nodes of this type. Such
+categories are distinguished with a prefix "/Node/" in their titles. For
+example, a category with name "/Node/ Box" can contain only settings of the
+"Box" node. Such categories are created automatically.
+
 Presets are saved as `.json` files under Blender configuration directory, in
 `datafiles/sverchok/presets`. Preset categories are represented as directories
 under that one.
@@ -132,6 +138,10 @@ It can be good idea to store as a preset (and maybe share) the following things:
   combination often", so that later you can start with this preset and add some
   nodes to it or tweak it somehow.
 
+There are some presets distributed with Sverchok itself. You can not edit or
+remove such presets from Blender's UI. Such presets are marked with a word
+``[standard]`` in tooltips of corresponding buttons in the Presets panel.
+
 Panel Buttons
 -------------
 
@@ -147,6 +157,11 @@ The Presets panel has the following buttons:
   this preset should be known. You need to enter some descriptive name and
   press Ok. After that, the preset will become available in the lower part of
   the panel.
+
+   When there is a presets category of specific node type selected, the "Save
+   Preset" button is only available when a single node of corresponding type is
+   selected.
+
 * **Manage Presets**. This is a toggle button. It switches you between "presets
   usage mode" (which is the default, when button is not pressed) and "presets
   management mode" (when the button is pressed).
@@ -190,6 +205,64 @@ The following buttons (in this order) are shown for each preset you have:
   .. image:: https://user-images.githubusercontent.com/284644/34521620-7ca698dc-f0b0-11e7-94a9-757975ec1ec7.png
 
 * **Delete preset**. You will be asked for confirmation.
+
+It is not possible to edit or remove presets that are distributed with Sverchok.
+
+Node's N panel
+==============
+
+The panel in the right part of node editor window is toggled by the `N`
+keyboard shortcut, so it is called the N panel. Here we will consider the first
+tab of this panel, named "Item". This tab contains some information and
+parameters concerning the currently active node. It is not shown if there is no
+active node in the tree.
+
+.. image:: https://user-images.githubusercontent.com/284644/81494064-31322480-92bf-11ea-82eb-910a71ccc78a.png
+
+The "Item" tab of the N panel contains the following parts:
+
+* **Node** rolldown:
+
+  * **Name**: node name. This is an identifier of the node within the tree. If you
+    try to give the node a name, which is already taken by another node,
+    Blender will automatically add something like ``.001`` to the name.
+  * **Label**: node label to be displayed in the node editor. If not specified,
+    then the node name will be used.
+  * Below that, there is a text box displaying the identifier of the type of
+    active node (so-called ``bl_idname``). It may be useful for scripting or
+    for searching information about the node. The button next to the text box
+    copies that identifier into the clipboard.
+  * Following is the **Presets** section. It contains:
+
+    * **Load Preset** menu. This dropdown menu contains all presets that were
+      created for this type of node. Select a preset from the menu to apply it.
+      Settings loaded from the preset will overwrite current settings of the
+      node. **Note**: the same menu is available in the node editor, when a
+      node is active, by **Shift-P** shortcut.
+    * **Save Preset** button. Save current settings of the node as a new
+      preset. You will be asked for a name for the new preset.
+
+   You can edit and remove your presets in the **Presets** section of the node
+   editor's T panel, if you enable the **Manage Presets** mode (see description
+   above).
+
+   * **Help & Docs** section. This contains buttons for accessing the
+     documentation of currently active node.
+   * **Edit Source** section allows you to edit the source code of the node:
+
+     * **Externally**. Open an external text editor application to edit the file.
+     * **Internally**. Load the source code of the node into Blender's text block.
+
+  * **Re-Create Node** button. This removes the node and replaces it with a new
+    instance of the same node, trying to save all node's settings and
+    connections. This button is mostly useful in the development stage of the
+    node, if you for some reason have to re-initialize the node.
+
+* **Properties** rolldown. This contains all specific settings of the active
+  node type. For most types of nodes, this contains all the same parameters
+  that can be found in the node interface itself. Some types of nodes have
+  additional parameters here - usually ones you do not have to change in most
+  cases, or some kind of "advanced parameters".
 
 3D Panel
 ========

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -242,16 +242,16 @@ The "Item" tab of the N panel contains the following parts:
     * **Save Preset** button. Save current settings of the node as a new
       preset. You will be asked for a name for the new preset.
 
-   You can edit and remove your presets in the **Presets** section of the node
-   editor's T panel, if you enable the **Manage Presets** mode (see description
-   above).
+  You can edit and remove your presets in the **Presets** section of the node
+  editor's T panel, if you enable the **Manage Presets** mode (see description
+  above).
 
-   * **Help & Docs** section. This contains buttons for accessing the
-     documentation of currently active node.
-   * **Edit Source** section allows you to edit the source code of the node:
+  * **Help & Docs** section. This contains buttons for accessing the
+    documentation of currently active node.
+  * **Edit Source** section allows you to edit the source code of the node:
 
-     * **Externally**. Open an external text editor application to edit the file.
-     * **Internally**. Load the source code of the node into Blender's text block.
+    * **Externally**. Open an external text editor application to edit the file.
+    * **Internally**. Load the source code of the node into Blender's text block.
 
   * **Re-Create Node** button. This removes the node and replaces it with a new
     instance of the same node, trying to save all node's settings and

--- a/presets/Examples/Lloyd 2D.json
+++ b/presets/Examples/Lloyd 2D.json
@@ -1,0 +1,54 @@
+{
+  "export_version": "0.079",
+  "framed_nodes": {},
+  "groups": {
+    "Lloyd2D": "{\"nodes\": {\"Group Inputs Exp\": {\"params\": {\"node_kind\": \"outputs\"}, \"bl_idname\": \"SvGroupInputsNodeExp\", \"outputs\": [[\"Vertices\", \"SvVerticesSocket\"]], \"height\": 100.0, \"width\": 140.0, \"label\": \"\", \"hide\": false, \"location\": [-155.0909423828125, 286.998291015625], \"color\": [0.8308190107345581, 0.911391019821167, 0.7545620203018188], \"use_custom_color\": true}, \"Group Outputs Exp\": {\"params\": {\"node_kind\": \"inputs\"}, \"bl_idname\": \"SvGroupOutputsNodeExp\", \"inputs\": [[\"Origins\", \"SvVerticesSocket\"]], \"height\": 100.0, \"width\": 140.0, \"label\": \"\", \"hide\": false, \"location\": [934.9090576171875, 272.3114013671875], \"color\": [0.8308190107345581, 0.911391019821167, 0.7545620203018188], \"use_custom_color\": true}, \"Voronoi 2D\": {\"params\": {\"clip\": 0.10000000149011612, \"make_faces\": 1, \"max_sides\": 18}, \"bl_idname\": \"Voronoi2DNode\", \"height\": 100.0, \"width\": 140.0, \"label\": \"\", \"hide\": false, \"location\": [54.90906524658203, 263.77294921875]}, \"Origins\": {\"params\": {\"mode\": \"Faces\"}, \"bl_idname\": \"SvOrigins\", \"height\": 100.0, \"width\": 140.0, \"label\": \"\", \"hide\": false, \"location\": [409.5296630859375, 307.3299865722656]}}, \"groups\": {}, \"framed_nodes\": {}, \"update_lists\": [[\"Group Inputs Exp\", 0, \"Voronoi 2D\", 0], [\"Voronoi 2D\", 0, \"Origins\", 0], [\"Voronoi 2D\", 2, \"Origins\", 2], [\"Origins\", 0, \"Group Outputs Exp\", 0]], \"export_version\": \"0.079\", \"bl_idname\": \"SverchGroupTreeType\", \"cls_bl_idname\": \"SvGroupNodeMonad_139992150659903\"}"
+  },
+  "nodes": {
+    "Lloyd2D": {
+      "bl_idname": "SvMonadGenericNode",
+      "color": [
+        0.8308190107345581,
+        0.911391019821167,
+        0.7545620203018188
+      ],
+      "height": 100.0,
+      "hide": false,
+      "label": "Lloyd 2D",
+      "location": [
+        774.5697631835938,
+        142.70089721679688
+      ],
+      "params": {
+        "all_props": {
+          "cls_bl_idname": "SvGroupNodeMonad_139992150659903",
+          "float_props": {},
+          "int_props": {},
+          "name": "Lloyd2D"
+        },
+        "cls_dict": {
+          "cls_bl_idname": "SvGroupNodeMonad_139992150659903",
+          "input_template": [
+            [
+              "Vertices",
+              "SvVerticesSocket",
+              {}
+            ]
+          ],
+          "output_template": [
+            [
+              "Origins",
+              "SvVerticesSocket"
+            ]
+          ]
+        },
+        "loop_me": 1,
+        "loops": 5,
+        "monad": "Lloyd2D"
+      },
+      "use_custom_color": true,
+      "width": 140.0
+    }
+  },
+  "update_lists": []
+}

--- a/presets/SvBoxNodeMk2/Box 3x3x3.json
+++ b/presets/SvBoxNodeMk2/Box 3x3x3.json
@@ -1,0 +1,31 @@
+{
+  "export_version": "0.079",
+  "framed_nodes": {},
+  "groups": {},
+  "nodes": {
+    "Box": {
+      "bl_idname": "SvBoxNodeMk2",
+      "color": [
+        0.0,
+        0.5,
+        0.5
+      ],
+      "height": 100.0,
+      "hide": false,
+      "label": "",
+      "location": [
+        -482.1806945800781,
+        -171.5638885498047
+      ],
+      "params": {
+        "Divx": 3,
+        "Divy": 3,
+        "Divz": 3,
+        "Size": 3.0
+      },
+      "use_custom_color": true,
+      "width": 140.0
+    }
+  },
+  "update_lists": []
+}

--- a/presets/SvExCurveFormulaNode/Archimedian Spiral.json
+++ b/presets/SvExCurveFormulaNode/Archimedian Spiral.json
@@ -1,0 +1,25 @@
+{
+  "export_version": "0.079",
+  "framed_nodes": {},
+  "groups": {},
+  "nodes": {
+    "Curve Formula": {
+      "bl_idname": "SvExCurveFormulaNode",
+      "height": 100.0,
+      "hide": false,
+      "label": "",
+      "location": [
+        142.0477752685547,
+        116.76781463623047
+      ],
+      "params": {
+        "formula1": "A*t*cos(t)",
+        "formula2": "A*t*sin(t)",
+        "formula3": "0",
+        "t_max": 18.84955596923828
+      },
+      "width": 140.0
+    }
+  },
+  "update_lists": []
+}

--- a/presets/SvExCurveFormulaNode/Helix.json
+++ b/presets/SvExCurveFormulaNode/Helix.json
@@ -1,0 +1,28 @@
+{
+  "export_version": "0.079",
+  "framed_nodes": {},
+  "groups": {},
+  "nodes": {
+    "Curve Formula": {
+      "bl_idname": "SvExCurveFormulaNode",
+      "height": 100.0,
+      "hide": false,
+      "label": "",
+      "location": [
+        -134.51022338867188,
+        112.47943878173828
+      ],
+      "params": {
+        "formula1": "R*cos(t)",
+        "formula2": "R*sin(t)",
+        "formula3": "H*t/(2*pi)",
+        "output_mode": "XYZ",
+        "t_max": 6.2831854820251465,
+        "t_min": 0.0,
+        "use_numpy_function": true
+      },
+      "width": 140.0
+    }
+  },
+  "update_lists": []
+}

--- a/presets/SvExCurveFormulaNode/Logarithmic Spiral.json
+++ b/presets/SvExCurveFormulaNode/Logarithmic Spiral.json
@@ -1,0 +1,27 @@
+{
+  "export_version": "0.079",
+  "framed_nodes": {},
+  "groups": {},
+  "nodes": {
+    "Curve Formula": {
+      "bl_idname": "SvExCurveFormulaNode",
+      "height": 100.0,
+      "hide": false,
+      "label": "",
+      "location": [
+        -102.85584259033203,
+        64.97071838378906
+      ],
+      "params": {
+        "formula1": "A*exp(B*t)",
+        "formula2": "t",
+        "formula3": "0",
+        "output_mode": "CYL",
+        "t_max": 9.42477798461914,
+        "t_min": -9.42477798461914
+      },
+      "width": 140.0
+    }
+  },
+  "update_lists": []
+}

--- a/presets/SvExScalarFieldFormulaNode/Clebsch Cubic Implicit Surface.json
+++ b/presets/SvExScalarFieldFormulaNode/Clebsch Cubic Implicit Surface.json
@@ -1,0 +1,24 @@
+{
+  "export_version": "0.079",
+  "framed_nodes": {},
+  "groups": {},
+  "nodes": {
+    "Scalar Field Formula": {
+      "bl_idname": "SvExScalarFieldFormulaNode",
+      "height": 100.0,
+      "hide": false,
+      "label": "",
+      "location": [
+        14.335123062133789,
+        167.64987182617188
+      ],
+      "params": {
+        "formula": "81*(x**3 + y**3 + z**3) - 189*(x**2*y + x**2*z + y**2*x + y**2*z + z**2*x + z**2*y) + 54*(x*y*z) + 126*(x*y + x*z + y*z) - 9*(x**2 + y**2 + z**2) - 9*(x + y + z) + 1",
+        "input_mode": "XYZ",
+        "use_numpy_function": true
+      },
+      "width": 395.4254150390625
+    }
+  },
+  "update_lists": []
+}

--- a/presets/SvExScalarFieldFormulaNode/Pilz Implicit Surface.json
+++ b/presets/SvExScalarFieldFormulaNode/Pilz Implicit Surface.json
@@ -1,0 +1,24 @@
+{
+  "export_version": "0.079",
+  "framed_nodes": {},
+  "groups": {},
+  "nodes": {
+    "Scalar Field Formula": {
+      "bl_idname": "SvExScalarFieldFormulaNode",
+      "height": 100.0,
+      "hide": false,
+      "label": "",
+      "location": [
+        -279.73272705078125,
+        33.13140869140625
+      ],
+      "params": {
+        "formula": "((x**2 + y**2 - 1)**2 + (z -0.5)**2)**2 * ( (y**2/aa**2 + (z + hh)**2 -1)**2 +x**2) - ff * (1 + bb*(0*x**2 + 0*y**2 + (z-0.5)**2))",
+        "input_mode": "XYZ",
+        "use_numpy_function": true
+      },
+      "width": 545.8057250976562
+    }
+  },
+  "update_lists": []
+}

--- a/presets/SvExScalarFieldFormulaNode/Saddle Tower Implicit Surface.json
+++ b/presets/SvExScalarFieldFormulaNode/Saddle Tower Implicit Surface.json
@@ -1,0 +1,24 @@
+{
+  "export_version": "0.079",
+  "framed_nodes": {},
+  "groups": {},
+  "nodes": {
+    "Scalar Field Formula": {
+      "bl_idname": "SvExScalarFieldFormulaNode",
+      "height": 100.0,
+      "hide": false,
+      "label": "",
+      "location": [
+        -123.76757049560547,
+        -22.59556770324707
+      ],
+      "params": {
+        "formula": "sin(z) - sinh(x)*sinh(y)",
+        "input_mode": "XYZ",
+        "use_numpy_function": true
+      },
+      "width": 394.4968566894531
+    }
+  },
+  "update_lists": []
+}

--- a/presets/SvExSurfaceFormulaNode/Helicoid.json
+++ b/presets/SvExSurfaceFormulaNode/Helicoid.json
@@ -1,0 +1,30 @@
+{
+  "export_version": "0.079",
+  "framed_nodes": {},
+  "groups": {},
+  "nodes": {
+    "Surface Formula": {
+      "bl_idname": "SvExSurfaceFormulaNode",
+      "height": 100.0,
+      "hide": false,
+      "label": "",
+      "location": [
+        -124.90266418457031,
+        131.9246826171875
+      ],
+      "params": {
+        "formula1": "u*cos(v)",
+        "formula2": "u*sin(v)",
+        "formula3": "H*v",
+        "output_mode": "XYZ",
+        "u_max": 3.0,
+        "u_min": 0.0,
+        "use_numpy_function": true,
+        "v_max": 18.84955596923828,
+        "v_min": 0.0
+      },
+      "width": 140.0
+    }
+  },
+  "update_lists": []
+}

--- a/presets/SvExSurfaceFormulaNode/Monkey Saddle.json
+++ b/presets/SvExSurfaceFormulaNode/Monkey Saddle.json
@@ -1,0 +1,30 @@
+{
+  "export_version": "0.079",
+  "framed_nodes": {},
+  "groups": {},
+  "nodes": {
+    "Surface Formula": {
+      "bl_idname": "SvExSurfaceFormulaNode",
+      "height": 100.0,
+      "hide": false,
+      "label": "",
+      "location": [
+        40.65468978881836,
+        50.915157318115234
+      ],
+      "params": {
+        "formula1": "u",
+        "formula2": "v",
+        "formula3": "u**3 - 3*u*v**2",
+        "output_mode": "XYZ",
+        "u_max": 1.0,
+        "u_min": -1.0,
+        "use_numpy_function": true,
+        "v_max": 1.0,
+        "v_min": -1.0
+      },
+      "width": 140.0
+    }
+  },
+  "update_lists": []
+}

--- a/presets/SvExSurfaceFormulaNode/Möbius Strip.json
+++ b/presets/SvExSurfaceFormulaNode/Möbius Strip.json
@@ -1,0 +1,30 @@
+{
+  "export_version": "0.079",
+  "framed_nodes": {},
+  "groups": {},
+  "nodes": {
+    "Surface Formula": {
+      "bl_idname": "SvExSurfaceFormulaNode",
+      "height": 100.0,
+      "hide": false,
+      "label": "",
+      "location": [
+        -125.68179321289062,
+        127.20514678955078
+      ],
+      "params": {
+        "formula1": "A * (1 + v/2 * cos(u/2))*cos(u)",
+        "formula2": "A * (1 + v/2 * cos(u/2)) * sin(u)",
+        "formula3": "A * v/2 * sin(u/2)",
+        "output_mode": "XYZ",
+        "u_max": 6.2831854820251465,
+        "u_min": 0.0,
+        "use_numpy_function": true,
+        "v_max": 1.0,
+        "v_min": -1.0
+      },
+      "width": 217.093505859375
+    }
+  },
+  "update_lists": []
+}

--- a/presets/SvVDExperimental/Dark Blue.json
+++ b/presets/SvVDExperimental/Dark Blue.json
@@ -1,0 +1,78 @@
+{
+  "export_version": "0.079",
+  "framed_nodes": {},
+  "groups": {},
+  "metainfo": {
+    "author": "",
+    "description": "Dark Blue Viewer Draw",
+    "keywords": "",
+    "license": "CC-BY-SA"
+  },
+  "nodes": {
+    "Viewer Draw Mk3": {
+      "bl_idname": "SvVDExperimental",
+      "color": [
+        1.0,
+        0.5889999866485596,
+        0.21400000154972076
+      ],
+      "height": 100.0,
+      "hide": false,
+      "label": "",
+      "location": [
+        329.91375732421875,
+        156.2830047607422
+      ],
+      "params": {
+        "activate": true,
+        "custom_fragment_shader": "\n    uniform float brightness;\n\n    in vec3 pos;\n\n    void main()\n    {\n        gl_FragColor = vec4(pos * brightness, 1.0);\n    }\n",
+        "custom_shader_location": "",
+        "custom_vertex_shader": "\n    uniform mat4 viewProjectionMatrix;\n\n    in vec3 position;\n    out vec3 pos;\n\n    void main()\n    {\n        pos = position;\n        gl_Position = viewProjectionMatrix * vec4(position, 1.0f);\n    }\n",
+        "display_edges": true,
+        "display_faces": true,
+        "display_verts": false,
+        "draw_gl_polygonoffset": true,
+        "draw_gl_wireframe": false,
+        "edge_color": [
+          0.0,
+          0.0011443882249295712,
+          0.14550375938415527,
+          1.0
+        ],
+        "extended_matrix": false,
+        "face_color": [
+          0.14000000059604645,
+          0.5400000214576721,
+          0.8100000023841858,
+          1.0
+        ],
+        "handle_concave_quads": false,
+        "line_width": 1,
+        "node_ui_show_attrs_socket": false,
+        "point_size": 4.0,
+        "selected_draw_mode": "facet",
+        "u_dash_size": 0.11999999731779099,
+        "u_gap_size": 0.1899999976158142,
+        "u_resolution": [
+          25.0,
+          18.0
+        ],
+        "use_dashed": false,
+        "vector_light": [
+          0.20000000298023224,
+          0.6000000238418579,
+          0.4000000059604645
+        ],
+        "vert_color": [
+          0.800000011920929,
+          0.800000011920929,
+          0.800000011920929,
+          1.0
+        ]
+      },
+      "use_custom_color": true,
+      "width": 140.0
+    }
+  },
+  "update_lists": []
+}

--- a/presets/SvVDExperimental/Yellow.json
+++ b/presets/SvVDExperimental/Yellow.json
@@ -1,0 +1,78 @@
+{
+  "export_version": "0.079",
+  "framed_nodes": {},
+  "groups": {},
+  "metainfo": {
+    "author": "",
+    "description": "Yellow / red Viewer Draw",
+    "keywords": "",
+    "license": "CC-BY-SA"
+  },
+  "nodes": {
+    "Viewer Draw Mk3": {
+      "bl_idname": "SvVDExperimental",
+      "color": [
+        1.0,
+        0.5889999866485596,
+        0.21400000154972076
+      ],
+      "height": 100.0,
+      "hide": false,
+      "label": "",
+      "location": [
+        329.91375732421875,
+        156.2830047607422
+      ],
+      "params": {
+        "activate": true,
+        "custom_fragment_shader": "\n    uniform float brightness;\n\n    in vec3 pos;\n\n    void main()\n    {\n        gl_FragColor = vec4(pos * brightness, 1.0);\n    }\n",
+        "custom_shader_location": "",
+        "custom_vertex_shader": "\n    uniform mat4 viewProjectionMatrix;\n\n    in vec3 position;\n    out vec3 pos;\n\n    void main()\n    {\n        pos = position;\n        gl_Position = viewProjectionMatrix * vec4(position, 1.0f);\n    }\n",
+        "display_edges": true,
+        "display_faces": true,
+        "display_verts": false,
+        "draw_gl_polygonoffset": true,
+        "draw_gl_wireframe": false,
+        "edge_color": [
+          0.30573487281799316,
+          0.003269235836341977,
+          0.019176948815584183,
+          1.0
+        ],
+        "extended_matrix": false,
+        "face_color": [
+          1.0,
+          0.900135338306427,
+          0.5130714178085327,
+          1.0
+        ],
+        "handle_concave_quads": false,
+        "line_width": 1,
+        "node_ui_show_attrs_socket": false,
+        "point_size": 4.0,
+        "selected_draw_mode": "facet",
+        "u_dash_size": 0.11999999731779099,
+        "u_gap_size": 0.1899999976158142,
+        "u_resolution": [
+          25.0,
+          18.0
+        ],
+        "use_dashed": false,
+        "vector_light": [
+          0.20000000298023224,
+          0.6000000238418579,
+          0.4000000059604645
+        ],
+        "vert_color": [
+          0.9111706614494324,
+          0.4350321292877197,
+          0.2654842138290405,
+          1.0
+        ]
+      },
+      "use_custom_color": true,
+      "width": 140.0
+    }
+  },
+  "update_lists": []
+}

--- a/ui/development.py
+++ b/ui/development.py
@@ -227,21 +227,6 @@ def idname_draw(self, context):
     colom = row.column(align=True)
     colom.operator('node.copy_bl_idname', text='', icon='COPY_ID').name = bl_idname
 
-    # show these anyway, can fail and let us know..
-    row = col.row(align=True)
-    row.label(text='Help & Docs:')
-    row = col.row(align=True)
-    row.operator('node.view_node_help', text='Online').kind = 'online'
-    row.operator('node.view_node_help', text='Offline').kind = 'offline'
-    row.operator('node.view_node_help', text='Github').kind = 'github' #, icon='GHOST'
-    col.separator()
-    # view the source of the current node ( warning, some nodes rely on more than one file )
-    row = col.row(align=True)
-    row.label(text='Edit Source:')
-    row = col.row(align=True)
-    row.operator('node.sv_view_node_source', text='Externally').kind = 'external'
-    row.operator('node.sv_view_node_source', text='Internally').kind = 'internal'
-
     box = col.box()
     box.label(text="Presets:")
     presets_col = box.column(align=True)
@@ -257,6 +242,21 @@ def idname_draw(self, context):
     save.save_defaults = True
     selected_nodes = [node for node in ntree.nodes if node.select]
     save_row.enabled = len(selected_nodes) == 1
+
+    # show these anyway, can fail and let us know..
+    row = col.row(align=True)
+    row.label(text='Help & Docs:')
+    row = col.row(align=True)
+    row.operator('node.view_node_help', text='Online').kind = 'online'
+    row.operator('node.view_node_help', text='Offline').kind = 'offline'
+    row.operator('node.view_node_help', text='Github').kind = 'github' #, icon='GHOST'
+    col.separator()
+    # view the source of the current node ( warning, some nodes rely on more than one file )
+    row = col.row(align=True)
+    row.label(text='Edit Source:')
+    row = col.row(align=True)
+    row.operator('node.sv_view_node_source', text='Externally').kind = 'external'
+    row.operator('node.sv_view_node_source', text='Internally').kind = 'internal'
 
     if hasattr(node, 'replacement_nodes'):
         box = col.box()

--- a/ui/development.py
+++ b/ui/development.py
@@ -256,16 +256,18 @@ def idname_draw(self, context):
     colom = row.column(align=True)
     colom.operator('node.copy_bl_idname', text='', icon='COPY_ID').name = bl_idname
 
-    box = col.box()
-    box.label(text="Presets:")
-    box.menu("SV_MT_LoadPresetMenu")
-    save_row = box.row()
-    save = save_row.operator(SvSaveSelected.bl_idname, text="Save Preset", icon='SOLO_ON')
-    save.id_tree = ntree.name
-    save.category = node.bl_idname
-    save.save_defaults = True
-    selected_nodes = [node for node in ntree.nodes if node.select]
-    save_row.enabled = len(selected_nodes) == 1
+    is_monad = (bl_idname.startswith('SvGroupNodeMonad'))
+    if not is_monad:
+        box = col.box()
+        box.label(text="Presets:")
+        box.menu("SV_MT_LoadPresetMenu")
+        save_row = box.row()
+        save = save_row.operator(SvSaveSelected.bl_idname, text="Save Preset", icon='SOLO_ON')
+        save.id_tree = ntree.name
+        save.category = node.bl_idname
+        save.save_defaults = True
+        selected_nodes = [node for node in ntree.nodes if node.select]
+        save_row.enabled = len(selected_nodes) == 1
 
     # show these anyway, can fail and let us know..
     row = col.row(align=True)

--- a/ui/nodeview_keymaps.py
+++ b/ui/nodeview_keymaps.py
@@ -76,6 +76,10 @@ def add_keymap():
         kmi.properties.name = "NODEVIEW_MT_sv_rclick_menu"
         nodeview_keymaps.append((km, kmi))
 
+        kmi = km.keymap_items.new('wm.call_menu', 'P', 'PRESS', shift=True)
+        kmi.properties.name = "SV_MT_LoadPresetMenu"
+        nodeview_keymaps.append((km, kmi))
+
         # Ctrl + Left Click   | Connect Temporal Viewer
         kmi = km.keymap_items.new('node.sv_temporal_viewer', 'LEFTMOUSE', 'RELEASE', ctrl=True)
         kmi.properties.force_stethoscope = False

--- a/ui/presets.py
+++ b/ui/presets.py
@@ -424,6 +424,7 @@ class SvPresetProps(bpy.types.Operator):
 
     old_category: StringProperty(name="Old category", description="Preset category")
     new_category: EnumProperty(name="Category", description="New preset category", items = get_category_items)
+    allow_change_category : BoolProperty(default = True)
 
     old_name: StringProperty(name="Old name", description="Preset name")
     new_name: StringProperty(name="Name", description="New preset name")
@@ -436,7 +437,10 @@ class SvPresetProps(bpy.types.Operator):
 
     def draw(self, context):
         layout = self.layout
-        layout.prop(self, "new_category")
+        if self.allow_change_category:
+            layout.prop(self, "new_category")
+        else:
+            layout.label(text="Category: " + self.old_category)
         layout.prop(self, "new_name")
         layout.prop(self, "description")
         layout.prop(self, "keywords")
@@ -903,6 +907,8 @@ class SV_PT_UserPresetsPanel(bpy.types.Panel):
                         rename = row.operator('node.sv_preset_props', text="", icon="GREASEPENCIL")
                         rename.old_name = name
                         rename.old_category = panel_props.category
+                        rename.new_category = rename.old_category
+                        rename.allow_change_category = (category_node_class is None)
 
                         delete = row.operator('node.sv_preset_delete', text="", icon='CANCEL')
                         delete.preset_name = name

--- a/ui/presets.py
+++ b/ui/presets.py
@@ -255,9 +255,11 @@ class SvPreset(object):
 
         if (self.category, self.name) not in preset_add_operators:
 
+            preset_name = self.name if not self.description else self.description
+
             class SverchPresetAddOperator(bpy.types.Operator):
                 bl_idname = "node.sv_preset_" + get_preset_idname_for_operator(self.name, self.category)
-                bl_label = "Add {} preset ({} category)".format(self.name, self.category)
+                bl_label = "Add {} preset ({} category)".format(preset_name, self.category)
                 bl_options = {'REGISTER', 'UNDO'}
 
                 cursor_x: bpy.props.IntProperty()

--- a/ui/presets.py
+++ b/ui/presets.py
@@ -23,7 +23,7 @@ from glob import glob
 import json
 from urllib.parse import quote_plus
 import inspect
-import traceback
+import hashlib
 
 import bpy
 from bpy.props import StringProperty, BoolProperty, EnumProperty
@@ -58,7 +58,6 @@ def get_presets_directory(category=None, mkdir=True, standard=False):
     else:
         presets = join(bpy.utils.user_resource('DATAFILES', path=path_partial, create=mkdir))
     if not os.path.exists(presets) and mkdir and not standard:
-        print("Create: {}\n{}".format(presets, traceback.format_stack()))
         os.makedirs(presets)
     return presets
 
@@ -112,7 +111,7 @@ def get_preset_idname_for_operator(name, category=None):
         category = replace_bad_chars(category)
         name = category + "__" + name
     if len(name) > 45:
-        name = name[:45]
+        name = name[:38] + "_" + hashlib.sha1(name.encode('utf-8')).hexdigest()[:5]
     return name
 
 # We are creating and registering preset adding operators dynamically.

--- a/ui/presets.py
+++ b/ui/presets.py
@@ -22,50 +22,86 @@ import shutil
 from glob import glob
 import json
 from urllib.parse import quote_plus
+import inspect
+import traceback
 
 import bpy
 from bpy.props import StringProperty, BoolProperty, EnumProperty
 
-from sverchok.utils.sv_IO_panel_tools import write_json, create_dict_of_tree, import_tree
+from sverchok.utils.sv_IO_panel_tools import write_json, create_dict_of_tree, import_tree, import_node_settings
 from sverchok.utils.logging import debug, info, error, exception
 from sverchok.utils import sv_gist_tools
 from sverchok.utils import sv_IO_panel_tools
+from sverchok.utils import get_node_class_reference
+import sverchok
+
+# To be moved somewhere under core/
+def get_sverchok_directory():
+    filename = inspect.getfile(sverchok)
+    return dirname(filename)
 
 GENERAL = "General"
 
-def get_presets_directory(category=None, mkdir=True):
+def get_presets_directory(category=None, mkdir=True, standard=False):
     if category is None or category == GENERAL:
-        path_partial = os.path.join('sverchok', 'presets')
+        if standard:
+            path_partial = 'presets'
+        else:
+            path_partial = os.path.join('sverchok', 'presets')
     else:
-        path_partial = os.path.join('sverchok', 'presets', category)
-    presets = join(bpy.utils.user_resource('DATAFILES', path=path_partial, create=True))
-    if not os.path.exists(presets) and mkdir:
+        if standard:
+            path_partial = join('presets', category)
+        else:
+            path_partial = os.path.join('sverchok', 'presets', category)
+    if standard:
+        presets = join(get_sverchok_directory(), path_partial)
+    else:
+        presets = join(bpy.utils.user_resource('DATAFILES', path=path_partial, create=mkdir))
+    if not os.path.exists(presets) and mkdir and not standard:
+        print("Create: {}\n{}".format(presets, traceback.format_stack()))
         os.makedirs(presets)
     return presets
 
-def get_category_names():
-    base = get_presets_directory()
-    categories = []
-    for path in sorted(glob(join(base, "*"))):
-        if isdir(path):
-            name = basename(path)
-            categories.append(name)
+def get_category_names(mkdir=True):
+    standard = get_presets_directory(standard=True)
+    user = get_presets_directory(standard=False, mkdir=mkdir)
+    for base in [standard, user]:
+        categories = []
+        for path in sorted(glob(join(base, "*"))):
+            if isdir(path):
+                name = basename(path)
+                if name not in categories:
+                    categories.append(name)
     return categories
 
 def get_category_items(self, context):
     category_items = None
     category_items = [(GENERAL, "General", "Uncategorized presets", 0)]
+    node_category_items = []
     for idx, category in enumerate(get_category_names()):
-        category_items.append((category, category, category, idx+1))
+        node_class = get_node_class_reference(category)
+        if node_class:
+            title = "/Node/ {}".format(node_class.bl_label)
+            node_category_items.append((category, title, category, idx+1))
+        else:
+            title = category
+            category_items.append((category, title, category, idx+1))
+    if node_category_items:
+        category_items = category_items + [None] + node_category_items
     return category_items
 
-def get_preset_path(name, category=None):
-    presets = get_presets_directory(category)
+def get_preset_path(name, category=None, standard=False, mkdir=True):
+    presets = get_presets_directory(category, standard=standard, mkdir=mkdir)
     return join(presets, name + ".json")
 
-def get_preset_paths(category=None):
-    presets = get_presets_directory(category)
-    return list(sorted(glob(join(presets, "*.json"))))
+def get_preset_paths(category=None, mkdir=True):
+    standard = get_presets_directory(category, standard=True)
+    user = get_presets_directory(category, standard=False, mkdir=mkdir)
+    standard_presets = glob(join(standard, "*.json"))
+    user_presets = glob(join(user, "*.json"))
+    standard_presets.sort()
+    user_presets.sort()
+    return [(True, path) for path in standard_presets] + [(False, path) for path in user_presets]
 
 def replace_bad_chars(s):
     return quote_plus(s).replace('+', '_').replace('%', '_').replace('-','_').lower()
@@ -74,22 +110,24 @@ def get_preset_idname_for_operator(name, category=None):
     name = replace_bad_chars(name)
     if category:
         category = replace_bad_chars(category)
-        return category + "__" + name
-    else:
-        return name
+        name = category + "__" + name
+    if len(name) > 45:
+        name = name[:45]
+    return name
 
 # We are creating and registering preset adding operators dynamically.
 # So, we have to remember them in order to unregister them when needed.
 preset_add_operators = {}
 
 class SvPreset(object):
-    def __init__(self, name=None, path=None, category=None):
+    def __init__(self, name=None, path=None, category=None, standard=False):
         if name is None and path is None:
             raise Exception("Either name or path must be specified when initializing SvPreset")
         self._name = name
         self._path = path
         self._data = None
         self.category = category
+        self.standard = standard
 
     def get_name(self):
         if self._name is not None:
@@ -102,7 +140,8 @@ class SvPreset(object):
 
     def set_name(self, new_name):
         self._name = new_name
-        self._path = get_preset_path(new_name)
+        self._path = get_preset_path(new_name, standard=False)
+        self.standard = False
 
     name = property(get_name, set_name)
 
@@ -110,7 +149,7 @@ class SvPreset(object):
         if self._path is not None:
             return self._path
         else:
-            path = get_preset_path(self._name, self.category)
+            path = get_preset_path(self._name, self.category, standard=self.standard)
             self._path = path
             return path
 
@@ -254,6 +293,8 @@ class SvPreset(object):
 
             SverchPresetAddOperator.__name__ = self.name
             SverchPresetAddOperator.__doc__ = self.meta.get("description", self.name)
+            if self.standard:
+                SverchPresetAddOperator.__doc__ += " [standard]"
 
             preset_add_operators[(self.category, self.name)] = SverchPresetAddOperator
             bpy.utils.register_class(SverchPresetAddOperator)
@@ -265,15 +306,40 @@ class SvPreset(object):
             category = self.category
         op = layout.operator("node.sv_preset_"+get_preset_idname_for_operator(self.name, category), text=self.name)
 
-def get_presets(category=None, search=None):
+class SverchPresetReplaceOperator(bpy.types.Operator):
+    """Load node settings from preset"""
+    bl_idname = "node.sv_preset_replace_node"
+    bl_label = "Load node settings from preset"
+    bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
+
+    node_name : StringProperty()
+    preset_path : StringProperty()
+    preset_name : StringProperty()
+
+    @classmethod
+    def description(cls, context, properties):
+        return "Load node settings from the preset `{}' (overwrite current settings)".format(properties.preset_name)
+
+    def execute(self, context):
+        ntree = context.space_data.node_tree
+        node = ntree.nodes[self.node_name]
+        id_tree = ntree.name
+        ng = bpy.data.node_groups[id_tree]
+
+        preset = SvPreset(path = self.preset_path, category = node.bl_idname)
+        node_json = list(preset.data['nodes'].values())[0]
+        import_node_settings(node, node_json, overwrite_presentation_props = False)
+        return {'FINISHED'}
+
+def get_presets(category=None, search=None, mkdir=True):
     result = []
     if search:
-        categories = [GENERAL] + get_category_names()
+        categories = [GENERAL] + get_category_names(mkdir=mkdir)
     else:
         categories = [category]
     for category in categories:
-        for path in get_preset_paths(category):
-            preset = SvPreset(path=path, category=category)
+        for is_standard, path in get_preset_paths(category, mkdir=mkdir):
+            preset = SvPreset(path=path, category=category, standard=is_standard)
             if preset.matches(search):
                 result.append(preset)
     return result
@@ -305,6 +371,7 @@ class SvSaveSelected(bpy.types.Operator):
     preset_name: StringProperty(name="Name", description="Preset name")
     id_tree: StringProperty()
     category: StringProperty()
+    save_defaults : BoolProperty(default = False)
 
     def execute(self, context):
         if not self.id_tree:
@@ -328,7 +395,7 @@ class SvSaveSelected(bpy.types.Operator):
             self.report({'ERROR'}, msg)
             return {'CANCELLED'}
 
-        layout_dict = create_dict_of_tree(ng, selected=True)
+        layout_dict = create_dict_of_tree(ng, selected=True, save_defaults = self.save_defaults)
         preset = SvPreset(name=self.preset_name, category = self.category)
         preset.make_add_operator()
         destination_path = preset.path
@@ -790,7 +857,18 @@ class SV_PT_UserPresetsPanel(bpy.types.Panel):
         op = row.operator('node.sv_save_selected', text="Save Preset", icon='SOLO_ON')
         op.id_tree = ntree.name
         op.category = panel_props.category
-        row.enabled = any(node.select for node in ntree.nodes)
+
+        selected_nodes = [node for node in ntree.nodes if node.select]
+        can_save_preset = len(selected_nodes) > 0
+        category_node_class = get_node_class_reference(op.category)
+        if category_node_class is not None:
+            if len(selected_nodes) == 1:
+                selected_node = selected_nodes[0]
+                can_save_preset = can_save_preset and hasattr(selected_node, 'bl_idname') and selected_node.bl_idname == op.category
+            else:
+                can_save_preset = False
+        row.enabled = can_save_preset
+
         layout.separator()
 
         presets = get_presets(panel_props.category, search=needle)
@@ -822,13 +900,14 @@ class SV_PT_UserPresetsPanel(bpy.types.Panel):
                     export.preset_name = name
                     export.category = panel_props.category
 
-                    rename = row.operator('node.sv_preset_props', text="", icon="GREASEPENCIL")
-                    rename.old_name = name
-                    rename.old_category = panel_props.category
+                    if not preset.standard:
+                        rename = row.operator('node.sv_preset_props', text="", icon="GREASEPENCIL")
+                        rename.old_name = name
+                        rename.old_category = panel_props.category
 
-                    delete = row.operator('node.sv_preset_delete', text="", icon='CANCEL')
-                    delete.preset_name = name
-                    delete.category = panel_props.category
+                        delete = row.operator('node.sv_preset_delete', text="", icon='CANCEL')
+                        delete.preset_name = name
+                        delete.category = panel_props.category
             else:
                 layout.label(text="You do not have any presets")
                 layout.label(text="under `{}` category.".format(panel_props.category))
@@ -859,6 +938,7 @@ classes = [
     SvPresetCategoryDelete,
     SvPresetToGist,
     SvPresetToFile,
+    SverchPresetReplaceOperator,
     SV_PT_UserPresetsPanel
 ]
 

--- a/utils/sv_IO_panel_tools.py
+++ b/utils/sv_IO_panel_tools.py
@@ -255,7 +255,7 @@ def handle_enum_property(node, k, v, node_items, node_enums):
         node_items[k] = v
 
 
-def create_dict_of_tree(ng, skip_set={}, selected=False, identified_node=None):
+def create_dict_of_tree(ng, skip_set={}, selected=False, identified_node=None, save_defaults = False):
     nodes = ng.nodes
     layout_dict = {}
     nodes_dict = {}
@@ -283,7 +283,11 @@ def create_dict_of_tree(ng, skip_set={}, selected=False, identified_node=None):
 
         IsMonadInstanceNode = (node.bl_idname.startswith('SvGroupNodeMonad'))
 
-        for k, v in node.items():
+        if save_defaults:
+            node_props = ((k, getattr(node, k)) for k in node.bl_rna.__annotations__.keys())
+        else:
+            node_props = node.items()
+        for k, v in node_props:
 
             display_introspection_info(node, k, v)
 
@@ -589,6 +593,12 @@ def fix_enum_identifier_spaces_if_needed(node, node_ref):
             if " " in stored_value:
                 params[prop_name] = stored_value.replace(" ", "_")
 
+def import_node_settings(node, node_ref, overwrite_presentation_props=True):
+    apply_core_props(node, node_ref)
+    if overwrite_presentation_props:
+        apply_superficial_props(node, node_ref)
+    apply_post_processing(node, node_ref)
+    apply_custom_socket_props(node, node_ref)
 
 def add_node_to_tree(nodes, n, nodes_to_import, name_remap, create_texts):
     node_ref = nodes_to_import[n]
@@ -623,10 +633,7 @@ def add_node_to_tree(nodes, n, nodes_to_import, name_remap, create_texts):
             node.object_names.add().name = named_object
 
     gather_remapped_names(node, n, name_remap)
-    apply_core_props(node, node_ref)
-    apply_superficial_props(node, node_ref)
-    apply_post_processing(node, node_ref)
-    apply_custom_socket_props(node, node_ref)
+    import_node_settings(node, node_ref)
 
 
 def add_nodes(ng, nodes_to_import, nodes, create_texts):

--- a/utils/sv_IO_panel_tools.py
+++ b/utils/sv_IO_panel_tools.py
@@ -254,6 +254,13 @@ def handle_enum_property(node, k, v, node_items, node_enums):
         v = getattr(node, k)
         node_items[k] = v
 
+def get_node_annotations(node, include_pointer_props = False):
+    result = []
+    for key, ann in node.bl_rna.__annotations__.items():
+        prop_type = ann[0]
+        if include_pointer_props or prop_type != bpy.props.PointerProperty:
+            result.append((key, getattr(node, key)))
+    return result
 
 def create_dict_of_tree(ng, skip_set={}, selected=False, identified_node=None, save_defaults = False):
     nodes = ng.nodes
@@ -284,7 +291,7 @@ def create_dict_of_tree(ng, skip_set={}, selected=False, identified_node=None, s
         IsMonadInstanceNode = (node.bl_idname.startswith('SvGroupNodeMonad'))
 
         if save_defaults:
-            node_props = ((k, getattr(node, k)) for k in node.bl_rna.__annotations__.keys())
+            node_props = get_node_annotations(node)
         else:
             node_props = node.items()
         for k, v in node_props:


### PR DESCRIPTION
This adds:

* Support for "Standard" presets, which are supposed to be distributed with Sverchok (some kind of example settings). 
* Support for "Per-node presets", i.e. presets which store settings of one and only one node. Such presets are displayed in the node's N panel, so when the node is selected it is possible to switch it between several pre-saved settings. Some node classes already had similar functionality (I remember Spiral and Regular Solid).

"Per-node" presets are saved in special preset categories, which are distinguished with "/Node/" title prefix. For example, category "/Node/ Box" can only store presets for the "Box" node. Such categories are created automatically when you first create a preset for the certain type of node from the node's N panel. It is possible to use the usual Presets panel under the T panel to manage such presets.

![Screenshot_20200510_104238](https://user-images.githubusercontent.com/284644/81491742-0a69f300-92ab-11ea-9f23-18209f7b7f7d.png)

Also the list of all presets defined for the node is available in the node tree editor by *Shift-P* shortcut.

![Screenshot_20200510_104511](https://user-images.githubusercontent.com/284644/81491775-59b02380-92ab-11ea-8894-14779b6beb3a.png)

## Difference between standard presets and Examples

Historically, our Examples menu contained examples of more or less complete setups, consisting of several nodes. Some of those examples are relatively complex. So, Examples is for examples of what can one do with Sverchok.

Per-node Presets, which are to be distributed with Sverchok, are just some combinations of settings of specific complex node, which developer thinks will be frequently used.

Standard Presets that are not per-node may be some small parts of logic that developer thinks may be frequently used. Probably it worth wrapping such pieces into Monads before packing as presets. As an example of such preset, I included Lloyd 2D monad.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

