### PR TITLE
Nodeview ui test

### DIFF
--- a/nodes/number/easing.py
+++ b/nodes/number/easing.py
@@ -67,6 +67,9 @@ def add_offset(offset, coords):
 def simple28_grid_xy(x, y, args):
     """ x and y are passed by default so you could add font content """
 
+    geom, config = args
+    back_color, grid_color, line_color = config.palette
+    matrix = gpu.matrix.get_projection_matrix()
 
     bg_vertex_shader = '''
     in vec2 pos;
@@ -88,11 +91,6 @@ def simple28_grid_xy(x, y, args):
     }
     '''
 
-    geom, config = args
-    back_color, grid_color, line_color = config.palette
-
-    # draw background, this could be cached......
-    matrix = gpu.matrix.get_projection_matrix()
     # shader = gpu.shader.from_builtin('2D_UNIFORM_COLOR')
     shader = gpu.types.GPUShader(bg_vertex_shader, bg_fragment_shader)
     batch = batch_for_shader(shader, 'TRIS', {"pos": geom.background_coords}, indices=geom.background_indices)
@@ -100,12 +98,45 @@ def simple28_grid_xy(x, y, args):
     shader.uniform_float("color", back_color)
     shader.uniform_float("x_offset", x)
     shader.uniform_float("y_offset", y)
-    shader.uniform_float("viewProjectionMatrix", matrix)    
+    shader.uniform_float("viewProjectionMatrix", matrix)
     batch.draw(shader)
 
     # draw grid and graph
-    shader2 = gpu.shader.from_builtin('2D_SMOOTH_COLOR')
-    batch2 = batch_for_shader(shader2, 'LINES', {"pos": add_offset((x, y), geom.vertices), "color": geom.vertex_colors}, indices=geom.indices)
+
+    line_vertex_shader = '''
+    in vec2 pos;
+    layout(location=1) in vec4 color;
+
+    uniform mat4 viewProjectionMatrix;
+    uniform float x_offset;
+    uniform float y_offset;
+
+    out vec4 a_color;
+   
+    void main()
+    {
+        gl_Position = viewProjectionMatrix * vec4(pos.x + x_offset, pos.y + y_offset, 0.0f, 1.0f);
+        a_color = color;
+    }
+    '''
+
+    line_fragment_shader = '''
+    in vec4 a_color;
+
+    void main()
+    {
+        gl_FragColor = a_color;
+    }
+    '''
+
+    shader2 = gpu.types.GPUShader(line_vertex_shader, line_fragment_shader)
+    batch2 = batch_for_shader(shader2, 'LINES', {"pos": geom.vertices, "color": geom.vertex_colors}, indices=geom.indices)
+    # batch2 = batch_for_shader(shader2, 'LINES', {"pos": geom.vertices}, indices=geom.indices)
+    shader2.bind()
+    # shader2.uniform_float("color", line_color)
+    shader2.uniform_float("x_offset", x)
+    shader2.uniform_float("y_offset", y)
+    shader2.uniform_float("viewProjectionMatrix", matrix)
     batch2.draw(shader2)
 
 

--- a/nodes/number/easing.py
+++ b/nodes/number/easing.py
@@ -91,7 +91,6 @@ def simple28_grid_xy(x, y, args):
     }
     '''
 
-    # shader = gpu.shader.from_builtin('2D_UNIFORM_COLOR')
     shader = gpu.types.GPUShader(bg_vertex_shader, bg_fragment_shader)
     batch = batch_for_shader(shader, 'TRIS', {"pos": geom.background_coords}, indices=geom.background_indices)
     shader.bind()
@@ -131,9 +130,7 @@ def simple28_grid_xy(x, y, args):
 
     shader2 = gpu.types.GPUShader(line_vertex_shader, line_fragment_shader)
     batch2 = batch_for_shader(shader2, 'LINES', {"pos": geom.vertices, "color": geom.vertex_colors}, indices=geom.indices)
-    # batch2 = batch_for_shader(shader2, 'LINES', {"pos": geom.vertices}, indices=geom.indices)
     shader2.bind()
-    # shader2.uniform_float("color", line_color)
     shader2.uniform_float("x_offset", x)
     shader2.uniform_float("y_offset", y)
     shader2.uniform_float("viewProjectionMatrix", matrix)

--- a/nodes/number/easing.py
+++ b/nodes/number/easing.py
@@ -107,7 +107,7 @@ class SvEasingNode(bpy.types.Node, SverchCustomTreeNode):
     )
 
     selected_theme_mode: EnumProperty(
-        items=enum_item_4(["default", "scope", "sniper"]), default="default", update=updateNode
+        items=enum_item_4(["default", "scope", "sniper"]), default="sniper", update=updateNode
     )
 
     location_theta: FloatProperty(name="location theta")

--- a/nodes/number/easing.py
+++ b/nodes/number/easing.py
@@ -282,10 +282,10 @@ class SvEasingNode(bpy.types.Node, SverchCustomTreeNode):
         else:
             float_out.sv_set([[None]])
 
-        if self.activate:
+        if self.activate and self.inputs[0].is_linked:
 
             config = lambda: None
-            scale = self.get_drawing_attributes() #..not really used..
+            scale = self.get_drawing_attributes()
 
             config.loc = (0, 0)
             config.palette = palette_dict.get(self.selected_theme_mode)[:]
@@ -309,18 +309,7 @@ class SvEasingNode(bpy.types.Node, SverchCustomTreeNode):
         nvBGL.callback_disable(node_id(self))
 
     def sv_copy(self, node):
-        # reset n_id on copy
         self.n_id = ''
-
-    def sv_update(self):
-        # handle disconnecting sockets, also disconnect drawing to view?
-        if not ("Float" in self.inputs):
-            return
-        try:
-            if not self.inputs[0].other:
-                nvBGL.callback_disable(node_id(self))
-        except:
-            print('Easing node update holdout (not a problem)')
 
 
 classes = [SvEasingNode,]

--- a/nodes/text/stethoscope_v28.py
+++ b/nodes/text/stethoscope_v28.py
@@ -22,6 +22,7 @@ import re
 import bpy
 import blf
 from bpy.props import BoolProperty, FloatVectorProperty, StringProperty, IntProperty
+from bpy.props import FloatProperty
 from mathutils import Vector
 
 from sverchok.settings import get_params
@@ -46,8 +47,7 @@ def get_xy_for_bgl_drawing(node):
         _x, _y = Vector((_x, _y)) + Vector((node_width + 20, 0))
 
         # this alters location based on DPI/Scale settings.
-        _, location_theta = node.get_preferences()
-        draw_location = adjust_location(_x, _y, location_theta)
+        draw_location = adjust_location(_x, _y, node.location_theta)
         return draw_location
 
 def parse_socket(socket, rounding, element_index, view_by_element, props):
@@ -132,6 +132,7 @@ class SvStethoscopeNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     line_width: IntProperty(default=60, min=20, update=updateNode, name='Line Width (chars)')
     compact: BoolProperty(default=False, update=updateNode)
     depth: IntProperty(default=5, min=0, update=updateNode)
+    location_theta: FloatProperty(name='location_theta')
 
 
     def get_theme_colors_for_contrast(self):
@@ -194,7 +195,7 @@ class SvStethoscopeNodeMK2(bpy.types.Node, SverchCustomTreeNode):
         nvBGL.callback_disable(n_id)
 
         if self.activate and inputs[0].is_linked:
-            scale, location_theta = self.get_preferences()
+            scale, self.location_theta = self.get_preferences()
 
             # gather vertices from input
             data = inputs[0].sv_get(deepcopy=False)

--- a/nodes/text/stethoscope_v28.py
+++ b/nodes/text/stethoscope_v28.py
@@ -46,6 +46,7 @@ def get_xy_for_bgl_drawing(node):
         _x, _y = Vector((_x, _y)) + Vector((node_width + 20, 0))
 
         # this alters location based on DPI/Scale settings.
+        _, location_theta = node.get_preferences()
         draw_location = adjust_location(_x, _y, location_theta)
         return draw_location
 

--- a/nodes/text/stethoscope_v28.py
+++ b/nodes/text/stethoscope_v28.py
@@ -34,6 +34,21 @@ from sverchok.ui import bgl_callback_nodeview as nvBGL
 FAIL_COLOR = (0.1, 0.05, 0)
 READY_COLOR = (1, 0.3, 0)
 
+
+def adjust_location(_x, _y, location_theta):
+    return _x * location_theta, _y * location_theta
+
+def get_xy_for_bgl_drawing(node):
+        # adjust proposed text location in case node is framed.
+        # take into consideration the hidden state
+        node_width = node.width
+        _x, _y = node.absolute_location
+        _x, _y = Vector((_x, _y)) + Vector((node_width + 20, 0))
+
+        # this alters location based on DPI/Scale settings.
+        draw_location = adjust_location(_x, _y, location_theta)
+        return draw_location
+
 def parse_socket(socket, rounding, element_index, view_by_element, props):
 
     data = socket.sv_get(deepcopy=False)
@@ -81,8 +96,6 @@ def high_contrast_color(c):
     L = 0.2126 * (c.r**g) + 0.7152 * (c.g**g) + 0.0722 * (c.b**g)
     return [(.1, .1, .1), (.95, .95, .95)][int(L < 0.5)]
 
-def adjust_location(_x, _y, location_theta):
-    return _x * location_theta, _y * location_theta
 
 
 class SvStethoscopeNodeMK2(bpy.types.Node, SverchCustomTreeNode):
@@ -203,19 +216,12 @@ class SvStethoscopeNodeMK2(bpy.types.Node, SverchCustomTreeNode):
                 #                # implement another nvBGL parses for gfx
                 processed_data = data
 
-            # adjust proposed text location in case node is framed.
-            # take into consideration the hidden state
-            node_width = self.width
-            _x, _y = self.absolute_location
-            _x, _y = Vector((_x, _y)) + Vector((node_width + 20, 0))
-
-            # this alters location based on DPI/Scale settings.
-            draw_location = adjust_location(_x, _y, location_theta)
 
             draw_data = {
                 'tree_name': self.id_data.name[:],
+                'node_name': self.name[:],
                 'content': processed_data,
-                'location': draw_location,
+                'location': get_xy_for_bgl_drawing,
                 'color': self.text_color[:],
                 'scale' : float(scale),
                 'mode': self.selected_mode[:],

--- a/nodes/viz/console_node.py
+++ b/nodes/viz/console_node.py
@@ -26,6 +26,10 @@ from sverchok.utils.sv_update_utils import sv_get_local_path
 from sverchok.utils.sv_font_xml_parser import get_lookup_dict, letters_to_uv
 from sverchok.utils.sv_nodeview_draw_helper import SvNodeViewDrawMixin, get_console_grid
 
+def get_desired_xy(node):
+    x, y = node.xy_offset
+    return x * node.location_theta, y * node.location_theta
+
 def make_color(name, default):
     return bpy.props.FloatVectorProperty(name=name, default=default, size=4, min=0, max=1, update=updateNode, subtype="COLOR")
 
@@ -35,12 +39,44 @@ bitmap_font_location = os.path.join(sv_path, 'utils', 'modules', 'bitmap_font')
 
 lookup_dict_data = {}
 
+no_vertex_shader = '''
+    uniform mat4 ModelViewProjectionMatrix;
+
+    in vec2 texCoord;
+    in vec2 pos;
+    uniform float x_offset;
+    uniform float y_offset;    
+
+    out vec2 texCoord_interp;
+
+    void main()
+    {
+       gl_Position = ModelViewProjectionMatrix * vec4(pos.x + x_offset, pos.y + y_offset, 0.0f, 1.0f);
+       gl_Position.z = 1.0;
+       texCoord_interp = texCoord;
+    }
+'''
+no_fragment_shader = '''
+    in vec2 texCoord_interp;
+
+    out vec4 fragColor;
+    
+    uniform sampler2D image;
+    
+    void main()
+    {
+        fragColor = texture(image, texCoord_interp);
+    }
+'''
+
 vertex_shader = '''
     uniform mat4 ModelViewProjectionMatrix;
 
     in vec2 texCoord;
     in vec2 pos;
     in float lexer;
