### PR TITLE
"Solid from two Faces": move from Alpha

### DIFF
--- a/docs/nodes/solid/ruled_solid.rst
+++ b/docs/nodes/solid/ruled_solid.rst
@@ -1,4 +1,4 @@
-Solid from Faces
+Solid from two Faces
 ================
 
 Dependencies
@@ -11,11 +11,17 @@ This node requires FreeCAD_ library to work.
 Functionality
 -------------
 
-This node takes several Solid Face objects (i.e. Surfaces trimmed by some
-edges), and "glues" them to construct a Solid object. In order to make a proper
-Solid object, the faces must already have their edges and vertices exactly
-coinciding. Usually the only way to guarantee that is to construct all these
-Faces from the same set of Edges.
+This node generates a Solid object from two Faces ("floor" and "ceiling") by
+adding linear surfaces to connect their edges ("walls").
+
+**NOTE**: the node requires that two Face objects provided have exactly the
+same number of edges. Hint: if you are generating Faces from Curves, you can
+use "Split Curve" node to increase the number of edges.
+
+Depending on the way how you generate "floor" and "ceiling" surfaces, it can
+appear that the order or the direction of their edges will be incorrect; in
+such cases weird invalid bodies would be generated. To deal with such cases,
+the node suggest options to reverse the order of edges, or direction of edges.
 
 By default, the node will check that the Solid object it constructed is "valid"
 in terms of FreeCAD's OCCT kernel: all faces have coinciding edges, all normals
@@ -34,24 +40,27 @@ Face.
 Inputs
 ------
 
-This node has the following input:
+This node has the following inputs:
 
-* **SolidFaces**. Solid Face objects to make a Solid from. This input can
-  consume data with nesting level from 1 (list of faces) to 3 (list of lists of
-  lists of faces).  The node will make one Solid object from each list of
-  faces. This input is mandatory.
+* **SolidFace1**. The first Solid Face object (to be used as "floor", for
+  example). This input is mandatory.
+* **SolidFace2**. The second Solid Face object (to be used as "ceiling", for
+  example). This input is mandatory.
 
 Parameters
 ----------
 
 This node has the following parameters:
 
-* **Body is closed**. If checked, the node will check that the constructed
-  Solid object is closed, i.e. does not have open edges. If it finds that the
-  body is not closed, the node will raise an exception (become red) and
-  processing will stop. So if this parameter is checked, you can be sure that
-  all Solid objects it generates are closed. If not checked, the node will not
-  perform such check, and can generate not-closed objects. Checked by default.
+* **Flip Face 1**, **Flip Face 2**. If checked, the node will flip first or
+  second Face, correspondingly (invert it's normal direction). It can be
+  required to build a proper Solid object. Unchecked by default.
+* **Rev. Edges 1**, **Rev. Edges 2**. If checked, the node will reverse the
+  order of edges of first or second Face, correspondingly. It can be requierd
+  to build a proper Solid object. Unchecked by default.
+* **Flip Edges 1**, **Flip Edges 2**. If checked, the node will reverse the
+  direction of each edge of first or second Face, correspondingly. It can be
+  required to build a proper Solid object. Unchecked by default.
 * **Validate**. This parameter is available in the N panel only. If checked,
   the node will check that the Solid object it constructed is "valid" in terms
   of FreeCAD's OCCT kernel: all faces have coinciding edges, all normals are
@@ -77,9 +86,9 @@ This node has the following output:
 Example of usage
 ----------------
 
-Make a side surface by lofting between three cubic splines; make top and bottom
-faces with "Frame from Curve" node from the first and the last spline; then
-build the Solid object from these three surfaces:
+Generate two cubic splines from randomized polygons; subdivide each spline into
+four parts, to build a Coons surface from each of them; then connect these two
+surfaces into one Solid:
 
-.. image:: https://user-images.githubusercontent.com/284644/93717249-f5249f80-fb8d-11ea-9fcb-9b780c7623a7.png
+.. image:: https://user-images.githubusercontent.com/284644/93722058-7ccdd680-fbad-11ea-8319-d7f3e8cf04ac.png
 

--- a/docs/nodes/solid/solid_index.rst
+++ b/docs/nodes/solid/solid_index.rst
@@ -20,6 +20,7 @@ Solid
    mirror_solid
    offset_solid
    solid_from_faces
+   ruled_solid
    extrude_face
    solidify_face
    revolve_face

--- a/index.md
+++ b/index.md
@@ -230,6 +230,7 @@
    SvMirrorSolidNode
    SvOffsetSolidNode
    SvSolidFromFacesNode
+   SvRuledSolidNode
    SvSolidFaceExtrudeNode
    SvSolidFaceSolidifyNode
    SvSolidFaceRevolveNode
@@ -674,7 +675,6 @@
     SvPulgaPhysicsNode
     SvTopologySimple
     SvSweepModulator
-    SvRuledSolidNode
     ---
     SvGetPropNodeMK2
     SvSetPropNodeMK2

--- a/nodes/solid/ruled_solid.py
+++ b/nodes/solid/ruled_solid.py
@@ -101,8 +101,15 @@ class SvRuledSolidNode(bpy.types.Node, SverchCustomTreeNode):
             default = False,
             update = updateNode)
 
+    validate : BoolProperty(
+            name = "Validate",
+            description = "Make sure that the constructed body is valid in terms of OCC core",
+            default = True,
+            update = updateNode)
+
+
     precision: FloatProperty(
-            name = "Precision",
+            name = "Tolerance",
             default = 0.001,
             precision=6,
             update = updateNode)
