### PR TITLE
Built-in NURBS curves / surfaces implementation

### DIFF
--- a/docs/nodes/curve/nurbs_curve.rst
+++ b/docs/nodes/curve/nurbs_curve.rst
@@ -4,7 +4,7 @@ Build NURBS Curve
 Dependencies
 ------------
 
-This node requires Geomdl_ library to work.
+This node can optionally use Geomdl_ library.
 
 .. _Geomdl: https://onurraufbingol.com/NURBS-Python/
 
@@ -32,6 +32,14 @@ Parameters
 ----------
 
 This node has the following parameters:
+
+* **Implementation**. This defines the implementation of NURBS mathematics to be used. The available options are:
+
+  * **Geomdl**. Use Geomdl_ library. This option is available only when Geomdl package is installed.
+  * **Sverchok**. Use built-in Sverchok implementation.
+  
+  In general, built-in implementation should be faster; but Geomdl implementation is better tested.
+  The default option is **Geomdl**, when it is available; otherwise, built-in implementation is used.
 
 * **Curve mode**. This defines the type of curve to be built:
 

--- a/docs/nodes/surface/nurbs_surface.rst
+++ b/docs/nodes/surface/nurbs_surface.rst
@@ -6,7 +6,7 @@ Build NURBS surface
 Dependencies
 ------------
 
-This node requires Geomdl_ library to work.
+This node can optionally use Geomdl_ library.
 
 .. _Geomdl: https://onurraufbingol.com/NURBS-Python/
 
@@ -49,6 +49,14 @@ Parameters
 ----------
 
 This node has the following parameters:
+
+* **Implementation**. This defines the implementation of NURBS mathematics to be used. The available options are:
+
+  * **Geomdl**. Use Geomdl_ library. This option is available only when Geomdl package is installed.
+  * **Sverchok**. Use built-in Sverchok implementation.
+  
+  In general, built-in implementation should be faster; but Geomdl implementation is better tested.
+  The default option is **Geomdl**, when it is available; otherwise, built-in implementation is used.
 
 * **Surface mode**. Values: NURBS, BSpline
 * **Input mode**. The available values are:

--- a/nodes/curve/nurbs_curve.py
+++ b/nodes/curve/nurbs_curve.py
@@ -5,160 +5,161 @@ from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty
 from sverchok.node_tree import SverchCustomTreeNode, throttled
 from sverchok.data_structure import updateNode, zip_long_repeat, fullList
 from sverchok.utils.logging import info, exception
-from sverchok.utils.curve.nurbs import SvGeomdlCurve, SvNativeNurbsCurve
+from sverchok.utils.curve.nurbs import SvNurbsCurve
+from sverchok.utils.curve import knotvector as sv_knotvector
 from sverchok.utils.dummy_nodes import add_dummy
 from sverchok.dependencies import geomdl
 
