### PR TITLE
add custom enum 2

### DIFF
--- a/docs/nodes/generator/script1_lite.rst
+++ b/docs/nodes/generator/script1_lite.rst
@@ -66,6 +66,8 @@ in your code you might use them this way::
         v_out = b_verts
         f_out = rawdata[1]
 
+see a working script: https://github.com/nortikin/sverchok/pull/3455
+
 - add ``ddir`` (a dunderless dir() function) to local namespace.  ``ddir(object, filter_str="some_string")`` . filter_str is optional::
 
     def ddir(content, filter_str=None):

--- a/docs/nodes/generator/script1_lite.rst
+++ b/docs/nodes/generator/script1_lite.rst
@@ -66,7 +66,7 @@ in your code you might use them this way::
         v_out = b_verts
         f_out = rawdata[1]
 
-see a working script: https://github.com/nortikin/sverchok/pull/3455
+see a working script that ses two enums here: https://github.com/nortikin/sverchok/pull/3455
 
 - add ``ddir`` (a dunderless dir() function) to local namespace.  ``ddir(object, filter_str="some_string")`` . filter_str is optional::
 

--- a/docs/nodes/generator/script1_lite.rst
+++ b/docs/nodes/generator/script1_lite.rst
@@ -15,26 +15,27 @@ The script node implementation is intended for quick, non serious, experimentati
 Features
 --------
 
-- easy template importing directly to node, or to text block (the latter is useful for making changes to a template before loading... as is needed with the `custom_draw_complex` example )
+- easy template importing directly to node, or to text block (the latter is useful for making changes to a template before loading... 
+as is needed with the ``custom_draw_complex`` example )
 
 .. image:: https://cloud.githubusercontent.com/assets/619340/25421401/ff29eed2-2a5c-11e7-9594-f85295178f57.png
 
 - doesn't force an output socket, but an input socket is expected (else how does it update?!)
 - does allow you to set some defaults : numbers, and lists of stuff
 - does allow you to set the level of nestedness; means you don't need to unwrap/index stuff via code
-- does allow you to declare an override to the node's draw_button function, well... think of it more like an `append` to the draw code. There's an example of how you might make a light weight Curve mapping node by using the ui component of a RGB curve from a material node tree. it's a little convoluted, but it's usefulness musn't be dismissed.
-- has the option to **auto inject** the list of variable references as `parameters` much like javascript does for 'arguments` inside a function. In essence implemented like this ::
+- does allow you to declare an override to the node's draw_button function, well... think of it more like an ``append`` to the draw code. There's an example of how you might make a light weight Curve mapping node by using the ui component of a RGB curve from a material node tree. it's a little convoluted, but it's usefulness musn't be dismissed.
+- has the option to **auto inject** the list of variable references as **parameters** much like javascript does for **arguments** inside a function. In essence implemented like this ::
 
     parameters = eval("[" + ", ".join([i.name for i in self.inputs]) + "]")
 
 
-To enable this feature add the word "inject" on its own line in the header. If you have 3 input sockets, called `radius, amplitude, num_verts`,  then the variable `parameters` will be ::
+To enable this feature add the word "inject" on its own line in the header. If you have 3 input sockets, called ``radius, amplitude, num_verts``,  then the variable ``parameters`` will be ::
 
     parameters = [radius, amplitude, num_verts]
 
-This is handy for inner functions that are arranged to take arguments in exactly that order. See `<https://github.com/nortikin/sverchok/issues/942#issuecomment-264705956>`_ for an example use. Usually you'll use the 'vectorize' function with this to zip through each pair of arguments. see https://github.com/nortikin/sverchok/issues/942#issuecomment-263912890
+This is handy for inner functions that are arranged to take arguments in exactly that order. See <https://github.com/nortikin/sverchok/issues/942#issuecomment-264705956>_ for an example use. Usually you'll use the 'vectorize' function with this to zip through each pair of arguments. see https://github.com/nortikin/sverchok/issues/942#issuecomment-263912890
 
-- added a helper function `from sverchok.utils.snlite_utils import vectorize` , and this is made available to scripts without the need to import it now. Also see https://github.com/nortikin/sverchok/issues/942#issuecomment-263912890
+- added a helper function ``from sverchok.utils.snlite_utils import vectorize`` , and this is made available to scripts without the need to import it now. Also see https://github.com/nortikin/sverchok/issues/942#issuecomment-263912890
 
 - added an include directive::
 
@@ -45,7 +46,7 @@ This is handy for inner functions that are arranged to take arguments in exactly
 
 The include directive ensures the dependency is also stored in the gist when exported as json. The file named in angle brackets must be present in the current .blend file's text blocks.
 
