### PR TITLE
Standardise text nesting

### DIFF
--- a/nodes/network/file_path.py
+++ b/nodes/network/file_path.py
@@ -114,7 +114,7 @@ class SvFilePathNode(bpy.types.Node, SverchCustomTreeNode):
         for file_elem in self.files:
             filepath = os.path.join(directory, file_elem.name)
             files.append(filepath)
-        self.outputs['File Path'].sv_set(files)
+        self.outputs['File Path'].sv_set([files])
 
     # iojson stuff
 

--- a/nodes/solid/export_solid.py
+++ b/nodes/solid/export_solid.py
@@ -23,7 +23,7 @@ else:
 
             if not all(s.is_linked for s in node.inputs):
                 return {'FINISHED'}
-            folder_path = node.inputs[0].sv_get()[0]
+            folder_path = node.inputs[0].sv_get()[0][0]
             solids = node.inputs[1].sv_get()
             base_name = node.base_name
             if not base_name:

--- a/nodes/solid/import_solid.py
+++ b/nodes/solid/import_solid.py
@@ -27,7 +27,7 @@ else:
             if not any(socket.is_linked for socket in self.outputs):
                 return
 
-            files = self.inputs[0].sv_get()
+            files = self.inputs[0].sv_get()[0]
 
             solids = []
             for f in files:

--- a/nodes/svg/svg_document.py
+++ b/nodes/svg/svg_document.py
@@ -69,7 +69,7 @@ class SvSvgServer(bpy.types.Operator):
 
             return {'FINISHED'}
 
-        save_path = node.inputs[0].sv_get()[0]
+        save_path = node.inputs[0].sv_get()[0][0]
         file_name = node.file_name
         bpy.ops.node.svg_write(idtree=self.idtree, idname=self.idname)
         spawn_server(save_path, file_name)
@@ -120,8 +120,8 @@ class SvSVGWrite(bpy.types.Operator):
 
             return {'FINISHED'}
 
-        save_path = inputs[0].sv_get()[0]
-        template_path = inputs[1].sv_get() if inputs[1].is_linked else []
+        save_path = inputs[0].sv_get()[0][0]
+        template_path = inputs[1].sv_get()[0] if inputs[1].is_linked else []
         shapes = inputs[2].sv_get()
 
         svg = ''

--- a/nodes/text/note.py
+++ b/nodes/text/note.py
@@ -53,7 +53,7 @@ class NoteNode(bpy.types.Node, SverchCustomTreeNode):
 
     text: StringProperty(name='text', default='your text here', update=update_text)
 
-    show_text: BoolProperty(default=False, name="Show text", description="Show text box in node")
+    show_text: BoolProperty(default=True, name="Show text", description="Show text box in node")
 
     def format_text(self):
         n_id = node_id(self)
@@ -126,12 +126,7 @@ class NoteNode(bpy.types.Node, SverchCustomTreeNode):
             self.format_text()
 
         if self.outputs and self.outputs['Text Out'].is_linked:
-            # I'm not sure that this makes sense, but keeping it like
-            # old note right now. Would expect one value, and optional
-            # split, or split via a text processing node,
-            # but keeping this for now
-            text = [[a] for a in self.text.split()]
-            self.outputs['Text Out'].sv_set([text])
+            self.outputs['Text Out'].sv_set([[self.text]])
 
     def sv_copy(self, node):
         self.n_id = ''


### PR DESCRIPTION
Referring to #3555 - after playing around with ported Grasshopper nodes, I think that strings should use the same convention as numbers. E.g., they should nest like this: `[['foo bar baz']]`. I have tested this convention with the ladybug nodes I am working on, and it works extremely well :)

Currently, the note node splits text like this: `[[['foo', 'bar', 'baz']]]` and the filepath node doesn't nest, like this: `['foo bar baz']`. This PR standardises both nodes to output `[['foo bar baz']]`.

If this PR is approved, I can build a new node that does text `split()`, in case people prefer the splitted text.