-if geomdl is None:
-    add_dummy('SvExNurbsCurveNode', "Build NURBS Curve", 'geomdl')
-else:
-    from geomdl import NURBS, BSpline, knotvector
-    
-    class SvExNurbsCurveNode(bpy.types.Node, SverchCustomTreeNode):
-        """
-        Triggers: NURBS Curve
-        Tooltip: Generate NURBS Curve
-        """
-        bl_idname = 'SvExNurbsCurveNode'
-        bl_label = 'Build NURBS Curve'
-        bl_icon = 'CURVE_NCURVE'
+class SvExNurbsCurveNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: NURBS Curve
+    Tooltip: Generate NURBS Curve
+    """
+    bl_idname = 'SvExNurbsCurveNode'
+    bl_label = 'Build NURBS Curve'
+    bl_icon = 'CURVE_NCURVE'
 
-        @throttled
-        def update_sockets(self, context):
-            self.inputs['Weights'].hide_safe = self.surface_mode == 'BSPLINE'
-            self.inputs['Knots'].hide_safe = self.knot_mode == 'AUTO'
+    @throttled
+    def update_sockets(self, context):
+        self.inputs['Weights'].hide_safe = self.surface_mode == 'BSPLINE'
+        self.inputs['Knots'].hide_safe = self.knot_mode == 'AUTO'
 
-        surface_modes = [
-            ('NURBS', "NURBS", "NURBS Surface", 0),
-            ('BSPLINE', "BSpline", "BSpline Surface", 1)
-        ]
+    def get_implementations(self, context):
+        items = []
+        i = 0
+        if geomdl is not None:
+            item = (SvNurbsCurve.GEOMDL, "Geomdl", "Geomdl (NURBS-Python) package implementation",i)
+            i += 1
+            items.append(item)
+        item = (SvNurbsCurve.NATIVE, "Sverchok", "Sverchok built-in implementation", i)
+        items.append(item)
+        return items
 
-        surface_mode : EnumProperty(
-                name = "Curve mode",
-                items = surface_modes,
-                default = 'NURBS',
-                update = update_sockets)
+    implementation : EnumProperty(
+            name = "Implementation",
+            items = get_implementations,
+            update = updateNode)
 
-        knot_modes = [
-            ('AUTO', "Auto", "Generate knotvector automatically", 0),
-            ('EXPLICIT', "Explicit", "Specify knotvector explicitly", 1)
-        ]
+    surface_modes = [
+        ('NURBS', "NURBS", "NURBS Surface", 0),
+        ('BSPLINE', "BSpline", "BSpline Surface", 1)
+    ]
 
-        knot_mode : EnumProperty(
-                name = "Knotvector",
-                items = knot_modes,
-                default = 'AUTO',
-                update = update_sockets)
+    surface_mode : EnumProperty(
+            name = "Curve mode",
+            items = surface_modes,
+            default = 'NURBS',
+            update = update_sockets)
 
-        normalize_knots : BoolProperty(
-                name = "Normalize Knots",
-                default = True,
-                update = updateNode)
+    knot_modes = [
+        ('AUTO', "Auto", "Generate knotvector automatically", 0),
+        ('EXPLICIT', "Explicit", "Specify knotvector explicitly", 1)
+    ]
 
-        is_cyclic : BoolProperty(
-                name = "Cyclic",
-                default = False,
-                update = updateNode)
+    knot_mode : EnumProperty(
+            name = "Knotvector",
+            items = knot_modes,
+            default = 'AUTO',
+            update = update_sockets)
 
-        degree : IntProperty(
-                name = "Degree",
-                min = 2, max = 6,
-                default = 3,
-                update = updateNode)
+    normalize_knots : BoolProperty(
+            name = "Normalize Knots",
+            default = True,
+            update = updateNode)
 
-        def draw_buttons(self, context, layout):
-            layout.prop(self, "surface_mode", expand=True)
-            col = layout.column(align=True)
-            col.label(text='Knots:')
-            row = col.row()
-            row.prop(self, "knot_mode", expand=True)
-            col.prop(self, 'normalize_knots', toggle=True)
+    is_cyclic : BoolProperty(
+            name = "Cyclic",
+            default = False,
+            update = updateNode)
+
+    degree : IntProperty(
+            name = "Degree",
+            min = 2, max = 6,
+            default = 3,
+            update = updateNode)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'implementation', text='')
+        layout.prop(self, "surface_mode", expand=True)
+        col = layout.column(align=True)
+        col.label(text='Knots:')
+        row = col.row()
+        row.prop(self, "knot_mode", expand=True)
+        col.prop(self, 'normalize_knots', toggle=True)
+        if self.knot_mode == 'AUTO':
+            layout.prop(self, 'is_cyclic', toggle=True)
+
+    def sv_init(self, context):
+        self.inputs.new('SvVerticesSocket', "ControlPoints")
+        self.inputs.new('SvStringsSocket', "Weights")
+        self.inputs.new('SvStringsSocket', "Knots")
+        self.inputs.new('SvStringsSocket', "Degree").prop_name = 'degree'
+        self.outputs.new('SvCurveSocket', "Curve")
+        self.outputs.new('SvStringsSocket', "Knots")
+        self.update_sockets(context)
+
+    def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+
+        vertices_s = self.inputs['ControlPoints'].sv_get()
+        has_weights = self.inputs['Weights'].is_linked
+        weights_s = self.inputs['Weights'].sv_get(default = [[1.0]])
+        knots_s = self.inputs['Knots'].sv_get(default = [[]])
+        degree_s = self.inputs['Degree'].sv_get()
+
+        curves_out = []
+        knots_out = []
+        for vertices, weights, knots, degree in zip_long_repeat(vertices_s, weights_s, knots_s, degree_s):
+            if isinstance(degree, (tuple, list)):
+                degree = degree[0]
+
+            n_source = len(vertices)
+            fullList(weights, n_source)
+            if self.knot_mode == 'AUTO' and self.is_cyclic:
+                vertices = vertices + vertices[:degree+1]
+                weights = weights + weights[:degree+1]
+            n_total = len(vertices)
+
+            # Set degree
+            curve_degree = degree
+
+            if has_weights and self.surface_mode == 'NURBS':
+                curve_weights = weights
+            else:
+                curve_weights = None
+
+            # Set knot vector
             if self.knot_mode == 'AUTO':
-                layout.prop(self, 'is_cyclic', toggle=True)
-
-        def sv_init(self, context):
-            self.inputs.new('SvVerticesSocket', "ControlPoints")
-            self.inputs.new('SvStringsSocket', "Weights")
-            self.inputs.new('SvStringsSocket', "Knots")
-            self.inputs.new('SvStringsSocket', "Degree").prop_name = 'degree'
-            self.outputs.new('SvCurveSocket', "Curve")
-            self.outputs.new('SvStringsSocket', "Knots")
-            self.update_sockets(context)
-
-        def process(self):
-            if not any(socket.is_linked for socket in self.outputs):
-                return
-
-            vertices_s = self.inputs['ControlPoints'].sv_get()
-            has_weights = self.inputs['Weights'].is_linked
-            weights_s = self.inputs['Weights'].sv_get(default = [[1.0]])
-            knots_s = self.inputs['Knots'].sv_get(default = [[]])
-            degree_s = self.inputs['Degree'].sv_get()
-
-            curves_out = []
-            knots_out = []
-            for vertices, weights, knots, degree in zip_long_repeat(vertices_s, weights_s, knots_s, degree_s):
-                if isinstance(degree, (tuple, list)):
-                    degree = degree[0]
-
-                n_source = len(vertices)
-                fullList(weights, n_source)
-                if self.knot_mode == 'AUTO' and self.is_cyclic:
-                    vertices = vertices + vertices[:degree+1]
-                    weights = weights + weights[:degree+1]
-                n_total = len(vertices)
-
-                # Create a 3-dimensional B-spline Curve
-                if self.surface_mode == 'NURBS':
-                    curve = NURBS.Curve(normalize_kv = self.normalize_knots)
-                else:
-                    curve = BSpline.Curve(normalize_kv = self.normalize_knots)
-
-                # Set degree
-                curve.degree = degree
-
-                # Set control points (weights vector will be 1 by default)
-                # Use curve.ctrlptsw is if you are using homogeneous points as Pw
-                curve.ctrlpts = vertices
-                if has_weights and self.surface_mode == 'NURBS':
-                    curve.weights = weights
-
-                # Set knot vector
-                if self.knot_mode == 'AUTO':
-                    if self.is_cyclic:
-                        self.debug("N: %s, degree: %s", n_total, degree)
-                        knots = list(range(n_total + degree + 1))
-                    else:
-                        knots = knotvector.generate(curve.degree, n_total)
-                    self.debug('Auto knots: %s', knots)
-                    curve.knotvector = knots
-                else:
-                    self.debug('Manual knots: %s', knots)
-                    #if not knotvector.check(curve.degree, knots, len(curve.ctrlpts)):
-                    #    raise Exception("Explicitly provided knot vector is incorrect!")
-                    curve.knotvector = knots
-
-                new_curve = SvNativeNurbsCurve(degree, curve.knotvector, vertices, weights)
-                #new_curve = SvGeomdlCurve(curve)
                 if self.is_cyclic:
-                    u_min = curve.knotvector[degree]
-                    u_max = curve.knotvector[-degree-2]
-                    new_curve.u_bounds = u_min, u_max
+                    self.debug("N: %s, degree: %s", n_total, degree)
+                    knots = list(range(n_total + degree + 1))
                 else:
-                    u_min = min(curve.knotvector)
-                    u_max = max(curve.knotvector)
-                    new_curve.u_bounds = (u_min, u_max)
-                curves_out.append(new_curve)
-                knots_out.append(curve.knotvector)
+                    knots = sv_knotvector.generate(curve_degree, n_total)
+                self.debug('Auto knots: %s', knots)
+                curve_knotvector = knots
+            else:
+                self.debug('Manual knots: %s', knots)
+                curve_knotvector = knots
 
-            self.outputs['Curve'].sv_set(curves_out)
-            self.outputs['Knots'].sv_set(knots_out)
+            new_curve = SvNurbsCurve.build(self.implementation, degree, curve_knotvector, vertices, curve_weights)
+            if self.is_cyclic:
+                u_min = curve_knotvector[degree]
+                u_max = curve_knotvector[-degree-2]
+                new_curve.u_bounds = u_min, u_max
+            else:
+                u_min = min(curve_knotvector)
+                u_max = max(curve_knotvector)
+                new_curve.u_bounds = (u_min, u_max)
+            curves_out.append(new_curve)
+            knots_out.append(curve_knotvector)
+
+        self.outputs['Curve'].sv_set(curves_out)
+        self.outputs['Knots'].sv_set(knots_out)
 
 def register():
-    if geomdl is not None:
-        bpy.utils.register_class(SvExNurbsCurveNode)
+    bpy.utils.register_class(SvExNurbsCurveNode)
 
 def unregister():
-    if geomdl is not None:
-        bpy.utils.unregister_class(SvExNurbsCurveNode)
+    bpy.utils.unregister_class(SvExNurbsCurveNode)
 

--- a/nodes/curve/nurbs_curve.py
+++ b/nodes/curve/nurbs_curve.py
@@ -5,7 +5,7 @@ from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty
 from sverchok.node_tree import SverchCustomTreeNode, throttled
 from sverchok.data_structure import updateNode, zip_long_repeat, fullList
 from sverchok.utils.logging import info, exception
-from sverchok.utils.curve.nurbs import SvGeomdlCurve
+from sverchok.utils.curve.nurbs import SvGeomdlCurve, SvNativeNurbsCurve
 from sverchok.utils.dummy_nodes import add_dummy
 from sverchok.dependencies import geomdl
 
@@ -138,7 +138,8 @@ else:
                     #    raise Exception("Explicitly provided knot vector is incorrect!")
                     curve.knotvector = knots
 
-                new_curve = SvGeomdlCurve(curve)
+                new_curve = SvNativeNurbsCurve(degree, curve.knotvector, vertices, weights)
+                #new_curve = SvGeomdlCurve(curve)
                 if self.is_cyclic:
                     u_min = curve.knotvector[degree]
                     u_max = curve.knotvector[-degree-2]

--- a/nodes/exchange/export_rw3dm_json.py
+++ b/nodes/exchange/export_rw3dm_json.py
@@ -9,8 +9,8 @@ from sverchok.data_structure import updateNode, zip_long_repeat
 from sverchok.utils.logging import info, exception
 from sverchok.utils.curve import SvCurve
 from sverchok.utils.surface import SvSurface
-from sverchok.utils.curve.nurbs import SvGeomdlCurve
-from sverchok.utils.surface.nurbs import SvGeomdlSurface
+from sverchok.utils.curve.nurbs import SvNurbsCurve, SvGeomdlCurve
+from sverchok.utils.surface.nurbs import SvNurbsSurface, SvGeomdlSurface
 from sverchok.utils.dummy_nodes import add_dummy
 from sverchok.dependencies import geomdl
 
@@ -114,9 +114,9 @@ else:
                     curves = sum(curves, [])
                 container = multi.CurveContainer()
                 for i, curve in enumerate(curves):
-                    if not isinstance(curve, SvGeomdlCurve):
+                    if not isinstance(curve, SvNurbsCurve):
                         raise TypeError("Provided object #%s is not a NURBS curve, but %s!" % (i, type(curve)))
-                    container.append(curve.curve)
+                    container.append(SvGeomdlCurve.from_any_nurbs(curve).curve)
                 return container
             else: # SURFACE
                 surfaces = self.inputs['Surfaces'].sv_get()
@@ -124,9 +124,9 @@ else:
                     surfaces = sum(surfaces, [])
                 container = multi.SurfaceContainer()
                 for i, surface in enumerate(surfaces):
-                    if not isinstance(surface, SvGeomdlSurface):
+                    if not isinstance(surface, SvNurbsSurface):
                         raise TypeError("Provided object #%s is not a NURBS surface, but %s!" % (i, type(surface)))
-                    container.append(surface.surface)
+                    container.append(SvGeomdlSurface.from_any_nurbs(surface).surface)
                 return container
 
 def register():

--- a/nodes/surface/nurbs_surface.py
+++ b/nodes/surface/nurbs_surface.py
@@ -7,148 +7,163 @@ from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty
 from sverchok.node_tree import SverchCustomTreeNode, throttled
 from sverchok.data_structure import updateNode, zip_long_repeat, fullList, ensure_nesting_level, split_by_count
 from sverchok.utils.logging import info, exception
-from sverchok.utils.surface.nurbs import SvGeomdlSurface, SvNativeNurbsSurface
+from sverchok.utils.surface.nurbs import SvNurbsSurface
+from sverchok.utils.curve import knotvector as sv_knotvector
 from sverchok.utils.dummy_nodes import add_dummy
 from sverchok.dependencies import geomdl
 
-if geomdl is None:
-    add_dummy('SvExNurbsSurfaceNode', "Build NURBS Surface", 'geomdl')
-else:
-    from geomdl import NURBS, BSpline, knotvector
-    
-    class SvExNurbsSurfaceNode(bpy.types.Node, SverchCustomTreeNode):
-        """
-        Triggers: NURBS Surface
-        Tooltip: Build NURBS Surface
-        """
-        bl_idname = 'SvExNurbsSurfaceNode'
-        bl_label = 'Build NURBS Surface'
-        bl_icon = 'SURFACE_NSURFACE'
+class SvExNurbsSurfaceNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: NURBS Surface
+    Tooltip: Build NURBS Surface
+    """
+    bl_idname = 'SvExNurbsSurfaceNode'
+    bl_label = 'Build NURBS Surface'
+    bl_icon = 'SURFACE_NSURFACE'
 
