### PR TITLE
hard rename variable from gl_FragColor to FragColor

### DIFF
--- a/nodes/number/easing.py
+++ b/nodes/number/easing.py
@@ -85,10 +85,10 @@ def simple28_grid_xy(x, y, args):
 
     bg_fragment_shader = '''
     uniform vec4 color;
-    out vec4 gl_FragColor;
+    out vec4 FragColor;
     void main()
     {
-       gl_FragColor = color;
+       FragColor = color;
     }
     '''
 
@@ -122,10 +122,11 @@ def simple28_grid_xy(x, y, args):
 
     line_fragment_shader = '''
     in vec4 a_color;
-
+    out vec4 FragColor;
+    
     void main()
     {
-        gl_FragColor = a_color;
+        FragColor = a_color;
     }
     '''
 

--- a/nodes/viz/vd_draw_experimental.py
+++ b/nodes/viz/vd_draw_experimental.py
@@ -48,11 +48,11 @@ default_fragment_shader = '''
     uniform float brightness;
 
     in vec3 pos;
-    out vec4 gl_FragColor;
+    out vec4 FragColor;
 
     void main()
     {
-        gl_FragColor = vec4(pos * brightness, 1.0);
+        FragColor = vec4(pos * brightness, 1.0);
     }
 '''
 

--- a/nodes/viz/viewer_2d.py
+++ b/nodes/viz/viewer_2d.py
@@ -119,10 +119,11 @@ def get_2d_uniform_color_shader():
 
     uniform_2d_fragment_shader = '''
     uniform vec4 color;
-    out vec4 gl_FragColor;
+    out vec4 FragColor;
+
     void main()
     {
-       gl_FragColor = color;
+       FragColor = color;
     }
     '''
     return gpu.types.GPUShader(uniform_2d_vertex_shader, uniform_2d_fragment_shader)
@@ -149,10 +150,10 @@ def get_2d_smooth_color_shader():
     smooth_2d_fragment_shader = '''
     in vec4 a_color;
 
-    out vec4 gl_FragColor;
+    out vec4 FragColor;
     void main()
     {
-        gl_FragColor = a_color;
+        FragColor = a_color;
     }
     '''
     return gpu.types.GPUShader(smooth_2d_vertex_shader, smooth_2d_fragment_shader)

--- a/nodes/viz/viewer_waveform_output.py
+++ b/nodes/viz/viewer_waveform_output.py
@@ -190,10 +190,11 @@ def get_2d_uniform_color_shader():
 
     uniform_2d_fragment_shader = '''
     uniform vec4 color;
-    out vec4 gl_FragColor;
+    out vec4 FragColor;
+
     void main()
     {
-       gl_FragColor = color;
+       FragColor = color;
     }
     '''
     return gpu.types.GPUShader(uniform_2d_vertex_shader, uniform_2d_fragment_shader)
@@ -219,10 +220,11 @@ def get_2d_smooth_color_shader():
 
     smooth_2d_fragment_shader = '''
     in vec4 a_color;
-    out vec4 gl_FragColor;
+    out vec4 FragColor;
+
     void main()
     {
-        gl_FragColor = a_color;
+        FragColor = a_color;
     }
     '''
     return gpu.types.GPUShader(smooth_2d_vertex_shader, smooth_2d_fragment_shader)


### PR DESCRIPTION
on some OS, in some Blender builds, Blender will automatically inject the variable "gl_FragColor", as a convenience. But not in all builds on all operating systems. This is a non workable situation. This PR defines a new output variable,, and doesn't assume `gl_FragColor` is available.

The question is.. will that be all we need to hard code?