### PR TITLE
Solid Boolean node: upgrade

### DIFF
--- a/docs/nodes/solid/solid_boolean.rst
+++ b/docs/nodes/solid/solid_boolean.rst
@@ -1,29 +1,120 @@
 Solid Boolean
 =============
 
+Dependencies
+------------
+
+This node requires FreeCAD_ library to work.
+
+.. _FreeCAD: ../../solids.rst
+
 Functionality
 -------------
 
-Offers operations like Solid Union, Difference or Intersection.
+This node performs boolean operations on Solid objects: Union ("Fuse"),
+Intersection ("Common parts"), Difference ("Cut").
 
-The node has two main working modes Regular and Accumulative Nested.
+The node can operate either on pairs of objects (like "Solid A" plus "Solid
+B"), or on lists of objects (fuse several objects at once, or cut several holes
+in a body at once). In this "Accumulative" node, the node performs as follows:
 
-In the Regular mode the operation is done between each couple of Solid A and Solid B.
+* for Union operation: fuse each list of objects into one body.
+* for Intersection operation: take only the part which belongs to **all**
+  bodies in the list.
+* for Difference operation: take the first body in the list, and use all other
+  bodies as "tools", to cut "holes" in the first body.
 
-In the Accumulative Nested mode the operation is performed along a list of solids between all of them.
+This node can also produce information about which element of the resulting
+Solid object came from which source object.Calculating such information can
+take time, so this is an optional feature.
+
+Inputs
+------
+
+This node has the following inputs:
+
+* **Solid A**. The first Solid object to perform operation on. This input is
+  available and mandatory only if **Accumulate nested** parameter is not
+  checked. This input can consume data with nesting level 1 or 2, i.e. lists of
+  Solids or lists of lists of Solids.
+* **Solid B**. The second Solid object to perform operation on. This input is
+  available and mandatory only if **Accumulate nested** parameter is not
+  checked. This input can consume data with nesting level 1 or 2, i.e. lists of
+  Solids or lists of lists of Solids.
+* **Solids**. List of Solid objects to perform operation on. This input is
+  available and mandatory only if **Accumulate nested** parameter is checked.
+  This input can consume data with nesting level 1 or 2, i.e. lists of Solids
+  or lists of lists of Solids. The node will make one Solid out of each list of
+  Solids.
 
 Options
 -------
 
-The Union mode offers a 'Refine Solid' option to clean unnecessary edges
+This node has the following parameters:
+
+* **Operation**. Boolean operation to perform. The available options are:
+  **Intersect**, **Union**, **Difference**. The default option is
+  **Intersect**.
+* **Generate Masks**. If checked, the node will generate information about
+  which element of the resulting Solid came from which solid object. Unchecked
+  by default.
+* **Accumulate nested**. If checked, the node will operate on pairs of objects,
+  so **Solid A** and **Solid B** inputs will be available. Otherwise, the node
+  will operate on lists of objects (of arbitrary length), so **Solids** input
+  will be available. Unchecked by default.
+* **Refine Solid**. If checked, the node will refine the generated Solid
+  object, by removing unnecessary edges. In many cases this is required, but in
+  cases when this is not required this will only take time. This parameter is
+  available only if **Operation** parameter is set to **Union**. Checked by
+  default.
 
 Outputs
 -------
 
-- Solid
+This node has the following outputs:
+
+* **Solid**. The resulting Solid object. If **Accumulate nested** parameter is
+  checked, then this output will always contain data of nesting level 1
+  (list of Solids). If **Accumulate nested** parameter is not checked, then
+  this output will contain data of nesting level corresponding to nesting level
+  in the **Solids A** and **Solids B** inputs, considering the node makes one
+  Solid out of each pair of Solids.
+* **EdgesMask**. Mask for Edges of generated Solid object, which is True for
+  edges that come from more than one source object. For **Intersect**
+  operation, this mask will always contain all True. This output is only
+  available when **Generate Masks** parameter is checked.
+* **EdgeSources**. For each Edge of generated Solid object, this output
+  contains a list of indexes of source objects, from which this edge came. See
+  more detailed explanation below. This output is only available when
+  **Generate Masks** parameter is checked.
+* **FacesMask**. Mask for Faces of generated Solid object, which is True for
+  faces that come from more than one source object. For Union operation, this
+  output contains all False, because all "common" faces are always inside the
+  body. This output is only available when **Generate Masks** parameter is
+  checked.
+* **FaceSources**. For each Face of generated Solid object, this output
+  contains a list of indexes of source objects, from which this face came.
+  This output is only available when **Generate Masks** parameter is checked.
+
+The following illustrates how **EdgeSources** output is calculated:
+
+.. image:: https://user-images.githubusercontent.com/284644/94042893-8ccffb00-fde5-11ea-938e-328df1d65d7e.png
+
+Here we have two cubes, 0 (plugged into Solid A input), and 1 (plugged into
+Solid B input). Purple edges came from cube 0, for them EdgeSources output
+contains ``[0]``. Orange edges came from cube 1, for them EdgeSources output
+contains ``[1]``. Edges marked with cyan came from both cubes, for them
+EdgeSources output contains ``[0, 1]``.
+
+FaceSources output is calculated similarly, but for faces instead of edges.
 
 
 Examples
 --------
 
 .. image:: https://raw.githubusercontent.com/vicdoval/sverchok/docs_images/images_for_docs/solid/solid_boolean/solid_boolean_blender_sverchok_example.png
+
+Example of **EdgesMask** output usage:
+
+.. image:: https://user-images.githubusercontent.com/284644/94038496-f1885700-fddf-11ea-93e6-894aea236ef8.png
+

