### PR TITLE
Inputs auto links

### DIFF
--- a/core/sockets.py
+++ b/core/sockets.py
@@ -1001,6 +1001,7 @@ class SvCurveSocket(NodeSocket, SvSocketCommon):
 class SvScalarFieldSocket(NodeSocket, SvSocketCommon):
     bl_idname = "SvScalarFieldSocket"
     bl_label = "Scalar Field Socket"
+    quick_link_to_node = 'SvNumberNode'
 
     color = (0.9, 0.4, 0.1, 1.0)
     default_conversion_name = ConversionPolicies.FIELD.conversion_name
@@ -1014,6 +1015,7 @@ class SvScalarFieldSocket(NodeSocket, SvSocketCommon):
 class SvVectorFieldSocket(NodeSocket, SvSocketCommon):
     bl_idname = "SvVectorFieldSocket"
     bl_label = "Vector Field Socket"
+    quick_link_to_node = 'GenVectorsNode'
 
     color = (0.1, 0.1, 0.9, 1.0)
     default_conversion_name = ConversionPolicies.FIELD.conversion_name

--- a/core/sockets.py
+++ b/core/sockets.py
@@ -1137,6 +1137,7 @@ class SvInputLinkWifiMenuOp(bpy.types.Operator):
         if self.option == '__SV_PARAM_CREATE__':
             with node.sv_throttle_tree_update():
                 new_node = tree.nodes.new(socket.get_link_parameter_node())
+                new_node.label = socket.label or socket.name
                 socket.setup_parameter_node(new_node)
                 links_number = len([s for s in node.inputs if s.is_linked])
                 new_node.location = (node.location[0] - 200, node.location[1] - 100 * links_number)
@@ -1150,14 +1151,18 @@ class SvInputLinkWifiMenuOp(bpy.types.Operator):
 
         elif self.option == '__SV_WIFI_CREATE__':
             with node.sv_throttle_tree_update():
+                label = socket.label or socket.name
                 param_node = tree.nodes.new(socket.get_link_parameter_node())
+                param_node.label = label
 
                 wifi_in_node = tree.nodes.new('WifiInNode')
+                wifi_in_node.label = f"WiFi In - {label}"
                 wifi_in_node.gen_var_name()
                 wifi_var = wifi_in_node.var_name
                 print("new name", wifi_var)
 
                 wifi_out_node = tree.nodes.new('WifiOutNode')
+                wifi_out_node.label = f"WiFi Out - {label}"
                 wifi_out_node.var_name = wifi_var
 
                 socket.setup_parameter_node(param_node)

--- a/core/sockets.py
+++ b/core/sockets.py
@@ -359,7 +359,15 @@ class SvSocketCommon(SvSocketProcessing):
         if self.quick_link_to_node:
             layout.operator('node.sv_quicklink_new_node_input', text="", icon="PLUGIN")
 
+    def does_support_link_input_menu(self, context, layout, node):
+        param_node = self.get_link_parameter_node()
+        if not param_node:
+            return False
+        return True
+
     def draw_link_input_menu(self, context, layout, node):
+        if not self.does_support_link_input_menu(context, layout, node):
+            return
         op = layout.operator('node.sv_input_link_menu_popup', text="", icon="PLUGIN")
         op.tree_name = node.id_data.name
         op.node_name = node.name
@@ -585,6 +593,11 @@ class SvVerticesSocket(NodeSocket, SvSocketCommon):
         else:
             layout.label(text=text)
 
