### PR TITLE
"Quad Grid Sort" node

### DIFF
--- a/docs/nodes/vector/quad_grid.rst
+++ b/docs/nodes/vector/quad_grid.rst
@@ -1,0 +1,73 @@
+Sort Quad Grid
+==============
+
+Functionality
+-------------
+
+Consider you want to use a quad grid, i.e. a mesh made of quads only, arranged
+in topology equivalent to subdivided Plane object. If you make such mesh in
+other way than by use of Sverchok's "Plane" node, for example, by using
+Blender's standard "Subdivide" or "Extrude" operations, then most probably the
+order of vertices in such mesh will be near to random. On the other hand,
+sometimes you need these vertices to be ordered according to grid topology, row
+by row, column by column. For example, it can be useful for creating Nurbs
+surfaces with "Build NURBS Surface" node.
+
+This node takes a mesh (vertices, edges and faces) and outputs the sorted
+vertices. It can output a separate list of vertices for each row, or it can
+join all rows into one list.
+
+For cases when the mesh is placed in some non-trivial manner (for example,
+imagine a plane rolled up like a cylinder or a torus, or something even more
+complex), it can be not obvious from which corner the node should start
+enumerating vertices, and in which direction. For such cases, the node has
+parameters to manipulate the order of vertices.
+
+If the input mesh's topology is not equivalent to subdivided plane (i.e. M rows
+by N columns of vertices), the node will fail (become red).
+
+Inputs
+------
+
+This node has the following inputs:
+
+* **Vertices**. The vertices of the input mesh. This input is mandatory.
+* **Edges**. Edges of the input mesh. Either edges or faces must be provided.
+* **Faces**. Faces of the input mesh. Either edges or faces must be provided.
+
+Parameters
+----------
+
+This node has the following parameters:
+
+* **Reverse rows**. If checked, then the node will reverse the order of rows in the
+  output list: it will output last row first, and so on. Unchecked by default.
+* **Reverse columns**. If checked, the node will reverse the order of vertices in
+  each row. Unchecked by default.
+* **Transpose**. If checked, the node will transpose the resulting list of
+  vertices, i.e turn all rows into columns and vice versa. Unchecked by
+  default.
+* **Join rows**. If checked, the node will concatenate all rows of vertices
+  into one list. Otherwise, it will output a separate list of vertices for each
+  row. Unchecked by default.
+
+Outpus
+------
+
+This node has the following outputs:
+
+* **Vertices**. The sorted vertices.
+* **Indexes**. For each vertex in the **Verices** output, this output contains
+  the index of this vertex in the input list of vertices.
+
+Examples of usage
+-----------------
+
+Take manually subdivided plane (on the left) and sort it's vertices:
+
+.. image:: https://user-images.githubusercontent.com/284644/93013046-65e02080-f5be-11ea-9d0b-7369cf76b9e2.png
+
+Use together with "Build NURBS Surface" node:
+
+.. image:: https://user-images.githubusercontent.com/284644/93013197-9eccc500-f5bf-11ea-905b-4e929f1ee2bb.png
+

--- a/docs/nodes/vector/vector_index.rst
+++ b/docs/nodes/vector/vector_index.rst
@@ -24,6 +24,7 @@ Vector
    vector_polar_out
    vertices_delete_doubles
    vertices_sort
+   quad_grid
    variable_lacunarity
    turbulence
    color_input

--- a/index.md
+++ b/index.md
@@ -466,6 +466,7 @@
     SvVectorRewire
     ---
     SvVertSortNode
+    SvQuadGridSortVertsNode
     VectorDropNode
     VectorPolarInNode
     VectorPolarOutNode