--- a/docs/nodes/solid/solid_boolean.rst
+++ b/docs/nodes/solid/solid_boolean.rst
@@ -118,3 +118,7 @@ Example of **EdgesMask** output usage:
 
 .. image:: https://user-images.githubusercontent.com/284644/94038496-f1885700-fddf-11ea-93e6-894aea236ef8.png
 
+Example of **EdgeSources** output usage. Take five cubes, fuse them, then select only edges that came from intersection of cubes number 1 and 2 (starting from zero), and make fillet for them:
+
+.. image:: https://user-images.githubusercontent.com/284644/94045977-82176500-fde9-11ea-9c9d-2bce61012280.png
+

--- a/nodes/solid/solid_boolean.py
+++ b/nodes/solid/solid_boolean.py
@@ -140,6 +140,10 @@ class SvSolidBooleanNode(bpy.types.Node, SverchCustomTreeNode):
     def make_solid_general(self, solids):
         do_refine = self.refine_solid and self.selected_mode in {'UNION'}
 
+        for i in range(len(solids)):
+            if not isinstance(solids[i], Part.Solid):
+                solids[i] = Part.makeSolid(solids[i])
+
         fused = SvGeneralFuse(solids)
         if self.selected_mode == 'UNION':
             solid = fused.get_union_all(refine=do_refine)

--- a/nodes/solid/solid_boolean.py
+++ b/nodes/solid/solid_boolean.py
@@ -47,12 +47,6 @@ class SvSolidBooleanNode(bpy.types.Node, SverchCustomTreeNode):
     sv_icon = 'SV_SOLID_BOOLEAN'
     solid_catergory = "Operators"
 