+    uniform float x_offset;
+    uniform float y_offset;    
 
     out float v_lexer;
     out vec2 texCoord_interp;
@@ -48,7 +84,7 @@ vertex_shader = '''
     void main()
     {
        v_lexer = lexer;
-       gl_Position = ModelViewProjectionMatrix * vec4(pos.xy, 0.0f, 1.0f);
+       gl_Position = ModelViewProjectionMatrix * vec4(pos.x + x_offset, pos.y + y_offset, 0.0f, 1.0f);
        gl_Position.z = 1.0;
        texCoord_interp = texCoord;
     }
@@ -312,7 +348,7 @@ def terminal_text_to_uv(lines):
         uvs.extend(letters_to_uv(line, fnt))
     return uvs
 
-def simple_console_xy(context, args):
+def simple_console_xy(context, args, loc):
     texture, config = args
     act_tex = bgl.Buffer(bgl.GL_INT, 1)
     bgl.glBindTexture(bgl.GL_TEXTURE_2D, texture.texture_dict['texture'])
@@ -327,17 +363,18 @@ def simple_console_xy(context, args):
         for color_name, color_value in config.colors.items():
             config.shader.uniform_float(color_name, color_value)
 
+    x, y = loc 
+    config.shader.uniform_float("x_offset", x)
+    config.shader.uniform_float("y_offset", y)
     config.shader.uniform_int("image", act_tex)
     config.batch.draw(config.shader)
 
-def process_grid_for_shader(grid, loc):
-    x, y = loc
+def process_grid_for_shader(grid):
     positions, poly_indices = grid
-    translated_positions = [(p[0] + x, p[1] + y) for p in positions]
     verts = []
     for poly in poly_indices:
         for v_idx in poly:
-            verts.append(translated_positions[v_idx])
+            verts.append(positions[v_idx][:2])
     return verts
 
 def process_uvs_for_shader(node):
@@ -353,7 +390,7 @@ def generate_batch_shader(node, data):
     # print("len(verts)", len(verts), "len(uv_indices)", len(uv_indices))
 
     if node.syntax_mode == "None":
-        shader = gpu.shader.from_builtin('2D_IMAGE')
+        shader = gpu.types.GPUShader(no_vertex_shader, no_fragment_shader)
         batch = batch_for_shader(shader, 'TRIS', {"pos": verts, "texCoord": uv_indices})
     elif node.syntax_mode == "Code":
         shader = gpu.types.GPUShader(vertex_shader, lexed_fragment_shader)
@@ -544,12 +581,11 @@ class SvConsoleNode(bpy.types.Node, SverchCustomTreeNode, SvNodeViewDrawMixin):
         lexer = self.get_lexer()
         grid = self.prepare_for_grid()
 
-        x, y, width, height = self.adjust_position_and_dimensions(*self.dims)
-        verts = process_grid_for_shader(grid, loc=(x, y))
+        self.adjust_position_and_dimensions(*self.dims)
+        verts = process_grid_for_shader(grid)
         uvs = process_uvs_for_shader(self)
 
         batch, shader = generate_batch_shader(self, (verts, uvs, lexer))
-        config.loc = (x, y)
         config.batch = batch
         config.shader = shader
         config.syntax_mode = self.syntax_mode
@@ -561,6 +597,8 @@ class SvConsoleNode(bpy.types.Node, SverchCustomTreeNode, SvNodeViewDrawMixin):
 
         draw_data = {
             'tree_name': self.id_data.name[:],
+            'node_name': self.name[:],
+            'loc': get_desired_xy,
             'mode': 'custom_function_context', 
             'custom_function': simple_console_xy,
             'args': (texture, config)
@@ -596,16 +634,6 @@ class SvConsoleNode(bpy.types.Node, SverchCustomTreeNode, SvNodeViewDrawMixin):
 
         if not self.inputs[0].is_linked or not self.inputs[0].sv_get():
             return True
-
-    def sv_update(self):
-        if not ("text" in self.inputs):
-            return
-        try:
-            if not self.inputs[0].other:
-                self.free()
-        except:
-            # print('ConsoleNode was disconnected, holdout (not a problem)')
-            pass
 
 classes = [SvConsoleNode]
 register, unregister = bpy.utils.register_classes_factory(classes)

--- a/nodes/viz/viewer_2d.py
+++ b/nodes/viz/viewer_2d.py
@@ -104,9 +104,6 @@ def get_drawing_location(node):
     x, y = node.get_offset()
     return x * node.location_theta, y * node.location_theta
 
-def add_offset(offset, coords):
-    return [(x + offset[0], y + offset[1]) for x, y in coords]
-
 def get_2d_uniform_color_shader():
     uniform_2d_vertex_shader = '''
     in vec2 pos;
@@ -128,6 +125,7 @@ def get_2d_uniform_color_shader():
     }
     '''
     return gpu.types.GPUShader(uniform_2d_vertex_shader, uniform_2d_fragment_shader)
+
 def get_2d_smooth_color_shader():
 
     smooth_2d_vertex_shader = '''
@@ -168,8 +166,6 @@ def view_2d_geom(x, y, args):
     if config.draw_background:
         background_color = config.background_color
         # draw background, this could be cached......