-        input_modes = [
-                ('1D', "Single list", "List of all control points (concatenated)", 1),
-                ('2D', "Separated lists", "List of lists of control points", 2)
-            ]
-
-        @throttled
-        def update_sockets(self, context):
-            self.inputs['USize'].hide_safe = self.input_mode == '2D'
-            self.inputs['Weights'].hide_safe = self.surface_mode == 'BSPLINE'
-            self.inputs['KnotsU'].hide_safe = self.knot_mode == 'AUTO'
-            self.inputs['KnotsV'].hide_safe = self.knot_mode == 'AUTO'
-
-        input_mode : EnumProperty(
-                name = "Input mode",
-                default = '1D',
-                items = input_modes,
-                update = update_sockets)
-
-        u_size : IntProperty(
-                name = "U Size",
-                default = 5,
-                min = 3,
-                update = updateNode)
-
-        surface_modes = [
-            ('NURBS', "NURBS", "NURBS Surface", 0),
-            ('BSPLINE', "BSpline", "BSpline Surface", 1)
+    input_modes = [
+            ('1D', "Single list", "List of all control points (concatenated)", 1),
+            ('2D', "Separated lists", "List of lists of control points", 2)
         ]
 
-        surface_mode : EnumProperty(
-                name = "Surface mode",
-                items = surface_modes,
-                default = 'NURBS',
-                update = update_sockets)
+    @throttled
+    def update_sockets(self, context):
+        self.inputs['USize'].hide_safe = self.input_mode == '2D'
+        self.inputs['Weights'].hide_safe = self.surface_mode == 'BSPLINE'
+        self.inputs['KnotsU'].hide_safe = self.knot_mode == 'AUTO'
+        self.inputs['KnotsV'].hide_safe = self.knot_mode == 'AUTO'
 
-        knot_modes = [
-            ('AUTO', "Auto", "Generate knotvector automatically", 0),
-            ('EXPLICIT', "Explicit", "Specify knotvector explicitly", 1)
-        ]
+    def get_implementations(self, context):
+        items = []
+        i = 0
+        if geomdl is not None:
+            item = (SvNurbsSurface.GEOMDL, "Geomdl", "Geomdl (NURBS-Python) package implementation",i)
+            i += 1
+            items.append(item)
+        item = (SvNurbsSurface.NATIVE, "Sverchok", "Sverchok built-in implementation", i)
+        items.append(item)
+        return items
 
-        knot_mode : EnumProperty(
-                name = "Knotvector",
-                items = knot_modes,
-                default = 'AUTO',
-                update = update_sockets)
+    implementation : EnumProperty(
+            name = "Implementation",
+            items = get_implementations,
+            update = updateNode)
 
-        normalize_knots : BoolProperty(
-                name = "Normalize Knots",
-                default = True,
-                update = updateNode)
+    input_mode : EnumProperty(
+            name = "Input mode",
+            default = '1D',
+            items = input_modes,
+            update = update_sockets)
 
-        degree_u : IntProperty(
-                name = "Degree U",
-                min = 2, max = 6,
-                default = 3,
-                update = updateNode)
+    u_size : IntProperty(
+            name = "U Size",
+            default = 5,
+            min = 3,
+            update = updateNode)
 
-        degree_v : IntProperty(
-                name = "Degree V",
-                min = 2, max = 6,
-                default = 3,
-                update = updateNode)
+    surface_modes = [
+        ('NURBS', "NURBS", "NURBS Surface", 0),
+        ('BSPLINE', "BSpline", "BSpline Surface", 1)
+    ]
 
-        is_cyclic_u : BoolProperty(
-                name = "Cyclic U",
-                default = False,
-                update = updateNode)
+    surface_mode : EnumProperty(
+            name = "Surface mode",
+            items = surface_modes,
+            default = 'NURBS',
+            update = update_sockets)
 
-        is_cyclic_v : BoolProperty(
-                name = "Cyclic V",
-                default = False,
-                update = updateNode)
+    knot_modes = [
+        ('AUTO', "Auto", "Generate knotvector automatically", 0),
+        ('EXPLICIT', "Explicit", "Specify knotvector explicitly", 1)
+    ]
 
-        def sv_init(self, context):
-            self.inputs.new('SvVerticesSocket', "ControlPoints")
-            self.inputs.new('SvStringsSocket', "Weights")
-            self.inputs.new('SvStringsSocket', "KnotsU")
-            self.inputs.new('SvStringsSocket', "KnotsV")
-            self.inputs.new('SvStringsSocket', "DegreeU").prop_name = 'degree_u'
-            self.inputs.new('SvStringsSocket', "DegreeV").prop_name = 'degree_v'
-            self.inputs.new('SvStringsSocket', "USize").prop_name = 'u_size'
-            self.outputs.new('SvSurfaceSocket', "Surface")
-            self.update_sockets(context)
+    knot_mode : EnumProperty(
+            name = "Knotvector",
+            items = knot_modes,
+            default = 'AUTO',
+            update = update_sockets)
 
-        def draw_buttons(self, context, layout):
-            layout.prop(self, "surface_mode", expand=True)
-            layout.prop(self, "input_mode")
-            col = layout.column(align=True)
-            col.label(text='Knots:')
-            row = col.row()
-            row.prop(self, "knot_mode", expand=True)
-            col.prop(self, 'normalize_knots', toggle=True)
-            if self.knot_mode == 'AUTO':
-                row = col.row(align=True)
-                row.prop(self, 'is_cyclic_u', toggle=True)
-                row.prop(self, 'is_cyclic_v', toggle=True)
+    normalize_knots : BoolProperty(
+            name = "Normalize Knots",
+            default = True,
+            update = updateNode)
 
-        def process(self):
-            vertices_s = self.inputs['ControlPoints'].sv_get()
-            has_weights = self.inputs['Weights'].is_linked
-            weights_s = self.inputs['Weights'].sv_get(default = [[1.0]])
-            u_size_s = self.inputs['USize'].sv_get()
-            knots_u_s = self.inputs['KnotsU'].sv_get(default = [[]])
-            knots_v_s = self.inputs['KnotsV'].sv_get(default = [[]])
-            degree_u_s = self.inputs['DegreeU'].sv_get()
-            degree_v_s = self.inputs['DegreeV'].sv_get()
+    degree_u : IntProperty(
+            name = "Degree U",
+            min = 2, max = 6,
+            default = 3,
+            update = updateNode)
 
-            if self.input_mode == '1D':
-                vertices_s = ensure_nesting_level(vertices_s, 3)
-            else:
-                vertices_s = ensure_nesting_level(vertices_s, 4)
-            
-            def convert_row(verts_row, weights_row):
-                return [(x, y, z, w) for (x,y,z), w in zip(verts_row, weights_row)]
+    degree_v : IntProperty(
+            name = "Degree V",
+            min = 2, max = 6,
+            default = 3,
+            update = updateNode)
 
-            surfaces_out = []
-            inputs = zip_long_repeat(vertices_s, weights_s, knots_u_s, knots_v_s, degree_u_s, degree_v_s, u_size_s)
-            for vertices, weights, knots_u, knots_v, degree_u, degree_v, u_size in inputs:
-                if isinstance(degree_u, (tuple, list)):
-                    degree_u = degree_u[0]
-                if isinstance(degree_v, (tuple, list)):
-                    degree_v = degree_v[0]
-                if isinstance(u_size, (list, tuple)):
-                    u_size = u_size[0]
+    is_cyclic_u : BoolProperty(
+            name = "Cyclic U",
+            default = False,
+            update = updateNode)
+
+    is_cyclic_v : BoolProperty(
+            name = "Cyclic V",
+            default = False,
+            update = updateNode)
+
+    def sv_init(self, context):
+        self.inputs.new('SvVerticesSocket', "ControlPoints")
+        self.inputs.new('SvStringsSocket', "Weights")
+        self.inputs.new('SvStringsSocket', "KnotsU")
+        self.inputs.new('SvStringsSocket', "KnotsV")
+        self.inputs.new('SvStringsSocket', "DegreeU").prop_name = 'degree_u'
+        self.inputs.new('SvStringsSocket', "DegreeV").prop_name = 'degree_v'
+        self.inputs.new('SvStringsSocket', "USize").prop_name = 'u_size'
+        self.outputs.new('SvSurfaceSocket', "Surface")
+        self.update_sockets(context)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'implementation', text='')
+        layout.prop(self, "surface_mode", expand=True)
+        layout.prop(self, "input_mode")
+        col = layout.column(align=True)
+        col.label(text='Knots:')
+        row = col.row()
+        row.prop(self, "knot_mode", expand=True)
+        col.prop(self, 'normalize_knots', toggle=True)
+        if self.knot_mode == 'AUTO':
+            row = col.row(align=True)
+            row.prop(self, 'is_cyclic_u', toggle=True)
+            row.prop(self, 'is_cyclic_v', toggle=True)
+
+    def process(self):
+        vertices_s = self.inputs['ControlPoints'].sv_get()
+        has_weights = self.inputs['Weights'].is_linked
+        weights_s = self.inputs['Weights'].sv_get(default = [[1.0]])
+        u_size_s = self.inputs['USize'].sv_get()
+        knots_u_s = self.inputs['KnotsU'].sv_get(default = [[]])
+        knots_v_s = self.inputs['KnotsV'].sv_get(default = [[]])
+        degree_u_s = self.inputs['DegreeU'].sv_get()
+        degree_v_s = self.inputs['DegreeV'].sv_get()
+
+        if self.input_mode == '1D':
+            vertices_s = ensure_nesting_level(vertices_s, 3)
+        else:
+            vertices_s = ensure_nesting_level(vertices_s, 4)
+        
+        surfaces_out = []
+        inputs = zip_long_repeat(vertices_s, weights_s, knots_u_s, knots_v_s, degree_u_s, degree_v_s, u_size_s)
+        for vertices, weights, knots_u, knots_v, degree_u, degree_v, u_size in inputs:
+            if isinstance(degree_u, (tuple, list)):
+                degree_u = degree_u[0]
+            if isinstance(degree_v, (tuple, list)):
+                degree_v = degree_v[0]
+            if isinstance(u_size, (list, tuple)):
+                u_size = u_size[0]
+
+            if self.surface_mode != 'NURBS':
+                weights = None
+
+            if self.surface_mode == 'NURBS':
                 if self.input_mode == '1D':
                     fullList(weights, len(vertices))
                 else:
