### PR TITLE
FreeCAD: start supporting "native" curves where possible

### DIFF
--- a/nodes/solid/wire_face.py
+++ b/nodes/solid/wire_face.py
@@ -60,7 +60,7 @@ class SvSolidWireFaceNode(bpy.types.Node, SverchCustomTreeNode):
         for curves_i in curve_s:
             new_faces = []
             for curves in curves_i:
-                _, _, face = curves_to_face(curves, planar=self.planar)
+                face = curves_to_face(curves, planar=self.planar, force_nurbs=False)
                 new_faces.append(face)
             faces_out.append(new_faces)
 

--- a/utils/curve/freecad.py
+++ b/utils/curve/freecad.py
@@ -6,17 +6,49 @@
 # License-Filename: LICENSE
 
 import numpy as np
+import math
 
 from sverchok.utils.nurbs_common import SvNurbsMaths
 from sverchok.utils.curve.core import SvCurve
 from sverchok.utils.curve.nurbs import SvNurbsCurve
 from sverchok.utils.curve import knotvector as sv_knotvector
+from sverchok.utils.curve.primitives import SvLine, SvCircle
 
 from sverchok.dependencies import FreeCAD
 if FreeCAD is not None:
     from FreeCAD import Base
     import Part
     from Part import Geom2d
+
+curve_converters = dict()
+
+def line_to_freecad(line):
+    u_min, u_max = line.get_u_bounds()
+    p1 = tuple(line.evaluate(u_min))
+    p2 = tuple(line.evaluate(u_max))
+    p1 = Base.Vector(*p1)
+    p2 = Base.Vector(*p2)
+    fc_line = Part.LineSegment(p1, p2)
+    return fc_line
+
+curve_converters[SvLine] = line_to_freecad
+
+def circle_to_freecad(circle):
+    center = tuple(circle.center)
+    normal = tuple(circle.normal)
+    vectorx = tuple(circle.vectorx / np.linalg.norm(circle.vectorx))
+    radius = circle.radius
+    u_min, u_max = circle.get_u_bounds()
+
+    fc_circle = Part.Circle(Base.Vector(*center), Base.Vector(*normal), radius)
+    if u_min != 0 or u_max != 2*math.pi:
+        fc_arc = fc_circle.trim(u_min, u_max)
+        fc_arc.XAxis = Base.Vector(*vectorx)
+        return fc_arc
+    else:
+        return fc_circle
+
+curve_converters[SvCircle] = circle_to_freecad
 
 def curve_to_freecad_nurbs(sv_curve):
     """
@@ -28,7 +60,7 @@ def curve_to_freecad_nurbs(sv_curve):
     """
     nurbs = SvNurbsCurve.to_nurbs(sv_curve)
     if nurbs is None:
-        raise Exception("not a NURBS curve")
+        raise Exception(f"{sv_curve} is not a NURBS curve")
     fc_curve = SvNurbsMaths.build_curve(SvNurbsMaths.FREECAD,
                 nurbs.get_degree(),
                 nurbs.get_knotvector(),
@@ -248,4 +280,13 @@ class SvFreeCadNurbsCurve(SvNurbsCurve):
         return curve
 
 SvNurbsMaths.curve_classes[SvNurbsMaths.FREECAD] = SvFreeCadNurbsCurve
+
+def curve_to_freecad(sv_curve):
+    converter = curve_converters.get(type(sv_curve), None)
+    if converter is not None:
+        fc_curve = converter(sv_curve)
+        bounds = fc_curve.FirstParameter, fc_curve.LastParameter
+        return SvFreeCadCurve(fc_curve, bounds)
+    else:
+        return curve_to_freecad_nurbs(sv_curve)
 


### PR DESCRIPTION
At present, when passing curves into FreeCAD API, we always convert them into NURBS, even when this is a "well-known" curve such as Line or Circle, for which FreeCAD has it's own representation. It works, but consequently in, for example, STEP file you see BSplineCurve where could of be Circle or Line. Theoretically, this can make manufacturing process unnecessarily complex in some cases.

With this PR, I add support of passing of SvCircle and SvLine to FreeCAD API as their FreeCAD's counterparts. So in STEP you will see circles and lines. Note: it seems, when doing Booleans, FreeCAD always converts everything to NURBS anyway. Even if you are cutting cylinder from cylinder, the result will be NURBS. But still, at least in simple cases we will preserve parametric forms.

Later, support for other types of FreeCAD native curves (ellipses, other conics, Bezier curves) can be added.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