--- a/nodes/vector/quad_grid.py
+++ b/nodes/vector/quad_grid.py
@@ -1,0 +1,122 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import bpy
+from bpy.props import EnumProperty, BoolProperty
+import bmesh
+
+from sverchok.utils.quad_grid import SvQuadGridParser
+from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata, pydata_from_bmesh
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode, zip_long_repeat, transpose_list
+
+class SvQuadGridSortVertsNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: sort vertices quad grid
+    Tooltip: Sort vertices from a quad grid (subdivided plane) mesh, row by row
+    """
+    bl_idname = 'SvQuadGridSortVertsNode'
+    bl_label = 'Sort Quad Grid'
+    bl_icon = 'MESH_GRID'
+
+    reverse_rows : BoolProperty(
+            name = "Reverse rows",
+            description = "Reverse order of rows",
+            default = False,
+            update = updateNode)
+
+    reverse_cols : BoolProperty(
+            name = "Reverse columns",
+            description = "Reverse order of vertices in each column",
+            default = False,
+            update = updateNode)
+
+    transpose : BoolProperty(
+            name = "Transpose",
+            description = "Transpose the list: make rows from columns, and vice versa",
+            default = False,
+            update = updateNode)
+    
+    join_rows : BoolProperty(
+            name = "Join rows",
+            description = "Concatenate all rows (or columns, if `Transpose' is on) into one list",
+            default = False,
+            update = updateNode)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'reverse_rows')
+        layout.prop(self, 'reverse_cols')
+        layout.prop(self, 'transpose')
+        layout.prop(self, 'join_rows')
+
+    def sv_init(self, context):
+        self.inputs.new('SvVerticesSocket', 'Vertices')
+        self.inputs.new('SvStringsSocket', 'Edges')
+        self.inputs.new('SvStringsSocket', 'Faces')
+        self.outputs.new('SvVerticesSocket', "Vertices")
+        self.outputs.new('SvStringsSocket', "Indexes")
+
+    def process(self):
+        if not any (socket.is_linked for socket in self.outputs):
+            return
+
+        vertices_s = self.inputs['Vertices'].sv_get()
+        edges_s = self.inputs['Edges'].sv_get(default=[[]])
+        faces_s = self.inputs['Faces'].sv_get(default=[[]])
+
+        verts_out = []
+        idxs_out = []
+
+        for vertices, edges, faces in zip_long_repeat(vertices_s, edges_s, faces_s):
+            bm = bmesh_from_pydata(vertices, edges, faces)
+            bm.faces.index_update()
+
+            parser = SvQuadGridParser(bm)
+            new_idxs = parser.get_verts_sequence()
+            new_verts = parser.get_ordered_verts()
+            
+            if self.reverse_rows:
+                new_idxs = list(reversed(new_idxs))
+                new_verts = list(reversed(new_verts))
+
+            if self.reverse_cols:
+                new_idxs = [list(reversed(row)) for row in new_idxs]
+                new_verts = [list(reversed(row)) for row in new_verts]
+
+            if self.transpose:
+                new_idxs = transpose_list(new_idxs)
+                new_verts = transpose_list(new_verts)
+
+            if self.join_rows:
+                new_idxs = sum(new_idxs, [])
+                new_verts = sum(new_verts, [])
+
+            bm.free()
+
+            verts_out.append(new_verts)
+            idxs_out.append(new_idxs)
+
+        self.outputs['Vertices'].sv_set(verts_out)
+        self.outputs['Indexes'].sv_set(idxs_out)
+
+def register():
+    bpy.utils.register_class(SvQuadGridSortVertsNode)
+
+def unregister():
+    bpy.utils.unregister_class(SvQuadGridSortVertsNode)
+

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -144,4 +144,5 @@ utils_modules = [
     # geom 2d tools
     "geom_2d.lin_alg", "geom_2d.dcel", "geom_2d.dissolve_mesh", "geom_2d.merge_mesh", "geom_2d.intersections",
     "geom_2d.make_monotone", "geom_2d.sort_mesh", "geom_2d.dcel_debugger",
+    "quad_grid"
 ]

--- a/utils/quad_grid.py
+++ b/utils/quad_grid.py
@@ -1,0 +1,228 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import bmesh
+
+from sverchok.utils.logging import debug, info
+
+class Parser(object):
+    """
+    Parse a "bmesh" object, which contains a "quad grid", i.e.
+    mesh consisting of quads only, in topology similar to subdivided plane (m x n vertices).
+    Return vertices ordered row-by-row.
+    Raise exception if the given mesh has invalid topology.
+    """
+    def __init__(self, bm):
+        self.bmesh = bm
+        self._init_check()
+        self._init()
+
+    def _init_check(self):
+        # Run some checks that the mesh has correct topology.
+        # Not all necessary conditions are checked here, only
+        # simplest ones.
+        for face in self.bmesh.faces:
+            if len(face.verts) != 4:
+                raise Exception(f"One of faces has {len(face.verts)} vertices instead of 4")
+        corners_cnt = 0
+        edges_cnt = 0
+        for vert in self.bmesh.verts:
+            if vert.is_wire:
+                raise Exception("One of verts is a wire")
+            k = len(vert.link_edges)
+            if k not in {2,3,4}:
+                raise Exception(f"One of vertices has {k} adjacent edges instead of 2,3,4")
+            if k == 4 and vert.is_boundary:
+                raise Exception("Vertex with 4 adjacent edges is boundary")
+            if k != 4 and not vert.is_boundary:
+                raise Exception(f"Vertex with {k} adjacent edges is not boundary")
+            if k == 2:
+                corners_cnt += 1
+            if k == 3:
+                edges_cnt += 1
+        if corners_cnt != 4:
+            raise Exception(f"Mesh has {corners_cnt} corners instead of 4")
+        if edges_cnt % 2 != 0:
+            raise Exception("Mesh has {edges_cnt} edge vertices, which does not divide by 2")
+        for edge in self.bmesh.edges:
+            k = len(edge.link_faces)
+            if k not in {1,2}:
+                raise Exception(f"One of edges has {k} adjacent faces instead of 1,2")
+            if k == 2 and edge.is_boundary:
+                raise Exception("Edge with 2 adjacent faces is boundary!?")
+            if k == 1 and not edge.is_boundary:
+                raise Exception("Edge with 1 adjacent face is not boundary!?")
+
+    def _init(self):
+        # Find a corner to start with.
+        # We are searching for such a vertex and it's loop,
+        # so the edge is pointing in positive X direction.
+        # If we can't find such, then search for positive Y...
+        self.row_length = None
+        self.transposed = False
+        good_x = []
+        good_y = []
+        for vert in self.bmesh.verts:
+            if len(vert.link_edges) == 2:
+                for loop in vert.link_loops:
+                    other_vert = loop.edge.other_vert(vert)
+                    #debug(f"V#{vert.index}: x {vert.co.x} => #{other_vert.index} {other_vert.co.x}")
+                    if other_vert.co.x > vert.co.x:
+                        good_x.append(loop)
+                    if other_vert.co.y > vert.co.y:
+                        good_y.append(loop)
+        
+        if good_x:
+            loop = good_x[0]
+        elif good_y:
+            loop = good_y[0]
+        else:
+            raise Exception("Could not find a vertex to start from")
+
+        vert = loop.vert
+        #debug(f"Start with v.{vert.index}, loop {self._show_loop(loop)}")
+        self.current_loop = loop
+        self.current_vert = vert
+
+    def _show_loop(self, loop):
+        # Debug utility
+        vert = loop.vert
+        other_vert = loop.edge.other_vert(vert)
+        return f"[{vert.index}->{other_vert.index}]({loop.face.index})"
+
+    def _next_loop(self):
+        # Find the next loop in "forward" direction
+        start_k = len(self.current_vert.link_edges)
+        next_loop = self.current_loop.link_loop_next
+        k = len(next_loop.vert.link_edges)
+        #debug(f"> from {self._show_loop(self.current_loop)} => {self._show_loop(next_loop)}, k={k} (for v.{next_loop.vert.index}) of {self.row_start_k}")
+        if k == self.row_start_k:
+            loop = next_loop
+        else:
+            loop = next_loop.link_loop_radial_next.link_loop_next
+        #debug(f"> to {self._show_loop(loop)}")
+        return loop
+
+    def _prev_loop(self):
+        # Find the next loop in "backward" direction.
+        # This method is called only when processing the last row of vertices.
+        start_k = len(self.current_vert.link_edges)
+        next_loop = self.current_loop.link_loop_prev
+        other_vert = next_loop.edge.other_vert(next_loop.vert)
+        k = len(other_vert.link_edges)
+        #debug(f"< from {self._show_loop(self.current_loop)} => {self._show_loop(next_loop)}, k={k} for v.{other_vert.index}")
+        if k == 2:
+            loop = next_loop
+        else:
+            loop = next_loop.link_loop_radial_prev.link_loop_prev
+        #debug(f"< to {self._show_loop(loop)}")
+        return loop
+
+    def _step_forward(self):
+        # Step to the next loop in row.
+        self.current_loop = self._next_loop()
+        self.current_vert = self.current_loop.vert
+
+    def _step_backward(self):
+        # Step to the previous loop in row.
+        # This method is called only when processing the last loop of vertices.
+        self.current_loop = self._prev_loop()
+        self.current_vert = self.current_loop.vert
+
+    def _walk_row_forward(self):
+        # Walk along the row of vertices in "forward" direction.
+        self.row_start_loop = self.current_loop
+        self.row_start_vert = self.current_vert
+        self.row_start_k = len(self.current_vert.link_edges)
+
+        result = [self.current_vert.index]
+        while True:
+            self._step_forward()
+            k = len(self.current_vert.link_edges)
+            #debug(f"> C: {self.current_vert.index}, k={k}")
+            result.append(self.current_vert.index)
+            if self.current_vert.is_boundary and k == self.row_start_k:
+                break
+
+        n = len(result)
+        if self.row_length is None:
+            self.row_length = n
+        elif self.row_length != n:
+            raise Exception(f"Row has length {n} instead of {self.row_length}")
+        return result
+
+    def _walk_row_backward(self):
+        # Walk along the row of vertices in "backward" direction.
+        # This method is called only when processing the last loop of vertices.
+        if self.row_length is None:
+            raise Exception("_walk_row_backward was called before setting row_length")
+
+        self.row_start_loop = self.current_loop
+        self.row_start_vert = self.current_vert
+        self.row_start_k = len(self.current_vert.link_edges)
+
+        edge = self.current_loop.edge
+        vert = edge.other_vert(self.current_vert)
+        result = [vert.index]
+        for i in range(self.row_length-1):
+            self._step_backward()
+            k = len(self.current_vert.link_edges)
+            #debug(f"< C[{i}]: {self.current_vert.index}, k={k}")
+            edge = self.current_loop.edge
+            vert = edge.other_vert(self.current_vert)
+            result.append(vert.index)
+
+        n = len(result)
+        if n == self.row_length - 1:
+            result.append(self.current_vert.index)
+        elif self.row_length != n:
+            raise Exception(f"(Last) Row has length {n} ({result}) instead of {self.row_length}")
+        return result
+
+    def _next_row(self):
+        # Go to the next row of vertices.
+        # Return True if this row is the last one.
+        self.current_loop = self.row_start_loop
+        start_face_idx = self.current_loop.face.index
+        loop = self.current_loop.link_loop_prev.link_loop_prev.link_loop_radial_next
+        #debug(f"N/: F {loop.face.index}, V {loop.vert.index}, E {self._show_loop(loop)}")
+        self.current_loop = loop
+        self.current_vert = self.current_loop.vert
+        last = loop.face.index == start_face_idx
+        return last
+
+    def get_verts_sequence(self):
+        """
+        Return list of lists of vertices indexes,
+        sorted row-by-row.
+        """
+        result = []
+        last = False
+        while not last:
+            row = self._walk_row_forward()
+            result.append(row)
+            last = self._next_row()
+
+        row = self._walk_row_backward()
+        result.append(row)
+        return result
+
+    def get_ordered_verts(self, flat=False):
+        """
+        Return list of lists of vertices coordinates,
+        sorted row by row.
+        If flat==True, then return flat list of vertices.
+        """
+        result = []
+        for row_idxs in self.get_verts_sequence():
+            row = [tuple(self.bmesh.verts[i].co) for i in row_idxs]
+            if flat:
+                result.extend(row)
+            else:
+                result.append(row)
+        return result
+


### PR DESCRIPTION
## Addressed problem description

Consider you want to use a quad grid, i.e. a mesh made of quads only, arranged in topology equivalent to subdivided Plane object. If you make such mesh in other way than by use of Sverchok's "Plane" node, for example, by using Blender's standard "Subdivide" or "Extrude" operations, then most probably the order of vertices in such mesh will be near to random. On the other hand, sometimes you need these vertices to be ordered according to grid topology, row by row, column by column. For example, it can be useful for creating Nurbs surfaces with "Build NURBS Surface" node.

## Solution description

Make a new node, "Sort Quad Grid". It takes a mesh (vertices, edges and faces) and outputs sorted vertices. It can output a separate list of vertices for each row, or join all rows into one list.

Implemented with `bmesh`'s `BMLoop` API.

![Screenshot_20200913_121853](https://user-images.githubusercontent.com/284644/93013046-65e02080-f5be-11ea-9d0b-7369cf76b9e2.png)

![Screenshot_20200913_124937](https://user-images.githubusercontent.com/284644/93013197-9eccc500-f5bf-11ea-905b-4e929f1ee2bb.png)


## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