@@ -158,87 +173,70 @@ else:
                     for verts_u, weights_u in zip(vertices, weights):
                         fullList(weights_u, len(verts_u))
 
-                # Generate surface
-                if self.surface_mode == 'NURBS':
-                    surf = NURBS.Surface(normalize_kv = self.normalize_knots)
-                else: # BSPLINE
-                    surf = BSpline.Surface(normalize_kv = self.normalize_knots)
-                surf.degree_u = degree_u
-                surf.degree_v = degree_v
+            if self.input_mode == '1D':
+                n_v = u_size
+                n_u = len(vertices) // n_v
 
-                if self.input_mode == '1D':
-                    n_v = u_size
-                    n_u = len(vertices) // n_v
+                vertices = split_by_count(vertices, n_u)
+                weights = split_by_count(weights, n_u)
 
-                    vertices = split_by_count(vertices, n_u)
-                    weights = split_by_count(weights, n_u)
-
-                if self.knot_mode == 'AUTO':
-                    if self.is_cyclic_v:
-                        for row_idx in range(len(vertices)):
-                            vertices[row_idx].extend(vertices[row_idx][:degree_v+1])
-                            weights[row_idx].extend(weights[row_idx][:degree_v+1])
-                    if self.is_cyclic_u:
-                        vertices.extend(vertices[:degree_u+1])
-                        weights.extend(weights[:degree_u+1])
-                    self.debug("UxV: %s x %s", len(vertices), len(vertices[0]))
-
-                # Control points
-                if self.surface_mode == 'NURBS':
-                    ctrlpts = list(map(convert_row, vertices, weights))
-                    surf.ctrlpts2d = ctrlpts
-                else:
-                    surf.ctrlpts2d = vertices
-                n_u_total = len(vertices)
-                n_v_total= len(vertices[0])
-
-                if self.knot_mode == 'AUTO':
-                    if self.is_cyclic_u:
-                        knots_u = list(range(n_u_total + degree_u + 1))
-                    else:
-                        knots_u = knotvector.generate(surf.degree_u, n_u_total)
-                    self.debug("Auto knots U: %s", knots_u)
-                    surf.knotvector_u = knots_u
-
-                    if self.is_cyclic_v:
-                        knots_v = list(range(n_v_total + degree_v + 1))
-                    else:
-                        knots_v = knotvector.generate(surf.degree_v, n_v_total)
-                    self.debug("Auto knots V: %s", knots_v)
-                    surf.knotvector_v = knots_v
-                else:
-                    surf.knotvector_u = knots_u
-                    surf.knotvector_v = knots_v
-
-                #new_surf = SvGeomdlSurface(surf)
-                new_surf = SvNativeNurbsSurface(surf.degree_u, surf.degree_v, surf.knotvector_u, surf.knotvector_v, vertices, weights)
-                if self.is_cyclic_u:
-                    u_min = surf.knotvector_u[degree_u]
-                    u_max = surf.knotvector_u[-degree_u-2]
-                    new_surf.u_bounds = u_min, u_max
-                    #print("U:",new_surf.u_bounds)
-                else:
-                    u_min = min(surf.knotvector_u)
-                    u_max = max(surf.knotvector_u)
-                    new_surf.u_bounds = u_min, u_max
+            if self.knot_mode == 'AUTO':
                 if self.is_cyclic_v:
-                    v_min = surf.knotvector_v[degree_v]
-                    v_max = surf.knotvector_v[-degree_v-2]
-                    new_surf.v_bounds = v_min, v_max
-                    #print("V:",new_surf.v_bounds)
-                else:
-                    v_min = min(surf.knotvector_v)
-                    v_max = max(surf.knotvector_v)
-                    new_surf.v_bounds = v_min, v_max
-                surfaces_out.append(new_surf)
+                    for row_idx in range(len(vertices)):
+                        vertices[row_idx].extend(vertices[row_idx][:degree_v+1])
+                        weights[row_idx].extend(weights[row_idx][:degree_v+1])
+                if self.is_cyclic_u:
+                    vertices.extend(vertices[:degree_u+1])
+                    weights.extend(weights[:degree_u+1])
+                self.debug("UxV: %s x %s", len(vertices), len(vertices[0]))
 
-            self.outputs['Surface'].sv_set(surfaces_out)
+            n_u_total = len(vertices)
+            n_v_total= len(vertices[0])
+
+            if self.knot_mode == 'AUTO':
+                if self.is_cyclic_u:
+                    knots_u = list(range(n_u_total + degree_u + 1))
+                else:
+                    knots_u = sv_knotvector.generate(degree_u, n_u_total)
+                self.debug("Auto knots U: %s", knots_u)
+                surf_knotvector_u = knots_u
+
+                if self.is_cyclic_v:
+                    knots_v = list(range(n_v_total + degree_v + 1))
+                else:
+                    knots_v = sv_knotvector.generate(degree_v, n_v_total)
+                self.debug("Auto knots V: %s", knots_v)
+                surf_knotvector_v = knots_v
+            else:
+                surf_knotvector_u = knots_u
+                surf_knotvector_v = knots_v
+
+            new_surf = SvNurbsSurface.build(self.implementation, degree_u, degree_v, surf_knotvector_u, surf_knotvector_v, vertices, weights, self.normalize_knots)
+            if self.is_cyclic_u:
+                u_min = surf_knotvector_u[degree_u]
+                u_max = surf_knotvector_u[-degree_u-2]
+                new_surf.u_bounds = u_min, u_max
+                #print("U:",new_surf.u_bounds)
+            else:
+                u_min = min(surf_knotvector_u)
+                u_max = max(surf_knotvector_u)
+                new_surf.u_bounds = u_min, u_max
+            if self.is_cyclic_v:
+                v_min = surf_knotvector_v[degree_v]
+                v_max = surf_knotvector_v[-degree_v-2]
+                new_surf.v_bounds = v_min, v_max
+                #print("V:",new_surf.v_bounds)
+            else:
+                v_min = min(surf_knotvector_v)
+                v_max = max(surf_knotvector_v)
+                new_surf.v_bounds = v_min, v_max
+            surfaces_out.append(new_surf)
+
+        self.outputs['Surface'].sv_set(surfaces_out)
 
 def register():
-    if geomdl is not None:
-        bpy.utils.register_class(SvExNurbsSurfaceNode)
+    bpy.utils.register_class(SvExNurbsSurfaceNode)
 
 def unregister():
-    if geomdl is not None:
-        bpy.utils.unregister_class(SvExNurbsSurfaceNode)
+    bpy.utils.unregister_class(SvExNurbsSurfaceNode)
 

--- a/nodes/surface/nurbs_surface.py
+++ b/nodes/surface/nurbs_surface.py
@@ -210,8 +210,8 @@ else:
                     surf.knotvector_u = knots_u
                     surf.knotvector_v = knots_v
 
