### PR TITLE
Right click connect to viewer draw understands Curves and Surfaces

### DIFF
--- a/ui/nodeview_rclick_menu.py
+++ b/ui/nodeview_rclick_menu.py
@@ -40,7 +40,7 @@ def valid_active_node(nodes):
 def has_outputs(node):
     return node and len(node.outputs)
 
-def get_verts_edge_poly_output_sockets(node):
+def get_output_sockets_map(node):
     """
     because of inconsistent socket naming, we will use pattern matching (ignoring capitalization)
     - verts: verts, vers, vertices, vectors, vecs  (ver, vec)
@@ -97,7 +97,7 @@ def add_connection(tree, bl_idname_new_node, offset):
     nodes = tree.nodes
     links = tree.links
 
-    output_map = get_verts_edge_poly_output_sockets(nodes.active)
+    output_map = get_output_sockets_map(nodes.active)
 
     existing_node = nodes.active
 

--- a/ui/nodeview_rclick_menu.py
+++ b/ui/nodeview_rclick_menu.py
@@ -46,6 +46,7 @@ def get_verts_edge_poly_output_sockets(node):
     - verts: verts, vers, vertices, vectors, vecs  (ver, vec)
     - edges: edges, edgs, edgpol  (edg)
     - faces: faces, poly, pols, edgpol, (pol, fac)
+    For curves and surfaces checks if they belong to the corresponding class
 
     > generally the first 3 outputs of a node will contain these
     > generally if a node outputs polygons, it won't be necessary to connect edges

--- a/ui/sv_temporal_viewers.py
+++ b/ui/sv_temporal_viewers.py
@@ -19,7 +19,7 @@
 
 import bpy
 from bpy.types import Operator
-from sverchok.ui.nodeview_rclick_menu import get_verts_edge_poly_output_sockets
+from sverchok.ui.nodeview_rclick_menu import get_output_sockets_map
 from sverchok.utils.sv_node_utils import frame_adjust
 
 sv_tree_types = {'SverchCustomTreeType', 'SverchGroupTreeType'}
@@ -33,7 +33,7 @@ def add_temporal_viewer_draw(tree, nodes, links, existing_node, cut_links):
     previous_state = tree.sv_process
     tree.sv_process = False
     bl_idname_new_node = 'SvVDExperimental'
-    output_map = get_verts_edge_poly_output_sockets(existing_node)
+    output_map = get_output_sockets_map(existing_node)
     try:
         new_node = nodes['Temporal Viewer']
         if cut_links or ('verts' in output_map and 'faces' in output_map):

--- a/ui/sv_vep_connector.py
+++ b/ui/sv_vep_connector.py
@@ -18,7 +18,7 @@
 # ##### END GPL LICENSE BLOCK #####
 
 import bpy
-from sverchok.ui.nodeview_rclick_menu import get_verts_edge_poly_output_sockets
+from sverchok.ui.nodeview_rclick_menu import get_output_sockets_map
 from sverchok.utils.sv_node_utils import frame_adjust
 
 sv_tree_types = {'SverchCustomTreeType', 'SverchGroupTreeType'}


### PR DESCRIPTION
Expands the behaviour of the "Connect to Viewer Draw" of the right click menu to understand curves a surfaces placing a Evaluate Node between the active node and the Viewer Draw.

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