+    def does_support_link_input_menu(self, context, layout, node):
+        ok = super().does_support_link_input_menu(context, layout, node)
+        if not ok:
+            return False
+        return self.name not in {'Vertices', 'Verts'}
 
 class SvVerticesSocketInterface(bpy.types.NodeSocketInterface):
     """
@@ -744,6 +757,12 @@ class SvStringsSocket(NodeSocket, SvSocketCommon):
             return self.quick_link_to_node
         else:
             return 'SvNumberNode'
+
+    def does_support_link_input_menu(self, context, layout, node):
+        ok = super().does_support_link_input_menu(context, layout, node)
+        if not ok:
+            return False
+        return self.name not in {'Edges', 'Polygons', 'Edgs', 'Polys', 'Faces', 'EdgPol', 'Mask', 'EdgesMask', 'FaceMask'}
 
     def setup_parameter_node(self, param_node):
         if param_node.bl_idname == 'SvNumberNode':

--- a/core/sockets.py
+++ b/core/sockets.py
@@ -1109,11 +1109,19 @@ class SvInputLinkWifiMenuOp(bpy.types.Operator):
                     ('__SV_WIFI_CREATE__', "Create new WiFi pair", "Create new Wifi node", 1)
                 )
         i = 2
+
         for name, node in tree.nodes.items():
-            if node.bl_idname == 'WifiInNode':
-                item = ('WIFI_' + node.var_name, f"{node.name} - {node.var_name}", "Link to existing wifi input", i)
+            if node.bl_idname == link_param_node:
+                item = ('PARAM_' + node.name, f"Link to input: {node.label or node.name}", "Link to existing input node", i)
                 items.append(item)
                 i += 1
+
+        for name, node in tree.nodes.items():
+            if node.bl_idname == 'WifiInNode':
+                item = ('WIFI_' + node.var_name, f"Link to WiFi: {node.var_name}", "Link to existing wifi input", i)
+                items.append(item)
+                i += 1
+
         return items
 
     option : EnumProperty(items = get_items)
@@ -1175,6 +1183,11 @@ class SvInputLinkWifiMenuOp(bpy.types.Operator):
                 setup_new_node_location(param_node, wifi_in_node)
 
             param_node.process_node(context)
+
+        elif self.option.startswith('PARAM_'):
+            input_name = self.option[6:]
+            param_node = tree.nodes[input_name]
+            tree.links.new(param_node.outputs[0], socket)
 
         elif self.option.startswith('WIFI_'):
             wifi_var = self.option[5:]

--- a/core/sockets.py
+++ b/core/sockets.py
@@ -221,6 +221,12 @@ class SvSocketCommon(SvSocketProcessing):
 
     description : StringProperty()
 
+    def get_link_parameter_node(self):
+        return self.quick_link_to_node
+
+    def setup_parameter_node(self, param_node):
+        pass
+
     def get_prop_name(self):
         """
         Intended to return name of property related with socket owned by its node
@@ -353,6 +359,13 @@ class SvSocketCommon(SvSocketProcessing):
         if self.quick_link_to_node:
             layout.operator('node.sv_quicklink_new_node_input', text="", icon="PLUGIN")
 
+    def draw_link_input_menu(self, context, layout, node):
+        op = layout.operator('node.sv_input_link_wifi_menu', text="", icon="PLUGIN")
+        op.tree_name = node.id_data.name
+        op.node_name = node.name
+        op.input_name = self.name
+
+
     def draw(self, context, layout, node, text):
 
         def draw_label(text):
@@ -379,6 +392,7 @@ class SvSocketCommon(SvSocketProcessing):
 
         else:  # unlinked INPUT
             if self.get_prop_name():  # has property
+                self.draw_link_input_menu(context, layout, node)
                 self.draw_property(layout, prop_origin=node, prop_name=self.get_prop_name())
 
             elif self.node.bl_idname == 'SvGroupTreeNode' and hasattr(self, 'draw_group_property'):  # group node
@@ -392,6 +406,7 @@ class SvSocketCommon(SvSocketProcessing):
                     self.draw_group_property(layout, text, interface_socket)
 
             elif self.use_prop:  # no property but use default prop
+                self.draw_link_input_menu(context, layout, node)
                 self.draw_property(layout)
 
             else:  # no property and not use default prop
@@ -714,6 +729,24 @@ class SvStringsSocket(NodeSocket, SvSocketCommon):
     default_property_type: bpy.props.EnumProperty(items=[(i, i, '') for i in ['float', 'int']])
     default_float_property: bpy.props.FloatProperty(update=process_from_socket)
     default_int_property: bpy.props.IntProperty(update=process_from_socket)