-                new_surf = SvGeomdlSurface(surf)
-                #new_surf = SvNativeNurbsSurface(surf.degree_u, surf.degree_v, surf.knotvector_u, surf.knotvector_v, vertices, weights)
+                #new_surf = SvGeomdlSurface(surf)
+                new_surf = SvNativeNurbsSurface(surf.degree_u, surf.degree_v, surf.knotvector_u, surf.knotvector_v, vertices, weights)
                 if self.is_cyclic_u:
                     u_min = surf.knotvector_u[degree_u]
                     u_max = surf.knotvector_u[-degree_u-2]

--- a/nodes/surface/nurbs_surface.py
+++ b/nodes/surface/nurbs_surface.py
@@ -7,7 +7,7 @@ from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty
 from sverchok.node_tree import SverchCustomTreeNode, throttled
 from sverchok.data_structure import updateNode, zip_long_repeat, fullList, ensure_nesting_level, split_by_count
 from sverchok.utils.logging import info, exception
-from sverchok.utils.surface.nurbs import SvGeomdlSurface
+from sverchok.utils.surface.nurbs import SvGeomdlSurface, SvNativeNurbsSurface
 from sverchok.utils.dummy_nodes import add_dummy
 from sverchok.dependencies import geomdl
 
@@ -211,6 +211,7 @@ else:
                     surf.knotvector_v = knots_v
 
                 new_surf = SvGeomdlSurface(surf)
+                #new_surf = SvNativeNurbsSurface(surf.degree_u, surf.degree_v, surf.knotvector_u, surf.knotvector_v, vertices, weights)
                 if self.is_cyclic_u:
                     u_min = surf.knotvector_u[degree_u]
                     u_max = surf.knotvector_u[-degree_u-2]

--- a/tests/nurbs_tests.py
+++ b/tests/nurbs_tests.py
@@ -1,12 +1,15 @@
 import numpy as np
+import unittest
 
 from sverchok.utils.testing import SverchokTestCase, requires
 from sverchok.utils.curve.nurbs import SvGeomdlCurve, SvNativeNurbsCurve, SvNurbsBasisFunctions
+from sverchok.utils.surface.nurbs import SvGeomdlSurface, SvNativeNurbsSurface
 from sverchok.dependencies import geomdl
 
 if geomdl is not None:
     from geomdl.helpers import basis_function_one, basis_function_ders_one
 
+#@unittest.skip
 class NurbsCurveTests(SverchokTestCase):
     def setUp(self):
         super().setUp()
@@ -115,4 +118,105 @@ class NurbsCurveTests(SverchokTestCase):
         native_curve = SvNativeNurbsCurve(self.degree, self.knotvector, self.control_points, weights)
         t2s = native_curve.third_derivative_array(self.ts)
         self.assert_numpy_arrays_equal(t1s, t2s, precision=8)
+
+class NurbsSurfaceTests(SverchokTestCase):
+    def setUp(self):
+        super().setUp()
+        self.degree_u = 3
+        self.degree_v = 3
+        self.knotvector_u = [0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0]
+        self.knotvector_v = [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]
+        self.control_points = [[[-4.970711899389312, -4.87088638787232, 0.47476678569065944],
+                  [-1.6397367584736762, -5.04580711766634, 0.6740307856716949],
+                  [1.6292189956563377, -4.764936213541646, 2.1421219004527634],
+                  [4.930064915463923, -4.824964987583302, 0.13349452595165756]],
+                 [[-4.959173265777104, -2.244642032244925, -1.9818133620347351],
+                  [-1.9143890720803352, -2.7878689443774776, 1.536703648366153],
+                  [1.8335607072889166, -2.277992724284574, 2.2112166863418476],
+                  [5.17949512783129, -2.5231123812706358, 1.2960447623394078]],
+                 [[-5.229035330827069, 0.08395260779254865, -1.6477077713552284],
+                  [-1.399865332339516, 0.013108992268686115, -0.39426182747761507],
+                  [1.5254000423495906, 0.16454020385316903, -0.20258546014134948],
+                  [5.0410603668738005, -0.2887261025287691, 0.5434759830282379]],
+                 [[-4.932742570375402, 2.5701603939429685, 2.0501160719546263],
+                  [-1.557574493706977, 2.4157047453686604, -0.29091236624092165],
+                  [1.7852453771551835, 2.2361352987051246, 0.7704622062740487],
+                  [5.10238271566841, 2.3262295470018315, -1.7143604623685627]],
+                 [[-5.110742982844693, 4.9182264674396565, 0.324309071297221],
+                  [-1.7035057563934934, 5.293024285369926, -1.8385529288017533],
+                  [1.4919927307349463, 4.796785722843513, 0.7073604461282836],
+                  [4.851974970346849, 4.979786464918605, -1.1807537357044255]]]
+        self.weights = [[1.0 for i in row] for row in self.control_points]
+
+        us = np.linspace(0.0, 1.0, num=3)
+        vs = np.linspace(0.0, 1.0, num=4)
+        us, vs = np.meshgrid(us, vs)
+        self.us = us.flatten()
+        self.vs = vs.flatten()
+
+    @requires(geomdl)
+    #@unittest.skip
+    def test_eval(self):
+        geomdl_surface = SvGeomdlSurface.build(self.degree_u, self.degree_v, self.knotvector_u, self.knotvector_v, self.control_points, self.weights)
+        native_surface = SvNativeNurbsSurface(self.degree_u, self.degree_v, self.knotvector_u, self.knotvector_v, self.control_points, self.weights)
+        vs1 = geomdl_surface.evaluate_array(self.us, self.vs)
+        vs2 = native_surface.evaluate_array(self.us, self.vs)
+        self.assert_numpy_arrays_equal(vs1, vs2, precision=8)
+
+    @requires(geomdl)
+    #@unittest.skip
+    def test_eval_2(self):
+        weights = [[1,1,1,1], [1,2,3,1], [1,3,4,1], [1,4,5,1], [1,1,1,1]]
+
+        geomdl_surface = SvGeomdlSurface.build(self.degree_u, self.degree_v, self.knotvector_u, self.knotvector_v, self.control_points, weights)
+        native_surface = SvNativeNurbsSurface(self.degree_u, self.degree_v, self.knotvector_u, self.knotvector_v, self.control_points, weights)
+        vs1 = geomdl_surface.evaluate_array(self.us, self.vs)
+        vs2 = native_surface.evaluate_array(self.us, self.vs)
+        self.assert_numpy_arrays_equal(vs1, vs2, precision=8, fail_fast=False)
+
+    @requires(geomdl)
+    #@unittest.skip
+    def test_normal(self):
+        geomdl_surface = SvGeomdlSurface.build(self.degree_u, self.degree_v, self.knotvector_u, self.knotvector_v, self.control_points, self.weights)
+        native_surface = SvNativeNurbsSurface(self.degree_u, self.degree_v, self.knotvector_u, self.knotvector_v, self.control_points, self.weights)
+        vs1 = geomdl_surface.normal_array(self.us, self.vs)
+        vs2 = native_surface.normal_array(self.us, self.vs)
+        self.assert_numpy_arrays_equal(vs1, vs2, precision=8)
+
+    @requires(geomdl)
+    #@unittest.skip
+    def test_gauss_curvature(self):
+        geomdl_surface = SvGeomdlSurface.build(self.degree_u, self.degree_v, self.knotvector_u, self.knotvector_v, self.control_points, self.weights)
+        native_surface = SvNativeNurbsSurface(self.degree_u, self.degree_v, self.knotvector_u, self.knotvector_v, self.control_points, self.weights)
+        vs1 = geomdl_surface.gauss_curvature_array(self.us, self.vs)
+        vs2 = native_surface.gauss_curvature_array(self.us, self.vs)
+        self.assert_sverchok_data_equal(vs1, vs2, precision=8)
+
+    @requires(geomdl)
+    #@unittest.skip
+    def test_gauss_curvature_2(self):
+        weights = [[1,1,1,1], [1,2,3,1], [1,3,4,1], [1,4,5,1], [1,1,1,1]]
+        #us, vs = self.us, self.vs
+
+        us = np.linspace(0.0, 1.0, num=10)
+        vs = np.linspace(0.0, 1.0, num=20)
+        us, vs = np.meshgrid(us, vs)
+        us = us.flatten()
+        vs = vs.flatten()
+
+        geomdl_surface = SvGeomdlSurface.build(self.degree_u, self.degree_v, self.knotvector_u, self.knotvector_v, self.control_points, weights)
+        native_surface = SvNativeNurbsSurface(self.degree_u, self.degree_v, self.knotvector_u, self.knotvector_v, self.control_points, weights)
+        c1 = geomdl_surface.curvature_calculator(us, vs)
+        c2 = native_surface.curvature_calculator(us, vs)
+        self.assert_numpy_arrays_equal(c1.fu, c2.fu, precision=8)
+        self.assert_numpy_arrays_equal(c1.fv, c2.fv, precision=8)
+        self.assert_numpy_arrays_equal(c1.duu, c2.duu, precision=8)
+        self.assert_numpy_arrays_equal(c1.dvv, c2.dvv, precision=8)
+        self.assert_numpy_arrays_equal(c1.duv, c2.duv, precision=8)
+        self.assert_numpy_arrays_equal(c1.nuu, c2.nuu, precision=8, fail_fast=False)
+        self.assert_numpy_arrays_equal(c1.nvv, c2.nvv, precision=8)
+        self.assert_numpy_arrays_equal(c1.nuv, c2.nuv, precision=8)
+        vs1 = geomdl_surface.gauss_curvature_array(self.us, self.vs)
+        vs2 = native_surface.gauss_curvature_array(self.us, self.vs)
+        self.assert_numpy_arrays_equal(vs1, vs2, precision=8, fail_fast=False)
 

