### PR TITLE
"Track normal" mode for "Extrude curve along curve" node.

### DIFF
--- a/docs/nodes/surface/extrude_curve.rst
+++ b/docs/nodes/surface/extrude_curve.rst
@@ -4,12 +4,33 @@ Extrude Curve Along Curve
 Functionality
 -------------
 
-This node generates a Surface object by extruding one Curve (called "profile") along another Curve (called "Extrusion").
-The Profile curve may optionally be rotated while extruding, to make result look more naturally.
+This node generates a Surface object by extruding one Curve (called "profile")
+along another Curve (called "Extrusion").
 
 It is supposed that the profile curve is positioned so that it's "logical
 center" (i.e., the point, which is to be moved along the extrusion curve) is
 located at the global origin `(0, 0, 0)`.
+
+The Profile curve may optionally be rotated while extruding, to make result
+look more naturally.
+
+Several algorithms to calculate rotation of profile curve are available. In
+simplest cases, all of them will give very similar results. In more complex
+cases, results will be very different. Different algorithms give best results
+in different cases:
+
+* "Frenet" or "Zero-Twist" algorithms give very good results in case when
+  extrusion curve has non-zero curvature in all points. If the extrusion curve
+  has zero curvature points, or, even worse, it has straight segments, these
+  algorithms will either make "flipping" surface, or give an error.
+* "Householder", "Tracking" and "Rotation difference" algorithms are
+  "curve-agnostic", they work independently of curve by itself, depending only
+  on tangent direction. They give "good enough" result (at least, without
+  errors or sudden flips) for all extrusion curves, but may make twisted
+  surfaces in some special cases.
+* "Track normal" algorithm is supposed to give good results without twisting
+  for all extrusion curves. It will give better results with higher values of
+  "resolution" parameter, but that may be slow.
 
 Surface domain: Along U direction - the same as of "profile" curve; along V
 direction - the same as of "extrusion" curve.
@@ -20,11 +41,13 @@ Inputs
 This node has the following inputs:
 
 * **Profile**. The profile curve (one which is to be extruded). This input is mandatory.
-* **Extrusion**. The extrusion curve (the curve along which the profile is to be extruded). This input is mandatory.
-* **Resolution**. Number of samples for **Zero-Twist** rotation algorithm
+* **Extrusion**. The extrusion curve (the curve along which the profile is to
+  be extruded). This input is mandatory.
+* **Resolution**. Number of samples for **Zero-Twist** or **Track normal**
+  rotation algorithm
   calculation. The more the number is, the more precise the calculation is, but
   the slower. The default value is 50. This input is only available when
-  **Algorithm** parameter is set to **Zero-Twist**.
+  **Algorithm** parameter is set to **Zero-Twist** or **Track normal**.
 
 Parameters
 ----------
@@ -36,12 +59,13 @@ This node has the following parameters:
   * **None**. Do not rotate the profile curve, just extrude it as it is. This mode is the default one.
   * **Frenet**. Rotate the profile curve according to Frenet frame of the extrusion curve.
   * **Zero-Twist**. Rotate the profile curve according to "zero-twist" frame of the extrusion curve.
-  * Householder: calculate rotation by using Householder's reflection matrix
+  * **Householder**: calculate rotation by using Householder's reflection matrix
     (see Wikipedia_ article).                   
-  * Tracking: use the same algorithm as in Blender's "TrackTo" kinematic
+  * **Tracking**: use the same algorithm as in Blender's "TrackTo" kinematic
     constraint. This node currently always uses X as the Up axis.
-  * Rotation difference: calculate rotation as rotation difference between two
+  * **Rotation difference**: calculate rotation as rotation difference between two
     vectors.                                         
+  * **Track normal**: try to maintain constant normal direction by tracking it along the curve.
 
 * **Origin**. This parameter defines the position of the resulting surface with
   relation to the positions of the profile curve and the extrusion curve. It is
@@ -51,7 +75,7 @@ This node has the following parameters:
    * **Global origin**. The beginning of the surface will be placed at global origin.
    * **Extrusion origin**. The beginning of the surface will be placed at the beginning of the extrusion curve.
    
-  The default option is **Global origin**.
+  The default option is **Extrusion origin**.
 
 .. _Wikipedia: https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 


### PR DESCRIPTION
From #3306.

To "rotate matrix according to curve's tangent", we have the following approaches:

a) historically (in Sverchok) the first: use Householder, Tracking or Rotation Difference algorithm. These algorithms take two vectors: initial tangent direction and tangent direction you want, and return a rotation matrix that converts the source tangent direction to the target. Note: these algorithms do not know at all what the "curve" is. They depend on tangent direction only.

b) Frenet and "zero-twist" algorithms. Frenet algorithm takes Frenet matrix of the curve, made from tangent direction, normal and binormal directions of the curve. "Zero-twist" is similar, it takes Frenet matrices first, and then it "substracts" rotation around the tangent, which is calculated by integrating curve torsion. These algorithms are not "curve-agnostic", they are based on differential geometry, so for "good" curves they give better results. "Good" means curve with non-zero curvature, i.e. curve which has non-zero second derivative in all points. If the curve has points with zero curvature, or, even worse, it has straight segments, then everything is suddenly very bad. 

c) New algorithm. First, let's split curve in N pieces and calculate tangent vectors at these points ("knots"). Then we take curve's normal vector at curve's starting point (let's assume that at least at this point the curve has non-zero curvature). Then we iterate through all knots. At each knot, we build a plane through the knot point, orthogonal to curve's tangent vector at this knot point; and we project normal vector from previous point to this plane. So we have N normal vectors. Then for any value of T in curve's domain, we can calculate normal vector by interpolating normals between knot points somehow. In the following script, quaternions linear interpolation is used.

For compassion, "Tracking" algorithm, which for this particular curve gives the best result among all implemented algorithms:

![Screenshot_20200608_012849](https://user-images.githubusercontent.com/284644/83979411-8b0e2480-a927-11ea-824a-43ad121c2732.png)

Note the twisting at the left side.

New algorithm:
![Screenshot_20200608_010829](https://user-images.githubusercontent.com/284644/83979132-92343300-a925-11ea-9e58-35c0f8dc8596.png)

Another example:

![Screenshot_20200608_222636](https://user-images.githubusercontent.com/284644/84063176-0fb97b00-a9da-11ea-9724-e93abcbffa30.png)


## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