-
-        shader = gpu.shader.from_builtin('2D_UNIFORM_COLOR')
 
         shader = get_2d_uniform_color_shader()
         batch = batch_for_shader(shader, 'TRIS', {"pos": geom.background_coords}, indices=geom.background_indices)
@@ -637,6 +633,7 @@ class SvViewer2D(bpy.types.Node, SverchCustomTreeNode):
     draw_background: BoolProperty(
         update=updateNode, name='Display Background', default=True
         )
+
     location_theta: FloatProperty(name="location theta")
 
     def draw_buttons(self, context, layout):
@@ -819,7 +816,6 @@ class SvViewer2D(bpy.types.Node, SverchCustomTreeNode):
         draw_data = {
             'mode': 'custom_function',
             'tree_name': self.id_data.name[:],
-            # 'loc': (x, y),
             'node_name': self.name[:],
             'loc': get_drawing_location,
             'custom_function': view_2d_geom,

--- a/nodes/viz/viewer_2d.py
+++ b/nodes/viz/viewer_2d.py
@@ -91,7 +91,7 @@ def fill_points_colors(vectors_color, data, color_per_point, random_colors):
     else:
         for nums, col in zip(data, cycle(vectors_color[0])):
             if random_colors:
-                r_color = [random(),random(),random(),1]
+                r_color = [random(), random(), random(), 1]
                 for n in nums:
                     points_color.append(r_color)
             else:
@@ -100,6 +100,62 @@ def fill_points_colors(vectors_color, data, color_per_point, random_colors):
 
     return points_color
 
+def get_drawing_location(node):
+    x, y = node.get_offset()
+    return x * node.location_theta, y * node.location_theta
+
+def add_offset(offset, coords):
+    return [(x + offset[0], y + offset[1]) for x, y in coords]
+
+def get_2d_uniform_color_shader():
+    uniform_2d_vertex_shader = '''
+    in vec2 pos;
+    uniform mat4 viewProjectionMatrix;
+    uniform float x_offset;
+    uniform float y_offset;
+
+    void main()
+    {
+       gl_Position = viewProjectionMatrix * vec4(pos.x + x_offset, pos.y + y_offset, 0.0f, 1.0f);
+    }
+    '''
+
+    uniform_2d_fragment_shader = '''
+    uniform vec4 color;
+    void main()
+    {
+       gl_FragColor = color;
+    }
+    '''
+    return gpu.types.GPUShader(uniform_2d_vertex_shader, uniform_2d_fragment_shader)
+def get_2d_smooth_color_shader():
+
+    smooth_2d_vertex_shader = '''
+    in vec2 pos;
+    layout(location=1) in vec4 color;
+
+    uniform mat4 viewProjectionMatrix;
+    uniform float x_offset;
+    uniform float y_offset;
+
+    out vec4 a_color;
+
+    void main()
+    {
+        gl_Position = viewProjectionMatrix * vec4(pos.x + x_offset, pos.y + y_offset, 0.0f, 1.0f);
+        a_color = color;
+    }
+    '''
+
+    smooth_2d_fragment_shader = '''
+    in vec4 a_color;
+
+    void main()
+    {
+        gl_FragColor = a_color;
+    }
+    '''
+    return gpu.types.GPUShader(smooth_2d_vertex_shader, smooth_2d_fragment_shader)
 
 def view_2d_geom(x, y, args):
     """
@@ -108,25 +164,47 @@ def view_2d_geom(x, y, args):
     """
 
     geom, config = args
+    matrix = gpu.matrix.get_projection_matrix()
     if config.draw_background:
         background_color = config.background_color
         # draw background, this could be cached......
+
         shader = gpu.shader.from_builtin('2D_UNIFORM_COLOR')
+
+        shader = get_2d_uniform_color_shader()
         batch = batch_for_shader(shader, 'TRIS', {"pos": geom.background_coords}, indices=geom.background_indices)
         shader.bind()
         shader.uniform_float("color", background_color)
+        shader.uniform_float("x_offset", x)
+        shader.uniform_float("y_offset", y)
+        shader.uniform_float("viewProjectionMatrix", matrix)
         batch.draw(shader)
 
     if config.draw_polys and config.mode == 'Mesh':
+        config.p_batch = batch_for_shader(config.p_shader, 'TRIS', {"pos": geom.p_vertices, "color": geom.p_vertex_colors}, indices=geom.p_indices)
+        config.p_shader.bind()
+        config.p_shader.uniform_float("x_offset", x)
+        config.p_shader.uniform_float("y_offset", y)
+        config.p_shader.uniform_float("viewProjectionMatrix", matrix)
         config.p_batch.draw(config.p_shader)
 
     if config.draw_edges:
         bgl.glLineWidth(config.edge_width)
+        config.e_batch = batch_for_shader(config.e_shader, 'LINES', {"pos": geom.e_vertices, "color": geom.e_vertex_colors}, indices=geom.e_indices)
+        config.e_shader.bind()
+        config.e_shader.uniform_float("x_offset", x)
+        config.e_shader.uniform_float("y_offset", y)
+        config.e_shader.uniform_float("viewProjectionMatrix", matrix)
         config.e_batch.draw(config.e_shader)
         bgl.glLineWidth(1)
 
     if config.draw_verts:
         bgl.glPointSize(config.point_size)
+        config.v_batch = batch_for_shader(config.v_shader, 'POINTS', {"pos": geom.v_vertices, "color": geom.points_color})
+        config.v_shader.bind()
+        config.v_shader.uniform_float("x_offset", x)
+        config.v_shader.uniform_float("y_offset", y)
+        config.v_shader.uniform_float("viewProjectionMatrix", matrix)
         config.v_batch.draw(config.v_shader)
         bgl.glPointSize(1)
 
@@ -197,20 +275,19 @@ def generate_number_geom(config, numbers):
 
 
     points_color = fill_points_colors(config.vector_color, numbers, config.color_per_point, config.random_colors)
-    geom.points_color = points_color
-    geom.points_vertices = v_vertices
-    geom.vertices = e_vertices
-    geom.vertex_colors = vertex_colors
-    geom.indices = indices
+
 
     if config.draw_verts:
-        config.v_shader = gpu.shader.from_builtin('2D_SMOOTH_COLOR')
-        config.v_batch = batch_for_shader(config.v_shader, 'POINTS', {"pos": v_vertices, "color": points_color})
+        config.v_shader = get_2d_smooth_color_shader()
+        geom.v_vertices, geom.points_color = v_vertices, points_color
+
     if config.draw_edges:
         if config.edges_use_vertex_color:
             vertex_colors = points_color
-        config.e_shader = gpu.shader.from_builtin('2D_SMOOTH_COLOR')
-        config.e_batch = batch_for_shader(config.e_shader, 'LINES', {"pos": e_vertices, "color": vertex_colors}, indices=indices)
+
+        config.e_shader = get_2d_smooth_color_shader()
+        geom.e_vertices, geom.e_vertex_colors, geom.e_indices = e_vertices, vertex_colors, indices
+
 
     return geom
 
@@ -276,14 +353,15 @@ def generate_graph_geom(config, paths):
     points_color = fill_points_colors(config.vector_color, paths, config.color_per_point, config.random_colors)
 
     if config.draw_verts:
-        config.v_shader = gpu.shader.from_builtin('2D_SMOOTH_COLOR')
-        config.v_batch = batch_for_shader(config.v_shader, 'POINTS', {"pos": v_vertices, "color": points_color})
+        config.v_shader = get_2d_smooth_color_shader()
+        geom.v_vertices, geom.points_color = v_vertices, points_color
 
     if config.draw_edges:
         if config.edges_use_vertex_color:
             e_vertex_colors = points_color
-        config.e_shader = gpu.shader.from_builtin('2D_SMOOTH_COLOR')
-        config.e_batch = batch_for_shader(config.e_shader, 'LINES', {"pos": e_vertices, "color": e_vertex_colors}, indices=e_indices)
+
+        config.e_shader = get_2d_smooth_color_shader()
+        geom.e_vertices, geom.e_vertex_colors, geom.e_indices = e_vertices, e_vertex_colors, e_indices
 
     return geom
 
@@ -400,20 +478,23 @@ def generate_mesh_geom(config, vecs_in):
     points_color = fill_points_colors(config.vector_color, vecs_in, config.color_per_point, config.random_colors)
 
     if config.draw_verts:
-        config.v_shader = gpu.shader.from_builtin('2D_SMOOTH_COLOR')
-        config.v_batch = batch_for_shader(config.v_shader, 'POINTS', {"pos": v_vertices, "color": points_color})
+
+        config.v_shader = get_2d_smooth_color_shader()
+        geom.v_vertices, geom.points_color = v_vertices, points_color
 
     if config.draw_edges:
         if config.edges_use_vertex_color and e_vertices:
             e_vertex_colors = points_color
-        config.e_shader = gpu.shader.from_builtin('2D_SMOOTH_COLOR')
-        config.e_batch = batch_for_shader(config.e_shader, 'LINES', {"pos": e_vertices, "color": e_vertex_colors}, indices=e_indices)
+
+        config.e_shader = get_2d_smooth_color_shader()
+        geom.e_vertices, geom.e_vertex_colors, geom.e_indices = e_vertices, e_vertex_colors, e_indices
+
 
     if config.draw_polys:
         if config.polygon_use_vertex_color:
             p_vertex_colors = points_color
-        config.p_shader = gpu.shader.from_builtin('2D_SMOOTH_COLOR')
-        config.p_batch = batch_for_shader(config.p_shader, 'TRIS', {"pos": p_vertices, "color": p_vertex_colors}, indices=p_indices)
+        config.p_shader = get_2d_smooth_color_shader()
+        geom.p_vertices, geom.p_vertex_colors, geom.p_indices = p_vertices, p_vertex_colors, p_indices
 
     return geom
 
@@ -426,16 +507,16 @@ class SvViewer2D(bpy.types.Node, SverchCustomTreeNode):
     sv_icon = 'SV_EASING'
 
     modes = [
-        ('Number', 'Number', 'Input UV coordinates to evaluate texture', '', 1),
-        ('Path', 'Path', 'Matrix to apply to verts before evaluating texture', '', 2),
-        ('Curve', 'Curve', 'Matrix of texture (External Object matrix)', '', 3),
-        ('Mesh', 'Mesh', 'Matrix of texture (External Object matrix)', '', 4),
+        ('Number', 'Number', 'Visualize number list', '', 1),
+        ('Path', 'Path', 'Visualize vertices sequence', '', 2),
+        ('Curve', 'Curve', 'Visualize curve', '', 3),
+        ('Mesh', 'Mesh', 'Visualize mesh data', '', 4),
 
     ]
     plane = [
-        ('XY', 'XY', 'Input UV coordinates to evaluate texture', '', 1),
-        ('XZ', 'XZ', 'Matrix to apply to verts before evaluating texture', '', 2),
-        ('YZ', 'YZ', 'Matrix of texture (External Object matrix)', '', 3),
+        ('XY', 'XY', 'Project on XY plane', '', 1),
+        ('XZ', 'XZ', 'Project on XZ plane', '', 2),
+        ('YZ', 'YZ', 'Project on YZ plane', '', 3),
 
 
     ]
@@ -471,7 +552,7 @@ class SvViewer2D(bpy.types.Node, SverchCustomTreeNode):
         default=True, update=updateNode
     )
     cyclic: BoolProperty(
-        name='Cycle', description='Activate drawing',
+        name='Cycle', description='Join first and last vertices',
         default=True, update=updateNode
     )
 