--- a/tests/nurbs_tests.py
+++ b/tests/nurbs_tests.py
@@ -1,0 +1,118 @@
+import numpy as np
+
+from sverchok.utils.testing import SverchokTestCase, requires
+from sverchok.utils.curve.nurbs import SvGeomdlCurve, SvNativeNurbsCurve, SvNurbsBasisFunctions
+from sverchok.dependencies import geomdl
+
+if geomdl is not None:
+    from geomdl.helpers import basis_function_one, basis_function_ders_one
+
+class NurbsCurveTests(SverchokTestCase):
+    def setUp(self):
+        super().setUp()
+        self.knotvector = [0, 0, 0, 0, 1, 1, 1, 1]
+        self.degree = 3
+        self.span = 2
+        self.ts = np.linspace(0, 1.0, num=20)
+        self.control_points = [[0.0, 0.0, 0.0],
+              [1.7846156358718872, 2.7446157932281494, 0.0],
+              [4.566154479980469, 2.8430774211883545, 0.0],
+              [5.821539402008057, 0.03692317008972168, 0.0]]
+
+        self.weights = [1.0 for i in self.control_points]
+
+    @requires(geomdl)
+    def test_basis_function(self):
+        "Test basis functions values"
+        v1s = []
+        for t in self.ts:
+            v1 = basis_function_one(self.degree, self.knotvector, self.span, t)
+            v1s.append(v1)
+        v1s = np.array(v1s)
+
+        functions = SvNurbsBasisFunctions(self.knotvector)
+        v2s = functions.function(self.span, self.degree)(self.ts)
+
+        self.assert_numpy_arrays_equal(v1s, v2s, precision=8)
+
+    def test_basis_derivative(self):
+        "Test basis functions derivative"
+
+        expected = np.array([ 0.0,          0.29085873,  0.53185596,  0.72299169,  0.86426593,  0.95567867,
+                  0.99722992,  0.98891967,  0.93074792,  0.82271468,  0.66481994,  0.45706371,
+                  0.19944598, -0.10803324, -0.46537396, -0.87257618, -1.32963989, -1.8365651,
+                 -2.3933518,  -3.0        ])
+
+        functions = SvNurbsBasisFunctions(self.knotvector)
+        d2s = functions.derivative(self.span, self.degree, 1)(self.ts)
+
+        self.assert_numpy_arrays_equal(expected, d2s, precision=8)
+
+    @requires(geomdl)
+    def test_curve_eval(self):
+        geomdl_curve = SvGeomdlCurve.build(self.degree, self.knotvector, self.control_points, self.weights)
+        t1s = geomdl_curve.evaluate_array(self.ts)
+        native_curve = SvNativeNurbsCurve(self.degree, self.knotvector, self.control_points, self.weights)
+        t2s = native_curve.evaluate_array(self.ts)
+        self.assert_numpy_arrays_equal(t1s, t2s, precision=8)
+
+    @requires(geomdl)
+    def test_curve_eval_2(self):
+        weights = [1.0, 2.0, 3.0, 1.0]
+        geomdl_curve = SvGeomdlCurve.build(self.degree, self.knotvector, self.control_points, weights)
+        t1s = geomdl_curve.evaluate_array(self.ts)
+        native_curve = SvNativeNurbsCurve(self.degree, self.knotvector, self.control_points, weights)
+        t2s = native_curve.evaluate_array(self.ts)
+        self.assert_numpy_arrays_equal(t1s, t2s, precision=8)
+
+    @requires(geomdl)
+    def test_curve_tangent(self):
+        geomdl_curve = SvGeomdlCurve.build(self.degree, self.knotvector, self.control_points, self.weights)
+        t1s = geomdl_curve.tangent_array(self.ts)
+        native_curve = SvNativeNurbsCurve(self.degree, self.knotvector, self.control_points, self.weights)
+        t2s = native_curve.tangent_array(self.ts)
+        self.assert_numpy_arrays_equal(t1s, t2s, precision=8)
+
+    @requires(geomdl)
+    def test_curve_tangent_2(self):
+        weights = [1.0, 2.0, 3.0, 1.0]
+        geomdl_curve = SvGeomdlCurve.build(self.degree, self.knotvector, self.control_points, weights)
+        t1s = geomdl_curve.tangent_array(self.ts)
+        native_curve = SvNativeNurbsCurve(self.degree, self.knotvector, self.control_points, weights)
+        t2s = native_curve.tangent_array(self.ts)
+        self.assert_numpy_arrays_equal(t1s, t2s, precision=8)
+
+    @requires(geomdl)
+    def test_curve_second(self):
+        geomdl_curve = SvGeomdlCurve.build(self.degree, self.knotvector, self.control_points, self.weights)
+        t1s = geomdl_curve.second_derivative_array(self.ts)
+        native_curve = SvNativeNurbsCurve(self.degree, self.knotvector, self.control_points, self.weights)
+        t2s = native_curve.second_derivative_array(self.ts)
+        self.assert_numpy_arrays_equal(t1s, t2s, precision=8)
+
+    @requires(geomdl)
+    def test_curve_second(self):
+        weights = [1.0, 2.0, 3.0, 1.0]
+        geomdl_curve = SvGeomdlCurve.build(self.degree, self.knotvector, self.control_points, weights)
+        t1s = geomdl_curve.second_derivative_array(self.ts)
+        native_curve = SvNativeNurbsCurve(self.degree, self.knotvector, self.control_points, weights)
+        t2s = native_curve.second_derivative_array(self.ts)
+        self.assert_numpy_arrays_equal(t1s, t2s, precision=8)
+
+    @requires(geomdl)
+    def test_curve_third(self):
+        geomdl_curve = SvGeomdlCurve.build(self.degree, self.knotvector, self.control_points, self.weights)
+        t1s = geomdl_curve.third_derivative_array(self.ts)
+        native_curve = SvNativeNurbsCurve(self.degree, self.knotvector, self.control_points, self.weights)
+        t2s = native_curve.third_derivative_array(self.ts)
+        self.assert_numpy_arrays_equal(t1s, t2s, precision=8)
+
+    @requires(geomdl)
+    def test_curve_third_2(self):
+        weights = [1.0, 2.0, 3.0, 1.0]
+        geomdl_curve = SvGeomdlCurve.build(self.degree, self.knotvector, self.control_points, weights)
+        t1s = geomdl_curve.third_derivative_array(self.ts)
+        native_curve = SvNativeNurbsCurve(self.degree, self.knotvector, self.control_points, weights)
+        t2s = native_curve.third_derivative_array(self.ts)
+        self.assert_numpy_arrays_equal(t1s, t2s, precision=8)
+

--- a/utils/curve/core.py
+++ b/utils/curve/core.py
@@ -91,6 +91,9 @@ class SvCurve(object):
         v2s = self.evaluate_array(ts+h)
         return (v2s - 2*v1s + v0s) / (h * h)
 
+    def third_derivative(self, t):
+        return self.third_derivative_array(np.array([t]))[0]
+
     def third_derivative_array(self, ts):
         h = 0.001
         v0s = self.evaluate_array(ts)

--- a/utils/curve/core.py
+++ b/utils/curve/core.py
@@ -218,6 +218,20 @@ class SvCurve(object):
         matrices_np = np.linalg.inv(matrices_np)
         return matrices_np, normals, binormals
 
+    def frame_by_plane_array(self, ts, plane_normal):
+        n = len(ts)
+        tangents = self.tangent_array(ts)
+        tangents /= np.linalg.norm(tangents, axis=1, keepdims=True)
+        plane_normals = np.tile(plane_normal[np.newaxis].T, n).T
+        normals = np.cross(tangents, plane_normals)
+        normals /= np.linalg.norm(normals, axis=1, keepdims=True)
+        binormals = np.cross(tangents, normals)
+
+        matrices_np = np.dstack((normals, binormals, tangents))
+        matrices_np = np.transpose(matrices_np, axes=(0,2,1))
+        matrices_np = np.linalg.inv(matrices_np)
+        return matrices_np, normals, binormals
+
     FAIL = 'fail'
     ASIS = 'asis'
     RETURN_NONE = 'none'