-- added two (semi) customizable enums to make the custom draw a bit more useful, called `self.custom_enum` and `self.custom_enum_2`. No spaces in the elements, yes spaces between the elements.::
+- added two (semi) customizable enums to make the custom draw a bit more useful, called **self.custom_enum** and **self.custom_enum_2**. No spaces in the elements, yes spaces between the elements.::
 
     """
     enum = word1 word2 word3
@@ -66,7 +67,7 @@ in your code you might use them this way::
         f_out = rawdata[1]
 
 
-- add `ddir` (`dunderless dir`) to local namespace.  `ddir(object, filter_str="some_string")` . filter_str is optional.::
+- add ``ddir`` (``dunderless dir``) to local namespace.  ``ddir(object, filter_str="some_string")`` . filter_str is optional.::
 
     def ddir(content, filter_str=None):
         vals = []

--- a/docs/nodes/generator/script1_lite.rst
+++ b/docs/nodes/generator/script1_lite.rst
@@ -66,8 +66,7 @@ in your code you might use them this way::
         v_out = b_verts
         f_out = rawdata[1]
 
-
-- add ``ddir`` (``dunderless dir``) to local namespace.  ``ddir(object, filter_str="some_string")`` . filter_str is optional.::
+- add ``ddir`` (a dunderless dir() function) to local namespace.  ``ddir(object, filter_str="some_string")`` . filter_str is optional::
 
     def ddir(content, filter_str=None):
         vals = []
@@ -78,13 +77,13 @@ in your code you might use them this way::
         return vals
 
 - There are several aliases provided so they don't need to be imported manually::
+
      bmesh_from_pydata
      pydata_from_bmesh
      ddir
      np
      bpy
      vectorize
-
 
 - add operator callback. See: https://github.com/nortikin/sverchok/issues/942#issuecomment-300162017 ::
 

--- a/docs/nodes/generator/script1_lite.rst
+++ b/docs/nodes/generator/script1_lite.rst
@@ -25,12 +25,12 @@ Features
 - does allow you to declare an override to the node's draw_button function, well... think of it more like an `append` to the draw code. There's an example of how you might make a light weight Curve mapping node by using the ui component of a RGB curve from a material node tree. it's a little convoluted, but it's usefulness musn't be dismissed.
 - has the option to **auto inject** the list of variable references as `parameters` much like javascript does for 'arguments` inside a function. In essence implemented like this ::
 
-        parameters = eval("[" + ", ".join([i.name for i in self.inputs]) + "]")
+    parameters = eval("[" + ", ".join([i.name for i in self.inputs]) + "]")
 
 
 To enable this feature add the word "inject" on its own line in the header. If you have 3 input sockets, called `radius, amplitude, num_verts`,  then the variable `parameters` will be ::
 
-     parameters = [radius, amplitude, num_verts]
+    parameters = [radius, amplitude, num_verts]
 
 This is handy for inner functions that are arranged to take arguments in exactly that order. See `<https://github.com/nortikin/sverchok/issues/942#issuecomment-264705956>`_ for an example use. Usually you'll use the 'vectorize' function with this to zip through each pair of arguments. see https://github.com/nortikin/sverchok/issues/942#issuecomment-263912890
 
@@ -45,11 +45,26 @@ This is handy for inner functions that are arranged to take arguments in exactly
 
 The include directive ensures the dependency is also stored in the gist when exported as json. The file named in angle brackets must be present in the current .blend file's text blocks.
 
-- added a default enum to make the custom draw a bit more useful. For the time being there is only one custom enum, the default is "A","B" . called `self.custom_enum`. No spaces in the elements, yes spaces between the elements.::
+- added two (semi) customizable enums to make the custom draw a bit more useful, called `self.custom_enum` and `self.custom_enum_2`. No spaces in the elements, yes spaces between the elements.::
 
     """
     enum = word1 word2 word3
+    enum2 = raw clean
     """
+you make them visible on the ui by doing::
+
+    def ui(self, context, layout):
+        layout.prop(self, 'custom_enum', expand=True)
+        layout.prop(self, 'custom_enum_2', expand=True)
+
+in your code you might use them this way::
+
+    if self.custom_enum_2 == "clean":        
+        v_out, f_out = join_tris(b_verts, rawdata[1], params)
+    else:
+        v_out = b_verts
+        f_out = rawdata[1]
+
 
 - add `ddir` (`dunderless dir`) to local namespace.  `ddir(object, filter_str="some_string")` . filter_str is optional.::
 
@@ -61,7 +76,15 @@ The include directive ensures the dependency is also stored in the gist when exp
             vals = [n for n in dir(content) if not n.startswith('__') and filter_str in n]
         return vals
 
-- add `bmesh_from_pydata` and `pydata_from_bmesh` locally, so you don't have to import.
+- There are several aliases provided so they don't need to be imported manually::
+     bmesh_from_pydata
+     pydata_from_bmesh
+     ddir
+     np
+     bpy
+     vectorize
+
+
 - add operator callback. See: https://github.com/nortikin/sverchok/issues/942#issuecomment-300162017 ::
 
    """

--- a/docs/nodes/generator/script1_lite.rst
+++ b/docs/nodes/generator/script1_lite.rst
@@ -66,7 +66,7 @@ in your code you might use them this way::
         v_out = b_verts
         f_out = rawdata[1]
 
