### PR TITLE
add docstring for jointriangles

### DIFF
--- a/nodes/modifier_make/join_tris.py
+++ b/nodes/modifier_make/join_tris.py
@@ -50,7 +50,12 @@ def join_tris(verts, faces, self):
 
 
 class SvJoinTrianglesNode(bpy.types.Node, SverchCustomTreeNode):
-    '''Join coplanar Triangles'''
+
+    """
+    Triggers: join tris to quads
+    Tooltip: Join coplanar Triangles
+    """
+
     bl_idname = 'SvJoinTrianglesNode'
     bl_label = 'Join Triangles'
     bl_icon = 'OUTLINER_OB_EMPTY'


### PR DESCRIPTION
allows users to find the functionality of this node if they want to 
- join coplanar
- tris to quads