--- a/utils/curve/knotvector.py
+++ b/utils/curve/knotvector.py
@@ -1,0 +1,119 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+#
+# Adopted from Geomdl library: https://raw.githubusercontent.com/orbingol/NURBS-Python/5.x/geomdl/knotvector.py
+#
+"""
+.. module:: knotvector
+    :platform: Unix, Windows
+    :synopsis: Provides utility functions related to knot vector generation and validation
+
+.. moduleauthor:: Onur Rauf Bingol <orbingol@gmail.com>
+
+"""
+
+import numpy as np
+
+def generate(degree, num_ctrlpts, clamped=True):
+    """ Generates an equally spaced knot vector.
+
+    It uses the following equality to generate knot vector: :math:`m = n + p + 1`
+
+    where;
+
+    * :math:`p`, degree
+    * :math:`n + 1`, number of control points
+    * :math:`m + 1`, number of knots
+
+    Keyword Arguments:
+
+        * ``clamped``: Flag to choose from clamped or unclamped knot vector options. *Default: True*
+
+    :param degree: degree
+    :type degree: int
+    :param num_ctrlpts: number of control points
+    :type num_ctrlpts: int
+    :return: knot vector
+    :rtype: np.array of shape (m+1,)
+    """
+    if degree == 0 or num_ctrlpts == 0:
+        raise ValueError("Input values should be different than zero.")
+
+    # Number of repetitions at the start and end of the array
+    num_repeat = degree
+
+    # Number of knots in the middle
+    num_segments = num_ctrlpts - (degree + 1)
+
+    if not clamped:
+        # No repetitions at the start and end
+        num_repeat = 0
+        # Should conform the rule: m = n + p + 1
+        num_segments = degree + num_ctrlpts - 1
+
+    # First knots
+    knot_vector = [0.0 for _ in range(0, num_repeat)]
+
+    # Middle knots
+    knot_vector += list(np.linspace(0.0, 1.0, num_segments + 2))
+
+    # Last knots
+    knot_vector += [1.0 for _ in range(0, num_repeat)]
+
+    # Return auto-generated knot vector
+    return np.array(knot_vector)
+
+def normalize(knot_vector):
+    """ Normalizes the input knot vector to [0, 1] domain.
+
+    :param knot_vector: knot vector to be normalized
+    :type knot_vector: np.array of shape (X,)
+    :return: normalized knot vector
+    :rtype: np.array
+    """
+    m = knot_vector.min()
+    M = knot_vector.max()
+    if m >= M:
+        raise Exception("All knot values are equal")
+    return (knot_vector - m) / (M - m)
+
+def check(degree, knot_vector, num_ctrlpts):
+    """ Checks the validity of the input knot vector.
+
+    Please refer to The NURBS Book (2nd Edition), p.50 for details.
+
+    :param degree: degree of the curve or the surface
+    :type degree: int
+    :param knot_vector: knot vector to be checked
+    :type knot_vector: np.array of shape (X,)
+    :param num_ctrlpts: number of control points
+    :type num_ctrlpts: int
+    :return: True if the knot vector is valid, False otherwise
+    :rtype: bool
+    """
+    try:
+        if knot_vector is None or len(knot_vector) == 0:
+            raise ValueError("Input knot vector cannot be empty")
+    except TypeError as e:
+        print("An error occurred: {}".format(e.args[-1]))
+        raise TypeError("Knot vector must be a list or tuple")
+    except Exception:
+        raise
+
+    # Check the formula; m = p + n + 1
+    if len(knot_vector) != degree + num_ctrlpts + 1:
+        return False
+
+    # Check ascending order
+    prev_knot = knot_vector[0]
+    for knot in knot_vector:
+        if prev_knot > knot:
+            return False
+        prev_knot = knot
+
+    return True
+

--- a/utils/curve/nurbs.py
+++ b/utils/curve/nurbs.py
@@ -175,13 +175,15 @@ class SvNativeNurbsCurve(SvCurve):
         return self.evaluate_array(np.array([t]))[0]
 
     def fraction(self, deriv_order, ts):
+        n = len(ts)
         p = self.degree
         k = len(self.control_points)
         ns = np.array([self.basis.derivative(i, p, deriv_order)(ts) for i in range(k)]) # (k, n)
         coeffs = ns * self.weights[np.newaxis].T # (k, n)
-        numerator = (coeffs[np.newaxis].T * self.control_points).sum(axis=1)
-        denominator = coeffs.sum(axis=0) # (n,1)
-        #print(denominator)
+        coeffs_t = coeffs[np.newaxis].T # (n, k, 1)
+        numerator = (coeffs_t * self.control_points) # (n, k, 3)
+        numerator = numerator.sum(axis=1) # (n, 3)
+        denominator = coeffs.sum(axis=0) # (n,)
 
         return numerator, denominator[np.newaxis].T
 

--- a/utils/curve/nurbs.py
+++ b/utils/curve/nurbs.py
@@ -283,52 +283,63 @@ class SvNativeNurbsCurve(SvNurbsCurve):
         return self.tangent_array(np.array([t]))[0]
 
     def tangent_array(self, ts):
-        N, D = self.fraction(0, ts)
-        C = N / D
-        N1, D1 = self.fraction(1, ts)
-        C1 = (N1 - C*D1) / D
-        return C1
+        # curve = numerator / denominator
+        # ergo:
+        # numerator = curve * denominator
+        # ergo:
+        # numerator' = curve' * denominator + curve * denominator'
+        # ergo:
+        # curve' = (numerator' - curve*denominator') / denominator
+        numerator, denominator = self.fraction(0, ts)
+        curve = numerator / denominator
+        numerator1, denominator1 = self.fraction(1, ts)
+        curve1 = (numerator1 - curve*denominator1) / denominator
+        return curve1
 
     def second_derivative(self, t):
         return self.second_derivative_array(np.array([t]))[0]
 
     def second_derivative_array(self, ts):
-        N, D = self.fraction(0, ts)
-        C = N / D
-        N1, D1 = self.fraction(1, ts)
-        C1 = (N1 - C*D1) / D
-        N2, D2 = self.fraction(2, ts)
-        C2 = (N2 - 2*C1*D1 - C*D2) / D
-        return C2
+        # numerator'' = (curve * denominator)'' =
+        #  = curve'' * denominator + 2 * curve' * denominator' + curve * denominator''
+        numerator, denominator = self.fraction(0, ts)
+        curve = numerator / denominator
+        numerator1, denominator1 = self.fraction(1, ts)
+        curve1 = (numerator1 - curve*denominator1) / denominator
+        numerator2, denominator2 = self.fraction(2, ts)
+        curve2 = (numerator2 - 2*curve1*denominator1 - curve*denominator2) / denominator
+        return curve2
 
     def third_derivative_array(self, ts):
-        N, D = self.fraction(0, ts)
-        C = N / D
-        N1, D1 = self.fraction(1, ts)
-        C1 = (N1 - C*D1) / D
-        N2, D2 = self.fraction(2, ts)
-        C2 = (N2 - 2*C1*D1 - C*D2) / D
-        N3, D3 = self.fraction(3, ts)
+        # numerator''' = (curve * denominator)''' = 
+        #  = curve''' * denominator + 3 * curve'' * denominator' + 3 * curve' * denominator'' + denominator'''
+        numerator, denominator = self.fraction(0, ts)
+        curve = numerator / denominator
+        numerator1, denominator1 = self.fraction(1, ts)
+        curve1 = (numerator1 - curve*denominator1) / denominator
+        numerator2, denominator2 = self.fraction(2, ts)
+        curve2 = (numerator2 - 2*curve1*denominator1 - curve*denominator2) / denominator
+        numerator3, denominator3 = self.fraction(3, ts)
 
-        C3 = (N3 - 3*C2*D1 - 3*C1*D2 - C*D3) / D
-        return C3
+        curve3 = (numerator3 - 3*curve2*denominator1 - 3*curve1*denominator2 - curve*denominator3) / denominator
+        return curve3
 
     def derivatives_array(self, n, ts):
         result = []
         if n >= 1:
-            N, D = self.fraction(0, ts)
-            C = N / D
-            N1, D1 = self.fraction(1, ts)
-            C1 = (N1 - C*D1) / D
-            result.append(C1)
+            numerator, denominator = self.fraction(0, ts)
+            curve = numerator / denominator
+            numerator1, denominator1 = self.fraction(1, ts)
+            curve1 = (numerator1 - curve*denominator1) / denominator
+            result.append(curve1)
         if n >= 2:
-            N2, D2 = self.fraction(2, ts)
-            C2 = (N2 - 2*C1*D1 - C*D2) / D
-            result.append(C2)
+            numerator2, denominator2 = self.fraction(2, ts)
+            curve2 = (numerator2 - 2*curve1*denominator1 - curve*denominator2) / denominator
+            result.append(curve2)
         if n >= 3:
-            N3, D3 = self.fraction(3, ts)
-            C3 = (N3 - 3*C2*D1 - 3*C1*D2 - C*D3) / D
-            result.append(C3)
+            numerator3, denominator3 = self.fraction(3, ts)
+            curve3 = (numerator3 - 3*curve2*denominator1 - 3*curve1*denominator2 - curve*denominator3) / denominator
+            result.append(curve3)
         return result
 
     def get_u_bounds(self):

