### PR TITLE
Show errors update

### DIFF
--- a/data_structure.py
+++ b/data_structure.py
@@ -112,6 +112,8 @@ def match_long_repeat(lsts):
     max_l = 0
     tmp = []
     for l in lsts:
+        if not hasattr(l, '__len__'):
+            raise TypeError(f"Cannot perform data matching: input of type {type(l)} is not a list or tuple, but an atomic object")
         max_l = max(max_l, len(l))
     for l in lsts:
         if len(l) == max_l:
@@ -811,6 +813,15 @@ def unzip_dict_recursive(data, item_type=dict, to_dict=None):
             return result
 
     return helper(data)
+
+def is_ultimately(data, data_types):
+    """
+    Check if data is a nested list / tuple / array
+    which ultimately consists of items of data_types.
+    """
+    if isinstance(data, (list, tuple, ndarray)):
+        return is_ultimately(data[0], data_types)
+    return isinstance(data, data_types)
 
 #####################################################
 ################### matrix magic ####################

--- a/node_tree.py
+++ b/node_tree.py
@@ -235,9 +235,16 @@ class SverchCustomTree(NodeTree, SvNodeTreeCommon):
     # option whether error message of nodes should be shown in tree space or not
     # for showing error message all tree should be reevaluated what is not nice
     sv_show_error_in_tree: BoolProperty(
-        description="This will show Node Exceptions in the 3dview, right beside the node",
-        name="Show error in tree", default=False, update=lambda s, c: process_tree(s), options=set())
-    
+        description="This will show Node Exceptions in the node view, right beside the node",
+        name="Show error in tree", default=True, update=lambda s, c: process_tree(s), options=set())
+
+    sv_show_error_details : BoolProperty(
+            name = "Show error details",
+            description = "Display exception stack in the node view as well",
+            default = False, 
+            update=lambda s, c: process_tree(s),
+            options=set())
+
     sv_show_socket_menus : BoolProperty(
         name = "Show socket menus",
         description = "Display socket dropdown menu buttons. NOTE: options that are enabled in those menus will be effective regardless of this checkbox!",

--- a/ui/sv_panels.py
+++ b/ui/sv_panels.py
@@ -82,6 +82,8 @@ class SV_PT_ActiveTreePanel(SverchokPanels, bpy.types.Panel):
         row = col.row(align=True)
         row.prop(ng, "sv_subtree_evaluation_order", text="Eval order", expand=True)
         col.prop(ng, "sv_show_error_in_tree", text="Show error")
+        if ng.sv_show_error_in_tree:
+            col.prop(ng, "sv_show_error_details")
         col.prop(ng, "sv_show_socket_menus")
 
 


### PR DESCRIPTION
Update of displaying errors in node tree
    
* show errors in node view by default (for newly created node trees)
* do not show stacks in node view by default, but add an option to    enable them

Additionally:
* Support implicit conversions of NURBS-like curves/surfaces to Solids

@zeffii @vicdoval @Durman 

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [ ] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

