### PR TITLE
Loop in out nodes

### DIFF
--- a/core/sockets.py
+++ b/core/sockets.py
@@ -101,7 +101,7 @@ class SvSocketProcessing(object):
                     self.use_wrap = False
             finally:
                 self.skip_wrap_mode_update = False
-                
+
         process_from_socket(self, context)
 
     def update_wrap_flag(self, context):
@@ -115,7 +115,7 @@ class SvSocketProcessing(object):
                     self.use_unwrap = False
             finally:
                 self.skip_wrap_mode_update = False
-                
+
         process_from_socket(self, context)
 
     use_unwrap : BoolProperty(
@@ -139,7 +139,7 @@ class SvSocketProcessing(object):
                     self.use_simplify = False
             finally:
                 self.skip_simplify_mode_update = False
-                
+
         process_from_socket(self, context)
 
     def update_simplify_flag(self, context):
@@ -153,7 +153,7 @@ class SvSocketProcessing(object):
                     self.use_flatten = False
             finally:
                 self.skip_simplify_mode_update = False
-                
+
         process_from_socket(self, context)
 
     # Only one of properties can be set to true: use_flatten or use_simplfy
@@ -610,7 +610,7 @@ class SvVerticesSocket(NodeSocket, SvSocketCommon):
             param_node.x_ = value[0]
             param_node.y_ = value[1]
             param_node.z_ = value[2]
-        
+
 
     # this property is needed for back capability, after renaming prop to default_property
     # should be removed after https://github.com/nortikin/sverchok/issues/3514
@@ -664,7 +664,7 @@ class SvVerticesSocket(NodeSocket, SvSocketCommon):
 
 class SvVerticesSocketInterface(bpy.types.NodeSocketInterface):
     """
-    This socket will be created in tree.inputs to tree.outputs collection 
+    This socket will be created in tree.inputs to tree.outputs collection
     when normal socket will be connected to input or output group nodes
     """
     # The only reason of existing this class
@@ -940,7 +940,7 @@ class SvStringsSocket(NodeSocket, SvSocketCommon):
 
 class SvStringsSocketInterface(bpy.types.NodeSocketInterface):
     """
-    This socket will be created in tree.inputs to tree.outputs collection 
+    This socket will be created in tree.inputs to tree.outputs collection
     when normal socket will be connected to input or output group nodes
     """
     bl_idname = "SvStringsSocketInterface"
@@ -999,6 +999,14 @@ class SvPulgaForceSocket(NodeSocket, SvSocketCommon):
     bl_label = "Pulga Force Socket"
 
     color = (0.4, 0.3, 0.6, 1.0)
+
+class SvLoopControlSocket(NodeSocket, SvSocketCommon):
+    '''For loop in-loop out node pair'''
+    bl_idname = "SvLoopControlSocket"
+    bl_label = "Loop Control Socket"
+
+    color = (0.1, 0.1, 0.1, 1.0)
+    quick_link_to_node = 'SvLoopInNode'
 
 class SvDictionarySocket(NodeSocket, SvSocketCommon):
     '''For dictionary data'''
@@ -1357,7 +1365,8 @@ classes = [
     SvColorSocket, SvQuaternionSocket, SvDummySocket, SvSeparatorSocket,
     SvTextSocket, SvObjectSocket, SvDictionarySocket, SvChameleonSocket,
     SvSurfaceSocket, SvCurveSocket, SvScalarFieldSocket, SvVectorFieldSocket,
-    SvSolidSocket, SvSvgSocket, SvPulgaForceSocket, SvLinkNewNodeInput,
+    SvSolidSocket, SvSvgSocket, SvPulgaForceSocket, SvLoopControlSocket,
+    SvLinkNewNodeInput,
     SvStringsSocketInterface, SvVerticesSocketInterface,
     SvSocketHelpOp, SvInputLinkMenuOp
 ]
@@ -1400,4 +1409,3 @@ def socket_interface_classes():
 
 
 register, unregister = bpy.utils.register_classes_factory(classes + list(socket_interface_classes()))
-

--- a/docs/nodes/logic/logic_index.rst
+++ b/docs/nodes/logic/logic_index.rst
@@ -13,3 +13,5 @@ Logic
    input_switch_mod
    custom_switcher
    range_switch
+   loop_in
+   loop_out

--- a/docs/nodes/logic/loop_in.rst
+++ b/docs/nodes/logic/loop_in.rst
@@ -56,6 +56,6 @@ For Each mode example, Skip input used to mask the results.
 
 .. image:: https://user-images.githubusercontent.com/10011941/101334215-e047d600-3877-11eb-89df-cfaaf73dd427.png
 
-You can change socket the socket labels in the N-Panel
+You can change the socket labels in the N-Panel
 
 .. image:: https://user-images.githubusercontent.com/10011941/101360702-519a7f80-389e-11eb-826d-0e1c5a7152d1.png

--- a/docs/nodes/logic/loop_in.rst
+++ b/docs/nodes/logic/loop_in.rst
@@ -48,6 +48,14 @@ Data0, Data1... output sockets will be created when the last input is linked
 Examples
 --------
 
+Range mode example, Break used to control the maximum vertices.
+
 .. image:: https://user-images.githubusercontent.com/10011941/101332093-22234d00-3875-11eb-819a-68e86ef8c2c2.png
 
+For Each mode example, Skip input used to mask the results.
+
 .. image:: https://user-images.githubusercontent.com/10011941/101334215-e047d600-3877-11eb-89df-cfaaf73dd427.png
+
+You can change socket the socket labels in the N-Panel
+
+.. image:: https://user-images.githubusercontent.com/10011941/101360702-519a7f80-389e-11eb-826d-0e1c5a7152d1.png

--- a/docs/nodes/logic/loop_in.rst
+++ b/docs/nodes/logic/loop_in.rst
@@ -1,0 +1,53 @@
+Loop In
+=======
+
+This node in conjunction with the Loop out node can create loops with nodes
+
+Offers two different modes 'Range' and 'For Each'
+
+Range
+-----
+
+In this mode the all the data inputted to the Loop In node will be processed every iteration.
+
+For Each
+--------
+
+In this mode the inputted data will be splitted before being processed and there will be one loop per every level 1 object.
+
+Operators
+---------
+
+**Create Loop Out**: creates a Loop out node and links the Loop In - Loop Out socket.
+
+
+Inputs
+------
+
+**Iterations**: Number of repetitions (only in Range mode).
+
+Data0, Data1... inputs will be created when the last one is linked
+
+Options
+-------
+
+**Max Iterations**: Maximum iterations (in N-panel and Contextual Sverchok Menu)
+**Socket Labels**: To change sockets names (in N-panel)
+
+Outputs
+-------
+
+**Loop Out**: Socket to link with the Loop Out node.
+
+**Loop Number / Item Number**: Actual Repetition / Item.
+
+**Total Loops / Total Items**: Total Repetitions / Items.
+
+Data0, Data1... output sockets will be created when the last input is linked
+
+Examples
+--------
+
+.. image:: https://user-images.githubusercontent.com/10011941/101332093-22234d00-3875-11eb-819a-68e86ef8c2c2.png
+
+.. image:: https://user-images.githubusercontent.com/10011941/101334215-e047d600-3877-11eb-89df-cfaaf73dd427.png

--- a/docs/nodes/logic/loop_out.rst
+++ b/docs/nodes/logic/loop_out.rst
@@ -1,0 +1,39 @@
+Loop In
+=======
+
+This node in conjunction with the Loop In node can create loops with nodes
+
+Offers two different modes 'Range' and 'For Each'
+
+
+Operators
+---------
+
+**Create Loop In**: creates a Loop In node and links the Loop In - Loop Out socket.
+
+
+Inputs
+------
+
+**Loop Out**: Socket to link with the Loop Out node.
+
+**Break**: If a True value is inputted the loop will stop (Only if Loop In is in Range Mode).
+
+**Skip**: If a True value is inputted the loop the result wont be added to the output, like a internal mask.  (Only if Loop In is in For Each Mode).
+
+Data0, Data1... inputs will be created coping the Loop in Outputs
+
+
+Outputs
+-------
+
+
+Data0, Data1... inputs will be created coping the Loop in Outputs
+
+
+Examples
+--------
+
+.. image:: https://user-images.githubusercontent.com/10011941/101332093-22234d00-3875-11eb-819a-68e86ef8c2c2.png
+
+.. image:: https://user-images.githubusercontent.com/10011941/101334215-e047d600-3877-11eb-89df-cfaaf73dd427.png

--- a/index.md
+++ b/index.md
@@ -536,6 +536,9 @@
     SvCustomSwitcher
     SvRangeSwitchNode
     ---
+    SvLoopInNode
+    SvLoopOutNode
+    ---
     SvEvolverNode
     SvGenesHolderNode
 

--- a/nodes/logic/loop_in.py
+++ b/nodes/logic/loop_in.py
@@ -154,8 +154,12 @@ class SvLoopInNode(bpy.types.Node, SverchCustomTreeNode):
             for inp, outp in zip(self.inputs[1:-1], self.outputs[3:]):
                 outp.sv_set(inp.sv_get(deepcopy=False, default=[]))
         else:
+            lens = []
             for inp, outp in zip(self.inputs[1:-1], self.outputs[3:]):
-                outp.sv_set([inp.sv_get(deepcopy=False, default=[])[0]])
+                data = inp.sv_get(deepcopy=False, default=[])
+                lens.append(len(data))
+                outp.sv_set([data[0]])
+            self.outputs[2].sv_set([[max(lens)]])
 
 
 

--- a/nodes/logic/loop_in.py
+++ b/nodes/logic/loop_in.py
@@ -1,0 +1,139 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import bpy
+from bpy.props import IntProperty, EnumProperty, BoolProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode
+from sverchok.utils.sv_node_utils import frame_adjust
+
+class SvCreateLoopOut(bpy.types.Operator):
+
+    bl_idname = "node.create_loop_out"
+    bl_label = "Create Loop Out"
+
+    idtree: bpy.props.StringProperty(default='')
+    idname: bpy.props.StringProperty(default='')
+
+    def execute(self, context):
+        tree = bpy.data.node_groups[self.idtree]
+        node = bpy.data.node_groups[self.idtree].nodes[self.idname]
+
+        new_node =tree.nodes.new('SvLoopOutNode')
+        new_node.parent = None
+        new_node.location = (node.location.x + node.width + 400, node.location.y)
+        tree.links.new(node.outputs[0], new_node.inputs[0])
+        frame_adjust(node, new_node)
+        return {'FINISHED'}
+
+class SvLoopInNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: For Loop Start,
+    Tooltip: Start node to define a nodes for-loop.
+    """
+    bl_idname = 'SvLoopInNode'
+    bl_label = 'Loop In'
+    bl_icon = 'FILE_REFRESH'
+
+    def update_iterations(self, context):
+        if self.iterations > self.max_iterations:
+            self.iterations = self.max_iterations
+        else:
+            updateNode(self, context)
+    iterations: IntProperty(
+        name='Iterations', description='Times to repeat the loop (define maximum value on N-Panel properties)',
+        default=1, min=0, update=update_iterations)
+
+    def update_max_iterations(self, context):
+        if self.iterations > self.max_iterations:
+            self.iterations = self.max_iterations
+
+    max_iterations: IntProperty(
+        name='Max Iterations', description='Maximum allowed iterations',
+        default=5, min=2, update=update_max_iterations)
+
+    node_dict = {}
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Iterations').prop_name = "iterations"
+        self.inputs.new('SvStringsSocket', 'Data 0')
+
+        self.outputs.new('SvLoopControlSocket', 'Loop Out')
+        self.outputs["Loop Out"].link_limit = 1
+        self.outputs.new('SvStringsSocket', 'Loop Number')
+        self.outputs.new('SvStringsSocket', 'Total Loops')
+
+    def draw_buttons(self,ctx, layout):
+        if not (self.outputs[0].is_linked and self.outputs[0].links[0].to_socket.node.bl_idname=='SvLoopOutNode'):
+            self.wrapper_tracked_ui_draw_op(layout, "node.create_loop_out", icon='CON_FOLLOWPATH', text="Create Loop Out")
+
+    def draw_buttons_ext(self, ctx, layout):
+        layout.prop(self, "max_iterations")
+
+    def rclick_menu(self, context, layout):
+        layout.prop(self, "max_iterations")
+
+
+    def sv_update(self):
+
+        # socket handling
+        print("updating loopin")
+        if self.inputs[-1].links:
+            print("updating loopin adding inputs")
+            name_input = 'Data '+str(len(self.inputs)-1)
+            name_output = 'Data '+str(len(self.inputs)-2)
+            self.inputs.new('SvStringsSocket', name_input)
+            self.outputs.new('SvStringsSocket', name_output)
+        else:
+            while len(self.inputs) > 2 and not self.inputs[-2].links:
+                self.inputs.remove(self.inputs[-1])
+                self.outputs.remove(self.outputs[-1])
+        # check number of connections and type match input socket n with output socket n
+        count_inputs = 0
+        count_outputs = 0
+        for idx, socket in enumerate(self.inputs[1:]):
+            if socket.name in self.outputs and self.outputs[socket.name].links:
+                count_outputs += 1
+            if socket.links:
+                count_inputs += 1
+                if type(socket.links[0].from_socket) != type(self.outputs[socket.name]):
+                    self.outputs.remove(self.outputs[socket.name])
+                    self.outputs.new(socket.links[0].from_socket.bl_idname, socket.name)
+                    self.outputs.move(len(self.outputs)-1, idx+3)
+
+    def process(self):
+
+
+        self.outputs[0].sv_set([["Link to Loop Out node"]])
+        self.outputs[1].sv_set([[0]])
+        iterations = int(self.inputs['Iterations'].sv_get()[0][0])
+        self.outputs['Total Loops'].sv_set([[min(iterations, self.max_iterations)]])
+        for inp, outp in zip(self.inputs[1:-1], self.outputs[3:]):
+            outp.sv_set(inp.sv_get(deepcopy=False, default=[]))
+
+
+
+def register():
+    bpy.utils.register_class(SvCreateLoopOut)
+    bpy.utils.register_class(SvLoopInNode)
+
+
+def unregister():
+    bpy.utils.unregister_class(SvLoopInNode)
+    bpy.utils.unregister_class(SvCreateLoopOut)

--- a/nodes/logic/loop_in.py
+++ b/nodes/logic/loop_in.py
@@ -28,9 +28,6 @@ class SvCreateLoopOut(bpy.types.Operator):
     bl_idname = "node.create_loop_out"
     bl_label = "Create Loop Out"
 
-    idtree: bpy.props.StringProperty(default='')
-    idname: bpy.props.StringProperty(default='')
-
     def execute(self, context):
 
         node = context.node
@@ -46,9 +43,6 @@ class SvUpdateLoopSocketLabels(bpy.types.Operator):
     '''Update Loop socket Labels'''
     bl_idname = "node.update_loop_socket_labels"
     bl_label = "Update Loop Socket Labels"
-
-    idtree: bpy.props.StringProperty(default='')
-    idname: bpy.props.StringProperty(default='')
 
     def execute(self, context):
         node = context.node
@@ -88,7 +82,7 @@ class SvLoopInNode(SverchCustomTreeNode, bpy.types.Node):
     max_iterations: IntProperty(
         name='Max Iterations', description='Maximum allowed iterations',
         default=5, min=2, update=update_max_iterations)
-        
+
     linked_to_loop_out: BoolProperty(
         name='linked_to_loop_out', description='Maximum allowed iterations',
         default=False)
@@ -126,7 +120,7 @@ class SvLoopInNode(SverchCustomTreeNode, bpy.types.Node):
 
     def draw_buttons(self,ctx, layout):
         if not self.linked_to_loop_out:
-            self.wrapper_tracked_ui_draw_op(layout, "node.create_loop_out", icon='CON_FOLLOWPATH', text="Create Loop Out")
+            layout.operator("node.create_loop_out", icon='CON_FOLLOWPATH', text="Create Loop Out")
         layout.prop(self, 'mode', expand=True)
     def draw_buttons_ext(self, ctx, layout):
         layout.prop(self, 'mode', expand=True)
@@ -138,8 +132,7 @@ class SvLoopInNode(SverchCustomTreeNode, bpy.types.Node):
         socket_labels.label(text="Socket Labels")
         for socket in self.inputs[1:]:
             socket_labels.prop(socket, "label", text=socket.name)
-        self.wrapper_tracked_ui_draw_op(socket_labels, "node.update_loop_socket_labels", icon='CON_FOLLOWPATH', text="Update Socket Labels")
-
+        socket_labels.operator("node.update_loop_socket_labels", icon='CON_FOLLOWPATH', text="Update Socket Labels")
 
     def rclick_menu(self, context, layout):
         layout.prop_menu_enum(self, 'mode')

--- a/nodes/logic/loop_out.py
+++ b/nodes/logic/loop_out.py
@@ -24,12 +24,12 @@ from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.core.update_system import make_tree_from_nodes, do_update
 from sverchok.data_structure import list_match_func
 
-def process_looped_nodes(node_list, tree_nodes):
+def process_looped_nodes(node_list, tree_nodes, process_name, iteration):
     for node_name in node_list:
         try:
             tree_nodes[node_name].process()
         except Exception as e:
-            raise type(e)(str(e) + ' @ %s node' % node_name)
+            raise type(e)(str(e) + f' @ {node_name} node. {process_name} number: {iteration}')
 
 class SvLoopOutNode(bpy.types.Node, SverchCustomTreeNode):
     """
@@ -179,7 +179,7 @@ class SvLoopOutNode(bpy.types.Node, SverchCustomTreeNode):
                     loop_in_node.outputs[j+3].sv_set([data])
                 loop_in_node.outputs['Loop Number'].sv_set([[idx]])
                 idx += 1
-                process_looped_nodes(intersection[1:-1], tree_nodes)
+                process_looped_nodes(intersection[1:-1], tree_nodes, 'Element', idx)
 
                 for inp, out in zip(self.inputs[1:], out_data):
                     out.append(inp.sv_get(deepcopy=False, default=[[]])[0])
@@ -216,7 +216,7 @@ class SvLoopOutNode(bpy.types.Node, SverchCustomTreeNode):
                     loop_in_node.outputs[j+3].sv_set(data)
                 loop_in_node.outputs['Loop Number'].sv_set([[i+1]])
 
-                process_looped_nodes(intersection[1:-1], tree_nodes)
+                process_looped_nodes(intersection[1:-1], tree_nodes, 'Iteration', i+1)
 
 
 

--- a/nodes/logic/loop_out.py
+++ b/nodes/logic/loop_out.py
@@ -33,7 +33,7 @@ def process_looped_nodes(node_list, tree_nodes, process_name, iteration):
 
 socket_labels = { 'Range': 'Break', 'For_Each': 'Skip'}
 
-class SvLoopOutNode(bpy.types.Node, SverchCustomTreeNode):
+class SvLoopOutNode(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: For Loop End,
     Tooltip: End node to define a nodes for-loop.

--- a/nodes/logic/loop_out.py
+++ b/nodes/logic/loop_out.py
@@ -157,14 +157,16 @@ class SvLoopOutNode(bpy.types.Node, SverchCustomTreeNode):
 
             iterations = min(int(loop_in_node.inputs['Iterations'].sv_get()[0][0]), loop_in_node.max_iterations)
             do_update(intersection[:-1], self.id_data.nodes)
-
+            tree_nodes = self.id_data.nodes
             for i in range(iterations-1):
 
                 for j, socket in enumerate(self.inputs[1:]):
                     data = socket.sv_get(deepcopy=False, default=[])
                     loop_in_node.outputs[j+3].sv_set(data)
-                do_update(intersection[1:-1], self.id_data.nodes)
                 loop_in_node.outputs['Loop Number'].sv_set([[i+1]])
+                for node_name in intersection[1:-1]:
+                    tree_nodes[node_name].process()
+
 
             for inp, outp in zip(self.inputs[1:], self.outputs):
                 outp.sv_set(inp.sv_get(deepcopy=False, default=[]))

--- a/nodes/logic/loop_out.py
+++ b/nodes/logic/loop_out.py
@@ -1,0 +1,182 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+from sverchok.core.update_system import make_tree_from_nodes, do_update
+
+
+class SvLoopOutNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: For Loop End,
+    Tooltip: End node to define a nodes for-loop.
+    """
+    bl_idname = 'SvLoopOutNode'
+    bl_label = 'Loop Out'
+    bl_icon = 'CON_FOLLOWPATH'
+
+
+
+    def sv_init(self, context):
+        self.inputs.new('SvLoopControlSocket', 'Loop In')
+        self.inputs.new('SvStringsSocket', 'Data 0')
+        self.inputs.new('SvStringsSocket', 'Data 1')
+        self.outputs.new('SvStringsSocket', 'Data 0')
+        self.outputs.new('SvStringsSocket', 'Data 1')
+
+
+    def sv_update(self):
+
+
+        if not self.inputs[0].is_linked:
+            return
+
+        loop_in_node = self.inputs[0].links[0].from_socket.node
+        if not loop_in_node.bl_idname == 'SvLoopInNode':
+            return
+
+        print("updating loopout")
+
+
+        while len(loop_in_node.inputs)-1 > len(self.inputs):
+            print("updating loopout adding inputs")
+            name = 'Data '+str(len(self.inputs)-1)
+
+            self.inputs.new('SvStringsSocket', name)
+            self.outputs.new('SvStringsSocket', name)
+        while len(loop_in_node.inputs)-1 < len(self.inputs):
+            print("updating loopout removing inputs")
+            self.inputs.remove(self.inputs[-1])
+            self.outputs.remove(self.outputs[-1])
+        if loop_in_node.inputs[-1].links:
+            name = 'Data '+str(len(self.inputs)-1)
+            self.inputs.new('SvStringsSocket', name)
+            self.outputs.new('SvStringsSocket', name)
+        # check number of connections and type match input socket n with output socket n
+        count_inputs = 0
+        count_outputs = 0
+        for idx, socket in enumerate(loop_in_node.inputs):
+            if socket.name in self.outputs and self.outputs[socket.name].links:
+                count_outputs += 1
+            if socket.links:
+                count_inputs += 1
+                if type(socket.links[0].from_socket) != type(self.outputs[socket.name]):
+                    self.inputs.remove(self.inputs[socket.name])
+                    self.inputs.new(socket.links[0].from_socket.bl_idname, socket.name)
+                    self.inputs.move(len(self.inputs)-1, idx)
+                    self.outputs.remove(self.outputs[socket.name])
+                    self.outputs.new(socket.links[0].from_socket.bl_idname, socket.name)
+                    self.outputs.move(len(self.outputs)-1, idx-1)
+
+    def bad_inner_loops(self, intersection):
+        inner_loops_out, inner_loops_in = [],[]
+        ng = self.id_data
+        for node in intersection:
+            if ng.nodes[node].bl_idname == 'SvLoopOutNode':
+                inner_loops_out.append(node)
+            if ng.nodes[node].bl_idname == 'SvLoopInNode':
+                inner_loops_in.append(node)
+        for node in inner_loops_out:
+            if not ng.nodes[node].ready():
+                return True
+
+            inner_loop_in_node = ng.nodes[node].inputs[0].links[0].from_socket.node
+            if not inner_loop_in_node.name in inner_loops_in:
+                print("Inner Loop not well connected")
+                return True
+            else:
+                inner_loops_in.remove(inner_loop_in_node.name)
+        if inner_loops_in:
+            return True
+
+        return False
+
+    def get_affected_nodes(self, loop_in_node):
+        nodes_to_loop_out = make_tree_from_nodes([self.name], self.id_data, down=False)
+        nodes_from_loop_in = make_tree_from_nodes([loop_in_node.name], self.id_data, down=True)
+        nodes_from_loop_out = make_tree_from_nodes([self.name], self.id_data, down=True)
+
+        set_nodes_from_loop_in = frozenset(nodes_from_loop_in)
+        set_nodes_from_loop_out = frozenset(nodes_from_loop_out)
+        # set_nodes_to_loop_out = frozenset(nodes_to_loop_out)
+
+        intersection = [x for x in nodes_to_loop_out if x in set_nodes_from_loop_in]
+        related_nodes = [x for x in nodes_from_loop_in if x not in set_nodes_from_loop_out and x not in intersection]
+
+        return intersection, related_nodes
+
+    def ready(self):
+        if not self.inputs[0].is_linked:
+            print("Inner Loop not connected")
+            return False
+        if not any([socket.is_linked for socket in self.outputs]):
+            return False
+        loop_in_node = self.inputs[0].links[0].from_socket.node
+        if not loop_in_node.bl_idname == 'SvLoopInNode':
+            print("Inner Loop not well connected")
+            return False
+        return True
+
+    def process(self):
+        if not self.ready():
+            return
+
+        loop_in_node = self.inputs[0].links[0].from_socket.node
+        if loop_in_node.iterations == 0:
+            for inp, outp in zip(loop_in_node.inputs[1:-1], self.outputs):
+                outp.sv_set(inp.sv_get(deepcopy=False, default=[]))
+
+        elif loop_in_node.iterations == 1:
+
+            for inp, outp in zip(self.inputs[1:], self.outputs):
+                outp.sv_set(inp.sv_get(deepcopy=False, default=[]))
+        else:
+
+            intersection, related_nodes = self.get_affected_nodes(loop_in_node)
+            if self.bad_inner_loops(intersection):
+                raise Exception("Loops inside not well connected")
+
+
+            iterations = min(int(loop_in_node.inputs['Iterations'].sv_get()[0][0]), loop_in_node.max_iterations)
+            do_update(intersection[:-1], self.id_data.nodes)
+
+            for i in range(iterations-1):
+
+                for j, socket in enumerate(self.inputs[1:]):
+                    data = socket.sv_get(deepcopy=False, default=[])
+                    loop_in_node.outputs[j+3].sv_set(data)
+                do_update(intersection[1:-1], self.id_data.nodes)
+                loop_in_node.outputs['Loop Number'].sv_set([[i+1]])
+
+            for inp, outp in zip(self.inputs[1:], self.outputs):
+                outp.sv_set(inp.sv_get(deepcopy=False, default=[]))
+
+            do_update(related_nodes, self.id_data.nodes)
+
+
+
+
+def register():
+    bpy.utils.register_class(SvLoopOutNode)
+
+
+def unregister():
+    bpy.utils.unregister_class(SvLoopOutNode)

--- a/nodes/logic/loop_out.py
+++ b/nodes/logic/loop_out.py
@@ -31,7 +31,7 @@ def process_looped_nodes(node_list, tree_nodes, process_name, iteration):
         except Exception as e:
             raise type(e)(str(e) + f' @ {node_name} node. {process_name} number: {iteration}')
 
-socket_labels = { 'Range': 'Break', 'For_Each': 'Skip'}
+socket_labels = {'Range': 'Break', 'For_Each': 'Skip'}
 
 class SvLoopOutNode(SverchCustomTreeNode, bpy.types.Node):
     """
@@ -113,8 +113,8 @@ class SvLoopOutNode(SverchCustomTreeNode, bpy.types.Node):
             if not inner_loop_in_node.name in inner_loops_in:
                 print("Inner Loop not well connected")
                 return True
-            else:
-                inner_loops_in.remove(inner_loop_in_node.name)
+            inner_loops_in.remove(inner_loop_in_node.name)
+
         if inner_loops_in:
             return True
 

--- a/nodes/logic/loop_out.py
+++ b/nodes/logic/loop_out.py
@@ -93,6 +93,9 @@ class SvLoopOutNode(bpy.types.Node, SverchCustomTreeNode):
                     self.outputs.remove(self.outputs[socket.name])
                     self.outputs.new(socket.links[0].from_socket.bl_idname, socket.name)
                     self.outputs.move(len(self.outputs)-1, idx-1)
+        for inp, self_inp, self_outp in zip(loop_in_node.inputs[1:], self.inputs[2:], self.outputs):
+            self_outp.label = inp.label
+            self_inp.label = inp.label
 
     def bad_inner_loops(self, intersection):
         inner_loops_out, inner_loops_in = [],[]

--- a/ui/sv_panel_display_nodes.py
+++ b/ui/sv_panel_display_nodes.py
@@ -21,7 +21,7 @@ from bpy.props import IntProperty, StringProperty, BoolProperty, FloatProperty, 
 
 from sverchok.utils.context_managers import sv_preferences
 from sverchok.menu import make_node_cats
-
+from sverchok.utils.dummy_nodes import is_dependent
 from pprint import pprint
 
 DEBUG = False
@@ -215,74 +215,75 @@ class SvDisplayNodePanelProperties(bpy.types.PropertyGroup):
             max_node_height = 0
             max_node_area = 0
             for node in nodes:
-                w = node.dimensions[0]
-                h = node.dimensions[1]
-                max_node_width = max(max_node_width, w)
-                max_node_height = max(max_node_height, h)
-                max_node_area = max(max_node_height, w * h)
-
-            if self.constrain_layout == "HEIGHT":
-                bins = binpack(nodes, self.grid_height)
-
-            elif self.constrain_layout == "WIDTH":
-                # find the height that has total width less than max width
-                found = False
-                height = 100
-                while not found:
-                    bins = binpack(nodes, height)
-                    # find max width for current layout
-                    totalWidth = 0
-                    for bin in bins:
-                        totalWidth = totalWidth + bin.width
-
-                    if DEBUG:
-                        print("For height= %d total width = %d" % (height, totalWidth))
-
-                    if totalWidth > max(max_node_width, self.grid_width):
-                        height = height + 10
-                        # try again with larger height
-                    else:  # found it
-                        found = True
-            else:
-                # find the height and width closest to the user aspect ratio
-                target_aspect = self.grid_width / self.grid_height
-
-                found = False
-                height = 100
-                while not found:
-                    bins = binpack(nodes, height)
-                    # find max width for current layout
-                    totalWidth = 0
-                    for bin in bins:
-                        totalWidth = totalWidth + bin.width
-
-                    if DEBUG:
-                        print("For height= %d total width = %d" % (height, totalWidth))
-
-                    current_aspect = totalWidth / height
-
-                    if current_aspect > target_aspect:
-                        height = height + 10
-                        # try again with larger height
-                    else:  # found it
-                        found = True
+                # w = node.dimensions[0]
+                print(node,node.dimensions)
+                # h = node.dimensions[1]
+                # max_node_width = max(max_node_width, w)
+                # max_node_height = max(max_node_height, h)
+                # max_node_area = max(max_node_height, w * h)
+            #
+            # if self.constrain_layout == "HEIGHT":
+            #     bins = binpack(nodes, self.grid_height)
+            #
+            # elif self.constrain_layout == "WIDTH":
+            #     # find the height that has total width less than max width
+            #     found = False
+            #     height = 100
+            #     while not found:
+            #         bins = binpack(nodes, height)
+            #         # find max width for current layout
+            #         totalWidth = 0
+            #         for bin in bins:
+            #             totalWidth = totalWidth + bin.width
+            #
+            #         if DEBUG:
+            #             print("For height= %d total width = %d" % (height, totalWidth))
+            #
+            #         if totalWidth > max(max_node_width, self.grid_width):
+            #             height = height + 10
+            #             # try again with larger height
+            #         else:  # found it
+            #             found = True
+            # else:
+            #     # find the height and width closest to the user aspect ratio
+            #     target_aspect = self.grid_width / self.grid_height
+            #
+            #     found = False
+            #     height = 100
+                # while not found:
+                #     bins = binpack(nodes, height)
+                #     # find max width for current layout
+                #     totalWidth = 0
+                #     for bin in bins:
+                #         totalWidth = totalWidth + bin.width
+                #
+                #     if DEBUG:
+                #         print("For height= %d total width = %d" % (height, totalWidth))
+                #
+                #     current_aspect = totalWidth / height
+                #
+                #     if current_aspect > target_aspect:
+                #         height = height + 10
+                #         # try again with larger height
+                #     else:  # found it
+                #         found = True
 
             # arrange the nodes in the bins on the grid
-            x = 0
-            for bin in bins:
-                max_x_width = max([item[0][0] for item in bin.items])
-                y = 0
-                for item in bin.items:
-                    node_width = item[0][0]
-                    node_height = item[0][1]
-                    node_name = item[1]
-                    node = item[2]
-                    if DEBUG:
-                        print("node = ", node_name, " : ", node_width, " x ", node_height)
-                    node.location[0] = x + 0.5 * (max_x_width - node_width)
-                    node.location[1] = y
-                    y = y - node_height - self.grid_y_space
-                x = x + max_x_width + self.grid_x_space
+            # x = 0
+            # for bin in bins:
+            #     max_x_width = max([item[0][0] for item in bin.items])
+            #     y = 0
+            #     for item in bin.items:
+            #         node_width = item[0][0]
+            #         node_height = item[0][1]
+            #         node_name = item[1]
+            #         node = item[2]
+            #         if DEBUG:
+            #             print("node = ", node_name, " : ", node_width, " x ", node_height)
+            #         node.location[0] = x + 0.5 * (max_x_width - node_width)
+            #         node.location[1] = y
+            #         y = y - node_height - self.grid_y_space
+            #     x = x + max_x_width + self.grid_x_space
         except Exception as e:
             print('well.. some exception occurred:', str(e))
 
@@ -306,7 +307,10 @@ class SvDisplayNodePanelProperties(bpy.types.PropertyGroup):
             name = node_name
             if name == "separator":
                 continue
-
+            if is_dependent(name):
+                continue
+            if '@' in name:
+                continue
             if DEBUG:
                 print("Spawning Node %d : %s" % (i, name))
 


### PR DESCRIPTION
New nodes to create node loops. It seems very stable (much more than monads) although the inside logic is pretty similar, also pretty basic.
The loop is performed in the Loop Out node, this creates less interference with the actual update system.
Also they can do nested loops and use any viewer
![image](https://user-images.githubusercontent.com/10011941/100526201-ff36d000-31c6-11eb-8d90-e2eef53d0c81.png)
![image](https://user-images.githubusercontent.com/10011941/100529270-16d18100-31e6-11eb-8547-846acf17fb97.png)


- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