+
+    def get_link_parameter_node(self):
+        if self.quick_link_to_node:
+            return self.quick_link_to_node
+        else:
+            return 'SvNumberNode'
+
+    def setup_parameter_node(self, param_node):
+        if param_node.bl_idname == 'SvNumberNode':
+            if self.use_prop or self.get_prop_name():
+                value = self.sv_get()[0][0]
+                print("V", value)
+                if isinstance(value, int):
+                    param_node.selected_mode = 'int'
+                    param_node.int_ = value
+                elif isinstance(value, float):
+                    param_node.selected_mode = 'float'
+                    param_node.float_ = value
 
     @property
     def default_property(self):
@@ -1039,15 +1072,144 @@ class SvSocketHelpOp(bpy.types.Operator):
         bpy.context.window_manager.popup_menu(draw, title="Socket description", icon='QUESTION')
         return {'FINISHED'}
 
+def setup_new_node_location(new_node, old_node):
+    links_number = len([s for s in old_node.inputs if s.is_linked])
+    new_node.location = (old_node.location[0] - 200, old_node.location[1] - 100 * links_number)
+    if old_node.parent:
+        new_node.parent = old_node.parent
+        new_node.location = new_node.absolute_location
+
+class SvInputLinkWifiMenuOp(bpy.types.Operator):
+    bl_idname = "node.sv_input_link_wifi_menu"
+    bl_label = "Link Wifi - menu"
+    bl_options = {'INTERNAL', 'REGISTER'}
+    bl_property = "option"
+
+    def get_items(self, context):
+        tree = context.space_data.node_tree
+        node = tree.nodes[self.node_name]
+        socket = node.inputs[self.input_name]
+
+        items = []
+        link_param_node = socket.get_link_parameter_node()
+        if link_param_node:
+            items.append(
+                    ('__SV_PARAM_CREATE__', "Create new parameter", "Create new node", 0)
+                )
+
+        items.append(
+                    ('__SV_WIFI_CREATE__', "Create new WiFi pair", "Create new Wifi node", 1)
+                )
+        i = 2
+        for name, node in tree.nodes.items():
+            if node.bl_idname == 'WifiInNode':
+                item = ('WIFI_' + node.var_name, f"{node.name} - {node.var_name}", "Link to existing wifi input", i)
+                items.append(item)
+                i += 1
+        return items
+
+    option : EnumProperty(items = get_items)
+    tree_name : StringProperty()
+    node_name : StringProperty()
+    input_name : StringProperty()
+
+    def execute(self, context):
+        print(self.option)
+
+        tree = bpy.data.node_groups[self.tree_name]
+        node = tree.nodes[self.node_name]
+        socket = node.inputs[self.input_name]
+
+        def is_linked(node1, node2):
+            for link in tree.links:
+                if link.from_node == node1 and link.to_node == node2:
+                    return True
+            return False
+
+        if self.option == '__SV_PARAM_CREATE__':
+            with node.sv_throttle_tree_update():
+                new_node = tree.nodes.new(socket.get_link_parameter_node())
+                socket.setup_parameter_node(new_node)
+                links_number = len([s for s in node.inputs if s.is_linked])
+                new_node.location = (node.location[0] - 200, node.location[1] - 100 * links_number)
+                tree.links.new(new_node.outputs[0], socket)
+
+                if node.parent:
+                    new_node.parent = node.parent
+                    new_node.location = new_node.absolute_location
+
+            new_node.process_node(context)
+
+        elif self.option == '__SV_WIFI_CREATE__':
+            with node.sv_throttle_tree_update():
+                param_node = tree.nodes.new(socket.get_link_parameter_node())
+
+                wifi_in_node = tree.nodes.new('WifiInNode')
+                wifi_in_node.gen_var_name()
+                wifi_var = wifi_in_node.var_name
+                print("new name", wifi_var)
+
+                wifi_out_node = tree.nodes.new('WifiOutNode')
+                wifi_out_node.var_name = wifi_var
+
+                socket.setup_parameter_node(param_node)
+
+                tree.links.new(param_node.outputs[0], wifi_in_node.inputs[0])
+                tree.links.new(wifi_out_node.outputs[0], socket)
+
+                setup_new_node_location(wifi_out_node, node)
+                setup_new_node_location(wifi_in_node, wifi_out_node)
+                setup_new_node_location(param_node, wifi_in_node)
+
+            param_node.process_node(context)
+
+        elif self.option.startswith('WIFI_'):
+            wifi_var = self.option[5:]
+
+            found_existing = False
+            for name, wifi_node in tree.nodes.items():
+                if wifi_node.bl_idname == 'WifiOutNode' and is_linked(wifi_node, node):
+                    if wifi_node.var_name == wifi_var:
+                        tree.links.new(wifi_node.outputs[0], socket)
+                        found_existing = True
+                        break
+
+            if not found_existing:
+                new_node = tree.nodes.new('WifiOutNode')
+                new_node.var_name = wifi_var
+                new_node.set_var_name()
+                links_number = len([s for s in node.inputs if s.is_linked])
+                new_node.location = (node.location[0] - 200, node.location[1] - 100 * links_number)
+                tree.links.new(new_node.outputs[0], socket)
+
+                if node.parent:
+                    new_node.parent = node.parent
+                    new_node.location = new_node.absolute_location
+
+                new_node.process_node(context)
+
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        context.space_data.cursor_location_from_region(event.mouse_region_x, event.mouse_region_y)
+        wm = context.window_manager
+        wm.invoke_search_popup(self)
+        return {'FINISHED'}
+
 classes = [
     SV_MT_SocketOptionsMenu,
     SvVerticesSocket, SvMatrixSocket, SvStringsSocket, SvFilePathSocket,
     SvColorSocket, SvQuaternionSocket, SvDummySocket, SvSeparatorSocket,
     SvTextSocket, SvObjectSocket, SvDictionarySocket, SvChameleonSocket,
     SvSurfaceSocket, SvCurveSocket, SvScalarFieldSocket, SvVectorFieldSocket,
+<<<<<<< HEAD
     SvSolidSocket, SvSvgSocket, SvPulgaForceSocket, SvLinkNewNodeInput,
     SvStringsSocketInterface, SvVerticesSocketInterface,
     SvSocketHelpOp
+=======
+    SvSolidSocket, SvSvgSocket, SvLinkNewNodeInput, SvSocketHelpOp,
+    SvInputLinkWifiMenuOp
+>>>>>>> "quick links" menu
 ]
 
 def socket_interface_classes():

