### PR TITLE
Curve frame on surface

### DIFF
--- a/docs/nodes/curve/curve_frame_on_surface.rst
+++ b/docs/nodes/curve/curve_frame_on_surface.rst
@@ -1,0 +1,60 @@
+Curve Frame on Surface
+======================
+
+Functionality
+-------------
+
+Given a surface and a curve in the surface's U/V space, this node calculates a reference frame of a curve for the given value of curve's T parameter. The frame is calculated so that:
+
+* it's X axis is pointing along surface's normal;
+* it's Z axis is pointing along curve's tangent (in 3D space);
+* it's Y axis is perpendicular to both X and Z.
+
+This node allows one to place some object at the curve on the surface, while
+aligning it both with curve's tangent and surface's normal.
+
+Inputs
+------
+
+This node has the following inputs:
+
+* **Surface**. The surface to put the curve into. This input is mandatory.
+* **UVCurve**. The curve to calculate frame for. The curve is supposed to lie
+  in XOY plane; X coordinate means U parameter of the surface, and Y coordinate
+  means V parameter. This input is mandatory.
+* **T**. The value of curve's T parameter. The default value is 0.5.
+
+Parameters
+----------
+
+This node has the following parameter:
+
+* **Join**. If checked, then the node will output single (concatenated) list of
+  matrices for all input curves. Otherwise, it will output separate list of
+  matrices per each input curve. Checked by default.
+
+Outputs
+-------
+
+This node has the following outputs:
+
+* **Matrix**. The matrix defining the frame for the curve at the specified
+  value of T parameter. The location component of the matrix is the point of
+  the curve.
+* **Tangent**. The direction of curve's tangent vector at the specified value of T parameter.
+* **Normal**. The direction of curve's main normal at the specified value of T parameter.
+* **Binormal**. The direction of curve's binormal at the specified value of T parameter.
+
+Examples of usage
+-----------------
+
+Let's generate an ellipse by generating a sine wave in U/V space of cylindrical
+curve. Then we use "Curve Frame" node to place cubes along that ellipse:
+
+.. image:: https://user-images.githubusercontent.com/284644/89296471-d28d0480-d67b-11ea-9ac0-d6104821ea94.png
+
+As you can see, the cubes are aligned with a plane where the ellipse lies, but
+they are not aligned with the cylinder surface. Now let's use "Curve frame on surface" node instead:
+
+.. image:: https://user-images.githubusercontent.com/284644/89296479-d456c800-d67b-11ea-9409-2f83e9db415b.png
+

--- a/docs/nodes/curve/curve_index.rst
+++ b/docs/nodes/curve/curve_index.rst
@@ -31,6 +31,7 @@ Curves
    curvature
    torsion
    curve_frame
+   curve_frame_on_surface
    zero_twist_frame
    endpoints
    iso_uv_curve

