### PR TITLE
Add text split node

### DIFF
--- a/index.md
+++ b/index.md
@@ -569,6 +569,7 @@
     SvTextOutNodeMK2
     ---
     NoteNode
+    TextSplitNode
     SvGTextNode
 
 ## BPY Data

--- a/nodes/text/split.py
+++ b/nodes/text/split.py
@@ -1,0 +1,53 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import bpy
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class TextSplitNode(bpy.types.Node, SverchCustomTreeNode):
+    ''' Text split node '''
+    bl_idname = 'TextSplitNode'
+    bl_label = 'Text Split'
+    bl_icon = 'OUTLINER_OB_EMPTY'
+    sv_icon = 'SV_LIST_DEL_LEVELS'
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'text')
+        self.outputs.new('SvStringsSocket', 'text')
+
+    def process(self):
+        if self.outputs['text'].is_linked:
+            text = self.inputs['text'].sv_get()
+            self.outputs['text'].sv_set(self._split_text(text))
+
+    def _split_text(self, text):
+        if isinstance(text, list):
+            for i, value in enumerate(text):
+                text[i] = self._split_text(value)
+            return text
+        else:
+            return text.split()
+
+
+def register():
+    bpy.utils.register_class(TextSplitNode)
+
+
+def unregister():
+    bpy.utils.unregister_class(TextSplitNode)


### PR DESCRIPTION
## Addressed problem description

In #3565 it was identified that text nesting was inconsistent, and that the Note node actually implicitly split text. As part of the proposal to standardise text nesting, I also suggested that for those who preferred the old behaviour of split text, a new split node would be added. As seen in #3618 - users need this split node :) so here it is!

## Solution description

In the old Note node, if you typed `'foo bar'`, it would come out as `[[['foo', 'bar']]]`. Now it comes out as `[['foo bar']]`. If you then apply this new explicit split mode, it will split (by whitespace, but maybe we can add a configurable delimiter in the future?) into the original behaviour.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete. (Not sure what to document, quite straightforward)
- [ ] Documentation for users complete (Will add if people are happy with behaviour).
- [x] Manual testing done. 
- [ ] Unit-tests implemented. (What's the process for this?)
- [ ] Ready for merge.