--- a/core/sockets.py
+++ b/core/sockets.py
@@ -1210,14 +1210,9 @@ classes = [
     SvColorSocket, SvQuaternionSocket, SvDummySocket, SvSeparatorSocket,
     SvTextSocket, SvObjectSocket, SvDictionarySocket, SvChameleonSocket,
     SvSurfaceSocket, SvCurveSocket, SvScalarFieldSocket, SvVectorFieldSocket,
-<<<<<<< HEAD
     SvSolidSocket, SvSvgSocket, SvPulgaForceSocket, SvLinkNewNodeInput,
     SvStringsSocketInterface, SvVerticesSocketInterface,
-    SvSocketHelpOp
-=======
-    SvSolidSocket, SvSvgSocket, SvLinkNewNodeInput, SvSocketHelpOp,
-    SvInputLinkWifiMenuOp
->>>>>>> "quick links" menu
+    SvSocketHelpOp, SvInputLinkWifiMenuOp
 ]
 
 def socket_interface_classes():

--- a/core/sockets.py
+++ b/core/sockets.py
@@ -34,6 +34,8 @@ from sverchok.data_structure import (
     SIMPLE_DATA_TYPES,
     flatten_data, graft_data, map_at_level, wrap_data)
 
+from sverchok.settings import get_params
+
 from sverchok.utils.field.scalar import SvScalarField, SvConstantScalarField
 from sverchok.utils.field.vector import SvVectorField, SvMatrixVectorField, SvConstantVectorField
 from sverchok.utils.curve import SvCurve
@@ -386,6 +388,8 @@ class SvSocketCommon(SvSocketProcessing):
             else:
                 layout.label(text=text)
 
