### PR TITLE
rename basedata_name sv_obj_helper Operator

### DIFF
--- a/utils/sv_obj_helper.py
+++ b/utils/sv_obj_helper.py
@@ -105,10 +105,21 @@ class SvObjectRenameDialog(bpy.types.Operator):
             return {'CANCELLED'}
 
         with n.sv_throttle_tree_update():
-            # n.basedata_name = self.basedata_name
-            print('rename not implemented yet')
-            pass
+            n.activate = False
 
+            objs = n.get_children()
+            for obj in objs:
+                obj.name = obj.name.replace(n.basedata_name, self.basedata_name)
+                obj['basedata_name'] = self.basedata_name
+
+            if n.grouping:
+                collections = bpy.data.collections
+                named = n.custom_collection_name or n.basedata_name
+                collection = collections.get(named)
+                collection.name = self.basedata_name
+
+            n.basedata_name = self.basedata_name
+            n.activate = True
 
         return {'FINISHED'}
 

--- a/utils/sv_obj_helper.py
+++ b/utils/sv_obj_helper.py
@@ -330,7 +330,10 @@ class SvObjHelper():
             row = col.row(align=True)
             row.scale_y = 1
             row.prop(self, "basedata_name", text="", icon=self.bl_icon)
-            tracked_operator(self, row, fn_name='rename_basedata', icon="SYNTAX_OFF")
+            
+            if self.bl_idname in {'SvBmeshViewerNodeV28'}:
+                # this feature is not implemented for all sv_obj viewers yet, only those in this list
+                tracked_operator(self, row, fn_name='rename_basedata', icon="SYNTAX_OFF")
 
             row = col.row(align=True)
             row.scale_y = 2

--- a/utils/sv_obj_helper.py
+++ b/utils/sv_obj_helper.py
@@ -87,6 +87,7 @@ class SvObjectRenameDialog(bpy.types.Operator):
     bl_label = "Sverchok Rename Objects (basedata)"
 
     basedata_name: bpy.props.StringProperty(name="New Name")
+    change_data_name_too: bpy.props.BoolProperty(default=True, name="Change Data Name")
     tree_name: StringProperty(default='')
     node_name: StringProperty(default='')
 
@@ -111,6 +112,8 @@ class SvObjectRenameDialog(bpy.types.Operator):
             for obj in objs:
                 obj.name = obj.name.replace(n.basedata_name, self.basedata_name)
                 obj['basedata_name'] = self.basedata_name
+                if self.change_data_name_too:
+                    obj.data.name = obj.name
 
             if n.grouping:
                 collections = bpy.data.collections

--- a/utils/sv_obj_helper.py
+++ b/utils/sv_obj_helper.py
@@ -102,7 +102,13 @@ class SvObjectRenameDialog(bpy.types.Operator):
         if self.tree_name and self.node_name:
             n = bpy.data.node_groups[self.tree_name].nodes[self.node_name]
         else:
-            n = context.node
+            return {'CANCELLED'}
+
+        with n.sv_throttle_tree_update():
+            # n.basedata_name = self.basedata_name
+            print('rename not implemented yet')
+            pass
+
 
         return {'FINISHED'}
 


### PR DESCRIPTION
addresses #2825 and #3391

allowing inplace-renaming `basedata_name` a feature which was never implemented fully

- [x] first implement a canonical Operator which handles BMviewer as generically as possible.
- [ ] handle name collisions (other nodes with same `basedata_name` breaks the abstraction, it must not be allowed)
- [x] offer to auto rename the datablock too
- [x] add operator to UI drawing func of sv_obj
- [ ] gradually make sure all `sv_obj_helper` heirs are handled individually
    - [x] bmesh viewer
    - [ ] curve viewer
    - [ ] polyline viewer
    - [ ] .... etc
- [ ] experiment with changing the default update function of the `basedata_name` StringProperty, so that the button is not needed and the update function instead triggers the appropriate code to handle the type of viewer node.