--- a/nodes/curve/curve_frame_on_surface.py
+++ b/nodes/curve/curve_frame_on_surface.py
@@ -1,0 +1,125 @@
+import numpy as np
+
+from mathutils import Matrix, Vector
+import bpy
+from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty
+
+from sverchok.node_tree import SverchCustomTreeNode, throttled
+from sverchok.data_structure import updateNode, zip_long_repeat, ensure_nesting_level
+from sverchok.utils.curve import SvCurve, ZeroCurvatureException
+from sverchok.utils.curve.algorithms import curve_frame_on_surface_array
+from sverchok.utils.surface.core import SvSurface
+
+class SvCurveFrameOnSurfNode(bpy.types.Node, SverchCustomTreeNode):
+        """
+        Triggers: Curve Frame on Surface
+        Tooltip: Calculate reference frame of the curve in UV space of the surface, which is lying in the surface
+        """
+        bl_idname = 'SvCurveFrameOnSurfNode'
+        bl_label = 'Curve Frame on Surface'
+        bl_icon = 'OUTLINER_OB_EMPTY'
+        sv_icon = 'SV_CURVE_FRAME'
+
+        t_value : FloatProperty(
+                name = "T",
+                default = 0.5,
+                update = updateNode)
+
+        join : BoolProperty(
+                name = "Join",
+                description = "If enabled, join generated lists of matrices; otherwise, output separate list of matrices for each curve",
+                default = True,
+                update = updateNode)
+
+        error_modes = [
+                ('ERROR', "Raise error", "Raise an error", 0),
+                ('ANY', "Arbitrary frame", "Calculate any frame that has Z axis along curve's tangent", 1)
+            ]
+
+        on_error : EnumProperty(
+                name = "On zero curvature",
+                description = "What the node should do if it encounters a point with zero curvature - it is impossible to calculate correct Frenet frame at such points",
+                items = error_modes,
+                default = 'ERROR',
+                update = updateNode)
+
+        def draw_buttons(self, context, layout):
+            layout.prop(self, 'join', toggle=True)
+
+        def draw_buttons_ext(self, context, layout):
+            layout.label(text='On zero curvature:')
+            layout.prop(self, 'on_error', text='')
+
+        def sv_init(self, context):
+            self.inputs.new('SvSurfaceSocket', "Surface")
+            self.inputs.new('SvCurveSocket', "UVCurve")
+            self.inputs.new('SvStringsSocket', "T").prop_name = 't_value'
+            self.outputs.new('SvMatrixSocket', 'Matrix')
+            self.outputs.new('SvVerticesSocket', 'Tangent')
+            self.outputs.new('SvVerticesSocket', 'Normal')
+            self.outputs.new('SvVerticesSocket', 'Binormal')
+
+        def process(self):
+            if not any(socket.is_linked for socket in self.outputs):
+                return
+
+            surface_s = self.inputs['Surface'].sv_get()
+            curve_s = self.inputs['UVCurve'].sv_get()
+            ts_s = self.inputs['T'].sv_get()
+
+            surface_s = ensure_nesting_level(surface_s, 2, data_types = (SvSurface,))
+            curve_s = ensure_nesting_level(curve_s, 2, data_types = (SvCurve,))
+            ts_s = ensure_nesting_level(ts_s, 3)
+
+            matrix_out = []
+            tangents_out = []
+            normals_out = []
+            binormals_out = []
+            for surfaces_i, curves_i, ts_i in zip_long_repeat(surface_s, curve_s, ts_s):
+                new_matrices = []
+                new_tangents = []
+                new_normals = []
+                new_binormals = []
+                for surface, curve, ts in zip_long_repeat(surfaces_i, curves_i, ts_i):
+                    ts = np.array(ts)
+
+                    matrices_np, points, tangents, normals, binormals = curve_frame_on_surface_array(surface, curve, ts)
+                    curve_matrices = []
+                    for matrix_np, point in zip(matrices_np, points):
+                        matrix = Matrix(matrix_np.tolist()).to_4x4()
+                        matrix.translation = Vector(point)
+                        curve_matrices.append(matrix)
+
+                    if self.join:
+                        new_matrices.extend(curve_matrices)
+                        new_tangents.extend(tangents.tolist())
+                        new_normals.extend(normals.tolist())
+                        new_binormals.extend(binormals.tolist())
+                    else:
+                        new_matrices.append(curve_matrices)
+                        new_tangents.append(tangents.tolist())
+                        new_normals.append(normals.tolist())
+                        new_binormals.append(binormals.tolist())
+
+                if self.join:
+                    matrix_out.extend(new_matrices)
+                    tangents_out.extend(new_tangents)
+                    normals_out.extend(new_normals)
+                    binormals_out.extend(new_binormals)
+                else:
+                    matrix_out.append(new_matrices)
+                    tangents_out.append(new_tangents)
+                    normals_out.append(new_normals)
+                    binormals_out.append(new_binormals)
+
+            self.outputs['Matrix'].sv_set(matrix_out)
+            self.outputs['Tangent'].sv_set(tangents_out)
+            self.outputs['Normal'].sv_set(normals_out)
+            self.outputs['Binormal'].sv_set(binormals_out)
+
+def register():
+    bpy.utils.register_class(SvCurveFrameOnSurfNode)
+
+def unregister():
+    bpy.utils.unregister_class(SvCurveFrameOnSurfNode)
+

--- a/nodes/curve/curve_frame_on_surface.py
+++ b/nodes/curve/curve_frame_on_surface.py
@@ -36,19 +36,8 @@ class SvCurveFrameOnSurfNode(bpy.types.Node, SverchCustomTreeNode):
                 ('ANY', "Arbitrary frame", "Calculate any frame that has Z axis along curve's tangent", 1)
             ]
 
-        on_error : EnumProperty(
-                name = "On zero curvature",
-                description = "What the node should do if it encounters a point with zero curvature - it is impossible to calculate correct Frenet frame at such points",
-                items = error_modes,
-                default = 'ERROR',
-                update = updateNode)
-
         def draw_buttons(self, context, layout):
             layout.prop(self, 'join', toggle=True)
-
-        def draw_buttons_ext(self, context, layout):
-            layout.label(text='On zero curvature:')
-            layout.prop(self, 'on_error', text='')
 
         def sv_init(self, context):
             self.inputs.new('SvSurfaceSocket', "Surface")


### PR DESCRIPTION
Given a surface and a curve in the surface's U/V space, this node calculates a reference frame of a curve for the given value of curve's T parameter. The frame is calculated so that:

* it's X axis is pointing along surface's normal;
* it's Z axis is pointing along curve's tangent (in 3D space);
* it's Y axis is perpendicular to both X and Z.

This node allows one to place some object at the curve on the surface, while
aligning it both with curve's tangent and surface's normal.

Usual "curve frame":
![Screenshot_20200804_141023](https://user-images.githubusercontent.com/284644/89296471-d28d0480-d67b-11ea-9ac0-d6104821ea94.png)

Curve frame on surface:
![Screenshot_20200804_141225](https://user-images.githubusercontent.com/284644/89296479-d456c800-d67b-11ea-9409-2f83e9db415b.png)


## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

