### PR TITLE
Snlite remove raise

### DIFF
--- a/nodes/generator/script1_lite.py
+++ b/nodes/generator/script1_lite.py
@@ -182,6 +182,8 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
         items=custom_enum_func, description="custom enum", update=updateNode
     )
 
+    snlite_raise_exception = BoolProperty(name="raise exception")
+
     def draw_label(self):
         if self.script_name:
             return 'SN: ' + self.script_name
@@ -436,7 +438,8 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
             print('on line: ', lineno)
             show = traceback.print_exception
             show(exc_type, exc_value, exc_traceback, limit=2, file=sys.stdout)
-            raise #   SNLITE_EXCEPTION(sys.exc_info()[2]) from err
+            if self.snlite_raise_exception:
+                raise #   SNLITE_EXCEPTION(sys.exc_info()[2]) from err
 
     def custom_draw(self, context, layout):
         tk = self.node_dict.get(hash(self))

--- a/nodes/generator/script1_lite.py
+++ b/nodes/generator/script1_lite.py
@@ -438,7 +438,7 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
             print('on line: ', lineno)
             show = traceback.print_exception
             show(exc_type, exc_value, exc_traceback, limit=2, file=sys.stdout)
-            if self.snlite_raise_exception:
+            if hasattr(self, "snlite_raise_exception") and self.snlite_raise_exception:
                 raise #   SNLITE_EXCEPTION(sys.exc_info()[2]) from err
 
     def custom_draw(self, context, layout):


### PR DESCRIPTION
fixes an issue in underdefined snlite scripts that raise exception during snlite import via gists.

in order to get proper exceptions from snlite, user must set the node's self.snlite_raise_exception to True, else the exception must be read from the Console.