+        menu_option = get_params({'show_input_menus': 'QUICKLINK'}).show_input_menus
+
         # just handle custom draw..be it input or output.
         if self.custom_draw:
             # does the node have the draw function referred to by
@@ -401,7 +405,8 @@ class SvSocketCommon(SvSocketProcessing):
 
         else:  # unlinked INPUT
             if self.get_prop_name():  # has property
-                self.draw_link_input_menu(context, layout, node)
+                if menu_option == 'ALL':
+                    self.draw_link_input_menu(context, layout, node)
                 self.draw_property(layout, prop_origin=node, prop_name=self.get_prop_name())
 
             elif self.node.bl_idname == 'SvGroupTreeNode' and hasattr(self, 'draw_group_property'):  # group node
@@ -415,12 +420,15 @@ class SvSocketCommon(SvSocketProcessing):
                     self.draw_group_property(layout, text, interface_socket)
 
             elif self.use_prop:  # no property but use default prop
-                self.draw_link_input_menu(context, layout, node)
+                if menu_option == 'ALL':
+                    self.draw_link_input_menu(context, layout, node)
                 self.draw_property(layout)
 
             else:  # no property and not use default prop
-                self.draw_link_input_menu(context, layout, node)
-                #self.draw_quick_link(context, layout, node)
+                if menu_option == 'QUICKLINK':
+                    self.draw_quick_link(context, layout, node)
+                elif menu_option == 'ALL':
+                    self.draw_link_input_menu(context, layout, node)
                 draw_label(self.label or text)
 
         if self.has_menu(context):

--- a/core/sockets.py
+++ b/core/sockets.py
@@ -410,7 +410,8 @@ class SvSocketCommon(SvSocketProcessing):
                 self.draw_property(layout)
 
             else:  # no property and not use default prop
-                self.draw_quick_link(context, layout, node)
+                self.draw_link_input_menu(context, layout, node)
+                #self.draw_quick_link(context, layout, node)
                 draw_label(self.label or text)
 
         if self.has_menu(context):
@@ -1101,15 +1102,17 @@ class SvInputLinkMenuOp(bpy.types.Operator):
 
         items = []
         link_param_node = socket.get_link_parameter_node()
+        i = 0
         if link_param_node:
             items.append(
-                    ('__SV_PARAM_CREATE__', "Create new parameter", "Create new parameter node", 0)
+                    ('__SV_PARAM_CREATE__', "Create new parameter", "Create new parameter node", i)
                 )
+            i += 1
 
-        items.append(
-                    ('__SV_WIFI_CREATE__', "Create new parameter via WiFi", "Create new parameter node and link it via WiFi pair", 1)
-                )
-        i = 2
+            items.append(
+                        ('__SV_WIFI_CREATE__', "Create new parameter via WiFi", "Create new parameter node and link it via WiFi pair", 1)
+                    )
+            i += 1
 
         for name, node in tree.nodes.items():
             if node.bl_idname == link_param_node:
@@ -1125,7 +1128,7 @@ class SvInputLinkMenuOp(bpy.types.Operator):
 
         return items
 
-    option : EnumProperty(items = get_items)
+    option : EnumProperty(name = "Action", description = "Action to be executed", items = get_items)
     tree_name : StringProperty()
     node_name : StringProperty()
     input_name : StringProperty()

--- a/core/sockets.py
+++ b/core/sockets.py
@@ -360,7 +360,7 @@ class SvSocketCommon(SvSocketProcessing):
             layout.operator('node.sv_quicklink_new_node_input', text="", icon="PLUGIN")
 
     def draw_link_input_menu(self, context, layout, node):
-        op = layout.operator('node.sv_input_link_wifi_menu', text="", icon="PLUGIN")
+        op = layout.operator('node.sv_input_link_menu_popup', text="", icon="PLUGIN")
         op.tree_name = node.id_data.name
         op.node_name = node.name
         op.input_name = self.name
@@ -1087,9 +1087,10 @@ def setup_new_node_location(new_node, old_node):
         new_node.parent = old_node.parent
         new_node.location = new_node.absolute_location
 