-see a working script that ses two enums here: https://github.com/nortikin/sverchok/pull/3455
+see a working script that uses two enums here: https://github.com/nortikin/sverchok/pull/3455
 
 - add ``ddir`` (a dunderless dir() function) to local namespace.  ``ddir(object, filter_str="some_string")`` . filter_str is optional::
 

--- a/nodes/generator/script1_lite.py
+++ b/nodes/generator/script1_lite.py
@@ -21,6 +21,7 @@ import sys
 import ast
 import json
 import traceback
+import numpy as np
 
 import bpy
 from bpy.props import StringProperty, IntVectorProperty, FloatVectorProperty, BoolProperty
@@ -122,6 +123,15 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
 
         return [("A", "A", '', 0), ("B", "B", '', 1)]
 
+    def custom_enum_func_2(self, context):
+        ND = self.node_dict.get(hash(self))
+        if ND:
+            enum_list = ND['sockets']['custom_enum_2']
+            if enum_list:
+                return [(ce, ce, '', idx) for idx, ce in enumerate(enum_list)]
+
+        return [("A", "A", '', 0), ("B", "B", '', 1)]
+
 
     def custom_callback(self, context, operator):
         ND = self.node_dict.get(hash(self))
@@ -181,6 +191,10 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     custom_enum: bpy.props.EnumProperty(
         items=custom_enum_func, description="custom enum", update=updateNode
     )
+    custom_enum_2: bpy.props.EnumProperty(
+        items=custom_enum_func_2, description="custom enum 2", update=updateNode
+    )
+
 
     snlite_raise_exception: BoolProperty(name="raise exception")
 
@@ -402,6 +416,7 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
         locals().update({
             'vectorize': vectorize,
             'bpy': bpy,
+            'np': np,
             'ddir': ddir,
             'bmesh_from_pydata': bmesh_from_pydata,
             'pydata_from_bmesh': pydata_from_bmesh

--- a/utils/snlite_importhelper.py
+++ b/utils/snlite_importhelper.py
@@ -125,7 +125,7 @@ def parse_sockets(node):
             snlite_info['custom_enum'] = L[6:].strip().split(' ')
 
         elif L.startswith('enum2 ='):
-            snlite_info['custom_enum_2'] = L[6:].strip().split(' ')
+            snlite_info['custom_enum_2'] = L[7:].strip().split(' ')
 
         elif L.startswith('include <') and L.endswith('>'):
             filename = L[9:-1]

--- a/utils/snlite_importhelper.py
+++ b/utils/snlite_importhelper.py
@@ -95,7 +95,8 @@ def parse_sockets(node):
     snlite_info = {
         'inputs': [], 'outputs': [],
         'snlite_ui': [], 'includes': {},
-        'custom_enum': [], 'callbacks': {}
+        'custom_enum': [], 'custom_enum_2': [],
+        'callbacks': {}
     }
 
     quotes = 0
@@ -122,6 +123,9 @@ def parse_sockets(node):
 
         elif L.startswith('enum ='):
             snlite_info['custom_enum'] = L[6:].strip().split(' ')
+
+        elif L.startswith('enum2 ='):
+            snlite_info['custom_enum_2'] = L[6:].strip().split(' ')
 
         elif L.startswith('include <') and L.endswith('>'):
             filename = L[9:-1]


### PR DESCRIPTION
- adds `enum2` to the allowed directives, 
- adds `np` to the default import (makes it an available alias)

allows us to do 
```python
"""
in verts_a v
in faces_a s
in verts_b v
in faces_b s
in precision s d=0.1 n=2
in face_threshold s d=3.0 n=2
in shape_threshold s d=3.0 n=2
out verts_new v
out faces_new s
enum = common fuse cut
enum2 = raw clean
"""

def ui(self, context, layout):
    layout.prop(self, 'custom_enum', expand=True)
    layout.prop(self, 'custom_enum_2', expand=True)
    

from sverchok.nodes.solid.mesh_to_solid import ensure_triangles
from sverchok.utils.solid import svmesh_to_solid
from sverchok.nodes.modifier_make.join_tris import join_tris
from sverchok.data_structure import sv_lambda, updateNode, match_long_repeat as mlr


params = sv_lambda(face_threshold=face_threshold, shape_threshold=shape_threshold)

for v1, f1, v2, f2 in zip(*mlr([verts_a, faces_a, verts_b, faces_b])):
 
    solid_a = svmesh_to_solid(v1, f1, precision)
    solid_b = svmesh_to_solid(v2, f2, precision)
    solid_out = getattr(solid_a, self.custom_enum)(solid_b)
    solid_out = solid_out.removeSplitter()
    
    rawdata = solid_out.tessellate(precision)
    b_verts = [(v.x, v.y, v.z) for v in rawdata[0]]

    if self.custom_enum_2 == "clean":        
        v_out, f_out = join_tris(b_verts, rawdata[1], params)
    else:
        v_out = b_verts
        f_out = rawdata[1]

    verts_new.append(v_out)
    faces_new.append(f_out)

```
and that looks like
![image](https://user-images.githubusercontent.com/619340/89996466-1d65d800-dc8b-11ea-8ef5-1affa9935c09.png)
