### PR TITLE
New sorting modes for Vector Sort node.

### DIFF
--- a/docs/nodes/vector/vertices_sort.rst
+++ b/docs/nodes/vector/vertices_sort.rst
@@ -15,19 +15,61 @@ and optional inputs(Vector, matrix and user data)
 Parameters
 ----------
 
-+----------------+---------------+-------------+----------------------------------------------------+
-| Param          | Type          | Default     | Description                                        |
-+================+===============+=============+====================================================+
-| **Vertices**   | Vector        |             | vertices from nodes generators or lists (in, out)  |
-+----------------+---------------+-------------+----------------------------------------------------+
-| **PolyEdge**   | Int           |             | index of polgons or edges     (in, out)            |
-+----------------+---------------+-------------+----------------------------------------------------+
-| **Sortmode**   | XYZ, Dist,    | XYZ         | will sort the index according to different criteria|
-|                | Axis, Connect,|             |                                                    |
-|                | User          |             |                                                    |
-+----------------+---------------+-------------+----------------------------------------------------+
-| **Item order** | Int           |             | output the index sequence                          |
-+----------------+---------------+-------------+----------------------------------------------------+
++----------------+-----------------+-------------+----------------------------------------------------+
+| Param          | Type            | Default     | Description                                        |
++================+=================+=============+====================================================+
+| **Vertices**   | Vector          |             | vertices from nodes generators or lists (in, out)  |
++----------------+-----------------+-------------+----------------------------------------------------+
+| **PolyEdge**   | Int             |             | index of polgons or edges     (in, out)            |
++----------------+-----------------+-------------+----------------------------------------------------+
+| **Sortmode**   | XYZ, Dist,      | XYZ         | will sort the index according to different criteria|
+|                | Axis, Connect,  |             |                                                    |
+|                | Auto XYZ,       |             |                                                    |
+|                | Auto Direction, |             |                                                    |
+|                | Auto Phi / Z,   |             |                                                    |
+|                | User            |             |                                                    |
++----------------+-----------------+-------------+----------------------------------------------------+
+| **Reverse**    | Boolean         | False       | Reverse the sorting order. Available for           |
+|                |                 |             | **Auto Direction** and **Auto Phi / Z** modes.     |
++----------------+-----------------+-------------+----------------------------------------------------+
+| **Reverse X**, | Boolean         | False       | Reverse the sorting order when sorting by X, Y or  |
+| **Reverse Y**, |                 |             | Z, correspondingly. Available for **XYZ** and      |
+| **Reverse Z**  |                 |             | **Auto XYZ** modes only.                           |
++----------------+-----------------+-------------+----------------------------------------------------+
+| **Item order** | Int             |             | output the index sequence                          |
++----------------+-----------------+-------------+----------------------------------------------------+
+| **Mat**        | Matrix          |             | Matrix for the **Axis** mode.                      |
++----------------+-----------------+-------------+----------------------------------------------------+
+| **Base Point** | Vector          |             | Central point for the **Dist** mode.               |
++----------------+-----------------+-------------+----------------------------------------------------+
+
+The sorting modes work as follows:
+
+* **XYZ**. Sort vertices according to X coordinate value, then sort all the
+  result according to Y value, then sort all the result according to Z value.
+* **Dist**. Sort vertices according to distance from a point specified in the
+  **Base Point** input.
+* **Axis**.
+* **Connect**. Sort vertices according to the order in which they are connected by edges.
+* **Auto XYZ**. Automatically detect a plane where all vertices are lying (or a
+  plane most similar to that). Then sort vertices in the reference frame of
+  that plane: first along X (which is some arbitrary direction along the
+  plane), then, if there are some points with the same X - sort them along Y
+  (which is some another direction in the plane, but perpendicular to X), and
+  then if there are still points with same X and Y - sort them along Z (i.e.
+  along the normal of the plane).
+* **Auto Direction**. Automatically detect a straight line along which all
+  points are lying (or a line most similar to that). Then sort all vertices
+  along that line.
+* **Auto Phi / Z**. Automatically detect a plane where all the vertices are
+  lying (or a plane most similar to that); also calculate a central point in
+  that plane (barycenter of all vertices). Then express all vertices in terms
+  of cylindrical coordinates in reference frame of such a plane: Z axis is
+  pointing along plane's normal, Phi is going counterclockwise around plane's
+  normal. Then sort the vertices: first according to Phi value; then, if there
+  are points with the same Phi, sort them according to Z value; and, if there
+  are points with the same Phi and Z, sort them according to Rho value
+  (distance from central normal).
 
 Outputs
 -------