-class SvInputLinkWifiMenuOp(bpy.types.Operator):
-    bl_idname = "node.sv_input_link_wifi_menu"
-    bl_label = "Link Wifi - menu"
+class SvInputLinkMenuOp(bpy.types.Operator):
+    "Opens a menu"
+    bl_idname = "node.sv_input_link_menu_popup"
+    bl_label = "Link to existing parameter or add a new one"
     bl_options = {'INTERNAL', 'REGISTER'}
     bl_property = "option"
 
@@ -1102,23 +1103,23 @@ class SvInputLinkWifiMenuOp(bpy.types.Operator):
         link_param_node = socket.get_link_parameter_node()
         if link_param_node:
             items.append(
-                    ('__SV_PARAM_CREATE__', "Create new parameter", "Create new node", 0)
+                    ('__SV_PARAM_CREATE__', "Create new parameter", "Create new parameter node", 0)
                 )
 
         items.append(
-                    ('__SV_WIFI_CREATE__', "Create new WiFi pair", "Create new Wifi node", 1)
+                    ('__SV_WIFI_CREATE__', "Create new parameter via WiFi", "Create new parameter node and link it via WiFi pair", 1)
                 )
         i = 2
 
         for name, node in tree.nodes.items():
             if node.bl_idname == link_param_node:
-                item = ('PARAM_' + node.name, f"Link to input: {node.label or node.name}", "Link to existing input node", i)
+                item = ('PARAM_' + node.name, f"Link to parameter: {node.label or node.name}", "Link to existing input node", i)
                 items.append(item)
                 i += 1
 
         for name, node in tree.nodes.items():
             if node.bl_idname == 'WifiInNode':
-                item = ('WIFI_' + node.var_name, f"Link to WiFi: {node.var_name}", "Link to existing wifi input", i)
+                item = ('WIFI_' + node.var_name, f"Link to WiFi: {node.var_name}", "Link to existing WiFi input node", i)
                 items.append(item)
                 i += 1
 
@@ -1130,7 +1131,6 @@ class SvInputLinkWifiMenuOp(bpy.types.Operator):
     input_name : StringProperty()
 
     def execute(self, context):
-        print(self.option)
 
         tree = bpy.data.node_groups[self.tree_name]
         node = tree.nodes[self.node_name]
@@ -1167,7 +1167,6 @@ class SvInputLinkWifiMenuOp(bpy.types.Operator):
                 wifi_in_node.label = f"WiFi In - {label}"
                 wifi_in_node.gen_var_name()
                 wifi_var = wifi_in_node.var_name
-                print("new name", wifi_var)
 
                 wifi_out_node = tree.nodes.new('WifiOutNode')
                 wifi_out_node.label = f"WiFi Out - {label}"
@@ -1230,7 +1229,7 @@ classes = [
     SvSurfaceSocket, SvCurveSocket, SvScalarFieldSocket, SvVectorFieldSocket,
     SvSolidSocket, SvSvgSocket, SvPulgaForceSocket, SvLinkNewNodeInput,
     SvStringsSocketInterface, SvVerticesSocketInterface,
-    SvSocketHelpOp, SvInputLinkWifiMenuOp
+    SvSocketHelpOp, SvInputLinkMenuOp
 ]
 
 def socket_interface_classes():

--- a/core/sockets.py
+++ b/core/sockets.py
@@ -532,6 +532,14 @@ class SvVerticesSocket(NodeSocket, SvSocketCommon):
     color = (0.9, 0.6, 0.2, 1.0)
     quick_link_to_node = 'GenVectorsNode'
 
+    def setup_parameter_node(self, param_node):
+        if self.use_prop or self.get_prop_name():
+            value = self.sv_get()[0][0]
+            param_node.x_ = value[0]
+            param_node.y_ = value[1]
+            param_node.z_ = value[2]
+        
+
     # this property is needed for back capability, after renaming prop to default_property
     # should be removed after https://github.com/nortikin/sverchok/issues/3514
     # using via default_property property