@@ -556,6 +637,7 @@ class SvViewer2D(bpy.types.Node, SverchCustomTreeNode):
     draw_background: BoolProperty(
         update=updateNode, name='Display Background', default=True
         )
+    location_theta: FloatProperty(name="location theta")
 
     def draw_buttons(self, context, layout):
         r0 = layout.row()
@@ -636,8 +718,6 @@ class SvViewer2D(bpy.types.Node, SverchCustomTreeNode):
         """
         adjust render location based on preference multiplier setting
         """
-        x, y = [int(j) for j in (Vector(self.absolute_location) + Vector((self.width + 20, 0)))[:]]
-
         try:
             with sv_preferences() as prefs:
                 multiplier = prefs.render_location_xy_multiplier
@@ -646,16 +726,19 @@ class SvViewer2D(bpy.types.Node, SverchCustomTreeNode):
             # print('did not find preferences - you need to save user preferences')
             multiplier = 1.0
             scale = 1.0
-        x, y = [x * multiplier, y * multiplier]
 
-        return x, y, scale, multiplier
+        # cache this.
+        self.location_theta = multiplier
+        return scale
 
+    def get_offset(self):
+        return [int(j) for j in (Vector(self.absolute_location) + Vector((self.width + 20, 0)))[:]]
     def create_config(self):
         config = lambda: None
-        x, y, scale, _ = self.get_drawing_attributes()
+        scale = self.get_drawing_attributes()
         margin = 10* scale
         config.mode = self.mode
-        config.loc = (x, y - margin)
+        config.loc = (0, 0 - margin)
         config.sys_scale = scale
         config.scale = scale * self.draw_scale
         config.cyclic = self.cyclic
@@ -674,7 +757,7 @@ class SvViewer2D(bpy.types.Node, SverchCustomTreeNode):
         config.edges_use_vertex_color = self.edges_use_vertex_color
         config.random_colors = self.vector_random_colors
 
-        return x, y, config
+        return config
 
     def process(self):
         n_id = node_id(self)
@@ -703,7 +786,7 @@ class SvViewer2D(bpy.types.Node, SverchCustomTreeNode):
         edge_color = inputs['Edge Color'].sv_get(default=[[self.edge_color]])
         poly_color = inputs['Polygon Color'].sv_get(default=[[self.polygon_color]])
         seed_set(self.random_seed)
-        x, y, config = self.create_config()
+        config = self.create_config()
 
         config.vector_color = vector_color
         config.edge_color = edge_color
@@ -736,7 +819,9 @@ class SvViewer2D(bpy.types.Node, SverchCustomTreeNode):
         draw_data = {
             'mode': 'custom_function',
             'tree_name': self.id_data.name[:],
-            'loc': (x, y),
+            # 'loc': (x, y),
+            'node_name': self.name[:],
+            'loc': get_drawing_location,
             'custom_function': view_2d_geom,
             'args': (geom, config)
         }
@@ -744,10 +829,6 @@ class SvViewer2D(bpy.types.Node, SverchCustomTreeNode):
 
     def sv_free(self):
         nvBGL.callback_disable(node_id(self))
-
-    def sv_copy(self, node):
-        # reset n_id on copy
-        self.n_id = ''
 
 
 

--- a/nodes/viz/viewer_texture.py
+++ b/nodes/viz/viewer_texture.py
@@ -26,6 +26,7 @@ from sverchok.data_structure import updateNode, node_id
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.ui import bgl_callback_nodeview as nvBGL2
 from sverchok.ui import sv_image as svIMG