--- a/utils/curve/nurbs.py
+++ b/utils/curve/nurbs.py
@@ -86,6 +86,16 @@ class SvGeomdlCurve(SvNurbsCurve):
         curve.knotvector = knotvector
         return SvGeomdlCurve(curve)
 
+    @classmethod
+    def from_any_nurbs(cls, curve):
+        if not isinstance(curve, SvNurbsCurve):
+            raise TypeError("Invalid surface type")
+        if isinstance(curve, SvGeomdlCurve):
+            return curve
+        return SvGeomdlCurve.build(curve.get_degree(), curve.get_knotvector(),
+                    curve.get_control_points(), 
+                    curve.get_weights())
+
     def get_control_points(self):
         return np.array(self.curve.ctrlpts)
 

--- a/utils/curve/nurbs.py
+++ b/utils/curve/nurbs.py
@@ -1,7 +1,17 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
 
 import numpy as np
 
 from sverchok.utils.curve import SvCurve
+from sverchok.dependencies import geomdl
+
+if geomdl is not None:
+    from geomdl import NURBS
 
 ##################
 #                #
@@ -16,6 +26,15 @@ class SvGeomdlCurve(SvCurve):
     def __init__(self, curve):
         self.curve = curve
         self.u_bounds = (0.0, 1.0)
+
+    @classmethod
+    def build(cls, degree, knotvector, control_points, weights, normalize_knots=False):
+        curve = NURBS.Curve(normalize_kv = normalize_knots)
+        curve.degree = degree
+        curve.ctrlpts = control_points
+        curve.weights = weights
+        curve.knotvector = knotvector
+        return SvGeomdlCurve(curve)
 
     def evaluate(self, t):
         v = self.curve.evaluate_single(t)
@@ -63,4 +82,167 @@ class SvGeomdlCurve(SvCurve):
 
     def get_u_bounds(self):
         return self.u_bounds
+
+class SvNurbsBasisFunctions(object):
+    def __init__(self, knotvector):
+        self.knotvector = np.array(knotvector)
+        self._cache = dict()
+
+    def function(self, i, p):
+        f = self._cache.get((i,p, 0))
+        if f is not None:
+            return f
+
+        u = self.knotvector
+        if p == 0:
+            if i < 0 or i >= len(self.knotvector):
+
+                def n0(us):
+                    return np.zeros_like(us)
+            else:
+
+                def n0(us):
+                    is_last = u[i+1] >= self.knotvector[-1]
+                    if is_last:
+                        c2 = us <= u[i+1]
+                    else:
+                        c2 = us < u[i+1]
+                    condition = np.logical_and(u[i] <= us, c2)
+                    return np.where(condition, 1.0, 0.0)
+
+            self._cache[(i,p,0)] = n0
+            return n0
+        else:
+            n1 = self.function(i, p-1)
+            n2 = self.function(i+1, p-1)
+
+            def f(us):
+                denom1 = (u[i+p] - u[i])
+                denom2 = (u[i+p+1] - u[i+1])
+                if denom1 == 0:
+                    c1 = 0
+                else:
+                    c1 = (us - u[i]) / denom1
+                if denom2 == 0:
+                    c2 = 0
+                else:
+                    c2 = (u[i+p+1] - us) / denom2
+                return c1 * n1(us) + c2 * n2(us)
+
+            self._cache[(i,p,0)] = f
+            return f
+
+    def derivative(self, i, p, k):
+        if k == 0:
+            return self.function(i, p)
+        f = self._cache.get((i, p, k))
+        if f is not None:
+            return f
+        
+        n1 = self.derivative(i, p-1, k-1)
+        n2 = self.derivative(i+1, p-1, k-1)
+        u = self.knotvector
+
+        def f(us):
+            denom1 = u[i+p] - u[i]
+            denom2 = u[i+p+1] - u[i+1]
+
+            if denom1 == 0:
+                s1 = 0
+            else:
+                s1 = n1(us) / denom1
+
+            if denom2 == 0:
+                s2 = 0
+            else:
+                s2 = n2(us) / denom2
+
+            return p*(s1 - s2)
+        
+        self._cache[(i,p,k)] = f
+        return f
+
+class SvNativeNurbsCurve(SvCurve):
+    def __init__(self, degree, knotvector, control_points, weights):
+        self.control_points = np.array(control_points) # (k, 3)
+        self.weights = np.array(weights) # (k, )
+        self.knotvector = np.array(knotvector)
+        self.degree = degree
+        self.basis = SvNurbsBasisFunctions(knotvector)
+        self.tangent_delta = 0.001
+
+    def evaluate(self, t):
+        return self.evaluate_array(np.array([t]))[0]
+
+    def fraction(self, deriv_order, ts):
+        p = self.degree
+        k = len(self.control_points)
+        ns = np.array([self.basis.derivative(i, p, deriv_order)(ts) for i in range(k)]) # (k, n)
+        coeffs = ns * self.weights[np.newaxis].T # (k, n)
+        numerator = (coeffs[np.newaxis].T * self.control_points).sum(axis=1)
+        denominator = coeffs.sum(axis=0) # (n,1)
+        #print(denominator)
+
+        return numerator, denominator[np.newaxis].T
+
+    def evaluate_array(self, ts):
+        numerator, denominator = self.fraction(0, ts)
+        return numerator / denominator
+
+    def tangent(self, t):
+        return self.tangent_array(np.array([t]))[0]
+
+    def tangent_array(self, ts):
+        N, D = self.fraction(0, ts)
+        C = N / D
+        N1, D1 = self.fraction(1, ts)
+        C1 = (N1 - C*D1) / D
+        return C1
+
+    def second_derivative(self, t):
+        return self.second_derivative_array(np.array([t]))[0]
+
+    def second_derivative_array(self, ts):
+        N, D = self.fraction(0, ts)
+        C = N / D
+        N1, D1 = self.fraction(1, ts)
+        C1 = (N1 - C*D1) / D
+        N2, D2 = self.fraction(2, ts)
+        C2 = (N2 - 2*C1*D1 - C*D2) / D
+        return C2
+
+    def third_derivative_array(self, ts):
+        N, D = self.fraction(0, ts)
+        C = N / D
+        N1, D1 = self.fraction(1, ts)
+        C1 = (N1 - C*D1) / D
+        N2, D2 = self.fraction(2, ts)
+        C2 = (N2 - 2*C1*D1 - C*D2) / D
+        N3, D3 = self.fraction(3, ts)
+
+        C3 = (N3 - 3*C2*D1 - 3*C1*D2 - C*D3) / D
+        return C3
+
+    def derivatives_array(self, n, ts):
+        result = []
+        if n >= 1:
+            N, D = self.fraction(0, ts)
+            C = N / D
+            N1, D1 = self.fraction(1, ts)
+            C1 = (N1 - C*D1) / D
+            result.append(C1)
+        if n >= 2:
+            N2, D2 = self.fraction(2, ts)
+            C2 = (N2 - 2*C1*D1 - C*D2) / D
+            result.append(C2)
+        if n >= 3:
+            N3, D3 = self.fraction(3, ts)
+            C3 = (N3 - 3*C2*D1 - 3*C1*D2 - C*D3) / D
+            result.append(C3)
+        return result
+
+    def get_u_bounds(self):
+        m = self.knotvector.min()
+        M = self.knotvector.max()
+        return (m, M)
 

--- a/utils/surface/nurbs.py
+++ b/utils/surface/nurbs.py
@@ -122,6 +122,17 @@ class SvGeomdlSurface(SvNurbsSurface):
         surf.knotvector_v = knotvector_v
         return SvGeomdlSurface(surf)
 
+    @classmethod
+    def from_any_nurbs(cls, surface):
+        if not isinstance(surface, SvNurbsSurface):
+            raise TypeError("Invalid surface")
+        if isinstance(surface, SvGeomdlSurface):
+            return surface
+        return SvGeomdlSurface.build(surface.get_degree_u(), surface.get_degree_v(),
+                    surface.get_knotvector_u(), surface.get_knotvector_v(),
+                    surface.get_control_points(),
+                    surface.get_weights())
+
     def get_input_orientation(self):
         return 'Z'
 

--- a/utils/testing.py
+++ b/utils/testing.py
@@ -744,6 +744,9 @@ def interactive_only(func):
     else:
         return unittest.skip("This test is intended for interactive mode only")(func)
 
+def requires(module):
+    return unittest.skipIf(module is None, "This test requires a module which is not currently available")
+
 ######################################################
 # UI operator and panel classes
 ######################################################


### PR DESCRIPTION
In "Build NURBS Curve", "Build NURBS Surface" there is now "Implementation" parameter with two options: "Geomdl", "Native".

Geomdl implementation for now stays as default for cases when it is available. 

Native (numpy) implementation is much faster when generating a lot of points, at least in my tests.

"Approximate / Interpolate NURBS curve / surface" nodes still require geomdl.

There are test cases that check that native implementation gives exactly the same numbers as geomdl.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [x] Unit-tests implemented.
- [x] Ready for merge.

