### PR TITLE
add raise toggle in ext

### DIFF
--- a/nodes/generator/script1_lite.py
+++ b/nodes/generator/script1_lite.py
@@ -483,6 +483,14 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
         row.prop(self, 'selected_mode', expand=True)
         col = layout.column()
         col.menu(SV_MT_ScriptNodeLitePyMenu.bl_idname)
+        
+        box = layout.box()
+        r = box.row()
+        r.label(text="extra snlite features")
+        if hasattr(self, "snlite_raise_exception"):
+            r = box.row()
+            r.prop(self, "snlite_raise_exception", toggle=True, text="raise errors to tree level")
+
 
 
     # ---- IO Json storage is handled in this node locally ----


### PR DESCRIPTION
this adds a toggle in the draw_buttons_ext which lets the user of SNLite, switch whether or not 
 - an error during the script runtime is raised to the tree level (by Raise) or 
 - is continued to be suppressed and printed to stdout instead. (was the long term behaviour untill a few months ago)

The upside to `raise` is the tree can display the error, and the user knows that the node is in an error state.
The downside with `raise` on is that Gists, which contain snlite scripts which themselves are not fully handling the "not fully connected" state, those will fail.

so. this toggle is off by default. and only those of us that need it should bother enabling it.

![image](https://user-images.githubusercontent.com/619340/82045973-4b4d7780-96b0-11ea-8e98-da5d0d92b30f.png)

vs

![image](https://user-images.githubusercontent.com/619340/82046054-7afc7f80-96b0-11ea-90f9-ceb3af6fb1f4.png)