@@ -127,7 +134,9 @@ class SvRuledSolidNode(bpy.types.Node, SverchCustomTreeNode):
 
     def draw_buttons_ext(self, context, layout):
         self.draw_buttons(context, layout)
-        layout.prop(self, 'precision')
+        layout.prop(self, 'validate')
+        if self.validate:
+            layout.prop(self, 'precision')
 
     def make_solid(self, face1, face2):
         if self.flip_face1:
@@ -161,7 +170,11 @@ class SvRuledSolidNode(bpy.types.Node, SverchCustomTreeNode):
         if not solid.isValid():
             self.debug("Resulting solid is not valid!")
             if not solid.fix(self.precision, self.precision, self.precision):
-                self.error("Solid is not valid, and is not possible to fix")
+                message = "Solid is not valid, and is not possible to fix"
+                if self.validate:
+                    raise Exception(message)
+                else:
+                    self.error(message)
         return solid
 
     def process(self):

--- a/nodes/solid/ruled_solid.py
+++ b/nodes/solid/ruled_solid.py
@@ -101,21 +101,9 @@ class SvRuledSolidNode(bpy.types.Node, SverchCustomTreeNode):
             default = False,
             update = updateNode)
 
-    precision_min: FloatProperty(
-            name = "Min Precision",
-            default = 0.01,
-            precision=6,
-            update = updateNode)
-
-    precision_max: FloatProperty(
-            name = "Max Precision",
-            default = 0.01,
-            precision=6,
-            update = updateNode)
-
-    precision_work: FloatProperty(
-            name = "Working Precision",
-            default = 0.01,
+    precision: FloatProperty(
+            name = "Precision",
+            default = 0.001,
             precision=6,
             update = updateNode)
 
@@ -139,9 +127,7 @@ class SvRuledSolidNode(bpy.types.Node, SverchCustomTreeNode):
 
     def draw_buttons_ext(self, context, layout):
         self.draw_buttons(context, layout)
-        layout.prop(self, 'precision_work')
-        layout.prop(self, 'precision_min')
-        layout.prop(self, 'precision_max')
+        layout.prop(self, 'precision')
 
     def make_solid(self, face1, face2):
         if self.flip_face1:
@@ -174,7 +160,7 @@ class SvRuledSolidNode(bpy.types.Node, SverchCustomTreeNode):
         solid = Part.makeSolid(sh)
         if not solid.isValid():
             self.debug("Resulting solid is not valid!")
-            if not solid.fix(self.precision_work, self.precision_min, self.precision_max):
+            if not solid.fix(self.precision, self.precision, self.precision):
                 self.error("Solid is not valid, and is not possible to fix")
         return solid
 

--- a/tests/docs_tests.py
+++ b/tests/docs_tests.py
@@ -155,7 +155,6 @@ vd_attr_node.py
 scalar_field_point.py
 bvh_nearest_new.py
 quads_to_nurbs.py
-ruled_solid.py
 location.py
 sun_position.py""".split("\n")
 

--- a/utils/curve/bezier.py
+++ b/utils/curve/bezier.py
@@ -312,6 +312,12 @@ class SvBezierCurve(SvCurve):
             return SvBezierCurve(points)
         return self.to_nurbs().lerp_to(curve2, coefficient)
     
+    def split_at(self, t):
+        return self.to_nurbs().split_at(t)
+
+    def cut_segment(self, new_t_min, new_t_max, rescale=False):
+        return self.to_nurbs().cut_segment(new_t_min, new_t_max, rescale=rescale)
+
     def to_bezier(self):
         return self
 
@@ -447,6 +453,12 @@ class SvCubicBezierCurve(SvCurve):
             return SvCubicBezierCurve(p1, p2, p3, p4)
         return self.to_nurbs().lerp_to(curve2, coefficient)
     
+    def split_at(self, t):
+        return self.to_nurbs().split_at(t)
+
+    def cut_segment(self, new_t_min, new_t_max, rescale=False):
+        return self.to_nurbs().cut_segment(new_t_min, new_t_max, rescale=rescale)
+
     def to_bezier(self):
         return self
 

--- a/utils/curve/splines.py
+++ b/utils/curve/splines.py
@@ -85,3 +85,9 @@ class SvSplineCurve(SvCurve):
     def lerp_to(self, curve2, coefficient):
         return self.to_nurbs().lerp_to(curve2, coefficient)
 
+    def split_at(self, t):
+        return self.to_nurbs().split_at(t)
+
+    def cut_segment(self, new_t_min, new_t_max, rescale=False):
+        return self.to_nurbs().cut_segment(new_t_min, new_t_max, rescale=rescale)
+


### PR DESCRIPTION
This node generates a Solid object from two Faces ("floor" and "ceiling") by
adding linear surfaces to connect their edges ("walls").

**NOTE**: the node requires that two Face objects provided have exactly the
same number of edges. Hint: if you are generating Faces from Curves, you can
use "Split Curve" node to increase the number of edges.

Depending on the way how you generate "floor" and "ceiling" surfaces, it can
appear that the order or the direction of their edges will be incorrect; in
such cases weird invalid bodies would be generated. To deal with such cases,
the node suggest options to reverse the order of edges, or direction of edges.

This node was tecnhically introduced in #3501, but it was placed into Alpha category.
This PR:
* adds "validate & fix" option (checked by default)
* adds documentation
* moves to Solid category.

 **NOTE**: some operations with Solid objects which are  not "valid" (in terms of FreeCAD's OCCT kernel) are known to cause crashes. So it is strongly recommended to have "Validate" parameter checked.

![Screenshot_20200921_015434](https://user-images.githubusercontent.com/284644/93722058-7ccdd680-fbad-11ea-8319-d7f3e8cf04ac.png)


## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