-    precision: FloatProperty(
-        name="Length",
-        default=0.1,
-        precision=4,
-        update=updateNode)
-
     mode_options = [
         ("ITX", "Intersect", "", 0),
         ("UNION", "Union", "", 1),

--- a/nodes/solid/solid_boolean.py
+++ b/nodes/solid/solid_boolean.py
@@ -1,156 +1,138 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
 
+import bpy
+from bpy.props import BoolProperty, FloatProperty, EnumProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode, match_long_repeat as mlr, zip_long_repeat, ensure_nesting_level, get_data_nesting_level
 from sverchok.dependencies import FreeCAD
 from sverchok.utils.dummy_nodes import add_dummy
 
 if FreeCAD is None:
     add_dummy('SvSolidBooleanNode', 'Solid Boolean', 'FreeCAD')
 else:
-    import bpy
-    from bpy.props import BoolProperty, FloatProperty, EnumProperty
-    from sverchok.node_tree import SverchCustomTreeNode
-    from sverchok.data_structure import updateNode, match_long_repeat as mlr
     import Part
 
-    class SvSolidBooleanNode(bpy.types.Node, SverchCustomTreeNode):
-        """
-        Triggers: Union, Diff, Intersect
-        Tooltip: Perform Boolean Operations on Solids
-        """
-        bl_idname = 'SvSolidBooleanNode'
-        bl_label = 'Solid Boolean'
-        bl_icon = 'OUTLINER_OB_EMPTY'
-        sv_icon = 'SV_SOLID_BOOLEAN'
-        solid_catergory = "Operators"
+class SvSolidBooleanNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: Union, Diff, Intersect
+    Tooltip: Perform Boolean Operations on Solids
+    """
+    bl_idname = 'SvSolidBooleanNode'
+    bl_label = 'Solid Boolean'
+    bl_icon = 'OUTLINER_OB_EMPTY'
+    sv_icon = 'SV_SOLID_BOOLEAN'
+    solid_catergory = "Operators"
 
+    precision: FloatProperty(
+        name="Length",
+        default=0.1,
+        precision=4,
+        update=updateNode)
 
-        precision: FloatProperty(
-            name="Length",
-            default=0.1,
-            precision=4,
-            update=updateNode)
-        mode_options = [
-            ("ITX", "Intersect", "", 0),
-            ("UNION", "Union", "", 1),
-            ("DIFF", "Difference", "", 2)
-            ]
+    mode_options = [
+        ("ITX", "Intersect", "", 0),
+        ("UNION", "Union", "", 1),
+        ("DIFF", "Difference", "", 2)
+        ]
 
-        selected_mode: EnumProperty(
-            name='Operation',
-            items=mode_options,
-            description="basic booleans using solids",
-            default="ITX",
-            update=updateNode)
+    selected_mode: EnumProperty(
+        name='Operation',
+        items=mode_options,
+        description="basic booleans using solids",
+        default="ITX",
+        update=updateNode)
 
-        def update_mode(self, context):
-            self.inputs['Solid A'].hide_safe = self.nest_objs
-            self.inputs['Solid B'].hide_safe = self.nest_objs
-            self.inputs['Solids'].hide_safe = not self.nest_objs
-            updateNode(self, context)
+    def update_mode(self, context):
+        self.inputs['Solid A'].hide_safe = self.nest_objs
+        self.inputs['Solid B'].hide_safe = self.nest_objs
+        self.inputs['Solids'].hide_safe = not self.nest_objs
+        updateNode(self, context)
 
-        nest_objs: BoolProperty(
-            name="Accumulate nested",
-            description="bool first two solids, then applies rest to result one by one",
-            default=False,
-            update=update_mode)
-        refine_solid: BoolProperty(
-            name="Refine Solid",
-            description="Removes redundant edges (may slow the process)",
-            default=True,
-            update=updateNode)
+    nest_objs: BoolProperty(
+        name="Accumulate nested",
+        description="bool first two solids, then applies rest to result one by one",
+        default=False,
+        update=update_mode)
 
-        def draw_buttons(self, context, layout):
-            layout.prop(self, "selected_mode", toggle=True)
-            layout.prop(self, "nest_objs", toggle=True)
-            if self.selected_mode == 'UNION':
-                layout.prop(self, "refine_solid")
+    refine_solid: BoolProperty(
+        name="Refine Solid",
+        description="Removes redundant edges (may slow the process)",
+        default=True,
+        update=updateNode)
 
-        def sv_init(self, context):
-            self.inputs.new('SvSolidSocket', "Solid A")
-            self.inputs.new('SvSolidSocket', "Solid B")
-            self.inputs.new('SvSolidSocket', "Solids")
-            self.inputs['Solids'].hide_safe = True
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "selected_mode", toggle=True)
+        layout.prop(self, "nest_objs", toggle=True)
+        if self.selected_mode == 'UNION':
+            layout.prop(self, "refine_solid")
 
+    def sv_init(self, context):
+        self.inputs.new('SvSolidSocket', "Solid A")
+        self.inputs.new('SvSolidSocket', "Solid B")
+        self.inputs.new('SvSolidSocket', "Solids")
+        self.inputs['Solids'].hide_safe = True
 
-            self.outputs.new('SvSolidSocket', "Solid")
+        self.outputs.new('SvSolidSocket', "Solid")
 
+    def make_solid(self, solids):
+        do_refine = self.refine_solid and self.selected_mode in {'UNION'}
+        base = solids[0].copy()
+        rest = solids[1:]
+        if self.selected_mode == 'UNION':
+            solid = base.fuse(rest)
+        elif sel.selected_mode == 'ITX':
+            solid = base.common(rest)
+        elif self.selected_mode == 'DIFF':
+            solid = base.cut(rest)
+        else:
+            raise Exception("Unknown mode")
+        if do_refine:
+            solid = solid.removeSplitter()
+        return solid
 
+    def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
 
-        def single_union(self):
-            solids_a = self.inputs[0].sv_get()
-            solids_b = self.inputs[1].sv_get()
-            solids = []
-            for solid_a, solid_b in zip(*mlr([solids_a, solids_b])):
-                solid_out = solid_a.fuse(solid_b)
-                if self.refine_solid:
-                    solid_out = solid_out.removeSplitter()
-                solids.append(solid_out)
-            self.outputs[0].sv_set(solids)
+        solids_out = []
+        if self.nest_objs:
+            solids_in = self.inputs['Solids'].sv_get()
+            #level = get_data_nesting_level(solids_in, data_types=(Part.Shape,))
+            solids_in = ensure_nesting_level(solids_in, 2, data_types=(Part.Shape,))
 
-        def multi_union(self):
-            solids = self.inputs[2].sv_get()
-            base = solids[0].copy()
-            base = base.fuse(solids[1:])
-#             for s in solids[1:]:
-#                 base = base.fuse(s)
-            if self.refine_solid:
-                base = base.removeSplitter()
-            self.outputs[0].sv_set([base])
+            for solids in solids_in:
+                solid = self.make_solid(solids)
+                solids_out.append(solid)
 
-        def single_intersect(self):
-            solids_a = self.inputs[0].sv_get()
-            solids_b = self.inputs[1].sv_get()
-            solids = []
-            for solid_a, solid_b in zip(*mlr([solids_a, solids_b])):
-                solids.append(solid_a.common(solid_b))
-            self.outputs[0].sv_set(solids)
+            self.outputs['Solid'].sv_set(solids_out)
 
-        def multi_intersect(self):
-            solids = self.inputs[2].sv_get()
-            base = solids[0].copy()
-            base = base.common(solids[1:])
-#             for s in solids[1:]:
-#                 base = base.common(s)
-            self.outputs[0].sv_set([base])
+        else:
+            solids_a_in = self.inputs['Solid A'].sv_get()
+            solids_b_in = self.inputs['Solid B'].sv_get()
+            level_a = get_data_nesting_level(solids_a_in, data_types=(Part.Shape,))
+            level_b = get_data_nesting_level(solids_b_in, data_types=(Part.Shape,))
+            solids_a_in = ensure_nesting_level(solids_a_in, 2, data_types=(Part.Shape,))
+            solids_b_in = ensure_nesting_level(solids_b_in, 2, data_types=(Part.Shape,))
+            level = max(level_a, level_b)
 
-        def single_difference(self):
-            solids_a = self.inputs[0].sv_get()
-            solids_b = self.inputs[1].sv_get()
-            solids = []
-            for solid_a, solid_b in zip(*mlr([solids_a, solids_b])):
-                shape = solid_a.cut(solid_b)
-
-                solids.append(shape)
-            self.outputs[0].sv_set(solids)
-
-        def multi_difference(self):
-            solids = self.inputs[2].sv_get()
-            base = solids[0].copy()
-            base = base.cut(solids[1:])
-#             for s in solids[1:]:
-#                 base = base.cut(s)
-
-            self.outputs[0].sv_set([base])
-
-        def process(self):
-            if not any(socket.is_linked for socket in self.outputs):
-                return
-
-            if self.selected_mode == 'UNION':
-                if self.nest_objs:
-                    self.multi_union()
+            solids_out = []
+            for params in zip_long_repeat(solids_a_in, solids_b_in):
+                new_solids = []
+                for solid_a, solid_b in zip_long_repeat(*params):
+                    solid = self.make_solid([solid_a, solid_b])
+                    new_solids.append(solid)
+                if level == 1:
+                    solids_out.extend(new_solids)
                 else:
-                    self.single_union()
-            elif self.selected_mode == 'ITX':
-                if self.nest_objs:
-                    self.multi_intersect()
-                else:
-                    self.single_intersect()
-            else:
-                if self.nest_objs:
-                    self.multi_difference()
-                else:
-                    self.single_difference()
+                    solids_out.append(new_solids)
 
+            self.outputs['Solid'].sv_set(solids_out)
 
 def register():
     if FreeCAD is not None:

--- a/utils/solid.py
+++ b/utils/solid.py
@@ -234,6 +234,7 @@ class SvGeneralFuse(object):
 
             for item in items:
                 self._sources_by_part[item].add(src_key)
+                #print(f"{src_idx}: P[{item}] := {src_key}")
                 self._source_idxs_by_part[item].add(src_idx)
         
         self._edge_indirect_source_idxs = defaultdict(set)
@@ -244,6 +245,7 @@ class SvGeneralFuse(object):
             item = SvSolidTopology.Item(part)
             sources = self._sources_by_part[item]
             src_idxs = self._source_idxs_by_part[item]
+            #print(f"P? {item} => {src_idxs}")
 
             for edge in part.Edges:
                 edge_item = SvSolidTopology.Item(edge)

--- a/utils/solid.py
+++ b/utils/solid.py
@@ -22,267 +22,345 @@ if FreeCAD is not None:
     from FreeCAD import Base
     from sverchok.nodes.solid.mesh_to_solid import ensure_triangles
 
-    class SvSolidTopology(object):
-        class Item(object):
-            def __init__(self, item):
-                self.item = item
+class SvSolidTopology(object):
+    class Item(object):
+        def __init__(self, item):
+            self.item = item
 
-            def __hash__(self):
-                return self.item.hashCode()
+        def __hash__(self):
+            return self.item.hashCode()
 
-            def __eq__(self, other):
-                return self.item.isSame(other.item)
-
-            def __repr__(self):
-                return f"<Item: {type(self.item).__name__} #{self.item.hashCode()}>"
-
-        def __init__(self, solid):
-            self.solid = solid
-            self._init()
+        def __eq__(self, other):
+            return self.item.isSame(other.item)
 
         def __repr__(self):
-            v = len(self.solid.Vertexes)
-            e = len(self.solid.Edges)
-            f = len(self.solid.Faces)
-            return f"<Solid topology: {v} vertices, {e} edges, {f} faces>"
+            return f"<Item: {type(self.item).__name__} #{self.item.hashCode()}>"
 
-        def _init(self):
-            self._faces_by_vertex = defaultdict(set)
-            self._faces_by_edge = defaultdict(set)
-            self._edges_by_vertex = defaultdict(set)
+    def __init__(self, solid):
+        self.solid = solid
+        self._init()
 
-            for face in self.solid.Faces:
-                for vertex in face.Vertexes:
-                    self._faces_by_vertex[SvSolidTopology.Item(vertex)].add(SvSolidTopology.Item(face))
-                for edge in face.Edges:
-                    self._faces_by_edge[SvSolidTopology.Item(edge)].add(SvSolidTopology.Item(face))
-            
-            for edge in self.solid.Edges:
-                for vertex in edge.Vertexes:
-                    self._edges_by_vertex[SvSolidTopology.Item(vertex)].add(SvSolidTopology.Item(edge))
+    def __repr__(self):
+        v = len(self.solid.Vertexes)
+        e = len(self.solid.Edges)
+        f = len(self.solid.Faces)
+        return f"<Solid topology: {v} vertices, {e} edges, {f} faces>"
 
-            self._tree = KDTree(len(self.solid.Vertexes))
-            for i, vertex in enumerate(self.solid.Vertexes):
-                co = (vertex.X, vertex.Y, vertex.Z)
-                self._tree.insert(co, i)
-            self._tree.balance()
+    def _init(self):
+        self._faces_by_vertex = defaultdict(set)
+        self._faces_by_edge = defaultdict(set)
+        self._edges_by_vertex = defaultdict(set)
 
-        def tessellate(self, precision):
-            self._points_by_edge = defaultdict(list)
-            self._points_by_face = defaultdict(list)
+        for face in self.solid.Faces:
+            for vertex in face.Vertexes:
+                self._faces_by_vertex[SvSolidTopology.Item(vertex)].add(SvSolidTopology.Item(face))
+            for edge in face.Edges:
+                self._faces_by_edge[SvSolidTopology.Item(edge)].add(SvSolidTopology.Item(face))
+        
+        for edge in self.solid.Edges:
+            for vertex in edge.Vertexes:
+                self._edges_by_vertex[SvSolidTopology.Item(vertex)].add(SvSolidTopology.Item(edge))
 
-            for edge in self.solid.Edges:
-                points = edge.discretize(Deflection=precision)
-                i_edge = SvSolidTopology.Item(edge)
-                for pt in points:
-                    self._points_by_edge[i_edge].append((pt.x, pt.y, pt.z))
+        self._tree = KDTree(len(self.solid.Vertexes))
+        for i, vertex in enumerate(self.solid.Vertexes):
+            co = (vertex.X, vertex.Y, vertex.Z)
+            self._tree.insert(co, i)
+        self._tree.balance()
 
-            for face in self.solid.Faces:
-                data = face.tessellate(precision)
-                i_face = SvSolidTopology.Item(face)
-                for pt in data[0]:
-                    self._points_by_face[i_face].append((pt.x, pt.y, pt.z))
+    def tessellate(self, precision):
+        self._points_by_edge = defaultdict(list)
+        self._points_by_face = defaultdict(list)
 
-        def calc_normals(self):
-            self._normals_by_face = dict()
-            for face in self.solid.Faces:
-                #face.tessellate(precision)
-                #u_min, u_max, v_min, v_max = face.ParameterRange
-                sum_normal = Base.Vector(0,0,0)
-                for u, v in face.getUVNodes():
-                    normal = face.normalAt(u,v)
-                    sum_normal = sum_normal + normal
-                sum_normal = np.array([sum_normal.x, sum_normal.y, sum_normal.z])
-                sum_normal = sum_normal / np.linalg.norm(sum_normal)
-                self._normals_by_face[SvSolidTopology.Item(face)] = sum_normal
+        for edge in self.solid.Edges:
+            points = edge.discretize(Deflection=precision)
+            i_edge = SvSolidTopology.Item(edge)
+            for pt in points:
+                self._points_by_edge[i_edge].append((pt.x, pt.y, pt.z))
 
-        def get_normal_by_face(self, face):
-            return self._normals_by_face[SvSolidTopology.Item(face)]
+        for face in self.solid.Faces:
+            data = face.tessellate(precision)
+            i_face = SvSolidTopology.Item(face)
+            for pt in data[0]:
+                self._points_by_face[i_face].append((pt.x, pt.y, pt.z))
 
-        def get_vertices_by_location(self, condition):
-            to_tuple = lambda v : (v.X, v.Y, v.Z)
-            return [to_tuple(v) for v in self.solid.Vertexes if condition(to_tuple(v))]
+    def calc_normals(self):
+        self._normals_by_face = dict()
+        for face in self.solid.Faces:
+            #face.tessellate(precision)
+            #u_min, u_max, v_min, v_max = face.ParameterRange
+            sum_normal = Base.Vector(0,0,0)
+            for u, v in face.getUVNodes():
+                normal = face.normalAt(u,v)
+                sum_normal = sum_normal + normal
+            sum_normal = np.array([sum_normal.x, sum_normal.y, sum_normal.z])
+            sum_normal = sum_normal / np.linalg.norm(sum_normal)
+            self._normals_by_face[SvSolidTopology.Item(face)] = sum_normal
 
-        def get_vertices_by_location_mask(self, condition):
-            to_tuple = lambda v : (v.X, v.Y, v.Z)
-            return [condition(to_tuple(v)) for v in self.solid.Vertexes]
+    def get_normal_by_face(self, face):
+        return self._normals_by_face[SvSolidTopology.Item(face)]
 
-        def get_points_by_edge(self, edge):
-            return self._points_by_edge[SvSolidTopology.Item(edge)]
+    def get_vertices_by_location(self, condition):
+        to_tuple = lambda v : (v.X, v.Y, v.Z)
+        return [to_tuple(v) for v in self.solid.Vertexes if condition(to_tuple(v))]
 
-        def get_points_by_face(self, face):
-            return self._points_by_face[SvSolidTopology.Item(face)]
+    def get_vertices_by_location_mask(self, condition):
+        to_tuple = lambda v : (v.X, v.Y, v.Z)
+        return [condition(to_tuple(v)) for v in self.solid.Vertexes]
 
-        def get_edges_by_location_mask(self, condition, include_partial):
-            # condition is vectorized
-            check = any if include_partial else all
+    def get_points_by_edge(self, edge):
+        return self._points_by_edge[SvSolidTopology.Item(edge)]
+
+    def get_points_by_face(self, face):
+        return self._points_by_face[SvSolidTopology.Item(face)]
+
+    def get_edges_by_location_mask(self, condition, include_partial):
+        # condition is vectorized
+        check = any if include_partial else all
+        mask = []
+        for edge in self.solid.Edges:
+            test = condition(np.array(self._points_by_edge[SvSolidTopology.Item(edge)]))
+            mask.append(check(test))
+        return mask
+
+    def get_faces_by_location_mask(self, condition, include_partial):
+        # condition is vectorized
+        check = any if include_partial else all
+        mask = []
+        for face in self.solid.Faces:
+            test = condition(np.array(self._points_by_face[SvSolidTopology.Item(face)]))
+            mask.append(check(test))
+        return mask
+
+    def get_faces_by_vertex(self, vertex):
+        return [i.item for i in self._faces_by_vertex[SvSolidTopology.Item(vertex)]]
+
+    def get_faces_by_vertices_mask(self, vertices, include_partial=True):
+        if include_partial:
+            good = set()
+            for vertex in vertices:
+                new = self._faces_by_vertex[SvSolidTopology.Item(vertex)]
+                good.update(new)
+            return [SvSolidTopology.Item(face) in good for face in self.solid.Faces]
+        else:
+            vertices = set([SvSolidTopology.Item(v) for v in vertices])
             mask = []
-            for edge in self.solid.Edges:
-                test = condition(np.array(self._points_by_edge[SvSolidTopology.Item(edge)]))
-                mask.append(check(test))
+            for face in self.solid.Faces:
+                ok = all(SvSolidTopology.Item(v) in vertices for v in face.Vertexes)
+                mask.append(ok)
             return mask
 
-        def get_faces_by_location_mask(self, condition, include_partial):
-            # condition is vectorized
-            check = any if include_partial else all
-            mask = []
-            for face in self.solid.Faces:
-                test = condition(np.array(self._points_by_face[SvSolidTopology.Item(face)]))
-                mask.append(check(test))
-            return mask
+    def get_faces_by_edge(self, edge):
+        return [i.item for i in self._faces_by_edge[SvSolidTopology.Item(edge)]]
 
-        def get_faces_by_vertex(self, vertex):
-            return [i.item for i in self._faces_by_vertex[SvSolidTopology.Item(vertex)]]
-
-        def get_faces_by_vertices_mask(self, vertices, include_partial=True):
-            if include_partial:
-                good = set()
-                for vertex in vertices:
-                    new = self._faces_by_vertex[SvSolidTopology.Item(vertex)]
-                    good.update(new)
-                return [SvSolidTopology.Item(face) in good for face in self.solid.Faces]
-            else:
-                vertices = set([SvSolidTopology.Item(v) for v in vertices])
-                mask = []
-                for face in self.solid.Faces:
-                    ok = all(SvSolidTopology.Item(v) in vertices for v in face.Vertexes)
-                    mask.append(ok)
-                return mask
-
-        def get_faces_by_edge(self, edge):
-            return [i.item for i in self._faces_by_edge[SvSolidTopology.Item(edge)]]
-
-        def get_faces_by_edges_mask(self, edges, include_partial=True):
-            if include_partial:
-                good = set()
-                for edge in edges:
-                    new = self._faces_by_edge[SvSolidTopology.Item(edge)]
-                    good.update(new)
-                return [SvSolidTopology.Item(face) in good for face in self.solid.Faces]
-            else:
-                edges = set([SvSolidTopology.Item(e) for e in edges])
-                mask = []
-                for face in self.solid.Faces:
-                    ok = all(SvSolidTopology.Item(e) in edges for e in face.Edges)
-                    mask.append(ok)
-                return mask
-
-        def get_edges_by_vertex(self, vertex):
-            return [i.item for i in self._edges_by_vertex[SvSolidTopology.Item(vertex)]]
-
-        def get_edges_by_vertices_mask(self, vertices, include_partial=True):
-            if include_partial:
-                good = set()
-                for vertex in vertices:
-                    new = self._edges_by_vertex[SvSolidTopology.Item(vertex)]
-                    good.update(new)
-                return [SvSolidTopology.Item(edge) in good for edge in self.solid.Edges]
-            else:
-                vertices = set([SvSolidTopology.Item(v) for v in vertices])
-                mask = []
-                for edge in self.solid.Edges:
-                    ok = all(SvSolidTopology.Item(v) in vertices for v in edge.Vertexes)
-                    mask.append(ok)
-                return mask
-
-        def get_edges_by_faces_mask(self, faces):
-            good = set()
-            for face in faces:
-                new = set([SvSolidTopology.Item(e) for e in face.Edges])
-                good.update(new)
-            return [SvSolidTopology.Item(edge) in good for edge in self.solid.Edges]
-
-        def get_vertices_by_faces_mask(self, faces):
-            good = set()
-            for face in faces:
-                new = set([SvSolidTopology.Item(v) for v in face.Vertexes])
-                good.update(new)
-            return [SvSolidTopology.Item(vertex) in good for vertex in self.solid.Vertexes]
-
-        def get_vertices_by_edges_mask(self, edges):
+    def get_faces_by_edges_mask(self, edges, include_partial=True):
+        if include_partial:
             good = set()
             for edge in edges:
-                new = set([SvSolidTopology.Item(v) for v in edge.Vertexes])
+                new = self._faces_by_edge[SvSolidTopology.Item(edge)]
                 good.update(new)
-            return [SvSolidTopology.Item(vertex) in good for vertex in self.solid.Vertexes]
+            return [SvSolidTopology.Item(face) in good for face in self.solid.Faces]
+        else:
+            edges = set([SvSolidTopology.Item(e) for e in edges])
+            mask = []
+            for face in self.solid.Faces:
+                ok = all(SvSolidTopology.Item(e) in edges for e in face.Edges)
+                mask.append(ok)
+            return mask
 
-        def get_vertices_within_range(self, origin, distance):
-            found = self._tree.find_range(tuple(origin), distance)
-            idxs = [item[1] for item in found]
-            vertices = [self.solid.Vertexes[i] for i in idxs]
-            return vertices
+    def get_edges_by_vertex(self, vertex):
+        return [i.item for i in self._edges_by_vertex[SvSolidTopology.Item(vertex)]]
 
-        def get_vertices_within_range_mask(self, origin, distance):
-            found = self._tree.find_range(tuple(origin), distance)
-            idxs = set([item[1] for item in found])
-            return [i in idxs for i in range(len(self.solid.Vertexes))]
+    def get_edges_by_vertices_mask(self, vertices, include_partial=True):
+        if include_partial:
+            good = set()
+            for vertex in vertices:
+                new = self._edges_by_vertex[SvSolidTopology.Item(vertex)]
+                good.update(new)
+            return [SvSolidTopology.Item(edge) in good for edge in self.solid.Edges]
+        else:
+            vertices = set([SvSolidTopology.Item(v) for v in vertices])
+            mask = []
+            for edge in self.solid.Edges:
+                ok = all(SvSolidTopology.Item(v) in vertices for v in edge.Vertexes)
+                mask.append(ok)
+            return mask
 
-    def basic_mesher(solids, precisions):
-        verts = []
-        faces = []
-        for solid, precision in zip(*mlr([solids, precisions])):
-            rawdata = solid.tessellate(precision)
-            b_verts = []
-            b_faces = []
-            for v in rawdata[0]:
-                b_verts.append((v.x, v.y, v.z))
-            for f in rawdata[1]:
-                b_faces.append(f)
-            verts.append(b_verts)
-            faces.append(b_faces)
+    def get_edges_by_faces_mask(self, faces):
+        good = set()
+        for face in faces:
+            new = set([SvSolidTopology.Item(e) for e in face.Edges])
+            good.update(new)
+        return [SvSolidTopology.Item(edge) in good for edge in self.solid.Edges]
 
-        return verts, faces
+    def get_vertices_by_faces_mask(self, faces):
+        good = set()
+        for face in faces:
+            new = set([SvSolidTopology.Item(v) for v in face.Vertexes])
+            good.update(new)
+        return [SvSolidTopology.Item(vertex) in good for vertex in self.solid.Vertexes]
 
-    def standard_mesher(solids, surface_deviation, angle_deviation, relative_surface_deviation):
-        verts = []
-        faces = []
-        for solid, s_dev, ang_dev in zip(*mlr([solids, surface_deviation, angle_deviation])):
-            mesh = MeshPart.meshFromShape(
-                Shape=solid,
-                LinearDeflection=s_dev,
-                AngularDeflection=math.radians(ang_dev),
-                Relative=relative_surface_deviation)
+    def get_vertices_by_edges_mask(self, edges):
+        good = set()
+        for edge in edges:
+            new = set([SvSolidTopology.Item(v) for v in edge.Vertexes])
+            good.update(new)
+        return [SvSolidTopology.Item(vertex) in good for vertex in self.solid.Vertexes]
 
-            verts.append([v[:] for v in mesh.Topology[0]])
-            faces.append(mesh.Topology[1])
+    def get_vertices_within_range(self, origin, distance):
+        found = self._tree.find_range(tuple(origin), distance)
+        idxs = [item[1] for item in found]
+        vertices = [self.solid.Vertexes[i] for i in idxs]
+        return vertices
 
-        return verts, faces
+    def get_vertices_within_range_mask(self, origin, distance):
+        found = self._tree.find_range(tuple(origin), distance)
+        idxs = set([item[1] for item in found])
+        return [i in idxs for i in range(len(self.solid.Vertexes))]
 
-    def mefisto_mesher(solids, max_edge_length):
+class SvGeneralFuse(object):
+    def __init__(self, solids):
+        self.solids = solids
+        self.result, self.map = solids[0].generalFuse(solids[1:])
+        self._per_source = defaultdict(set)
+        self._per_source_idx = defaultdict(set)
+        for i, (source, items) in enumerate(zip(solids, self.map)):
+            items = set(SvSolidTopology.Item(i) for i in items)
+            key = SvSolidTopology.Item(source)
+            self._per_source[key] = items
+            self._per_source_idx[i] = items
+        
+        self._edge_sources = defaultdict(list)
+        for part in self.result.Solids:
+            for edge in part.Edges:
+                self._edge_sources[SvSolidTopology.Item(edge)].append(part)
+    
+    def get_all_parts(self):
+        return self.result.Solids
+    
+    def get_union_all(self):
+        solids = self.result.Solids
+        return solids[0].fuse(solids[1:])
 
-        verts = []
-        faces = []
-        for solid, max_edge in zip(*mlr([solids, max_edge_length])):
-            mesh = MeshPart.meshFromShape(
-                Shape=solid,
-                MaxLength=max_edge
-                )
+    def get_intersect_all(self):
+        result = None
+        for source, parts in self._per_source.items():
+            if result is None:
+                result = parts
+            else:
+                result.intersection_update(parts)
+        if not result:
+            return None
+        elif len(result) == 1:
+            return list(result)[0]
+        else:
+            solids = list(result)
+            return solids[0].fuse(solids[1:])
+    
+    def get_edge_sources(self, edge):
+        return self._edge_sources[SvSolidTopology.Item(edge)]
+    
+    def get_by_source(self, solid):
+        return self._per_source[SvSolidTopology.Item(solid)]
+    
+    def get_by_source_idx(self, idx):
+        return self._per_source_idx[idx]
+    
+    def get_intersection(self, solid_a, solid_b):
+        result_a = self._per_source[SvSolidTopology.Item(solid_a)]
+        result_b = self._per_source[SvSolidTopology.Item(solid_b)]
+        return result_a.intersection(result_b)
+    
+    def get_intersection_by_idx(self, idx_a, idx_b):
+        result_a = self._per_source_idx[idx_a]
+        result_b = self._per_source_idx[idx_b]
+        return result_a.intersection(result_b)
+    
+    def get_difference(self, solid_a, solid_b):
+        result_a = self._per_source[SvSolidTopology.Item(solid_a)]
+        result_b = self._per_source[SvSolidTopology.Item(solid_b)]
+        return result_a.difference(result_b)
+    
+    def get_clean_part(self, solid):
+        item = SvSolidTopology.Item(solid)
+        result = self._per_source[item].copy()
+        for source, results in self._per_source.items():
+            if source != item:
+                result.difference_update(results)
+        return result
+    
+    def get_clean_part_by_idx(self, idx):
+        result = self._per_source_idx[idx].copy()
+        for source_idx, results in self._per_source_idx.items():
+            if source_idx != idx:
+                result.difference_update(results)
+        return result
 
-            verts.append([v[:] for v in mesh.Topology[0]])
-            faces.append(mesh.Topology[1])
+def basic_mesher(solids, precisions):
+    verts = []
+    faces = []
+    for solid, precision in zip(*mlr([solids, precisions])):
+        rawdata = solid.tessellate(precision)
+        b_verts = []
+        b_faces = []
+        for v in rawdata[0]:
+            b_verts.append((v.x, v.y, v.z))
+        for f in rawdata[1]:
+            b_faces.append(f)
+        verts.append(b_verts)
+        faces.append(b_faces)
 
-        return verts, faces
+    return verts, faces
+
+def standard_mesher(solids, surface_deviation, angle_deviation, relative_surface_deviation):
+    verts = []
+    faces = []
+    for solid, s_dev, ang_dev in zip(*mlr([solids, surface_deviation, angle_deviation])):
+        mesh = MeshPart.meshFromShape(
+            Shape=solid,
+            LinearDeflection=s_dev,
+            AngularDeflection=math.radians(ang_dev),
+            Relative=relative_surface_deviation)
+
+        verts.append([v[:] for v in mesh.Topology[0]])
+        faces.append(mesh.Topology[1])
+
+    return verts, faces
+
+def mefisto_mesher(solids, max_edge_length):
+
+    verts = []
+    faces = []
+    for solid, max_edge in zip(*mlr([solids, max_edge_length])):
+        mesh = MeshPart.meshFromShape(
+            Shape=solid,
+            MaxLength=max_edge
+            )
+
+        verts.append([v[:] for v in mesh.Topology[0]])
+        faces.append(mesh.Topology[1])
+
+    return verts, faces
 
 
-    def svmesh_to_solid(verts, faces, precision, remove_splitter=True):
-        """
-        input:
-            verts: list of 3element iterables, [vector, vector...]
-            faces: list of lists of face indices
-            precision: a conversion factor defined in makeShapeFromMesh (FreeCAD)
-            remove_splitter: default True, removes duplicate geometry (edges)
-        output:
-            a FreeCAD solid
+def svmesh_to_solid(verts, faces, precision, remove_splitter=True):
+    """
+    input:
+        verts: list of 3element iterables, [vector, vector...]
+        faces: list of lists of face indices
+        precision: a conversion factor defined in makeShapeFromMesh (FreeCAD)
+        remove_splitter: default True, removes duplicate geometry (edges)
+    output:
+        a FreeCAD solid
 
-        """
-        tri_faces = ensure_triangles(verts, faces, True)
-        faces_t = [[verts[c] for c in f] for f in tri_faces]
-        mesh = Mesh.Mesh(faces_t)
-        shape = Part.Shape()
-        shape.makeShapeFromMesh(mesh.Topology, precision)
+    """
+    tri_faces = ensure_triangles(verts, faces, True)
+    faces_t = [[verts[c] for c in f] for f in tri_faces]
+    mesh = Mesh.Mesh(faces_t)
+    shape = Part.Shape()
+    shape.makeShapeFromMesh(mesh.Topology, precision)
 
-        if remove_splitter:
-            # may slow it down, or be totally necessary
-            shape = shape.removeSplitter() 
+    if remove_splitter:
+        # may slow it down, or be totally necessary
+        shape = shape.removeSplitter() 
 
-        return Part.makeSolid(shape)
+    return Part.makeSolid(shape)

--- a/utils/solid.py
+++ b/utils/solid.py
@@ -238,14 +238,22 @@ class SvGeneralFuse(object):
         
         self._edge_indirect_source_idxs = defaultdict(set)
         self._edge_indirect_sources = defaultdict(set)
+        self._face_indirect_source_idxs = defaultdict(set)
+        self._face_indirect_sources = defaultdict(set)
         for part in self.result.Solids:
             item = SvSolidTopology.Item(part)
             sources = self._sources_by_part[item]
             src_idxs = self._source_idxs_by_part[item]
+
             for edge in part.Edges:
                 edge_item = SvSolidTopology.Item(edge)
                 self._edge_indirect_sources[edge_item].update(sources)
                 self._edge_indirect_source_idxs[edge_item].update(src_idxs)
+
+            for face in part.Faces:
+                face_item = SvSolidTopology.Item(face)
+                self._face_indirect_source_idxs[face_item].update(src_idxs)
+                self._face_indirect_sources[face_item].update(sources)
 
 #         self._edge_direct_source_idxs = defaultdict(set)
 #         self._edge_direct_sources = defaultdict(set)
@@ -294,6 +302,12 @@ class SvGeneralFuse(object):
     
     def get_edge_source_idxs(self, edge):
         return self._edge_indirect_source_idxs[SvSolidTopology.Item(edge)]
+
+    def get_face_sources(self, face):
+        return self._face_indirect_sources[SvSolidTopology.Item(face)]
+    
+    def get_face_source_idxs(self, face):
+        return self._face_indirect_source_idxs[SvSolidTopology.Item(face)]
     
     def get_by_source(self, solid):
         return self._per_source[SvSolidTopology.Item(solid)]


### PR DESCRIPTION
* Support input nesting level 1 or 2.
* add ability to calculate which edge and face of the resulting Solid came from which source object(s). This is done via `generalFuse` method.

![Screenshot_20200923_210004](https://user-images.githubusercontent.com/284644/94038496-f1885700-fddf-11ea-93e6-894aea236ef8.png)

![Screenshot_20200923_220931](https://user-images.githubusercontent.com/284644/94045977-82176500-fde9-11ea-9c9d-2bce61012280.png)

The following illustrates how **EdgeSources** output is calculated:

![Screenshot_20200923_213528](https://user-images.githubusercontent.com/284644/94042893-8ccffb00-fde5-11ea-938e-328df1d65d7e.png)

Here we have two cubes, 0 (plugged into Solid A input), and 1 (plugged into
Solid B input). Purple edges came from cube 0, for them EdgeSources output
contains ``[0]``. Orange edges came from cube 1, for them EdgeSources output
contains ``[1]``. Edges marked with cyan came from both cubes, for them
EdgeSources output contains ``[0, 1]``.

FaceSources output is calculated similarly, but for faces instead of edges.


- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

@vicdoval you might want to make a review.