--- a/docs/induction.rst
+++ b/docs/induction.rst
@@ -36,5 +36,6 @@ The following Units will introduce no more than 10 node types per lesson. Take y
    Lesson 02 - A Circle <Unit_01/lesson_02>
    Lesson 03 - A Grid <Unit_01/lesson_03>
    
-   Data structure manipulation with socket menus <socket_menus>
+   Simplifying parameter node creation with input socket menus <input_menus>
+   Data structure manipulation with output socket menus <socket_menus>
 

--- a/docs/input_menus.rst
+++ b/docs/input_menus.rst
@@ -1,0 +1,57 @@
+Input Socket Menus
+******************
+
+Good node tree usually has most of it's "vital" parameters defined in "input"
+nodes, such as "A Number", "Vector In" and so on. It's better to have separate
+nodes for meaningful node parameters, because you can explicitly name them
+("Building Height" instead of "Z"). But linking all inputs of all nodes to
+separate input nodes and naming those nodes is tiresome process.
+
+Sverchok allows to simplify maninpulation with such nodes, by adding buttons to
+input sockets, which show a menu with options to create a new parameter node,
+or to link the input to existing parameter node.
+
+In Sverchok preferences, there is a setting named **Show input menus**, with
+which you can specify if you want to use such menus. There are three options
+available:
+
+* Do not show such menus at all.
+* Show the button only in cases where Sverchok thinks there is only one most
+  usable option, which is to create additional node and link it to this input.
+  "Vector In" and "Matrix In" nodes can be created this way. No menu will be
+  shown if this option is selected, the node will be created by click on the
+  button. This option is the default one.
+* Show "Create Parameter" menu. If this option is selected, there will be a
+  button, which opens a menu with options:
+
+   * create new input node and link it to this socket; the node will be
+     automatically named with the name of the socket.
+   * create new input node and link it to this socket, but instead of direct
+     link, create a pair of WiFi nodes and link input node via them;
+   * link this input to one of existing parameter nodes of corresponding type;
+   * link this input to existing WiFi In node.
+
+.. image:: https://user-images.githubusercontent.com/284644/97737935-811bd680-1aff-11eb-9175-097bb8d6aeaa.png
+
+The menu has a search box, so you can select an option by typing in a part of
+it's title.
+
+**Create new parameter** option creates a new parameter node ("A number",
+"Vector In" or other, depending on a socket type), and links it to the input.
+New node will be automatically given a label equal to the name of the socket.
+If the socket has associated parameter, then the value of this parameter will
+be copied to the newly created node.
+
+**Create new parameter via WiFi** option is similar, but additionally it
+creates a pair of linked "WiFi In" - "WiFi Out" nodes between the parameter
+node and existing node. This can be useful in large node trees.
+
+**Link to parameter Node** option just creates a link between existing
+parameter node and this input.
+
+**Link to WiFi Node** option links this input to existing "WiFi Out" node. This
+option is only shown if there already is a "WiFi Out" node linked to some other
+input of the same node.
+
+Some specific nodes can provide additional entries in this menu.
+

--- a/docs/socket_menus.rst
+++ b/docs/socket_menus.rst
@@ -1,5 +1,5 @@
-Socket Menus
-************
+Output Socket Menus
+*******************
 
 Most of output sockets in Sverchok's nodes have a button to call a dropdown menu:
 

--- a/nodes/surface/marching_cubes.py
+++ b/nodes/surface/marching_cubes.py
@@ -5,6 +5,7 @@ import bpy
 from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty, StringProperty
 
 from sverchok.node_tree import SverchCustomTreeNode, throttled
+from sverchok.core.sockets import setup_new_node_location
 from sverchok.data_structure import updateNode, zip_long_repeat, match_long_repeat
 from sverchok.utils.logging import info, exception
 from sverchok.utils.marching_cubes import isosurface_np
@@ -119,9 +120,21 @@ class SvExMarchingCubesNode(DraftMode, bpy.types.Node, SverchCustomTreeNode):
             items = get_modes,
             update = update_sockets)
 