--- a/tests/linear_approximation_tests.py
+++ b/tests/linear_approximation_tests.py
@@ -69,7 +69,7 @@ class PlaneTests(SverchokTestCase):
         plane2 = PlaneEquation.from_coordinate_plane('XZ')
         line = plane1.intersect_with_plane(plane2)
         self.assert_sverchok_data_equal(tuple(line.direction.normalized()), (1, 0, 0))
-        self.assert_sverchok_data_equal(tuple(line.point), (1, 0, 0))
+        self.assert_sverchok_data_equal(tuple(line.point), (-1, 0, 0))
 
 class LineTests(SverchokTestCase):
     def test_from_two_points(self):

--- a/tests/linear_approximation_tests.py
+++ b/tests/linear_approximation_tests.py
@@ -69,7 +69,7 @@ class PlaneTests(SverchokTestCase):
         plane2 = PlaneEquation.from_coordinate_plane('XZ')
         line = plane1.intersect_with_plane(plane2)
         self.assert_sverchok_data_equal(tuple(line.direction.normalized()), (1, 0, 0))
-        self.assert_sverchok_data_equal(tuple(line.point), (0, 0, 0))
+        self.assert_sverchok_data_equal(tuple(line.point), (1, 0, 0))
 
 class LineTests(SverchokTestCase):
     def test_from_two_points(self):

--- a/utils/geom.py
+++ b/utils/geom.py
@@ -1067,17 +1067,35 @@ class PlaneEquation(object):
         value = a*x + b*y + c*z + d
         return abs(value) < eps
 
+    def second_vector(self):
+        eps = 1e-6
+        if abs(self.c) > eps:
+            v = Vector((1, 0, -self.a/self.c))
+        elif abs(self.a) > eps:
+            v = Vector((-self.b/self.a, 1, 0))
+        elif abs(self.b) > eps:
+            v = Vector((1, -self.a/self.b, 0))
+        else:
+            raise Exception("plane normal is (almost) zero")
+        return v
+
     def two_vectors(self):
         """
         Return two vectors that are parallel two this plane.
         Note: the two vectors returned are orthogonal.
+        Lengths of the returned vector is arbitrary.
 
         output: (Vector, Vector)
         """
-        v1 = self.normal.orthogonal()
+        v1 = self.second_vector()
         v2 = v1.cross(self.normal)
         return v1, v2
 
+    def get_matrix(self):
+        x = self.second_vector().normalized()
+        z = self.normal.normalized()
+        y = z.cross(x)
+        return Matrix([x, y, z]).transposed()
 
     def evaluate(self, u, v):
         """


### PR DESCRIPTION
This adds several sorting modes:

* **Auto XYZ**. Automatically detect a plane where all vertices are lying (or a
  plane most similar to that). Then sort vertices in the reference frame of
  that plane: first along X (which is some arbitrary direction along the
  plane), then, if there are some points with the same X - sort them along Y
  (which is some another direction in the plane, but perpendicular to X), and
  then if there are still points with same X and Y - sort them along Z (i.e.
  along the normal of the plane).
* **Auto Direction**. Automatically detect a straight line along which all
  points are lying (or a line most similar to that). Then sort all vertices
  along that line.
* **Auto Phi / Z**. Automatically detect a plane where all the vertices are
  lying (or a plane most similar to that); also calculate a central point in
  that plane (barycenter of all vertices). Then express all vertices in terms
  of cylindrical coordinates in reference frame of such a plane: Z axis is
  pointing along plane's normal, Phi is going counterclockwise around plane's
  normal. Then sort the vertices: first according to Phi value; then, if there
  are points with the same Phi, sort them according to Z value; and, if there
  are points with the same Phi and Z, sort them according to Rho value
  (distance from central normal).

This also adds **reverse** toggles where it was not so hard to add:
* **Reverse** for **Auto Direction** and **Auto Phi / Z** modes;
* **Reverse X** / Y / Z for XYZ and **Auto XYZ** modes.

I've also tried to update documentation accordingly. However, I still don't quite understand what exactly **Axis** mode does, so I had do leave it undocumented.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

