### PR TITLE
Default presets

### DIFF
--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -118,6 +118,11 @@ categories are distinguished with a prefix "/Node/" in their titles. For
 example, a category with name "/Node/ Box" can contain only settings of the
 "Box" node. Such categories are created automatically.
 
+Among per-node presets, you can define a preset with special name ``Default``.
+Such preset will be automatically applied to the node of this type when you
+create it by selecting from Shift-A menu, from Search menu or from T panel (but
+not when it is created as a part of another preset being used).
+
 Presets are saved as `.json` files under Blender configuration directory, in
 `datafiles/sverchok/presets`. Preset categories are represented as directories
 under that one.

--- a/menu.py
+++ b/menu.py
@@ -34,6 +34,8 @@ from sverchok.ui.sv_icons import node_icon, icon
 from sverchok.utils.context_managers import sv_preferences
 from sverchok.utils.extra_categories import get_extra_categories
 from sverchok.core.update_system import set_first_run
+from sverchok.ui.presets import apply_default_preset
+from sverchok.utils.sv_json_import import JSONImporter
 
 class SverchNodeCategory(NodeCategory):
     @classmethod
@@ -241,7 +243,8 @@ class SverchNodeItem(object):
                 # SverchNodeItem instance.
                 operator.use_transform = True
                 operator.type = self.nodetype
-                operator.create_node(context)
+                node = operator.create_node(context)
+                apply_default_preset(node)
                 return {'FINISHED'}
 
         node_class = self.get_node_class()

--- a/ui/nodeview_rclick_menu.py
+++ b/ui/nodeview_rclick_menu.py
@@ -9,7 +9,7 @@
 import bpy
 from sverchok.utils.sv_node_utils import frame_adjust
 from sverchok.menu import draw_add_node_operator
-from sverchok.ui.presets import node_supports_presets
+from sverchok.ui.presets import node_supports_presets, apply_default_preset
 from sverchok.core.sockets import SvCurveSocket, SvSurfaceSocket, SvStringsSocket, SvSolidSocket
 
 sv_tree_types = {'SverchCustomTreeType', 'SverchGroupTreeType'}
@@ -110,6 +110,7 @@ def add_connection(tree, bl_idname_new_node, offset):
         # single new node..
 
         new_node = nodes.new(bl_idname_new_node)
+        apply_default_preset(new_node)
         offset_node_location(existing_node, new_node, offset)
         frame_adjust(existing_node, new_node)
 
@@ -146,6 +147,7 @@ def add_connection(tree, bl_idname_new_node, offset):
             elif 'curve' in output_map:
 
                 eval_node = nodes.new('SvExEvalCurveNode')
+                apply_default_preset(eval_node)
                 offset_node_location(existing_node, eval_node, offset)
                 frame_adjust(existing_node, eval_node)
                 offset_node_location(eval_node, new_node, offset)
@@ -156,6 +158,7 @@ def add_connection(tree, bl_idname_new_node, offset):
 
             elif 'surface' in output_map:
                 eval_node = nodes.new('SvExEvalSurfaceNode')
+                apply_default_preset(eval_node)
                 offset_node_location(existing_node, eval_node, offset)
                 frame_adjust(existing_node, eval_node)
                 offset_node_location(eval_node, new_node, offset)
@@ -167,6 +170,7 @@ def add_connection(tree, bl_idname_new_node, offset):
             elif 'solid' in output_map:
                 tree.nodes.remove(new_node)
                 new_node = nodes.new('SvSolidViewerNode')
+                apply_default_preset(new_node)
                 offset_node_location(existing_node, new_node, offset)
                 frame_adjust(existing_node, new_node)
                 links.new(outputs[output_map['solid']], new_node.inputs[0])

--- a/ui/presets.py
+++ b/ui/presets.py
@@ -358,6 +358,23 @@ def get_presets(category=None, search=None, mkdir=True):
                 result.append(preset)
     return result
 
+def get_preset(category, name):
+    file_name = name + ".json"
+    user = get_presets_directory(category, standard=False)
+    standard = get_presets_directory(category, standard=True)
+
+    for is_standard, directory in [(False, user), (True, standard)]:
+        path = join(directory, file_name)
+        if os.path.exists(path):
+            preset = SvPreset(path = path, category=category, standard=is_standard)
+            return preset
+    return None
+
+def apply_default_preset(node):
+    preset = get_preset(node.bl_idname, "Default")
+    if preset is not None:
+        JSONImporter(preset.data).import_node_settings(node)
+
 class SvUserPresetsPanelProps(bpy.types.PropertyGroup):
     manage_mode: BoolProperty(
         name="Manage Presets",

--- a/utils/sv_json_import.py
+++ b/utils/sv_json_import.py
@@ -264,6 +264,7 @@ class TreeGenerator:
         with self._fails_log.add_fail("Creating node", f'Tree: {self._tree_name}, Node: {node_name}'):
             if old_nodes.is_old(bl_type):  # old node classes are registered only by request
                 old_nodes.register_old(bl_type)
+            # import only here to do not create a cyclic import
             from sverchok.utils import dummy_nodes
             if dummy_nodes.is_dependent(bl_type):
                 # some node types are not registered if dependencies are not installed

--- a/utils/sv_json_import.py
+++ b/utils/sv_json_import.py
@@ -18,7 +18,6 @@ from sverchok.core.update_system import build_update_list, process_tree
 from sverchok import old_nodes
 from sverchok.utils.sv_IO_panel_tools import get_file_obj_from_zip
 from sverchok.utils.logging import info, warning, getLogger, logging
-from sverchok.utils import dummy_nodes
 from sverchok.utils.handle_blender_data import BPYProperty, BPYNode
 from sverchok.utils.sv_IO_monad_helpers import unpack_monad
 
@@ -265,6 +264,7 @@ class TreeGenerator:
         with self._fails_log.add_fail("Creating node", f'Tree: {self._tree_name}, Node: {node_name}'):
             if old_nodes.is_old(bl_type):  # old node classes are registered only by request
                 old_nodes.register_old(bl_type)
+            from sverchok.utils import dummy_nodes
             if dummy_nodes.is_dependent(bl_type):
                 # some node types are not registered if dependencies are not installed
                 # in this case such nodes are registered as dummies


### PR DESCRIPTION
## Addressed problem description

We used to have "custom defaults" mechanism for nodes. Now it is removed, but even when it worked it had a problem of being too hard to use. 

## Solution description

Now that we have Presets and per-node presets, let's use this mechanism to replace old custom defaults mechanism. How it works:

* You configure the node as you wish
* You go to it's Presets menu (in the N panel, or in the node's context menu, or you can press Shift-P), and select "Save current settings as node preset"
* Enter **Default** (case sensitive) as the name of the preset.

Now, when you create node of the same type by any usual way (from Shift-A menu, from T panel, from Search menu), this Default preset will be automatically applied. This preset will not be applied when the node is created as part of another (multi-node) preset being imported.

These Default presets are available in the Presets panel under T panel; you can rename them, or remove as well as others.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