+    class BoundsMenuHandler():
+        @classmethod
+        def get_items(cls, socket, context):
+            return [("BOX", "Add Box node", "Add Box node")]
+
+        @classmethod
+        def on_selected(cls, tree, node, socket, item, context):
+            new_node = tree.nodes.new('SvBoxNodeMk2')
+            new_node.label = "Bounds"
+            tree.links.new(new_node.outputs[0], node.inputs['Bounds'])
+            setup_new_node_location(new_node, node)
+
     def sv_init(self, context):
         self.inputs.new('SvScalarFieldSocket', "Field")
-        self.inputs.new('SvVerticesSocket', "Bounds")
+        self.inputs.new('SvVerticesSocket', "Bounds").link_menu_handler = 'BoundsMenuHandler'
         self.inputs.new('SvStringsSocket', "Value").prop_name = 'iso_value'
         self.inputs.new('SvStringsSocket', "Samples").prop_name = 'sample_size'
         self.inputs.new('SvStringsSocket', "SamplesX").prop_name = 'samples_x'

--- a/settings.py
+++ b/settings.py
@@ -305,6 +305,21 @@ class SverchokPreferences(AddonPreferences):
             min = 0, max = 12
         )
 
+    input_links_options = [
+            ('NONE', "Do not show", "Do not show", 0),
+            ('QUICKLINK', "Show single option only",
+                "Show the button only for cases when there is only one node to be created can be suggested; do not show the menu", 1),
+            ('ALL', "Show `Create parameter' options",
+                "Show the button with a menu with options to create parameter nodes", 2)
+        ]
+
+    show_input_menus : EnumProperty(
+            name = "Show input menus",
+            description = "Wheter to display buttons near node socket inputs to automatically create parameter nodes",
+            items = input_links_options,
+            default = 'QUICKLINK'
+        )
+
     ##  BLF/BGL/GPU  scale and location props
 
     render_scale: FloatProperty(
@@ -406,6 +421,8 @@ class SverchokPreferences(AddonPreferences):
             toolbar_box.prop(self, "node_panels_icons_only")
             if self.node_panels_icons_only:
                 toolbar_box.prop(self, "node_panels_columns")
+
+        col1.prop(self, 'show_input_menus')
 
         col1.prop(self, "over_sized_buttons")
         col1.prop(self, "external_editor", text="Ext Editor")


### PR DESCRIPTION
## Addressed problem description

Good node tree usually has most of it's "vital" parameters defined in "input" nodes, such as "A Number", "Vector In" and so on. It's better to have separate nodes for meaningful node parameters, because you can explicitly name them ("Building Height" instead of "Z"). But linking all inputs of all nodes to separate input nodes and naming those nodes is tiresome process.

Another thing is that I usually tend to group input nodes in specific places of my node trees; those places can be far from places where parameters are used, so there are very long noodles. WiFi nodes can make node trees cleaner, but manually creating and linking them is tiresome too.

## Solution description

For input sockets, that have good "input" node counterparts ("A Number" for Strings socket, "Vector In" for Vertices socket),  add a dropdown menu, that allows:

* create new input node and link it to this socket; the node will be automatically named with the name of the socket.
* create new input node and link it to this socket, but instead of direct link, create a pair of WiFi nodes and link input node via them;
* link this input to one of existing parameter nodes of corresponding type;
* link this input to existing WiFi In node.

The menu button is shown only for sockets that have associated node property. But maybe it worth to replace all existing "quicklink" buttons with this new menu?

Also I think I'll show these new buttons only when "Show socket menus" checkbox in the N panel of the tree is checked.

![Screenshot_20201030_222847](https://user-images.githubusercontent.com/284644/97737935-811bd680-1aff-11eb-9175-097bb8d6aeaa.png)

I know that @Durman has reservations about WiFi nodes being too implicit, and I partially understand his concerns. But also I think that WiFi nodes can be very useful when used wisely. So I wait for input from @vicdoval, @zeffii , @nortikin : is it good idea to simplify creation of WiFi node pairs? Will we continue to support them?


## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [ ] Code changes complete.
- [ ] Code documentation complete.
- [ ] Documentation for users complete (or not required, if user never sees these changes).
- [ ] Manual testing done. 
- [ ] Unit-tests implemented.
- [ ] Ready for merge.