+from sverchok.utils.sv_texture_utils import tx_vertex_shader, tx_fragment_shader
 
 from sverchok.utils.sv_operator_mixins import (
     SvGenericDirectorySelector, SvGenericCallbackWithParams

--- a/nodes/viz/viewer_texture.py
+++ b/nodes/viz/viewer_texture.py
@@ -95,40 +95,6 @@ factor_buffer_dict = {
     'RGBA': 4  # GL_RGBA
 }
 
-vertex_shader = '''
-    uniform mat4 ModelViewProjectionMatrix;
-
-    /* Keep in sync with intern/opencolorio/gpu_shader_display_transform_vertex.glsl */
-
-    in vec2 texCoord;
-    in vec2 pos;
-
-    out vec2 texCoord_interp;
-
-    void main()
-    {
-       gl_Position = ModelViewProjectionMatrix * vec4(pos.xy, 0.0f, 1.0f);
-       gl_Position.z = 1.0;
-       texCoord_interp = texCoord;
-    }
-'''
-
-fragment_shader = '''
-    in vec2 texCoord_interp;
-    out vec4 fragColor;
-
-    uniform sampler2D image;
-    uniform bool ColorMode;
-
-    void main()
-    {
-        if (ColorMode) {
-           fragColor = texture(image, texCoord_interp);
-        } else {
-           fragColor = texture(image, texCoord_interp).rrrr;
-        }
-    }
-'''
 
 def transfer_to_image(pixels, name, width, height, mode):
     # transfer pixels(data) from Node tree to image viewer
@@ -413,7 +379,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
         x, y, w, h = args
         positions = ((x, y), (x + w, y), (x + w, y - h), (x, y - h))
         indices = ((0, 1), (1, 1), (1, 0), (0, 0))
-        shader = gpu.types.GPUShader(vertex_shader, fragment_shader)
+        shader = gpu.types.GPUShader(tx_vertex_shader, tx_fragment_shader)
         batch = batch_for_shader(shader, 'TRI_FAN', {"pos": positions, "texCoord": indices})
         return batch, shader
 

--- a/nodes/viz/viewer_texture.py
+++ b/nodes/viz/viewer_texture.py
@@ -12,11 +12,10 @@
 import os
 import numpy as np
 
-
 import bpy
 import gpu
 import bgl
-from gpu_extras.batch import batch_for_shader
+
 from bpy.props import (
     FloatProperty, EnumProperty, StringProperty, BoolProperty, IntProperty
 )

--- a/nodes/viz/viewer_texture.py
+++ b/nodes/viz/viewer_texture.py
@@ -28,7 +28,7 @@ from sverchok.ui import bgl_callback_nodeview as nvBGL2
 from sverchok.ui import sv_image as svIMG
 
 # shared stuff between implementations
-from sverchok.utils.sv_texture_utils import tx_vertex_shader, tx_fragment_shader
+from sverchok.utils.sv_texture_utils import generate_batch_shader
 from sverchok.utils.sv_texture_utils import simple_screen, init_texture, get_drawing_location
 from sverchok.utils.sv_texture_utils import gl_color_list, gl_color_dict, factor_buffer_dict
 
@@ -308,7 +308,7 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
             init_texture(width, height, name[0], texture, gl_color_constant)
 
             width, height = self.get_dimensions(width, height)
-            batch, shader = self.generate_batch_shader((width, height))
+            batch, shader = generate_batch_shader((width, height))
 
             draw_data = {
                 'tree_name': self.id_data.name[:],
@@ -320,15 +320,6 @@ class SvTextureViewerNode(bpy.types.Node, SverchCustomTreeNode):
             }
 
             nvBGL2.callback_enable(n_id, draw_data)
-
-    def generate_batch_shader(self, args):
-        w, h = args
-        x, y = 0, 0
-        positions = ((x, y), (x + w, y), (x + w, y - h), (x, y - h))
-        indices = ((0, 1), (1, 1), (1, 0), (0, 0))
-        shader = gpu.types.GPUShader(tx_vertex_shader, tx_fragment_shader)
-        batch = batch_for_shader(shader, 'TRI_FAN', {"pos": positions, "texCoord": indices})
-        return batch, shader
 
     def get_preferences(self):
         # supplied with default, forces at least one value :)

--- a/nodes/viz/viewer_texture_lite.py
+++ b/nodes/viz/viewer_texture_lite.py
@@ -18,9 +18,10 @@ from sverchok.settings import get_params
 from sverchok.data_structure import updateNode, node_id
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.ui import bgl_callback_nodeview as nvBGL2
+
+from sverchok.utils.sv_texture_utils import tx_vertex_shader, tx_fragment_shader
 from sverchok.nodes.viz.viewer_texture import (
-    vertex_shader, fragment_shader, init_texture, simple_screen,
-    gl_color_list, gl_color_dict, factor_buffer_dict)
+    init_texture, simple_screen, gl_color_list, gl_color_dict, factor_buffer_dict)
 
 
 out_modes = [

--- a/nodes/viz/viewer_texture_lite.py
+++ b/nodes/viz/viewer_texture_lite.py
@@ -19,7 +19,7 @@ from sverchok.data_structure import updateNode, node_id
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.ui import bgl_callback_nodeview as nvBGL2
 
-from sverchok.utils.sv_texture_utils import tx_vertex_shader, tx_fragment_shader
+from sverchok.utils.sv_texture_utils import generate_batch_shader
 from sverchok.utils.sv_texture_utils import simple_screen, init_texture, get_drawing_location
 from sverchok.utils.sv_texture_utils import gl_color_list, gl_color_dict, factor_buffer_dict
 
@@ -123,7 +123,7 @@ class SvTextureViewerNodeLite(bpy.types.Node, SverchCustomTreeNode):
             init_texture(width, height, name[0], texture, gl_color_constant)
 
             width, height = self.get_dimensions(width, height)
-            batch, shader = self.generate_batch_shader((width, height))
+            batch, shader = generate_batch_shader((width, height))
 
             draw_data = {
                 'tree_name': self.id_data.name[:],
@@ -140,16 +140,6 @@ class SvTextureViewerNodeLite(bpy.types.Node, SverchCustomTreeNode):
 
             Im = bpy.data.images[self.image]
             Im.pixels = np.resize(self.inputs[0].sv_get(), len(Im.pixels))
-
-    def generate_batch_shader(self, args):
-        w, h = args
-        x = 0
-        y = 0
-        positions = ((x, y), (x + w, y), (x + w, y - h), (x, y - h))
-        indices = ((0, 1), (1, 1), (1, 0), (0, 0))
-        shader = gpu.types.GPUShader(tx_vertex_shader, tx_fragment_shader)
-        batch = batch_for_shader(shader, 'TRI_FAN', {"pos": positions, "texCoord": indices})
-        return batch, shader
 
     def get_preferences(self):
         # supplied with default, forces at least one value :)

--- a/nodes/viz/viewer_texture_lite.py
+++ b/nodes/viz/viewer_texture_lite.py
@@ -20,18 +20,14 @@ from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.ui import bgl_callback_nodeview as nvBGL2
 
 from sverchok.utils.sv_texture_utils import tx_vertex_shader, tx_fragment_shader
-from sverchok.nodes.viz.viewer_texture import (
-    init_texture, simple_screen, gl_color_list, gl_color_dict, factor_buffer_dict)
+from sverchok.utils.sv_texture_utils import simple_screen, init_texture, get_drawing_location
+from sverchok.utils.sv_texture_utils import gl_color_list, gl_color_dict, factor_buffer_dict
 
 
 out_modes = [
     ('image_editor', 'UV\image editor', 'insert values into image editor (only RGBA mode!)', '', 0),
     ('bgl', 'bgl', 'create texture inside nodetree', '', 1),
 ]
-
-def get_draw_location(node):
-    x, y = node.xy_offset
-    return x * self.location_theta, y * self.location_theta
 
 class SvTextureViewerNodeLite(bpy.types.Node, SverchCustomTreeNode):
     '''Texture Viewer node Lite'''
@@ -70,7 +66,7 @@ class SvTextureViewerNodeLite(bpy.types.Node, SverchCustomTreeNode):
         default="bgl", update=updateNode)
 
     properties_to_skip_iojson = ["image_pointer", "location_theta"]
-    location_theta = FloatProperty(name="location theta")
+    location_theta: FloatProperty(name="location theta")
 
     @property
     def xy_offset(self):
@@ -131,9 +127,10 @@ class SvTextureViewerNodeLite(bpy.types.Node, SverchCustomTreeNode):
 
             draw_data = {
                 'tree_name': self.id_data.name[:],
+                'node_name': self.name[:],
                 'mode': 'custom_function',
                 'custom_function': simple_screen,
-                'loc': get_draw_location,
+                'loc': get_drawing_location,
                 'args': (texture, self.texture[n_id], width, height, batch, shader, cMode)
             }
 
@@ -150,7 +147,7 @@ class SvTextureViewerNodeLite(bpy.types.Node, SverchCustomTreeNode):
         y = 0
         positions = ((x, y), (x + w, y), (x + w, y - h), (x, y - h))
         indices = ((0, 1), (1, 1), (1, 0), (0, 0))
-        shader = gpu.types.GPUShader(vertex_shader, fragment_shader)
+        shader = gpu.types.GPUShader(tx_vertex_shader, tx_fragment_shader)
         batch = batch_for_shader(shader, 'TRI_FAN', {"pos": positions, "texCoord": indices})
         return batch, shader
 

--- a/nodes/viz/viewer_texture_lite.py
+++ b/nodes/viz/viewer_texture_lite.py
@@ -11,7 +11,6 @@ import numpy as np
 import bgl
 import gpu
 import bpy
-from gpu_extras.batch import batch_for_shader
 from bpy.props import EnumProperty, StringProperty, IntProperty, PointerProperty, FloatProperty
 
 from sverchok.settings import get_params

--- a/nodes/viz/viewer_waveform_output.py
+++ b/nodes/viz/viewer_waveform_output.py
@@ -521,7 +521,7 @@ class SvWaveformViewer(bpy.types.Node, SverchCustomTreeNode):
 
         if self.activate:
 
-            if not self.inputs[0].other or self.inputs[1].other:
+            if not self.inputs[0].other:
                 return
 
             # parameter containers
@@ -529,7 +529,7 @@ class SvWaveformViewer(bpy.types.Node, SverchCustomTreeNode):
             geom = lambda: None
             palette = lambda: None
 
-            palette.high_colour = (0.13, 0.13, 0.13, 1.0)
+            palette.high_colour = (0.33, 0.33, 0.33, 1.0)
             palette.low_colour = (0.1, 0.1, 0.1, 1.0)
 
             scale = self.get_drawing_attributes()

--- a/nodes/viz/viewer_waveform_output.py
+++ b/nodes/viz/viewer_waveform_output.py
@@ -591,16 +591,6 @@ class SvWaveformViewer(bpy.types.Node, SverchCustomTreeNode):
     def sv_copy(self, node):
         self.n_id = ''
 
-    # def sv_update(self):
-    #     # handle disconnecting sockets, also disconnect drawing to view?
-    #     if not ("channel 1" in self.inputs):
-    #         return
-    #     try:
-    #         if not self.inputs[0].other or self.inputs[1].other:
-    #             nvBGL.callback_disable(node_id(self))
-    #     except:
-    #         print('Waveform Viewer node update holdout (not a problem)')
-
     def process_wave(self):
         print('process wave pressed')
         if not self.dirname and self.filename:

--- a/nodes/viz/viewer_waveform_output.py
+++ b/nodes/viz/viewer_waveform_output.py
@@ -27,10 +27,14 @@ from sverchok.ui import bgl_callback_nodeview as nvBGL
 
 DATA_SOCKET = 'SvStringsSocket'
 
+def get_offset_xy(node):
+    x, y = [int(j) for j in (Vector(node.absolute_location) + Vector((node.width + 20, 0)))[:]]
+    return x, y
+
 
 class gridshader():
     def __init__(self, dims, loc, palette, channels):
-        x, y = loc
+        x, y = (0, 0)
         w, h = dims
         
         if channels == 2:
@@ -101,21 +105,33 @@ class gridshader():
             
             self.background_colors = [lc, lc, hc, hc, lc, lc, hc, hc, lc, lc]
 
-def advanced_grid_xy(context, args):
+def advanced_grid_xy(context, args, xy):
+    x, y = xy
     geom, config = args
-    
-    ## background    
+    matrix = gpu.matrix.get_projection_matrix()
+
+    ## background
+    config.background_shader.bind()
+    config.background_shader.uniform_float("viewProjectionMatrix", matrix)
+    config.background_shader.uniform_float("x_offset", x)
+    config.background_shader.uniform_float("y_offset", y)    
     config.background_batch.draw(config.background_shader)
     
     ## background grid / ticks
     if hasattr(config, 'tick_shader'):
         config.tick_shader.bind()
+        config.tick_shader.uniform_float("viewProjectionMatrix", matrix)
         config.tick_shader.uniform_float("color", (0.4, 0.4, 0.9, 1))
+        config.tick_shader.uniform_float("x_offset", x)
+        config.tick_shader.uniform_float("y_offset", y)
         config.tick_batch.draw(config.tick_shader)
 
     ## line graph
     config.line_shader.bind()
+    config.line_shader.uniform_float("viewProjectionMatrix", matrix)
     config.line_shader.uniform_float("color", (1, 0, 0, 1))
+    config.line_shader.uniform_float("x_offset", x)
+    config.line_shader.uniform_float("y_offset", y)    
     config.line_batch.draw(config.line_shader)
 
 class NodeTreeGetter():
@@ -159,10 +175,56 @@ class SvWaveformViewerOperatorDP(bpy.types.Operator, NodeTreeGetter):
 
 # place here (out of node) to supress warnings during headless testing. i think.
 def get_2d_uniform_color_shader():
-    return gpu.shader.from_builtin('2D_UNIFORM_COLOR')
+    # return gpu.shader.from_builtin('2D_UNIFORM_COLOR')
+    uniform_2d_vertex_shader = '''
+    in vec2 pos;
+    uniform mat4 viewProjectionMatrix;
+    uniform float x_offset;
+    uniform float y_offset;
+
+    void main()
+    {
+       gl_Position = viewProjectionMatrix * vec4(pos.x + x_offset, pos.y + y_offset, 0.0f, 1.0f);
+    }
+    '''
+
+    uniform_2d_fragment_shader = '''
+    uniform vec4 color;
+    void main()
+    {
+       gl_FragColor = color;
+    }
+    '''
+    return gpu.types.GPUShader(uniform_2d_vertex_shader, uniform_2d_fragment_shader)
 
 def get_2d_smooth_color_shader():
-    return gpu.shader.from_builtin('2D_SMOOTH_COLOR')
+    # return gpu.shader.from_builtin('2D_SMOOTH_COLOR')
+    smooth_2d_vertex_shader = '''
+    in vec2 pos;
+    layout(location=1) in vec4 color;
+
+    uniform mat4 viewProjectionMatrix;
+    uniform float x_offset;
+    uniform float y_offset;
+
+    out vec4 a_color;
+   
+    void main()
+    {
+        gl_Position = viewProjectionMatrix * vec4(pos.x + x_offset, pos.y + y_offset, 0.0f, 1.0f);
+        a_color = color;
+    }
+    '''
+
+    smooth_2d_fragment_shader = '''
+    in vec4 a_color;
+
+    void main()
+    {
+        gl_FragColor = a_color;
+    }
+    '''
+    return gpu.types.GPUShader(smooth_2d_vertex_shader, smooth_2d_fragment_shader)    
 
 signed_digital_voltage_max = {
     8: 127,
@@ -210,6 +272,7 @@ class SvWaveformViewer(bpy.types.Node, SverchCustomTreeNode):
     bl_icon = 'FORCE_HARMONIC'
 
     n_id: bpy.props.StringProperty(default='')
+    location_theta: bpy.props.FloatProperty(name="location theta")
 
     def update_socket_count(self, context):
         ... # if self.num_channels < MAX_SOCKETS 
@@ -218,8 +281,6 @@ class SvWaveformViewer(bpy.types.Node, SverchCustomTreeNode):
         """
         adjust render location based on preference multiplier setting
         """
-        x, y = [int(j) for j in (Vector(self.absolute_location) + Vector((self.width + 20, 0)))[:]]
-
         try:
             with sv_preferences() as prefs:
                 multiplier = prefs.render_location_xy_multiplier
@@ -228,9 +289,10 @@ class SvWaveformViewer(bpy.types.Node, SverchCustomTreeNode):
             # print('did not find preferences - you need to save user preferences')
             multiplier = 1.0
             scale = 1.0
-        x, y = [x * multiplier, y * multiplier]
+        self.location_theta = multiplier
+        # x, y = [x * multiplier, y * multiplier]
 
-        return x, y, scale, multiplier
+        return scale
 
 
     activate: bpy.props.BoolProperty(name="show graph", update=updateNode)
@@ -335,7 +397,7 @@ class SvWaveformViewer(bpy.types.Node, SverchCustomTreeNode):
         tick_data.verts = []
         tick_data.indices = []
         w, h = dims
-        x, y = loc
+        x, y = (0, 0)
 
         if self.num_channels == 2:
             h *= 2
@@ -459,6 +521,9 @@ class SvWaveformViewer(bpy.types.Node, SverchCustomTreeNode):
 
         if self.activate:
 
+            if not self.inputs[0].other or self.inputs[1].other:
+                return
+
             # parameter containers
             config = lambda: None
             geom = lambda: None
@@ -467,14 +532,13 @@ class SvWaveformViewer(bpy.types.Node, SverchCustomTreeNode):
             palette.high_colour = (0.13, 0.13, 0.13, 1.0)
             palette.low_colour = (0.1, 0.1, 0.1, 1.0)
 
-            x, y, scale, multiplier = self.get_drawing_attributes()
+            scale = self.get_drawing_attributes()
 
             # some aliases
             w = self.graph_width
             h = self.graph_height
             dims = (w, h)
-            loc = (x, y)
-            config.loc = loc
+            loc = (0, 0)
             config.scale = scale
 
             grid_data = gridshader(dims, loc, palette, self.num_channels)
@@ -512,6 +576,8 @@ class SvWaveformViewer(bpy.types.Node, SverchCustomTreeNode):
             draw_data = {
                 'mode': 'custom_function_context',
                 'tree_name': self.id_data.name[:],
+                'node_name': self.name[:],
+                'loc': get_offset_xy,
                 'custom_function': advanced_grid_xy,
                 'args': (geom, config)
             }
@@ -525,15 +591,15 @@ class SvWaveformViewer(bpy.types.Node, SverchCustomTreeNode):
     def sv_copy(self, node):
         self.n_id = ''
 
-    def sv_update(self):
-        # handle disconnecting sockets, also disconnect drawing to view?
-        if not ("channel 1" in self.inputs):
-            return
-        try:
-            if not self.inputs[0].other or self.inputs[1].other:
-                nvBGL.callback_disable(node_id(self))
-        except:
-            print('Waveform Viewer node update holdout (not a problem)')
+    # def sv_update(self):
+    #     # handle disconnecting sockets, also disconnect drawing to view?
+    #     if not ("channel 1" in self.inputs):
+    #         return
+    #     try:
+    #         if not self.inputs[0].other or self.inputs[1].other:
+    #             nvBGL.callback_disable(node_id(self))
+    #     except:
+    #         print('Waveform Viewer node update holdout (not a problem)')
 
     def process_wave(self):
         print('process wave pressed')

--- a/ui/bgl_callback_nodeview.py
+++ b/ui/bgl_callback_nodeview.py
@@ -18,6 +18,8 @@
 
 # <pep8 compliant>
 
+from inspect import isfunction
+
 import bpy
 import blf
 import bgl
@@ -78,6 +80,19 @@ def restore_opengl_defaults():
     # bgl.glColor4f(0.0, 0.0, 0.0, 1.0)     # doesn't exist anymore ..    
 
 
+def get_sane_xy(data):
+    return_value = (120, 120)
+    location_function = data.get('loc')
+    if location_function:
+        ng = bpy.data.node_groups.get(data['tree_name'])
+        if ng:
+            node = ng.nodes.get(data['node_name'])
+            if node:
+                return_value = location_function(node)
+
+    return return_value    
+
+
 def draw_callback_px(n_id, data):
 
     space = bpy.context.space_data
@@ -102,8 +117,17 @@ def draw_callback_px(n_id, data):
         restore_opengl_defaults()
     elif data.get('mode') == 'custom_function':
         drawing_func = data.get('custom_function')
-        x, y = data.get('loc', (20, 20))
+
+        location = data.get('loc')
+        if isfunction(location):
+            x, y = get_sane_xy(data)
+        elif isinstance(location, (tuple, list)):
+            x, y = location
+        else:
+            x, y = 20, 20
+
         args = data.get('args', (None,))
+        
         drawing_func(x, y, args)
         restore_opengl_defaults()
     elif data.get('mode') == 'custom_function_context':

--- a/ui/bgl_callback_nodeview.py
+++ b/ui/bgl_callback_nodeview.py
@@ -80,6 +80,17 @@ def restore_opengl_defaults():
     # bgl.glColor4f(0.0, 0.0, 0.0, 1.0)     # doesn't exist anymore ..    
 
 
+def get_xy_from_data(data):
+    location = data.get('loc')
+    if isfunction(location):
+        x, y = get_sane_xy(data)
+    elif isinstance(location, (tuple, list)):
+        x, y = location
+    else:
+        x, y = 20, 20
+    return x, y
+
+
 def get_sane_xy(data):
     return_value = (120, 120)
     location_function = data.get('loc')
@@ -118,14 +129,7 @@ def draw_callback_px(n_id, data):
     elif data.get('mode') == 'custom_function':
         drawing_func = data.get('custom_function')
 
-        location = data.get('loc')
-        if isfunction(location):
-            x, y = get_sane_xy(data)
-        elif isinstance(location, (tuple, list)):
-            x, y = location
-        else:
-            x, y = 20, 20
-
+        x, y = get_xy_from_data(data)
         args = data.get('args', (None,))
         
         drawing_func(x, y, args)
@@ -139,12 +143,12 @@ def draw_callback_px(n_id, data):
 
             config = lambda: None
             config.shader_data = ...
-            config.loc = (x, y)  (for node location..)
 
             geom = lambda: None
             geom.stuff = ..
 
             draw_data = {
+                'loc': function_returning_xy,
                 'mode': 'custom_function_context',
                 'tree_name': self.id_data.name[:],
                 'custom_function': advanced_grid_xy,
@@ -154,10 +158,12 @@ def draw_callback_px(n_id, data):
             nvBGL.callback_enable(self.n_id, draw_data)
 
         '''
+        x, y = get_xy_from_data(data)
+
         bgl.glEnable(bgl.GL_DEPTH_TEST)
         drawing_func = data.get('custom_function')
         args = data.get('args', (None,))
-        drawing_func(bpy.context, args)
+        drawing_func(bpy.context, args, (x, y))
         restore_opengl_defaults()
         bgl.glDisable(bgl.GL_DEPTH_TEST)
         

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -140,6 +140,7 @@ utils_modules = [
     "sv_panels_tools", "sv_gist_tools", "sv_IO_panel_tools", "sv_load_archived_blend",
     "monad", "sv_help", "sv_default_macros", "sv_macro_utils", "sv_extra_search", "sv_3dview_tools",
     "sv_update_utils", "sv_obj_helper", "sv_batch_primitives", "sv_idx_viewer28_draw",
+    "sv_texture_utils",
     # geom 2d tools
     "geom_2d.lin_alg", "geom_2d.dcel", "geom_2d.dissolve_mesh", "geom_2d.merge_mesh", "geom_2d.intersections",
     "geom_2d.make_monotone", "geom_2d.sort_mesh", "geom_2d.dcel_debugger"

--- a/utils/exception_drawing_with_bgl.py
+++ b/utils/exception_drawing_with_bgl.py
@@ -54,6 +54,8 @@ def clear_exception_drawing_with_bgl(nodes):
     nvBGL2.callback_disable(ng_id)
 
 
+
+
 def start_exception_drawing_with_bgl(ng, node_name, error_text, err):
     """ start drawing the exception data beside the node """
     node = ng.nodes[node_name]
@@ -67,25 +69,30 @@ def start_exception_drawing_with_bgl(ng, node_name, error_text, err):
         text.body = error_text
 
     x, y, scale = adjust_position_and_dimensions(node, xyoffset(node))
-    config.loc = x, y
     config.scale = scale
+
+    def get_desired_xy(node):
+        nx, ny = xyoffset(node)
+        return nx * scale, ny * scale
 
     ng_id = exception_nodetree_id(ng)
     draw_data = {
         'tree_name': ng.name[:],
+        'node_name': node_name,
+        'loc': get_desired_xy,
         'mode': 'custom_function_context', 
         'custom_function': simple_exception_display,
         'args': (text, config)
     }
     nvBGL2.callback_enable(ng_id, draw_data)
 
-def simple_exception_display(context, args):
+def simple_exception_display(context, args, xy):
     """
     a simple bgl/blf exception showing tool for nodeview
     """
     text, config = args
 
-    x, y = config.loc
+    x, y = xy
     x, y = int(x), int(y)
     r, g, b = (1.0, 1.0, 1.0)
     font_id = 0

--- a/utils/sv_nodeview_draw_helper.py
+++ b/utils/sv_nodeview_draw_helper.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: GPL3
 # License-Filename: LICENSE
 
+import bpy
+
 import numpy as np
 from mathutils import Matrix
 
@@ -15,6 +17,8 @@ from sverchok.settings import get_params
 
 
 class SvNodeViewDrawMixin():
+
+    location_theta: bpy.props.FloatProperty(name="location theta")
 
     @property
     def xy_offset(self):
@@ -32,10 +36,7 @@ class SvNodeViewDrawMixin():
 
     def adjust_position_and_dimensions(self, x, y, width, height):
         scale, multiplier = self.get_preferences()
-        x, y = [x * multiplier, y * multiplier]
-        width, height = [width * scale, height * scale]
-        return x, y, width, height
-
+        self.location_theta = multiplier
 
 
 def faces_from_xy(ncx, ncy):

--- a/utils/sv_stethoscope_helper.py
+++ b/utils/sv_stethoscope_helper.py
@@ -6,17 +6,22 @@
 # License-Filename: LICENSE
 
 from collections import defaultdict
-import blf
 
+import blf
+import bpy
 
 def get_sane_xy(data):
     return_value = (120, 120)
     location_function = data.get('location')
+    print('hhhheeere')
     if location_function:
+        print('here 1')
         ng = bpy.data.node_groups.get(data['tree_name'])
         if ng:
-            node = ng.get(data['node_name'])
+            print('here 2')
+            node = ng.nodes.get(data['node_name'])
             if node:
+                print('here 3')
                 return_value = location_function(node)
 
     return return_value

--- a/utils/sv_stethoscope_helper.py
+++ b/utils/sv_stethoscope_helper.py
@@ -8,9 +8,26 @@
 from collections import defaultdict
 import blf
 
+
+def get_sane_xy(data):
+    return_value = (120, 120)
+    location_function = data.get('location')
+    if location_function:
+        ng = bpy.data.node_groups.get(data['tree_name'])
+        if ng:
+            node = ng.get(data['node_name'])
+            if node:
+                return_value = location_function(node)
+
+    return return_value
+
+
+
 def draw_text_data(data):
     lines = data.get('content', 'no data')
-    x, y = data.get('location', (120, 120))
+
+    x, y = get_sane_xy(data)
+    
     x, y = int(x), int(y)
     r, g, b = data.get('color', (0.1, 0.1, 0.1))
     font_id = data.get('font_id', 0)
@@ -31,7 +48,7 @@ def draw_text_data(data):
 
 def draw_graphical_data(data):
     lines = data.get('content')
-    x, y = data.get('location', (120, 120))
+    x, y = get_sane_xy(data)
     color = data.get('color', (0.1, 0.1, 0.1))
     font_id = data.get('font_id', 0)
     scale = data.get('scale', 1.0)

--- a/utils/sv_stethoscope_helper.py
+++ b/utils/sv_stethoscope_helper.py
@@ -13,15 +13,11 @@ import bpy
 def get_sane_xy(data):
     return_value = (120, 120)
     location_function = data.get('location')
-    print('hhhheeere')
     if location_function:
-        print('here 1')
         ng = bpy.data.node_groups.get(data['tree_name'])
         if ng:
-            print('here 2')
             node = ng.nodes.get(data['node_name'])
             if node:
-                print('here 3')
                 return_value = location_function(node)
 
     return return_value

--- a/utils/sv_texture_utils.py
+++ b/utils/sv_texture_utils.py
@@ -1,0 +1,41 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+tx_vertex_shader = '''
+    uniform mat4 ModelViewProjectionMatrix;
+
+    /* Keep in sync with intern/opencolorio/gpu_shader_display_transform_vertex.glsl */
+
+    in vec2 texCoord;
+    in vec2 pos;
+
+    out vec2 texCoord_interp;
+
+    void main()
+    {
+       gl_Position = ModelViewProjectionMatrix * vec4(pos.xy, 0.0f, 1.0f);
+       gl_Position.z = 1.0;
+       texCoord_interp = texCoord;
+    }
+'''
+
+tx_fragment_shader = '''
+    in vec2 texCoord_interp;
+    out vec4 fragColor;
+
+    uniform sampler2D image;
+    uniform bool ColorMode;
+
+    void main()
+    {
+        if (ColorMode) {
+           fragColor = texture(image, texCoord_interp);
+        } else {
+           fragColor = texture(image, texCoord_interp).rrrr;
+        }
+    }
+'''

--- a/utils/sv_texture_utils.py
+++ b/utils/sv_texture_utils.py
@@ -13,11 +13,14 @@ tx_vertex_shader = '''
     in vec2 texCoord;
     in vec2 pos;
 
+    uniform float x_offset;
+    uniform float y_offset;
+
     out vec2 texCoord_interp;
 
     void main()
     {
-       gl_Position = ModelViewProjectionMatrix * vec4(pos.xy, 0.0f, 1.0f);
+       gl_Position = ModelViewProjectionMatrix * vec4(pos.x + x_offset, pos.y + y_offset, 0.0f, 1.0f);
        gl_Position.z = 1.0;
        texCoord_interp = texCoord;
     }

--- a/utils/sv_texture_utils.py
+++ b/utils/sv_texture_utils.py
@@ -42,3 +42,71 @@ tx_fragment_shader = '''
         }
     }
 '''
+
+def init_texture(width, height, texname, texture, clr):
+    # function to init the texture
+    bgl.glPixelStorei(bgl.GL_UNPACK_ALIGNMENT, 1)
+
+    bgl.glEnable(bgl.GL_TEXTURE_2D)
+    bgl.glBindTexture(bgl.GL_TEXTURE_2D, texname)
+    bgl.glActiveTexture(bgl.GL_TEXTURE0)
+
+    bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_S, bgl.GL_CLAMP_TO_EDGE)
+    bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_T, bgl.GL_CLAMP_TO_EDGE)
+    bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MAG_FILTER, bgl.GL_LINEAR)
+    bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MIN_FILTER, bgl.GL_LINEAR)
+
+    bgl.glTexImage2D(
+        bgl.GL_TEXTURE_2D,
+        0, clr, width, height,
+        0, clr, bgl.GL_FLOAT, texture
+    )
+
+
+def simple_screen(x, y, args):
+    """ shader draw function for the texture """
+
+    # border_color = (0.390805, 0.754022, 1.000000, 1.00)
+    texture, texname, width, height, batch, shader, cMod = args
+
+    def draw_texture(x=0, y=0, w=30, h=10, texname=texname, c=cMod):
+        # function to draw a texture
+        bgl.glDisable(bgl.GL_DEPTH_TEST)
+
+        act_tex = bgl.Buffer(bgl.GL_INT, 1)
+        bgl.glBindTexture(bgl.GL_TEXTURE_2D, texname)
+
+        shader.bind()
+        shader.uniform_int("image", act_tex)
+        shader.uniform_bool("ColorMode", c)
+        shader.uniform_float("x_offset", x)
+        shader.uniform_float("y_offset", y)        
+        batch.draw(shader)
+
+        # restoring settings
+        bgl.glBindTexture(bgl.GL_TEXTURE_2D, act_tex[0])
+        bgl.glDisable(bgl.GL_TEXTURE_2D)
+
+    draw_texture(x=x, y=y, w=width, h=height, texname=texname, c=cMod)
+
+gl_color_list = [
+    ('BW', 'bw', 'grayscale texture', '', 0),
+    ('RGB', 'rgb', 'rgb colored texture', '', 1),
+    ('RGBA', 'rgba', 'rgba colored texture', '', 2)
+]
+
+gl_color_dict = {
+    'BW': 6403,  # GL_RED
+    'RGB': 6407,  # GL_RGB
+    'RGBA': 6408  # GL_RGBA
+}
+
+factor_buffer_dict = {
+    'BW': 1,  # GL_RED
+    'RGB': 3,  # GL_RGB
+    'RGBA': 4  # GL_RGBA
+}
+
+def get_drawing_location(node):
+    x, y = node.xy_offset
+    return x * node.location_theta, y * node.location_theta

