### PR TITLE
Do not update whole tree upon `show` attribute switching of a node tree

### DIFF
--- a/node_tree.py
+++ b/node_tree.py
@@ -180,7 +180,6 @@ class SverchCustomTree(NodeTree, SvNodeTreeCommon):
                 node.show_viewport(self.sv_show)
             except AttributeError:
                 pass
-        process_tree(self)
 
     def on_draft_mode_changed(self, context):
         """

--- a/nodes/viz/vd_draw_experimental.py
+++ b/nodes/viz/vd_draw_experimental.py
@@ -637,6 +637,17 @@ class SvVDExperimental(bpy.types.Node, SverchCustomTreeNode):
     def sv_free(self):
         callback_disable(node_id(self))
 
+    def show_viewport(self, is_show: bool):
+        """It should be called by node tree to show/hide objects"""
+        if not self.activate:
+            # just ignore request
+            pass
+        else:
+            if is_show:
+                self.process()
+            else:
+                callback_disable(node_id(self))
+
 
 classes = [SvVDExperimental]
 register, unregister = bpy.utils.register_classes_factory(classes)

--- a/nodes/viz/viewer_idx28.py
+++ b/nodes/viz/viewer_idx28.py
@@ -318,6 +318,18 @@ class SvIDXViewer28(bpy.types.Node, SverchCustomTreeNode):
         ''' reset n_id on copy '''
         self.n_id = ''
 
+    def show_viewport(self, is_show: bool):
+        """It should be called by node tree to show/hide objects"""
+        if not self.activate:
+            # just ignore request
+            pass
+        else:
+            if is_show:
+                self.process()
+            else:
+                callback_disable(node_id(self))
+
+
 def register():
     bpy.utils.register_class(SvIDXViewer28)
 


### PR DESCRIPTION
## Addressed problem description

![fix show tree](https://user-images.githubusercontent.com/28003269/93305316-63283a00-f80f-11ea-8c5b-93f818aa3fcf.gif)


- [x] Ready for merge.

