### PR TITLE
overloads G function nicely

### DIFF
--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -2,7 +2,7 @@ ui_modules = [
     "color_def", "sv_IO_panel", "sv_examples_menu",
     "sv_panels", "nodeview_rclick_menu", "nodeview_space_menu",
     "monad", "sv_icons", "presets", "nodes_replacement", "sv_panel_display_nodes",
-    "sv_temporal_viewers", "sv_vep_connector",
+    "sv_temporal_viewers", "sv_vep_connector", "sv_overload_node_ot_translate",
     # bgl modules
     "bgl_callback_3dview", "bgl_callback_nodeview",
     # show git info


### PR DESCRIPTION
adds a `bpy.types.Macro` to Sverchok, currently no keymap 

- have a node outputting into Stethoscope.
- select the stethoscope node.
- `f3` -> "Overload "   (shows Overload G function)
- hit Enter, move the mouse around
- hit enter to let go.   booooom.  automatic repositioning of callback / nodeview drawing.






