### PR TITLE
Curve frame zero curvature

### DIFF
--- a/docs/nodes/curve/curve_frame.rst
+++ b/docs/nodes/curve/curve_frame.rst
@@ -11,7 +11,7 @@ orientation.
 
 .. _Frenet: https://en.wikipedia.org/wiki/Frenet%E2%80%93Serret_formulas
 
-**Note 1**: Frenet frame of the curve rotates along curve's tangent according to
+**Note 1**: Frenet frame of the curve rotates around curve's tangent according to
 curve's own torsion. Thus, if you place something by this frame, the result can
 be somewhat twisted. If you want to minimize the twist, you may wish to use
 **Zero-Twist Frame** node.
@@ -31,18 +31,31 @@ This node has the following inputs:
 Parameters
 ----------
 
-This node has the following parameter:
+This node has the following parameters:
 
 * **Join**. If checked, the node will output the single list of matrices,
   joined from any number of input curves provided. Otherwise, the node will
   output a separate list of matrices for each input curve. Checked by default.
+* **On zero curvature**. This parameter is only available in the N panel. This
+  defines what the node should do if it is instructed to calculate curve frame
+  at the point where curve has zero curvature. The available options are:
+
+   * **Raise error**. The node will raise an error (become red) and will not
+     process such input.
+   * **Arbitrary frame**. The node will return some arbitrary frame, with only
+     guaranteed property of having Z axis parallel to curve's tangent (two
+     other axes will be chosen arbitrarily).
+   
+  The default option is **Raise error**.
 
 Outputs
 -------
 
 This node has the following outputs:
 
-* **Matrix**. The matrix defining the Frenet frame for the curve at the specified value of T parameter. The location component of the matrix is the point of the curve. Z axis of the matrix points along curve's tangent.
+* **Matrix**. The matrix defining the Frenet frame for the curve at the
+  specified value of T parameter. The location component of the matrix is the
+  point of the curve. Z axis of the matrix points along curve's tangent.
 * **Normal**. The direction of curve's main normal at the specified value of T parameter.
 * **Binormal**. The direction of curve's binormal at the specified value of T parameter.
 

--- a/nodes/curve/curve_frame.py
+++ b/nodes/curve/curve_frame.py
@@ -6,6 +6,7 @@ from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty
 
 from sverchok.node_tree import SverchCustomTreeNode, throttled
 from sverchok.data_structure import updateNode, zip_long_repeat
+from sverchok.utils.curve import SvCurve, ZeroCurvatureException
 
 class SvCurveFrameNode(bpy.types.Node, SverchCustomTreeNode):
         """
@@ -28,8 +29,24 @@ class SvCurveFrameNode(bpy.types.Node, SverchCustomTreeNode):
                 default = True,
                 update = updateNode)
 
+        error_modes = [
+                ('ERROR', "Raise error", "Raise an error", 0),
+                ('ANY', "Arbitrary frame", "Calculate any frame that has Z axis along curve's tangent", 1)
+            ]
+
+        on_error : EnumProperty(
+                name = "On zero curvature",
+                description = "What the node should do if it encounters a point with zero curvature - it is impossible to calculate correct Frenet frame at such points",
+                items = error_modes,
+                default = 'ERROR',
+                update = updateNode)
+
         def draw_buttons(self, context, layout):
             layout.prop(self, 'join', toggle=True)
+
+        def draw_buttons_ext(self, context, layout):
+            layout.label(text='On zero curvature:')
+            layout.prop(self, 'on_error', text='')
 
         def sv_init(self, context):
             self.inputs.new('SvCurveSocket', "Curve")
@@ -52,7 +69,25 @@ class SvCurveFrameNode(bpy.types.Node, SverchCustomTreeNode):
                 ts = np.array(ts)
 
                 verts = curve.evaluate_array(ts)
-                matrices_np, normals, binormals = curve.frame_array(ts)
+                try:
+                    matrices_np, normals, binormals = curve.frame_array(ts, on_zero_curvature = SvCurve.FAIL)
+                except ZeroCurvatureException as e:
+                    if self.on_error == 'ERROR':
+                        raise Exception(e.get_message() + ". It is impossible to calculate correct Frenet frames for such points")
+                    else: # ANY
+                        bad_mask = e.mask
+                        good_mask = np.logical_not(bad_mask)
+                        good_ts = ts[good_mask]
+                        bad_ts = ts[bad_mask]
+
+                        n = len(ts)
+                        matrices_np = np.zeros((n, 3, 3))
+                        normals = np.zeros((n, 3))
+                        binormals = np.zeros((n, 3))
+                        if good_mask.any():
+                            matrices_np[good_mask], normals[good_mask], binormals[good_mask] = curve.frame_array(good_ts)
+                        matrices_np[bad_mask], normals[bad_mask], binormals[bad_mask] = curve.arbitrary_frame_array(bad_ts)
+
                 new_matrices = []
                 for matrix_np, point in zip(matrices_np, verts):
                     matrix = Matrix(matrix_np.tolist()).to_4x4()

--- a/nodes/curve/curve_frame.py
+++ b/nodes/curve/curve_frame.py
@@ -10,7 +10,7 @@ from sverchok.utils.curve import SvCurve, ZeroCurvatureException
 
 class SvCurveFrameNode(bpy.types.Node, SverchCustomTreeNode):
         """
-        Triggers: Curve Frame
+        Triggers: Curve Frenet Frame
         Tooltip: Calculate (Frenet) frame matrix at any point of the curve
         """
         bl_idname = 'SvExCurveFrameNode'


### PR DESCRIPTION
The problem is described in #3307 .

This adds an option to "curve frame" node (visible in the N panel only) which defines what to do in some cases:
* give an error (default)
* or return some arbitrary matrix, with only property of having Z axis along curve's tangent (other two axes are arbitrary).

## Solution description

Please describe how do you intend to solve the problem: change some method, or introduce new class, or whatever.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