--- a/utils/sv_texture_utils.py
+++ b/utils/sv_texture_utils.py
@@ -110,3 +110,13 @@ factor_buffer_dict = {
 def get_drawing_location(node):
     x, y = node.xy_offset
     return x * node.location_theta, y * node.location_theta
+
+
+# def generate_batch_shader(args):
+#     w, h = args
+#     x, y = 0, 0
+#     positions = ((x, y), (x + w, y), (x + w, y - h), (x, y - h))
+#     indices = ((0, 1), (1, 1), (1, 0), (0, 0))
+#     shader = gpu.types.GPUShader(tx_vertex_shader, tx_fragment_shader)
+#     batch = batch_for_shader(shader, 'TRI_FAN', {"pos": positions, "texCoord": indices})
+#     return batch, shader

--- a/utils/sv_texture_utils.py
+++ b/utils/sv_texture_utils.py
@@ -5,6 +5,11 @@
 # SPDX-License-Identifier: GPL3
 # License-Filename: LICENSE
 
+import bgl
+import gpu
+from gpu_extras.batch import batch_for_shader
+
+
 tx_vertex_shader = '''
     uniform mat4 ModelViewProjectionMatrix;
 
@@ -112,11 +117,11 @@ def get_drawing_location(node):
     return x * node.location_theta, y * node.location_theta
 
 
-# def generate_batch_shader(args):
-#     w, h = args
-#     x, y = 0, 0
-#     positions = ((x, y), (x + w, y), (x + w, y - h), (x, y - h))
-#     indices = ((0, 1), (1, 1), (1, 0), (0, 0))
-#     shader = gpu.types.GPUShader(tx_vertex_shader, tx_fragment_shader)
-#     batch = batch_for_shader(shader, 'TRI_FAN', {"pos": positions, "texCoord": indices})
-#     return batch, shader
+def generate_batch_shader(args):
+    w, h = args
+    x, y = 0, 0
+    positions = ((x, y), (x + w, y), (x + w, y - h), (x, y - h))
+    indices = ((0, 1), (1, 1), (1, 0), (0, 0))
+    shader = gpu.types.GPUShader(tx_vertex_shader, tx_fragment_shader)
+    batch = batch_for_shader(shader, 'TRI_FAN', {"pos": positions, "texCoord": indices})
+    return batch, shader


### PR DESCRIPTION
some ui love.

![works](https://user-images.githubusercontent.com/619340/83504514-e1610a80-a4c4-11ea-8584-a21f93fcb94c.gif)

todo, related

- [x] nodes\number\easing.py:
- [x] nodes\viz\console_node.py:
- [ ] nodes\viz\viewer_2d.py:
- [x] nodes\viz\viewer_texture.py:
- [x] nodes\viz\viewer_texture_lite.py:
- [x] nodes\viz\viewer_waveform_output.py:
- [x] ui\bgl_callback_nodeview.py:
- [x] utils\exception_drawing_with_bgl.py:

each of those nodes must implement a function that calculates the desired X, Y location to start drawing. My preference is that the function is created outside of the node class, called with a reference to the node.
```
def get_dynamic_xy_for_2d_drawing(node):
    """
    take into account the node's absolute location
    take into account the node's current width
    apply any x, y offset
    apply any scaling to the final x, y
    """
    x = ...
    y = ...
    return x, y
```
something like the easing function would replace the `loc` entry with a function
```diff
            draw_data = {
                'mode': 'custom_function',
                'tree_name': self.id_data.name[:],
-               'loc': (x, y),
+               'node_name': self.name[:],
+               'loc': get_dynamic_xy_for_2d_drawing,
                'custom_function': simple28_grid_xy,
                'args': (geom, config)
            }
            nvBGL.callback_enable(n_id, draw_data)
```