### PR TITLE
Spatial nodes update

### DIFF
--- a/docs/nodes/spatial/field_random_probe.rst
+++ b/docs/nodes/spatial/field_random_probe.rst
@@ -13,7 +13,8 @@ This node generates random points, which are distributed according to the provid
   probability of the vertex appearence at some point is proportional to the
   value of the scalar field at that point.
 
-This node can make sure that generated points are not too close to one another. This can be controlled in one of two ways:
+This node can make sure that generated points are not too close to one another.
+This can be controlled in one of two ways:
 
 * By specifying minimum distance between any two different points;
 * Or by specifying a radius around each generated points, which should be free.
@@ -57,12 +58,29 @@ This node has the following inputs:
 Parameters
 ----------
 
-This node has the following parameter:
+This node has the following parameters:
+
+* **Distance**. This defines how minimum distance between generated points is
+  defined. The available options are:
+
+   * **Min. Distance**. The user provides minimum distance between any two
+     points in the **MinDistance** input.
+   * **RadiusField**. The user defines a radius of a shpere that should be
+     empty around each generated point, by providing a scalar field in the
+     **RadiusField** input. The node makes sure that these spheres will not
+     intersect.
+
+   The default value is **Min. Distance**.
 
 * **Proportional**. If checked, then the points density will be distributed
   proportionally to the values of scalar field. Otherwise, the points will be
   uniformly distributed in the area where the value of scalar field exceeds
   threshold. Unchecked by default.
+* **Random Radius**. This parameter is available only when **Distance**
+  parameter is set to **RadiusField**. If checked, then radiuses of empty
+  spheres will be generated randomly, by using uniform distribution between 0
+  (zero) and the value defined by the scalar field provided in the
+  **RadiusField** input. Unchecked by default.
 
 When **Proportional** mode is enabled, then the probability of vertex
 appearance at the certain point is calculated as ``P = (V - FieldMin) /

--- a/docs/nodes/spatial/field_random_probe.rst
+++ b/docs/nodes/spatial/field_random_probe.rst
@@ -13,6 +13,15 @@ This node generates random points, which are distributed according to the provid
   probability of the vertex appearence at some point is proportional to the
   value of the scalar field at that point.
 
+This node can make sure that generated points are not too close to one another. This can be controlled in one of two ways:
+
+* By specifying minimum distance between any two different points;
+* Or by specifying a radius around each generated points, which should be free.
+  More precisely, the node makes sure that if you place a sphere of specified
+  radius at each point as a center, these spheres will never intersect. The
+  radiuses of such spheres are provided as a scalar field: it defines a radius
+  value for any point in the space.
+
 Inputs
 ------
 
@@ -25,9 +34,13 @@ This node has the following inputs:
   generated. Only bounding box of these vertices will be used. This input is
   mandatory.
 * **Count**. The number of points to be generated. The default value is 50.
-* **MinDistance**. Minimum allowable distance between generated points. If set
-  to zero, there will be no restriction on distance between points. Default
-  value is 0.
+* **MinDistance**. This input is avaliable only when **Distance** parameter is
+  set to **Min. Distance**. Minimum allowable distance between generated
+  points. If set to zero, there will be no restriction on distance between
+  points. Default value is 0.
+* **RadiusField**. This input is available and mandatory only when **Distance**
+  parameter is set to **Radius Field**. The scalar field, which defines radius
+  of free sphere around any generated point.
 * **Threshold**. Threshold value: the node will not generate points in areas
   where the value of scalar field is less than this value. The default value is
   0.5.
@@ -73,4 +86,12 @@ Generate cubes near the cyllinder:
 Generate cubes according to the scalar field defined by some formula:
 
 .. image:: https://user-images.githubusercontent.com/284644/81504488-f94cd080-9302-11ea-9da5-f27f633f2191.png
+
+Example of "Radius Field** mode usage:
+
+.. image:: https://user-images.githubusercontent.com/284644/102390341-1ca4d000-3ff6-11eb-90f5-dfa07646f941.png
+
+Here we are placing spheres of different radiuses at each generated point.
+Since radiuses of the sphere are defined by the same scalar field which is used
+for RadiusField input, these spheres do never intersect.
 

--- a/docs/nodes/spatial/populate_solid.rst
+++ b/docs/nodes/spatial/populate_solid.rst
@@ -21,6 +21,16 @@ object according to the provided Scalar Field. It has two modes:
   probability of the vertex appearence at some point is proportional to the
   value of the scalar field at that point.
 
+This node can make sure that generated points are not too close to one another.
+This can be controlled in one of two ways:
+
+* By specifying minimum distance between any two different points;
+* Or by specifying a radius around each generated points, which should be free.
+  More precisely, the node makes sure that if you place a sphere of specified
+  radius at each point as a center, these spheres will never intersect. The
+  radiuses of such spheres are provided as a scalar field: it defines a radius
+  value for any point in the space.
+
 The node can generate points either inside the Solid body, or on it's surface.
 
 Inputs
@@ -34,9 +44,13 @@ This node has the following inputs:
   this input is not connected, the node will generate evenly distributed
   points. This input is mandatory, if **Proportional** parameter is checked.
 * **Count**. The number of points to be generated. The default value is 50.
-* **MinDistance**. Minimum allowable distance between generated points. If set
-  to zero, there will be no restriction on distance between points. Default
-  value is 0.
+* **MinDistance**. This input is avaliable only when **Distance** parameter is
+  set to **Min. Distance**. Minimum allowable distance between generated
+  points. If set to zero, there will be no restriction on distance between
+  points. Default value is 0.
+* **RadiusField**. This input is available and mandatory only when **Distance**
+  parameter is set to **Radius Field**. The scalar field, which defines radius
+  of free sphere around any generated point.
 * **Threshold**. Threshold value: the node will not generate points in areas
   where the value of scalar field is less than this value. The default value is
   0.5.
@@ -62,10 +76,27 @@ This node has the following parameters:
 
   The default value is **Volume**
 
+* **Distance**. This defines how minimum distance between generated points is
+  defined. The available options are:
+
+   * **Min. Distance**. The user provides minimum distance between any two
+     points in the **MinDistance** input.
+   * **RadiusField**. The user defines a radius of a shpere that should be
+     empty around each generated point, by providing a scalar field in the
+     **RadiusField** input. The node makes sure that these spheres will not
+     intersect.
+
+   The default value is **Min. Distance**.
+
 * **Proportional**. If checked, then the points density will be distributed
   proportionally to the values of scalar field. Otherwise, the points will be
   uniformly distributed in the area where the value of scalar field exceeds
   threshold. Unchecked by default.
+* **Random Radius**. This parameter is available only when **Distance**
+  parameter is set to **RadiusField**. If checked, then radiuses of empty
+  spheres will be generated randomly, by using uniform distribution between 0
+  (zero) and the value defined by the scalar field provided in the
+  **RadiusField** input. Unchecked by default.
 * **Accept in surface**. This parameter is only available when the **Generation
   mode** parameter is set to **Volume**. This defines whether it is acceptable
   to generate points on the surface of the body as well as inside it. Checked
@@ -91,4 +122,8 @@ Example of Usage
 ----------------
 
 .. image:: https://user-images.githubusercontent.com/284644/99146273-5b163a80-2698-11eb-8f1d-a41978cc96ea.png
+
+Example of "Radius Field" mode usage:
+
+.. image:: https://user-images.githubusercontent.com/284644/102390349-1dd5fd00-3ff6-11eb-98d1-6143b5312380.png
 

--- a/docs/nodes/spatial/populate_surface.rst
+++ b/docs/nodes/spatial/populate_surface.rst
@@ -14,6 +14,16 @@ according to the provided Scalar Field. It has two modes:
   probability of the vertex appearence at some point is proportional to the
   value of the scalar field at that point.
 
+This node can make sure that generated points are not too close to one another.
+This can be controlled in one of two ways:
+
+* By specifying minimum distance between any two different points;
+* Or by specifying a radius around each generated points, which should be free.
+  More precisely, the node makes sure that if you place a sphere of specified
+  radius at each point as a center, these spheres will never intersect. The
+  radiuses of such spheres are provided as a scalar field: it defines a radius
+  value for any point in the space.
+
 Inputs
 ------
 
@@ -25,9 +35,13 @@ This node has the following inputs:
   this input is not connected, the node will generate evenly distributed
   points. This input is mandatory, if **Proportional** parameter is checked.
 * **Count**. The number of points to be generated. The default value is 50.
-* **MinDistance**. Minimum allowable distance between generated points. If set
-  to zero, there will be no restriction on distance between points. Default
-  value is 0.
+* **MinDistance**. This input is avaliable only when **Distance** parameter is
+  set to **Min. Distance**. Minimum allowable distance between generated
+  points. If set to zero, there will be no restriction on distance between
+  points. Default value is 0.
+* **RadiusField**. This input is available and mandatory only when **Distance**
+  parameter is set to **Radius Field**. The scalar field, which defines radius
+  of free sphere around any generated point.
 * **Threshold**. Threshold value: the node will not generate points in areas
   where the value of scalar field is less than this value. The default value is
   0.5.
@@ -44,12 +58,29 @@ This node has the following inputs:
 Parameters
 ----------
 
-This node has the following parameter:
+This node has the following parameters:
+
+* **Distance**. This defines how minimum distance between generated points is
+  defined. The available options are:
+
+   * **Min. Distance**. The user provides minimum distance between any two
+     points in the **MinDistance** input.
+   * **RadiusField**. The user defines a radius of a shpere that should be
+     empty around each generated point, by providing a scalar field in the
+     **RadiusField** input. The node makes sure that these spheres will not
+     intersect.
+
+   The default value is **Min. Distance**.
 
 * **Proportional**. If checked, then the points density will be distributed
   proportionally to the values of scalar field. Otherwise, the points will be
   uniformly distributed in the area where the value of scalar field exceeds
   threshold. Unchecked by default.
+* **Random Radius**. This parameter is available only when **Distance**
+  parameter is set to **RadiusField**. If checked, then radiuses of empty
+  spheres will be generated randomly, by using uniform distribution between 0
+  (zero) and the value defined by the scalar field provided in the
+  **RadiusField** input. Unchecked by default.
 
 When **Proportional** mode is enabled, then the probability of vertex
 appearance at the certain point is calculated as ``P = (V - FieldMin) /
@@ -71,4 +102,8 @@ Example of usage
 Distribute points on a Moebius band according to some attractor field:
 
 .. image:: https://user-images.githubusercontent.com/284644/99146076-7ed88100-2696-11eb-8175-67b5f268f36e.png
+
+Example of "Radius Field" mode usage:
+
+.. image:: https://user-images.githubusercontent.com/284644/102106806-d5caa500-3e52-11eb-805e-73333b35350c.png
 

--- a/docs/nodes/spatial/random_points_on_mesh.rst
+++ b/docs/nodes/spatial/random_points_on_mesh.rst
@@ -26,8 +26,17 @@ Parameters
 
 This node has the following parameters:
 
-- **Proportional**. If checked, then the number of points on each face will be
-  proportional to the area of the face (and to the weight provided in the
+- **Mode**. The available options are:
+
+  * **Surface**. Generate points on the surface of the mesh.
+  * **Volume**. Generate points inside the volume of the mesh. The mesh is
+    expected to represent a closed volume in this case.
+
+  The default option is **Surface**.
+
+- **Proportional**. This parameter is available only when **Mode** parameter is
+  set to **Surface**. If checked, then the number of points on each face will
+  be proportional to the area of the face (and to the weight provided in the
   **Face weight** input). If not checked, then the number of points on each
   face will be only defined by **Face weight** input. Checked by default.
 
@@ -35,7 +44,8 @@ Outputs
 -------
 
 - **Verts** - random vertices on mesh
-- **Face index** - indexes of faces to which random vertices lays
+- **Face index** - indexes of faces to which random vertices lays. This input
+  is available only when **Mode** parameter is set to **Surface**.
 
 Examples
 --------

--- a/docs/nodes/spatial/spatial_index.rst
+++ b/docs/nodes/spatial/spatial_index.rst
@@ -17,6 +17,7 @@ Spatial
    delaunay_2d_cdt
    voronoi_sphere
    voronoi_on_surface
+   voronoi_on_mesh
    lloyd2d
    lloyd3d
    lloyd_on_sphere

--- a/docs/nodes/spatial/spatial_index.rst
+++ b/docs/nodes/spatial/spatial_index.rst
@@ -18,6 +18,7 @@ Spatial
    voronoi_sphere
    voronoi_on_surface
    voronoi_on_mesh
+   voronoi_on_solid
    lloyd2d
    lloyd3d
    lloyd_on_sphere

--- a/docs/nodes/spatial/voronoi_on_mesh.rst
+++ b/docs/nodes/spatial/voronoi_on_mesh.rst
@@ -31,7 +31,7 @@ This node has the following inputs:
   necessary. This input is mandatory.
 * **Spacing**. Percent of space to leave between generated fragment meshes.
   Zero means do not leave any space, i.e. regions will fully cover initial
-  mesh. Maximum possible value is 1.0. The default value is 0.
+  mesh. The default value is 0.
 
 Parameters
 ----------

--- a/docs/nodes/spatial/voronoi_on_mesh.rst
+++ b/docs/nodes/spatial/voronoi_on_mesh.rst
@@ -1,0 +1,78 @@
+Voronoi on Mesh
+===============
+
+Dependencies
+------------
+
+This node requires SciPy_ library to work.
+
+.. _SciPy: https://scipy.org/
+
+Functionality
+-------------
+
+This node creates Voronoi diagram on a given mesh, from specified set of
+initial points (sites). More specifically, it subdivides the mesh into regions
+of such Voronoi diagram. It is possible to subdivide:
+
+* either surface of the mesh, generating a series of flat meshes,
+* or the volume of the mesh, generating a series of closed-body meshes. In this
+  mode, it is required that the mesh represents a closed volume.
+
+Inputs
+------
+
+This node has the following inputs:
+
+* **Vertices**. Vertices of the mesh to generate Voronoi diagram on. This input is mandatory.
+* **Faces**. Faces of the mesh to generate Voronoi diagram on. This input is mandatory.
+* **Sites**. The points to generate Voronoi diagram for. Usually you want for
+  this points to lie either inside the mesh or on it's surface, but this is not
+  necessary. This input is mandatory.
+* **Spacing**. Percent of space to leave between generated fragment meshes.
+  Zero means do not leave any space, i.e. regions will fully cover initial
+  mesh. Maximum possible value is 1.0. The default value is 0.
+
+Parameters
+----------
+
+This node has the following parameters:
+
+* **Mode**. The available options are:
+
+  * **Split Volume**. Split closed-volume mesh into smaller closed-volume mesh regions.
+  * **Split Surface**. Split the surface of a mesh into smaller flat meshes.
+
+  The default value is **Split Volume**.
+
+* **Correct normals**. This parameter is available only when **Mode** parameter
+  is set to **Volume**. If checked, then the node will make sure that all
+  normals of generated meshes point outside. Otherwise, this is not guaranteed.
+  Checked by default.
+* **Output nesting**. This defines nesting structure of output sockets. The available options are:
+
+   * **Flat list**. Output a single flat list of mesh objects (Voronoi diagram
+     ridges / regions) for all input meshes.
+   * **Separate lists**. Output a separate list of mesh objects (Voronoi
+     diagram ridges / regions) for each input mesh.
+   * **Join meshes**. Output one mesh, joined from ridges / edges of Voronoi
+     diagram, for each input mesh.
+
+* **Accuracy**. This parameter is available in the N panel only. This defines
+  the precision of mesh calculation (number of digits after decimal point). The
+  default value is 6.
+
+Outputs
+-------
+
+This node has the following outputs:
+
+* **Vertices**. Vertices of generated mesh.
+* **Edges**. Edges of generated mesh.
+* **Faces**. Faces of generated mesh.
+
+Example of usage
+----------------
+
+.. image:: https://user-images.githubusercontent.com/284644/102384062-190d4b00-3fee-11eb-8405-71e8ed383d26.png
+

--- a/docs/nodes/spatial/voronoi_on_solid.rst
+++ b/docs/nodes/spatial/voronoi_on_solid.rst
@@ -1,0 +1,87 @@
+Voronoi on Solid
+================
+
+Dependencies
+------------
+
+This node requires both SciPy_ and FreeCAD_ libraries to work.
+
+.. _SciPy: https://scipy.org/
+.. _FreeCAD: ../../solids.rst
+
+Functionality
+-------------
+
+This node creates Voronoi diagram on a given Solid object. The result can be
+output as either series of fragments of the shell of Solid object (series of
+faces), or as a series of solid bodies.
+
+**Note**: this node uses FreeCAD's functionality of solid boolean operations
+internally. This functionality is known to be slow when working with objects
+defined by NURBS surfaces, especially when there are a lot of sites used. Also
+please be warned that this functionality is known to cause Blender crashes on
+some setups.
+
+Inputs
+------
+
+This node has the following inputs:
+
+* **Solid**. The solid object, on which the Voronoi diagram is to be generated.
+  This input is mandatory.
+* **Sites**. List of points, for which Voronoi diagram is to be generated. This
+  input is mandatory.
+* **Inset**. Percentage of space to leave between generated Voronoi regions.
+  Zero means the object will be fully covered by generated regions. Maximum
+  value is 1.0. The default value is 0.1.
+
+Parameters
+----------
+
+This node has the following parameters:
+
+* **Mode**. The available options are available:
+
+  * **Surface**. The node will split the surface (shell) of the solid body into
+    regions of Voronoi diagram.
+  * **Volume**. The node will split the volume of the solid body into regions
+    of Voronoi diagram.
+
+  The default value is **Surface**.
+
+* **Flat output**. If checked, output single flat list of fragments for all
+  output solids. Otherwise, output a separate list of fragments for each solid.
+  Checked by default.
+* **Accuracy**. This parameter is available in the N panel only. Precision of
+  calculations (number of digits after decimal point). The default value is 6.
+
+Outputs
+-------
+
+This node has the following outputs:
+
+* **InnerSolid**. Solid objects (or their shells, if **Surface** mode is used)
+  calculated as regions of Voronoi diagram.
+* **OuterSolid**. Solid object, representing the part of volume or shell, which
+  is left between the regions of Voronoi diagram. This object will be empty if
+  **Inset** input is set to zero.
+
+Examples of usage
+-----------------
+
+Inner solids with **Surface** mode:
+
+.. image:: https://user-images.githubusercontent.com/284644/103175519-411d6980-488c-11eb-86bf-151a4776f6ac.png
+
+Outer solid for the same setup:
+
+.. image:: https://user-images.githubusercontent.com/284644/103175520-424e9680-488c-11eb-99aa-d0ea147c29d6.png
+
+Inner solids with **Volume** mode:
+
+.. image:: https://user-images.githubusercontent.com/284644/103175523-437fc380-488c-11eb-817b-fe5826d184ed.png
+
+Outer solid with **Volume** mode:
+
+.. image:: https://user-images.githubusercontent.com/284644/103175522-42e72d00-488c-11eb-947b-ba57fc3b96f7.png
+

--- a/index.md
+++ b/index.md
@@ -314,7 +314,7 @@
     SvHomogenousVectorField
     SvRandomPointsOnMesh
     SvPopulateSurfaceMk2Node
-    SvPopulateSolidNode
+    SvPopulateSolidMk2Node
     SvFieldRandomProbeMk3Node
     ---
     DelaunayTriangulation2DNode

--- a/index.md
+++ b/index.md
@@ -326,6 +326,7 @@
     SvExVoronoiSphereNode
     SvVoronoiOnSurfaceNode
     SvVoronoiOnMeshNode
+    SvVoronoiOnSolidNode
     ---
     SvLloyd2dNode
     SvLloyd3dNode

--- a/index.md
+++ b/index.md
@@ -315,7 +315,7 @@
     SvRandomPointsOnMesh
     SvPopulateSurfaceNode
     SvPopulateSolidNode
-    SvFieldRandomProbeMk2Node
+    SvFieldRandomProbeMk3Node
     ---
     DelaunayTriangulation2DNode
     SvDelaunay2DCdt

--- a/index.md
+++ b/index.md
@@ -325,6 +325,7 @@
     SvExVoronoi3DNode
     SvExVoronoiSphereNode
     SvVoronoiOnSurfaceNode
+    SvVoronoiOnMeshNode
     ---
     SvLloyd2dNode
     SvLloyd3dNode

--- a/index.md
+++ b/index.md
@@ -313,7 +313,7 @@
 ## Spatial
     SvHomogenousVectorField
     SvRandomPointsOnMesh
-    SvPopulateSurfaceNode
+    SvPopulateSurfaceMk2Node
     SvPopulateSolidNode
     SvFieldRandomProbeMk3Node
     ---

--- a/nodes/solid/polygon_face.py
+++ b/nodes/solid/polygon_face.py
@@ -43,9 +43,9 @@ class SvSolidPolygonFaceNode(bpy.types.Node, SverchCustomTreeNode):
         for face_i in face_idxs:
             face_i = list(face_i)
             face_i.append(face_i[0])
-            verts = [verts[idx] for idx in face_i]
-            verts = [Base.Vector(*vert) for vert in verts]
-            wire = Part.makePolygon(verts)
+            fc_verts = [verts[idx] for idx in face_i]
+            fc_verts = [Base.Vector(*vert) for vert in fc_verts]
+            wire = Part.makePolygon(fc_verts)
             face = Part.Face(wire)
             surface = SvSolidFaceSurface(face)#.to_nurbs()
             result.append(surface)

--- a/nodes/solid/polygon_face.py
+++ b/nodes/solid/polygon_face.py
@@ -8,6 +8,7 @@
 import numpy as np
 
 import bpy
+from bpy.props import BoolProperty, IntProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import zip_long_repeat, ensure_nesting_level, updateNode
@@ -38,7 +39,19 @@ class SvSolidPolygonFaceNode(bpy.types.Node, SverchCustomTreeNode):
         self.inputs.new('SvStringsSocket', "Faces")
         self.outputs.new('SvSurfaceSocket', "SolidFaces")
 
+    accuracy : IntProperty(
+            name = "Accuracy",
+            description = "Tolerance parameter for checking if ends of edges coincide",
+            default = 8,
+            min = 1,
+            update = updateNode)
+
+    def draw_buttons_ext(self, context, layout):
+        layout.prop(self, 'accuracy')
+
     def make_faces(self, verts, face_idxs):
+        tolerance = 10 ** (-self.accuracy)
+
         result = []
         for face_i in face_idxs:
             face_i = list(face_i)
@@ -46,6 +59,7 @@ class SvSolidPolygonFaceNode(bpy.types.Node, SverchCustomTreeNode):
             fc_verts = [verts[idx] for idx in face_i]
             fc_verts = [Base.Vector(*vert) for vert in fc_verts]
             wire = Part.makePolygon(fc_verts)
+            wire.fixTolerance(tolerance)
             face = Part.Face(wire)
             surface = SvSolidFaceSurface(face)#.to_nurbs()
             result.append(surface)

--- a/nodes/solid/polygon_face.py
+++ b/nodes/solid/polygon_face.py
@@ -53,11 +53,12 @@ class SvSolidPolygonFaceNode(bpy.types.Node, SverchCustomTreeNode):
         tolerance = 10 ** (-self.accuracy)
 
         result = []
+        fc_vector = Base.Vector
         for face_i in face_idxs:
             face_i = list(face_i)
             face_i.append(face_i[0])
             fc_verts = [verts[idx] for idx in face_i]
-            fc_verts = [Base.Vector(*vert) for vert in fc_verts]
+            fc_verts = [fc_vector(*vert) for vert in fc_verts]
             wire = Part.makePolygon(fc_verts)
             wire.fixTolerance(tolerance)
             face = Part.Face(wire)

--- a/nodes/spatial/populate_solid.py
+++ b/nodes/spatial/populate_solid.py
@@ -121,11 +121,11 @@ class SvPopulateSolidMk2Node(bpy.types.Node, SverchCustomTreeNode):
             default = False,
             update = updateNode)
 
-    flat_output : BoolProperty(
-            name = "Flat output",
-            description = "If checked, generate one flat list of vertices for all input solids; otherwise, generate a separate list of vertices for each solid",
-            default = False,
-            update = updateNode)
+#     flat_output : BoolProperty(
+#             name = "Flat output",
+#             description = "If checked, generate one flat list of vertices for all input solids; otherwise, generate a separate list of vertices for each solid",
+#             default = False,
+#             update = updateNode)
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "gen_mode", text='Mode')
@@ -135,7 +135,7 @@ class SvPopulateSolidMk2Node(bpy.types.Node, SverchCustomTreeNode):
             layout.prop(self, "in_surface")
         if self.distance_mode == 'FIELD':
             layout.prop(self, 'random_radius')
-        layout.prop(self, "flat_output")
+#         layout.prop(self, "flat_output")
 
     def draw_buttons_ext(self, context, layout):
         self.draw_buttons(context, layout)
@@ -272,12 +272,8 @@ class SvPopulateSolidMk2Node(bpy.types.Node, SverchCustomTreeNode):
                 else:
                     verts, radiuses = self.generate_surface(solid, field, count, min_r, radius, threshold, field_min, field_max, mask)
 
-                if self.flat_output:
-                    new_verts.extend(verts)
-                    new_radius.extend(radiuses)
-                else:
-                    new_verts.append(verts)
-                    new_radius.append(radiuses)
+                new_verts.append(verts)
+                new_radius.append(radiuses)
 
             if nested_output:
                 verts_out.append(new_verts)

--- a/nodes/spatial/populate_surface.py
+++ b/nodes/spatial/populate_surface.py
@@ -89,18 +89,11 @@ class SvPopulateSurfaceMk2Node(bpy.types.Node, SverchCustomTreeNode):
             default = False,
             update = updateNode)
 
-    flat_output : BoolProperty(
-            name = "Flat output",
-            description = "If checked, generate one flat list of vertices for all input surfaces; otherwise, generate a separate list of vertices for each surface",
-            default = False,
-            update = updateNode)
-
     def draw_buttons(self, context, layout):
         layout.prop(self, 'distance_mode')
         layout.prop(self, "proportional")
         if self.distance_mode == 'FIELD':
             layout.prop(self, 'random_radius')
-        layout.prop(self, "flat_output")
 
     def sv_init(self, context):
         self.inputs.new('SvSurfaceSocket', "Surface")
@@ -174,14 +167,9 @@ class SvPopulateSurfaceMk2Node(bpy.types.Node, SverchCustomTreeNode):
                                         min_r = min_r, min_r_field = radius,
                                         random_radius = self.random_radius,
                                         seed = seed)
-                if self.flat_output:
-                    new_verts.extend(verts)
-                    new_uv.extend(uvs)
-                    new_radius.extend(radiuses)
-                else:
-                    new_verts.append(verts)
-                    new_uv.append(uvs)
-                    new_radius.append(radiuses)
+                new_verts.append(verts)
+                new_uv.append(uvs)
+                new_radius.append(radiuses)
 
             if nested_output:
                 verts_out.append(new_verts)

--- a/nodes/spatial/random_points_on_mesh.py
+++ b/nodes/spatial/random_points_on_mesh.py
@@ -17,7 +17,7 @@ from mathutils.bvhtree import BVHTree
 from mathutils.geometry import tessellate_polygon, area_tri
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import updateNode
+from sverchok.data_structure import updateNode, throttle_and_update_node
 from sverchok.utils.geom import calc_bounds
 from sverchok.utils.sv_mesh_utils import point_inside_mesh
 
@@ -185,6 +185,10 @@ class SvRandomPointsOnMesh(bpy.types.Node, SverchCustomTreeNode):
             default=True,
             update=updateNode)
 
+    @throttle_and_update_node
+    def update_sockets(self, context):
+        self.outputs['Face index'].hide_safe = self.mode != 'SURFACE'
+
     modes = [
             ('SURFACE', "Surface", "Surface", 0),
             ('VOLUME', "Volume", "Volume", 1)
@@ -194,10 +198,10 @@ class SvRandomPointsOnMesh(bpy.types.Node, SverchCustomTreeNode):
             name = "Mode",
             items = modes,
             default = 'SURFACE',
-            update=updateNode)
+            update=update_sockets)
     
     def draw_buttons(self, context, layout):
-        layout.prop(self, "mode")
+        layout.prop(self, "mode", text='')
         if self.mode == 'SURFACE':
             layout.prop(self, "proportional")
 

--- a/nodes/spatial/voronoi_on_mesh.py
+++ b/nodes/spatial/voronoi_on_mesh.py
@@ -134,7 +134,7 @@ class SvVoronoiOnMeshNode(bpy.types.Node, SverchCustomTreeNode):
             row.prop(self, 'clip_outer', toggle=True)
         layout.prop(self, 'do_clip', toggle=True)
         layout.prop(self, 'normals')
-        layout.label(text='Output:')
+        layout.label(text='Output nesting:')
         layout.prop(self, 'join_mode', text='')
 
     def process(self):

--- a/nodes/spatial/voronoi_on_mesh.py
+++ b/nodes/spatial/voronoi_on_mesh.py
@@ -100,6 +100,7 @@ class SvVoronoiOnMeshNode(bpy.types.Node, SverchCustomTreeNode):
         self.outputs.new('SvVerticesSocket', "Vertices")
         self.outputs.new('SvStringsSocket', "Edges")
         self.outputs.new('SvStringsSocket', "Faces")
+        self.outputs.new('SvVerticesSocket', "AllSites")
         self.update_sockets(context)
 
     def draw_buttons(self, context, layout):
@@ -138,12 +139,14 @@ class SvVoronoiOnMeshNode(bpy.types.Node, SverchCustomTreeNode):
         verts_out = []
         edges_out = []
         faces_out = []
+        sites_out = []
         for params in zip_long_repeat(verts_in, faces_in, sites_in, spacing_in):
             new_verts = []
             new_edges = []
             new_faces = []
+            new_sites = []
             for verts, faces, sites, spacing in zip_long_repeat(*params):
-                verts, edges, faces = voronoi_on_mesh(verts, faces, sites, thickness=0,
+                verts, edges, faces, sites = voronoi_on_mesh(verts, faces, sites, thickness=0,
                             spacing = spacing,
                             #clip_inner = self.clip_inner, clip_outer = self.clip_outer,
                             do_clip=True, clipping=None,
@@ -156,28 +159,34 @@ class SvVoronoiOnMeshNode(bpy.types.Node, SverchCustomTreeNode):
                     new_verts.extend(verts)
                     new_edges.extend(edges)
                     new_faces.extend(faces)
+                    new_sites.extend(sites)
                 elif self.join_mode == 'SEPARATE':
                     new_verts.append(verts)
                     new_edges.append(edges)
                     new_faces.append(faces)
+                    new_sites.append(sites)
                 else: # JOIN
                     verts, edges, faces = mesh_join(verts, edges, faces)
                     new_verts.append(verts)
                     new_edges.append(edges)
                     new_faces.append(faces)
+                    new_sites.append(sites)
 
             if nested_output:
                 verts_out.append(new_verts)
                 edges_out.append(new_edges)
                 faces_out.append(new_faces)
+                sites_out.append(new_sites)
             else:
                 verts_out.extend(new_verts)
                 edges_out.extend(new_edges)
                 faces_out.extend(new_faces)
+                sites_out.extend(new_sites)
 
         self.outputs['Vertices'].sv_set(verts_out)
         self.outputs['Edges'].sv_set(edges_out)
         self.outputs['Faces'].sv_set(faces_out)
+        self.outputs['AllSites'].sv_set(sites_out)
 
 def register():
     if scipy is not None:

--- a/nodes/spatial/voronoi_on_mesh.py
+++ b/nodes/spatial/voronoi_on_mesh.py
@@ -1,0 +1,212 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import numpy as np
+
+import bpy
+from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty
+import bmesh
+from mathutils import Vector
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode, zip_long_repeat, throttle_and_update_node, ensure_nesting_level, get_data_nesting_level
+from sverchok.utils.sv_bmesh_utils import recalc_normals
+from sverchok.utils.sv_mesh_utils import mesh_join
+from sverchok.utils.voronoi3d import voronoi_on_mesh
+from sverchok.utils.dummy_nodes import add_dummy
+from sverchok.dependencies import scipy
+
+if scipy is None:
+    add_dummy('SvVoronoiOnMeshNode', "Voronoi on Mesh", 'scipy')
+
+class SvVoronoiOnMeshNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: Voronoi Mesh
+    Tooltip: Generate Voronoi diagram on the surface of a mesh object
+    """
+    bl_idname = 'SvVoronoiOnMeshNode'
+    bl_label = 'Voronoi on Mesh'
+    bl_icon = 'OUTLINER_OB_EMPTY'
+    sv_icon = 'SV_VORONOI'
+
+    modes = [
+            ('VOLUME', "Split Volume", "Split volume of the mesh into regions of Voronoi diagram", 0),
+            ('SURFACE', "Split Surface", "Split the surface of the mesh into regions of Vornoi diagram", 1),
+            ('RIDGES', "Ridges near Surface", "Generate ridges of 3D Voronoi diagram near the surface of the mesh", 2),
+            ('REGIONS', "Regions near Surface", "Generate regions of 3D Voronoi diagram near the surface of the mesh", 3)
+        ]
+
+    thickness : FloatProperty(
+        name = "Thickness",
+        default = 1.0,
+        min = 0.0,
+        update=updateNode)
+
+    spacing : FloatProperty(
+        name = "Spacing",
+        default = 0.0,
+        min = 0.0,
+        update=updateNode)
+
+    normals : BoolProperty(
+        name = "Correct normals",
+        default = True,
+        update = updateNode)
+
+    @throttle_and_update_node
+    def update_sockets(self, context):
+        self.inputs['Clipping'].hide_safe = not self.do_clip
+        self.inputs['Thickness'].hide_safe = self.mode not in {'RIDGES', 'REGIONS'}
+        self.inputs['Spacing'].hide_safe = self.mode not in {'VOLUME', 'SURFACE'}
+
+    mode : EnumProperty(
+        name = "Mode",
+        items = modes,
+        default = 'VOLUME',
+        update = update_sockets)
+    
+    do_clip : BoolProperty(
+        name = "Clip Box",
+        default = True,
+        update = update_sockets)
+
+    clip_inner : BoolProperty(
+        name = "Clip Inner",
+        default = True,
+        update = updateNode)
+
+    clip_outer : BoolProperty(
+        name = "Clip Outer",
+        default = True,
+        update = updateNode)
+
+    clipping : FloatProperty(
+        name = "Clipping",
+        default = 1.0,
+        min = 0.0,
+        update = updateNode)
+
+    join_modes = [
+            ('FLAT', "Flat list", "Output a single flat list of mesh objects (Voronoi diagram ridges / regions) for all input meshes", 0),
+            ('SEPARATE', "Separate lists", "Output a separate list of mesh objects (Voronoi diagram ridges / regions) for each input mesh", 1),
+            ('JOIN', "Join meshes", "Output one mesh, joined from ridges / edges of Voronoi diagram, for each input mesh", 2)
+        ]
+
+    join_mode : EnumProperty(
+        name = "Output mode",
+        items = join_modes,
+        default = 'FLAT',
+        update = updateNode)
+
+    def sv_init(self, context):
+        self.inputs.new('SvVerticesSocket', 'Vertices')
+        self.inputs.new('SvStringsSocket', 'Faces')
+        self.inputs.new('SvVerticesSocket', "Sites")
+        self.inputs.new('SvStringsSocket', 'Thickness').prop_name = 'thickness'
+        self.inputs.new('SvStringsSocket', 'Spacing').prop_name = 'spacing'
+        self.inputs.new('SvStringsSocket', "Clipping").prop_name = 'clipping'
+        self.outputs.new('SvVerticesSocket', "Vertices")
+        self.outputs.new('SvStringsSocket', "Edges")
+        self.outputs.new('SvStringsSocket', "Faces")
+        self.update_sockets(context)
+
+    def draw_buttons(self, context, layout):
+        layout.label(text="Mode:")
+        layout.prop(self, "mode", text='')
+        if self.mode in {'REGIONS', 'RIDGES'}:
+            row = layout.row(align=True)
+            row.prop(self, 'clip_inner', toggle=True)
+            row.prop(self, 'clip_outer', toggle=True)
+        layout.prop(self, 'do_clip', toggle=True)
+        layout.prop(self, 'normals')
+        layout.label(text='Output:')
+        layout.prop(self, 'join_mode', text='')
+
+    def process(self):
+
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+
+        verts_in = self.inputs['Vertices'].sv_get()
+        faces_in = self.inputs['Faces'].sv_get()
+        sites_in = self.inputs['Sites'].sv_get()
+        thickness_in = self.inputs['Thickness'].sv_get()
+        spacing_in = self.inputs['Spacing'].sv_get()
+        clipping_in = self.inputs['Clipping'].sv_get()
+
+        verts_in = ensure_nesting_level(verts_in, 4)
+        input_level = get_data_nesting_level(sites_in)
+        sites_in = ensure_nesting_level(sites_in, 4)
+        faces_in = ensure_nesting_level(faces_in, 4)
+        thickness_in = ensure_nesting_level(thickness_in, 2)
+        spacing_in = ensure_nesting_level(spacing_in, 2)
+        clipping_in = ensure_nesting_level(clipping_in, 2)
+
+        nested_output = input_level > 3
+
+        verts_out = []
+        edges_out = []
+        faces_out = []
+        for params in zip_long_repeat(verts_in, faces_in, sites_in, thickness_in, spacing_in, clipping_in):
+            new_verts = []
+            new_edges = []
+            new_faces = []
+            for verts, faces, sites, thickness, spacing, clipping in zip_long_repeat(*params):
+                verts, edges, faces = voronoi_on_mesh(verts, faces, sites, thickness,
+                            spacing = spacing,
+                            clip_inner = self.clip_inner, clip_outer = self.clip_outer,
+                            do_clip=self.do_clip, clipping=clipping,
+                            mode = self.mode)
+                if self.normals:
+                    verts, edges, faces = recalc_normals(verts, edges, faces, loop=True)
+
+                if self.join_mode == 'FLAT':
+                    new_verts.extend(verts)
+                    new_edges.extend(edges)
+                    new_faces.extend(faces)
+                elif self.join_mode == 'SEPARATE':
+                    new_verts.append(verts)
+                    new_edges.append(edges)
+                    new_faces.append(faces)
+                else: # JOIN
+                    verts, edges, faces = mesh_join(verts, edges, faces)
+                    new_verts.append(verts)
+                    new_edges.append(edges)
+                    new_faces.append(faces)
+
+            if nested_output:
+                verts_out.append(new_verts)
+                edges_out.append(new_edges)
+                faces_out.append(new_faces)
+            else:
+                verts_out.extend(new_verts)
+                edges_out.extend(new_edges)
+                faces_out.extend(new_faces)
+
+        self.outputs['Vertices'].sv_set(verts_out)
+        self.outputs['Edges'].sv_set(edges_out)
+        self.outputs['Faces'].sv_set(faces_out)
+
+def register():
+    if scipy is not None:
+        bpy.utils.register_class(SvVoronoiOnMeshNode)
+
+def unregister():
+    if scipy is not None:
+        bpy.utils.unregister_class(SvVoronoiOnMeshNode)
+

--- a/nodes/spatial/voronoi_on_mesh.py
+++ b/nodes/spatial/voronoi_on_mesh.py
@@ -47,15 +47,15 @@ class SvVoronoiOnMeshNode(bpy.types.Node, SverchCustomTreeNode):
     modes = [
             ('VOLUME', "Split Volume", "Split volume of the mesh into regions of Voronoi diagram", 0),
             ('SURFACE', "Split Surface", "Split the surface of the mesh into regions of Vornoi diagram", 1),
-            ('RIDGES', "Ridges near Surface", "Generate ridges of 3D Voronoi diagram near the surface of the mesh", 2),
-            ('REGIONS', "Regions near Surface", "Generate regions of 3D Voronoi diagram near the surface of the mesh", 3)
+            #('RIDGES', "Ridges near Surface", "Generate ridges of 3D Voronoi diagram near the surface of the mesh", 2),
+            #('REGIONS', "Regions near Surface", "Generate regions of 3D Voronoi diagram near the surface of the mesh", 3)
         ]
 
-    thickness : FloatProperty(
-        name = "Thickness",
-        default = 1.0,
-        min = 0.0,
-        update=updateNode)
+#     thickness : FloatProperty(
+#         name = "Thickness",
+#         default = 1.0,
+#         min = 0.0,
+#         update=updateNode)
 
     spacing : FloatProperty(
         name = "Spacing",
@@ -71,7 +71,7 @@ class SvVoronoiOnMeshNode(bpy.types.Node, SverchCustomTreeNode):
     @throttle_and_update_node
     def update_sockets(self, context):
         self.inputs['Clipping'].hide_safe = not self.do_clip
-        self.inputs['Thickness'].hide_safe = self.mode not in {'RIDGES', 'REGIONS'}
+        #self.inputs['Thickness'].hide_safe = self.mode not in {'RIDGES', 'REGIONS'}
         self.inputs['Spacing'].hide_safe = self.mode not in {'VOLUME', 'SURFACE'}
 
     mode : EnumProperty(
@@ -85,15 +85,15 @@ class SvVoronoiOnMeshNode(bpy.types.Node, SverchCustomTreeNode):
         default = True,
         update = update_sockets)
 
-    clip_inner : BoolProperty(
-        name = "Clip Inner",
-        default = True,
-        update = updateNode)
-
-    clip_outer : BoolProperty(
-        name = "Clip Outer",
-        default = True,
-        update = updateNode)
+#     clip_inner : BoolProperty(
+#         name = "Clip Inner",
+#         default = True,
+#         update = updateNode)
+# 
+#     clip_outer : BoolProperty(
+#         name = "Clip Outer",
+#         default = True,
+#         update = updateNode)
 
     clipping : FloatProperty(
         name = "Clipping",
@@ -117,7 +117,7 @@ class SvVoronoiOnMeshNode(bpy.types.Node, SverchCustomTreeNode):
         self.inputs.new('SvVerticesSocket', 'Vertices')
         self.inputs.new('SvStringsSocket', 'Faces')
         self.inputs.new('SvVerticesSocket', "Sites")
-        self.inputs.new('SvStringsSocket', 'Thickness').prop_name = 'thickness'
+#         self.inputs.new('SvStringsSocket', 'Thickness').prop_name = 'thickness'
         self.inputs.new('SvStringsSocket', 'Spacing').prop_name = 'spacing'
         self.inputs.new('SvStringsSocket', "Clipping").prop_name = 'clipping'
         self.outputs.new('SvVerticesSocket', "Vertices")
@@ -128,10 +128,10 @@ class SvVoronoiOnMeshNode(bpy.types.Node, SverchCustomTreeNode):
     def draw_buttons(self, context, layout):
         layout.label(text="Mode:")
         layout.prop(self, "mode", text='')
-        if self.mode in {'REGIONS', 'RIDGES'}:
-            row = layout.row(align=True)
-            row.prop(self, 'clip_inner', toggle=True)
-            row.prop(self, 'clip_outer', toggle=True)
+#         if self.mode in {'REGIONS', 'RIDGES'}:
+#             row = layout.row(align=True)
+#             row.prop(self, 'clip_inner', toggle=True)
+#             row.prop(self, 'clip_outer', toggle=True)
         layout.prop(self, 'do_clip', toggle=True)
         layout.prop(self, 'normals')
         layout.label(text='Output nesting:')
@@ -145,7 +145,7 @@ class SvVoronoiOnMeshNode(bpy.types.Node, SverchCustomTreeNode):
         verts_in = self.inputs['Vertices'].sv_get()
         faces_in = self.inputs['Faces'].sv_get()
         sites_in = self.inputs['Sites'].sv_get()
-        thickness_in = self.inputs['Thickness'].sv_get()
+        #thickness_in = self.inputs['Thickness'].sv_get()
         spacing_in = self.inputs['Spacing'].sv_get()
         clipping_in = self.inputs['Clipping'].sv_get()
 
@@ -153,7 +153,7 @@ class SvVoronoiOnMeshNode(bpy.types.Node, SverchCustomTreeNode):
         input_level = get_data_nesting_level(sites_in)
         sites_in = ensure_nesting_level(sites_in, 4)
         faces_in = ensure_nesting_level(faces_in, 4)
-        thickness_in = ensure_nesting_level(thickness_in, 2)
+        #thickness_in = ensure_nesting_level(thickness_in, 2)
         spacing_in = ensure_nesting_level(spacing_in, 2)
         clipping_in = ensure_nesting_level(clipping_in, 2)
 
@@ -162,14 +162,14 @@ class SvVoronoiOnMeshNode(bpy.types.Node, SverchCustomTreeNode):
         verts_out = []
         edges_out = []
         faces_out = []
-        for params in zip_long_repeat(verts_in, faces_in, sites_in, thickness_in, spacing_in, clipping_in):
+        for params in zip_long_repeat(verts_in, faces_in, sites_in, spacing_in, clipping_in):
             new_verts = []
             new_edges = []
             new_faces = []
-            for verts, faces, sites, thickness, spacing, clipping in zip_long_repeat(*params):
-                verts, edges, faces = voronoi_on_mesh(verts, faces, sites, thickness,
+            for verts, faces, sites, spacing, clipping in zip_long_repeat(*params):
+                verts, edges, faces = voronoi_on_mesh(verts, faces, sites, thickness=0,
                             spacing = spacing,
-                            clip_inner = self.clip_inner, clip_outer = self.clip_outer,
+                            #clip_inner = self.clip_inner, clip_outer = self.clip_outer,
                             do_clip=self.do_clip, clipping=clipping,
                             mode = self.mode)
                 if self.normals:

--- a/nodes/spatial/voronoi_on_mesh.py
+++ b/nodes/spatial/voronoi_on_mesh.py
@@ -100,13 +100,14 @@ class SvVoronoiOnMeshNode(bpy.types.Node, SverchCustomTreeNode):
         self.outputs.new('SvVerticesSocket', "Vertices")
         self.outputs.new('SvStringsSocket', "Edges")
         self.outputs.new('SvStringsSocket', "Faces")
-        self.outputs.new('SvVerticesSocket', "AllSites")
+        #self.outputs.new('SvVerticesSocket', "AllSites")
         self.update_sockets(context)
 
     def draw_buttons(self, context, layout):
         layout.label(text="Mode:")
         layout.prop(self, "mode", text='')
-        layout.prop(self, 'normals')
+        if self.mode == 'VOLUME':
+            layout.prop(self, 'normals')
         layout.label(text='Output nesting:')
         layout.prop(self, 'join_mode', text='')
 
@@ -152,7 +153,7 @@ class SvVoronoiOnMeshNode(bpy.types.Node, SverchCustomTreeNode):
                             do_clip=True, clipping=None,
                             mode = self.mode,
                             precision = precision)
-                if self.normals:
+                if self.mode == 'VOLUME' and self.normals:
                     verts, edges, faces = recalc_normals(verts, edges, faces, loop=True)
 
                 if self.join_mode == 'FLAT':
@@ -186,7 +187,7 @@ class SvVoronoiOnMeshNode(bpy.types.Node, SverchCustomTreeNode):
         self.outputs['Vertices'].sv_set(verts_out)
         self.outputs['Edges'].sv_set(edges_out)
         self.outputs['Faces'].sv_set(faces_out)
-        self.outputs['AllSites'].sv_set(sites_out)
+        #self.outputs['AllSites'].sv_set(sites_out)
 
 def register():
     if scipy is not None:

--- a/nodes/spatial/voronoi_on_mesh.py
+++ b/nodes/spatial/voronoi_on_mesh.py
@@ -120,11 +120,11 @@ class SvVoronoiOnMeshNode(bpy.types.Node, SverchCustomTreeNode):
         if not any(socket.is_linked for socket in self.outputs):
             return
 
-        verts_in = self.inputs['Vertices'].sv_get()
-        faces_in = self.inputs['Faces'].sv_get()
-        sites_in = self.inputs['Sites'].sv_get()
+        verts_in = self.inputs['Vertices'].sv_get(deepcopy=False)
+        faces_in = self.inputs['Faces'].sv_get(deepcopy=False)
+        sites_in = self.inputs['Sites'].sv_get(deepcopy=False)
         #thickness_in = self.inputs['Thickness'].sv_get()
-        spacing_in = self.inputs['Spacing'].sv_get()
+        spacing_in = self.inputs['Spacing'].sv_get(deepcopy=False)
 
         verts_in = ensure_nesting_level(verts_in, 4)
         input_level = get_data_nesting_level(sites_in)

--- a/nodes/spatial/voronoi_on_solid.py
+++ b/nodes/spatial/voronoi_on_solid.py
@@ -40,52 +40,6 @@ if scipy is None or FreeCAD is None:
 if FreeCAD is not None:
     import Part
 
-def mesh_from_faces(fragments):
-    verts = [(v.X, v.Y, v.Z) for v in fragments.Vertexes]
-
-    all_fc_verts = {SvSolidTopology.Item(v) : i for i, v in enumerate(fragments.Vertexes)}
-    def find_vertex(v):
-        #for i, fc_vert in enumerate(fragments.Vertexes):
-        #    if v.isSame(fc_vert):
-        #        return i
-        #return None
-        return all_fc_verts[SvSolidTopology.Item(v)]
-
-    edges = []
-    for fc_edge in fragments.Edges:
-        edge = [find_vertex(v) for v in fc_edge.Vertexes]
-        if len(edge) == 2:
-            edges.append(edge)
-
-    faces = []
-    for fc_face in fragments.Faces:
-        incident_verts = defaultdict(set)
-        for fc_edge in fc_face.Edges:
-            edge = [find_vertex(v) for v in fc_edge.Vertexes]
-            if len(edge) == 2:
-                i, j = edge
-                incident_verts[i].add(j)
-                incident_verts[j].add(i)
-
-        face = [find_vertex(v) for v in fc_face.Vertexes]
-
-        vert_idx = face[0]
-        correct_face = [vert_idx]
-
-        for i in range(len(face)):
-            incident = list(incident_verts[vert_idx])
-            other_verts = [i for i in incident if i not in correct_face]
-            if not other_verts:
-                break
-            other_vert_idx = other_verts[0]
-            correct_face.append(other_vert_idx)
-            vert_idx = other_vert_idx
-
-        if len(correct_face) > 2:
-            faces.append(correct_face)
-
-    return verts, edges, faces
-
 class SvVoronoiOnSolidNode(bpy.types.Node, SverchCustomTreeNode):
     """
     Triggers: Voronoi Solid

--- a/nodes/spatial/voronoi_on_solid.py
+++ b/nodes/spatial/voronoi_on_solid.py
@@ -29,7 +29,7 @@ from sverchok.data_structure import updateNode, zip_long_repeat, throttle_and_up
 from sverchok.utils.sv_bmesh_utils import recalc_normals
 from sverchok.utils.voronoi3d import voronoi_on_solid
 from sverchok.utils.geom import scale_relative
-from sverchok.utils.solid import svmesh_to_solid, SvSolidTopology, SvGeneralFuse
+from sverchok.utils.solid import BMESH, svmesh_to_solid, SvSolidTopology, SvGeneralFuse
 from sverchok.utils.surface.freecad import SvSolidFaceSurface
 from sverchok.utils.dummy_nodes import add_dummy
 from sverchok.dependencies import scipy, FreeCAD

--- a/nodes/spatial/voronoi_on_solid.py
+++ b/nodes/spatial/voronoi_on_solid.py
@@ -127,7 +127,7 @@ class SvVoronoiOnSolidNode(bpy.types.Node, SverchCustomTreeNode):
                     scale = 1.0 - inset
                     verts = [scale_relative(vs, site, scale) for vs, site in zip(verts, sites)]
 
-                fragments = [svmesh_to_solid(vs, fs, precision) for vs, fs in zip(verts, faces)]
+                fragments = [svmesh_to_solid(vs, fs, precision, method=BMESH, remove_splitter=False) for vs, fs in zip(verts, faces)]
 
                 if self.mode == 'SURFACE':
                     if solid.Shells:

--- a/nodes/spatial/voronoi_on_solid.py
+++ b/nodes/spatial/voronoi_on_solid.py
@@ -1,0 +1,234 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import numpy as np
+from collections import defaultdict
+
+import bpy
+from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty
+import bmesh
+from mathutils import Vector
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode, zip_long_repeat, throttle_and_update_node, ensure_nesting_level, get_data_nesting_level
+from sverchok.utils.sv_bmesh_utils import recalc_normals
+from sverchok.utils.voronoi3d import voronoi_on_solid
+from sverchok.utils.geom import scale_relative
+from sverchok.utils.solid import svmesh_to_solid, SvSolidTopology
+from sverchok.utils.surface.freecad import SvSolidFaceSurface
+from sverchok.utils.dummy_nodes import add_dummy
+from sverchok.dependencies import scipy, FreeCAD
+
+if scipy is None or FreeCAD is None:
+    add_dummy('SvVoronoiOnSolidNode', "Voronoi on Solid", 'scipy and FreeCAD')
+
+if FreeCAD is not None:
+    import Part
+
+def mesh_from_faces(fragments):
+    verts = [(v.X, v.Y, v.Z) for v in fragments.Vertexes]
+
+    all_fc_verts = {SvSolidTopology.Item(v) : i for i, v in enumerate(fragments.Vertexes)}
+    def find_vertex(v):
+        #for i, fc_vert in enumerate(fragments.Vertexes):
+        #    if v.isSame(fc_vert):
+        #        return i
+        #return None
+        return all_fc_verts[SvSolidTopology.Item(v)]
+
+    edges = []
+    for fc_edge in fragments.Edges:
+        edge = [find_vertex(v) for v in fc_edge.Vertexes]
+        if len(edge) == 2:
+            edges.append(edge)
+
+    faces = []
+    for fc_face in fragments.Faces:
+        incident_verts = defaultdict(set)
+        for fc_edge in fc_face.Edges:
+            edge = [find_vertex(v) for v in fc_edge.Vertexes]
+            if len(edge) == 2:
+                i, j = edge
+                incident_verts[i].add(j)
+                incident_verts[j].add(i)
+
+        face = [find_vertex(v) for v in fc_face.Vertexes]
+
+        vert_idx = face[0]
+        correct_face = [vert_idx]
+
+        for i in range(len(face)):
+            incident = list(incident_verts[vert_idx])
+            other_verts = [i for i in incident if i not in correct_face]
+            if not other_verts:
+                break
+            other_vert_idx = other_verts[0]
+            correct_face.append(other_vert_idx)
+            vert_idx = other_vert_idx
+
+        if len(correct_face) > 2:
+            faces.append(correct_face)
+
+    return verts, edges, faces
+
+class SvVoronoiOnSolidNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: Voronoi Solid
+    Tooltip: Generate Voronoi diagram on the Solid object
+    """
+    bl_idname = 'SvVoronoiOnSolidNode'
+    bl_label = 'Voronoi on Solid'
+    bl_icon = 'OUTLINER_OB_EMPTY'
+    sv_icon = 'SV_VORONOI'
+
+    modes = [
+            ('FACES', "Surface - Inner", "Generate inner regions of Voronoi diagram on the surface of the solid", 0),
+            ('WIRE', "Surface - Outer", "Cut inner regions of Voronoi diagram from solid surface", 1),
+            ('REGIONS', "Volume", "Split volume of the solid body into regions of Voronoi diagram", 2),
+            ('NEGVOLUME', "Negative Volume", "Cut regions of Voronoi diagram from the volume of the solid object", 3),
+            ('MESH', "Mesh Faces", "Generate mesh", 4)
+        ]
+
+    @throttle_and_update_node
+    def update_sockets(self, context):
+        self.outputs['Vertices'].hide_safe = self.mode != 'MESH'
+        self.outputs['Edges'].hide_safe = self.mode != 'MESH'
+        self.outputs['Faces'].hide_safe = self.mode != 'MESH'
+        self.outputs['Solids'].hide_safe = self.mode not in {'FACES', 'WIRE', 'REGIONS', 'NEGVOLUME'}
+
+    mode : EnumProperty(
+        name = "Mode",
+        items = modes,
+        update = update_sockets)
+    
+    accuracy : IntProperty(
+            name = "Accuracy",
+            description = "Accuracy for mesh to solid transformation",
+            default = 6,
+            min = 1,
+            update = updateNode)
+
+    inset : FloatProperty(
+        name = "Inset",
+        min = 0.0, max = 1.0,
+        default = 0.0,
+        update = updateNode)
+
+    def sv_init(self, context):
+        self.inputs.new('SvSolidSocket', 'Solid')
+        self.inputs.new('SvVerticesSocket', "Sites")
+        self.inputs.new('SvStringsSocket', "Inset").prop_name = 'inset'
+        self.outputs.new('SvVerticesSocket', "Vertices")
+        self.outputs.new('SvStringsSocket', "Edges")
+        self.outputs.new('SvStringsSocket', "Faces")
+        self.outputs.new('SvSolidSocket', "Solids")
+        self.update_sockets(context)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "mode")
+
+    def draw_buttons_ext(self, context, layout):
+        self.draw_buttons(context, layout)
+        layout.prop(self, 'accuracy')
+
+    def process(self):
+
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+
+        solid_in = self.inputs['Solid'].sv_get()
+        sites_in = self.inputs['Sites'].sv_get()
+        inset_in = self.inputs['Inset'].sv_get()
+
+        solid_in = ensure_nesting_level(solid_in, 2, data_types=(Part.Shape,))
+        input_level = get_data_nesting_level(sites_in)
+        sites_in = ensure_nesting_level(sites_in, 4)
+        inset_in = ensure_nesting_level(inset_in, 2)
+
+        nested_output = input_level > 3
+
+        precision = 10 ** (-self.accuracy)
+
+        verts_out = []
+        edges_out = []
+        faces_out = []
+        fragment_faces_out = []
+        for params in zip_long_repeat(solid_in, sites_in, inset_in):
+            new_verts = []
+            new_edges = []
+            new_faces = []
+            new_fragment_faces = []
+            for solid, sites, inset in zip_long_repeat(*params):
+                verts, edges, faces = voronoi_on_solid(solid, sites,
+                            do_clip=True, clipping=None)
+
+                if inset != 0.0:
+                    scale = 1.0 - inset
+                    verts = [scale_relative(vs, site, scale) for vs, site in zip(verts, sites)]
+
+                fragments = [svmesh_to_solid(vs, fs, precision) for vs, fs in zip(verts, faces)]
+
+                if solid.Shells:
+                    shell = solid.Shells[0]
+                else:
+                    shell = Part.Shell(solid.Faces)
+
+                if self.mode == 'FACES':
+                    fragments = [shell.common(fragment) for fragment in fragments]
+                elif self.mode == 'WIRE':
+                    fragments = [shell.cut(fragments)]
+                elif self.mode == 'REGIONS':
+                    fragments = [solid.common(fragment) for fragment in fragments]
+                elif self.mode == 'NEGVOLUME':
+                    fragments = [solid.cut(fragments)]
+                else: # MESH
+                    fragments = shell.common(fragments)
+
+                if self.mode in {'FACES', 'WIRE', 'REGIONS', 'NEGVOLUME'}:
+                    new_fragment_faces.append(fragments)
+                else: # MESH
+                    verts, edges, faces = mesh_from_faces(fragments)
+
+                new_verts.append(verts)
+                new_edges.append(edges)
+                new_faces.append(faces)
+
+            if nested_output:
+                verts_out.append(new_verts)
+                edges_out.append(new_edges)
+                faces_out.append(new_faces)
+                fragment_faces_out.append(new_fragment_faces)
+            else:
+                verts_out.extend(new_verts)
+                edges_out.extend(new_edges)
+                faces_out.extend(new_faces)
+                fragment_faces_out.extend(new_fragment_faces)
+
+        self.outputs['Vertices'].sv_set(verts_out)
+        self.outputs['Edges'].sv_set(edges_out)
+        self.outputs['Faces'].sv_set(faces_out)
+        self.outputs['Solids'].sv_set(fragment_faces_out)
+
+def register():
+    if scipy is not None and FreeCAD is not None:
+        bpy.utils.register_class(SvVoronoiOnSolidNode)
+
+def unregister():
+    if scipy is not None and FreeCAD is not None:
+        bpy.utils.unregister_class(SvVoronoiOnSolidNode)
+

--- a/nodes/spatial/voronoi_on_solid.py
+++ b/nodes/spatial/voronoi_on_solid.py
@@ -119,6 +119,12 @@ class SvVoronoiOnSolidNode(bpy.types.Node, SverchCustomTreeNode):
         default = 0.0,
         update = updateNode)
 
+    flat_output : BoolProperty(
+        name = "Flat output",
+        description = "If checked, output single flat list of fragments for all input solids; otherwise, output a separate list of fragments for each solid.",
+        default = True,
+        update = updateNode)
+
     def sv_init(self, context):
         self.inputs.new('SvSolidSocket', 'Solid')
         self.inputs.new('SvVerticesSocket', "Sites")
@@ -128,6 +134,7 @@ class SvVoronoiOnSolidNode(bpy.types.Node, SverchCustomTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "mode")
+        layout.prop(self, "flat_output")
 
     def draw_buttons_ext(self, context, layout):
         self.draw_buttons(context, layout)
@@ -179,11 +186,17 @@ class SvVoronoiOnSolidNode(bpy.types.Node, SverchCustomTreeNode):
 
                 if need_inner:
                     inner = [src.common(fragment) for fragment in fragments]
-                    new_inner_fragments.append(inner)
+                    if self.flat_output:
+                        new_inner_fragments.extend(inner)
+                    else:
+                        new_inner_fragments.append(inner)
 
                 if need_outer:
                     outer = [src.cut(fragments)]
-                    new_outer_fragments.append(outer)
+                    if self.flat_output:
+                        new_outer_fragments.extend(outer)
+                    else:
+                        new_outer_fragments.append(outer)
 
             if nested_output:
                 inner_fragments_out.append(new_inner_fragments)

--- a/nodes/spatial/voronoi_on_solid.py
+++ b/nodes/spatial/voronoi_on_solid.py
@@ -70,7 +70,7 @@ class SvVoronoiOnSolidNode(bpy.types.Node, SverchCustomTreeNode):
     inset : FloatProperty(
         name = "Inset",
         min = 0.0, max = 1.0,
-        default = 0.0,
+        default = 0.1,
         update = updateNode)
 
     flat_output : BoolProperty(

--- a/old_nodes/field_random_probe_mk2.py
+++ b/old_nodes/field_random_probe_mk2.py
@@ -20,12 +20,12 @@ from sverchok.core.socket_data import SvNoDataError
 from sverchok.utils.field.scalar import SvScalarField
 from sverchok.utils.field.probe import field_random_probe
 
-class SvFieldRandomProbeMk3Node(bpy.types.Node, SverchCustomTreeNode):
+class SvFieldRandomProbeMk2Node(bpy.types.Node, SverchCustomTreeNode):
     """
     Triggers: Scalar Field Random Probe
     Tooltip: Generate random points according to scalar field
     """
-    bl_idname = 'SvFieldRandomProbeMk3Node'
+    bl_idname = 'SvFieldRandomProbeMk2Node'
     bl_label = 'Field Random Probe'
     bl_icon = 'OUTLINER_OB_EMPTY'
     sv_icon = 'SV_FIELD_RANDOM_PROBE'
@@ -53,26 +53,6 @@ class SvFieldRandomProbeMk3Node(bpy.types.Node, SverchCustomTreeNode):
             min = 1,
             update = updateNode)
 
-    @throttle_and_update_node
-    def update_sockets(self, context):
-        self.inputs['FieldMin'].hide_safe = self.proportional != True
-        self.inputs['FieldMax'].hide_safe = self.proportional != True
-        self.inputs['RadiusField'].hide_safe = self.distance_mode != 'FIELD'
-        self.inputs['MinDistance'].hide_safe = self.distance_mode != 'CONST'
-        self.outputs['Radius'].hide_safe = self.distance_mode != 'FIELD'
-
-    distance_modes = [
-            ('CONST', "Min. Distance", "Specify minimum distance between points", 0),
-            ('FIELD', "Radius Field", "Specify radius of empty sphere around each point by scalar field", 1)
-        ]
-
-    distance_mode : EnumProperty(
-            name = "Distance",
-            description = "How minimum distance between points is restricted",
-            items = distance_modes,
-            default = 'CONST',
-            update = update_sockets)
-
     min_r : FloatProperty(
             name = "Min.Distance",
             description = "Minimum distance between generated points; set to 0 to disable the check",
@@ -80,30 +60,18 @@ class SvFieldRandomProbeMk3Node(bpy.types.Node, SverchCustomTreeNode):
             min = 0.0,
             update = updateNode)
 
+    @throttle_and_update_node
+    def update_sockets(self, context):
+        self.inputs['FieldMin'].hide_safe = self.proportional != True
+        self.inputs['FieldMax'].hide_safe = self.proportional != True
+
     proportional : BoolProperty(
             name = "Proportional",
-            description = "Make points density proportional to field value",
             default = False,
             update = update_sockets)
 
-    random_radius : BoolProperty(
-            name = "Random radius",
-            description = "Make sphere radiuses random, restricted by scalar field values",
-            default = False,
-            update = updateNode)
-
-    flat_output : BoolProperty(
-            name = "Flat output",
-            description = "If checked, generate one flat list of vertices for all input fields; otherwise, generate a separate list of vertices for each field",
-            default = True,
-            update = updateNode)
-
     def draw_buttons(self, context, layout):
-        layout.prop(self, 'distance_mode')
-        layout.prop(self, "proportional")
-        if self.distance_mode == 'FIELD':
-            layout.prop(self, 'random_radius')
-        layout.prop(self, "flat_output")
+        layout.prop(self, "proportional", toggle=True)
 
     class BoundsMenuHandler():
         @classmethod
@@ -122,13 +90,11 @@ class SvFieldRandomProbeMk3Node(bpy.types.Node, SverchCustomTreeNode):
         self.inputs.new('SvVerticesSocket', "Bounds").link_menu_handler = 'BoundsMenuHandler'
         self.inputs.new('SvStringsSocket', "Count").prop_name = 'count'
         self.inputs.new('SvStringsSocket', "MinDistance").prop_name = 'min_r'
-        self.inputs.new('SvScalarFieldSocket', "RadiusField")
         self.inputs.new('SvStringsSocket', "Threshold").prop_name = 'threshold'
         self.inputs.new('SvStringsSocket', "FieldMin").prop_name = 'field_min'
         self.inputs.new('SvStringsSocket', "FieldMax").prop_name = 'field_max'
         self.inputs.new('SvStringsSocket', 'Seed').prop_name = 'seed'
         self.outputs.new('SvVerticesSocket', "Vertices")
-        self.outputs.new('SvStringsSocket', "Radius")
         self.update_sockets(context)
 
     def get_bounds(self, vertices):
@@ -145,10 +111,6 @@ class SvFieldRandomProbeMk3Node(bpy.types.Node, SverchCustomTreeNode):
             raise SvNoDataError(socket=self.inputs['Field'], node=self)
 
         fields_s = self.inputs['Field'].sv_get(default=[[None]])
-        if self.distance_mode == 'FIELD':
-            radius_s = self.inputs['RadiusField'].sv_get()
-        else:
-            radius_s = [[None]]
         vertices_s = self.inputs['Bounds'].sv_get()
         count_s = self.inputs['Count'].sv_get()
         min_r_s = self.inputs['MinDistance'].sv_get()
@@ -159,19 +121,6 @@ class SvFieldRandomProbeMk3Node(bpy.types.Node, SverchCustomTreeNode):
 
         if self.inputs['Field'].is_linked:
             fields_s = ensure_nesting_level(fields_s, 2, data_types=(SvScalarField,))
-            input_level = get_data_nesting_level(fields_s, data_types=(SvScalarField,))
-            nested_field = input_level > 1
-        else:
-            nested_field = False
-        if self.inputs['RadiusField'].is_linked:
-            radius_s = ensure_nesting_level(radius_s, 2, data_types=(SvScalarField,))
-            input_level = get_data_nesting_level(radius_s, data_types=(SvScalarField,))
-            nested_radius = input_level > 1
-        else:
-            nested_radius = False
-
-        verts_level = get_data_nesting_level(vertices_s)
-        nested_verts = verts_level > 3
         vertices_s = ensure_nesting_level(vertices_s, 4)
         count_s = ensure_nesting_level(count_s, 2)
         min_r_s = ensure_nesting_level(min_r_s, 2)
@@ -180,46 +129,21 @@ class SvFieldRandomProbeMk3Node(bpy.types.Node, SverchCustomTreeNode):
         field_max_s = ensure_nesting_level(field_max_s, 2)
         seed_s = ensure_nesting_level(seed_s, 2)
 
-        nested_output = nested_field or nested_radius or nested_verts
-
         verts_out = []
-        radius_out = []
-        inputs = zip_long_repeat(fields_s, radius_s, vertices_s, threshold_s, field_min_s, field_max_s, count_s, min_r_s, seed_s)
+        inputs = zip_long_repeat(fields_s, vertices_s, threshold_s, field_min_s, field_max_s, count_s, min_r_s, seed_s)
         for objects in inputs:
-            new_verts = []
-            new_radiuses = []
-            for field, radius_field, vertices, threshold, field_min, field_max, count, min_r, seed in zip_long_repeat(*objects):
+            for field, vertices, threshold, field_min, field_max, count, min_r, seed in zip_long_repeat(*objects):
 
                 bbox = self.get_bounds(vertices)
-                if self.distance_mode == 'FIELD':
-                    min_r = 0
-                verts, radiuses = field_random_probe(field, bbox, count,
-                                threshold, self.proportional,
-                                field_min, field_max,
-                                min_r = min_r, min_r_field = radius_field,
-                                random_radius = self.random_radius,
-                                seed = seed)
+                new_verts = field_random_probe(field, bbox, count, threshold, self.proportional, field_min, field_max, min_r, seed)
 
-                if self.flat_output:
-                    new_verts.extend(verts)
-                    new_radiuses.extend(radiuses)
-                else:
-                    new_verts.append(verts)
-                    new_radiuses.append(radiuses)
-
-            if nested_output:
                 verts_out.append(new_verts)
-                radius_out.append(new_radiuses)
-            else:
-                verts_out.extend(new_verts)
-                radius_out.extend(new_radiuses)
 
         self.outputs['Vertices'].sv_set(verts_out)
-        self.outputs['Radius'].sv_set(radius_out)
 
 def register():
-    bpy.utils.register_class(SvFieldRandomProbeMk3Node)
+    bpy.utils.register_class(SvFieldRandomProbeMk2Node)
 
 def unregister():
-    bpy.utils.unregister_class(SvFieldRandomProbeMk3Node)
+    bpy.utils.unregister_class(SvFieldRandomProbeMk2Node)
 

--- a/old_nodes/populate_solid.py
+++ b/old_nodes/populate_solid.py
@@ -36,6 +36,8 @@ class SvPopulateSolidNode(bpy.types.Node, SverchCustomTreeNode):
     bl_icon = 'OUTLINER_OB_EMPTY'
     sv_icon = 'SV_POPULATE_SOLID'
 
+    replacement_nodes = [('SvPopulateSolidMk2Node', None, None)]
+
     @throttle_and_update_node
     def update_sockets(self, context):
         self.inputs['FieldMin'].hide_safe = self.proportional != True

--- a/old_nodes/populate_surface.py
+++ b/old_nodes/populate_surface.py
@@ -29,6 +29,8 @@ class SvPopulateSurfaceNode(bpy.types.Node, SverchCustomTreeNode):
     bl_icon = 'OUTLINER_OB_EMPTY'
     sv_icon = 'SV_POPULATE_SURFACE'
 
+    replacement_nodes = [('SvPopulateSurfaceMk2Node', None, None)]
+
     threshold : FloatProperty(
             name = "Threshold",
             default = 0.5,

--- a/old_nodes/populate_surface.py
+++ b/old_nodes/populate_surface.py
@@ -19,12 +19,12 @@ from sverchok.utils.surface import SvSurface
 from sverchok.utils.surface.populate import populate_surface
 from sverchok.utils.field.scalar import SvScalarField
 
-class SvPopulateSurfaceMk2Node(bpy.types.Node, SverchCustomTreeNode):
+class SvPopulateSurfaceNode(bpy.types.Node, SverchCustomTreeNode):
     """
     Triggers: Populate Surface
     Tooltip: Generate random points on the surface
     """
-    bl_idname = 'SvPopulateSurfaceMk2Node'
+    bl_idname = 'SvPopulateSurfaceNode'
     bl_label = 'Populate Surface'
     bl_icon = 'OUTLINER_OB_EMPTY'
     sv_icon = 'SV_POPULATE_SURFACE'
@@ -56,9 +56,6 @@ class SvPopulateSurfaceMk2Node(bpy.types.Node, SverchCustomTreeNode):
     def update_sockets(self, context):
         self.inputs['FieldMin'].hide_safe = self.proportional != True
         self.inputs['FieldMax'].hide_safe = self.proportional != True
-        self.inputs['RadiusField'].hide_safe = self.distance_mode != 'FIELD'
-        self.inputs['MinDistance'].hide_safe = self.distance_mode != 'CONST'
-        self.outputs['Radiuses'].hide_safe = self.distance_mode != 'FIELD'
 
     proportional : BoolProperty(
             name = "Proportional",
@@ -71,50 +68,20 @@ class SvPopulateSurfaceMk2Node(bpy.types.Node, SverchCustomTreeNode):
             min = 0,
             update = updateNode)
 
-    distance_modes = [
-            ('CONST', "Min. Distance", "Specify minimum distance between points", 0),
-            ('FIELD', "Radius Field", "Specify radius of empty sphere around each point by scalar field", 1)
-        ]
-
-    distance_mode : EnumProperty(
-            name = "Distance",
-            description = "How minimum distance between points is restricted",
-            items = distance_modes,
-            default = 'CONST',
-            update = update_sockets)
-
-    random_radius : BoolProperty(
-            name = "Random radius",
-            description = "Make sphere radiuses random, restricted by scalar field values",
-            default = False,
-            update = updateNode)
-
-    flat_output : BoolProperty(
-            name = "Flat output",
-            description = "If checked, generate one flat list of vertices for all input surfaces; otherwise, generate a separate list of vertices for each surface",
-            default = False,
-            update = updateNode)
-
     def draw_buttons(self, context, layout):
-        layout.prop(self, 'distance_mode')
         layout.prop(self, "proportional")
-        if self.distance_mode == 'FIELD':
-            layout.prop(self, 'random_radius')
-        layout.prop(self, "flat_output")
 
     def sv_init(self, context):
         self.inputs.new('SvSurfaceSocket', "Surface")
         self.inputs.new('SvScalarFieldSocket', "Field").enable_input_link_menu = False
         self.inputs.new('SvStringsSocket', "Count").prop_name = 'count'
         self.inputs.new('SvStringsSocket', "MinDistance").prop_name = 'min_r'
-        self.inputs.new('SvScalarFieldSocket', "RadiusField")
         self.inputs.new('SvStringsSocket', "Threshold").prop_name = 'threshold'
         self.inputs.new('SvStringsSocket', "FieldMin").prop_name = 'field_min'
         self.inputs.new('SvStringsSocket', "FieldMax").prop_name = 'field_max'
         self.inputs.new('SvStringsSocket', 'Seed').prop_name = 'seed'
         self.outputs.new('SvVerticesSocket', "Vertices")
         self.outputs.new('SvVerticesSocket', "UVPoints")
-        self.outputs.new('SvStringsSocket', "Radiuses")
         self.update_sockets(context)
 
     def process(self):
@@ -131,74 +98,30 @@ class SvPopulateSurfaceMk2Node(bpy.types.Node, SverchCustomTreeNode):
         field_min_s = self.inputs['FieldMin'].sv_get()
         field_max_s = self.inputs['FieldMax'].sv_get()
         min_r_s = self.inputs['MinDistance'].sv_get()
-        if self.distance_mode == 'FIELD':
-            radius_s = self.inputs['RadiusField'].sv_get()
-        else:
-            radius_s = [[None]]
         seed_s = self.inputs['Seed'].sv_get()
 
-        input_level = get_data_nesting_level(surface_s, data_types=(SvSurface,))
-        nested_surface = input_level > 1
         surface_s = ensure_nesting_level(surface_s, 2, data_types=(SvSurface,))
         has_field = self.inputs['Field'].is_linked
         if has_field:
-            input_level = get_data_nesting_level(fields_s, data_types=(SvScalarField,))
-            nested_field = input_level > 1
             fields_s = ensure_nesting_level(fields_s, 2, data_types=(SvScalarField,))
-        else:
-            nested_field = False
-
-        if self.distance_mode == 'FIELD':
-            input_level = get_data_nesting_level(radius_s, data_types=(SvScalarField,))
-            nested_radius = input_level > 1
-            radius_s = ensure_nesting_level(radius_s, 2, data_types=(SvScalarField,))
-        else:
-            nested_radius = False
-
-        nested_output = nested_surface or nested_field or nested_radius
 
         verts_out = []
         uv_out = []
-        radius_out = []
 
-        inputs = zip_long_repeat(surface_s, fields_s, radius_s, count_s, threshold_s, field_min_s, field_max_s, min_r_s, seed_s)
-        for params in inputs:
-            new_uv = []
-            new_verts = []
-            new_radius = []
-            for surface, field, radius, count, threshold, field_min, field_max, min_r, seed in zip_long_repeat(*params):
-                if self.distance_mode == 'FIELD':
-                    min_r = 0
-                uvs, verts, radiuses = populate_surface(surface, field, count, threshold,
-                                        self.proportional, field_min, field_max,
-                                        min_r = min_r, min_r_field = radius,
-                                        random_radius = self.random_radius,
-                                        seed = seed)
-                if self.flat_output:
-                    new_verts.extend(verts)
-                    new_uv.extend(uvs)
-                    new_radius.extend(radiuses)
-                else:
-                    new_verts.append(verts)
-                    new_uv.append(uvs)
-                    new_radius.append(radiuses)
-
-            if nested_output:
+        parameters = zip_long_repeat(surface_s, fields_s, count_s, threshold_s, field_min_s, field_max_s, min_r_s, seed_s)
+        for surfaces, fields, counts, thresholds, field_mins, field_maxs, min_rs, seeds in parameters:
+            objects = zip_long_repeat(surfaces, fields, counts, thresholds, field_mins, field_maxs, min_rs, seeds)
+            for surface, field, count, threshold, field_min, field_max, min_r, seed in objects:
+                new_uv, new_verts = populate_surface(surface, field, count, threshold, self.proportional, field_min, field_max, min_r, seed)
                 verts_out.append(new_verts)
                 uv_out.append(new_uv)
-                radius_out.append(new_radius)
-            else:
-                verts_out.extend(new_verts)
-                uv_out.extend(new_uv)
-                radius_out.extend(new_radius)
 
         self.outputs['Vertices'].sv_set(verts_out)
         self.outputs['UVPoints'].sv_set(uv_out)
-        self.outputs['Radiuses'].sv_set(radius_out)
 
 def register():
-    bpy.utils.register_class(SvPopulateSurfaceMk2Node)
+    bpy.utils.register_class(SvPopulateSurfaceNode)
 
 def unregister():
-    bpy.utils.unregister_class(SvPopulateSurfaceMk2Node)
+    bpy.utils.unregister_class(SvPopulateSurfaceNode)
 

--- a/ui/nodeview_rclick_menu.py
+++ b/ui/nodeview_rclick_menu.py
@@ -66,6 +66,9 @@ def get_output_sockets_map(node):
     # we can surely use regex for this, but for now this will work.
     for socket in node.outputs:
 
+        if socket.hide or socket.hide_safe:
+            continue
+
         socket_name = socket.name.lower()
 
         if not got_verts and ('ver' in socket_name or 'vec' in socket_name):

--- a/utils/field/probe.py
+++ b/utils/field/probe.py
@@ -139,7 +139,9 @@ def field_random_probe(field, bbox, count,
                     good_verts.append(candidate.tolist())
 
         if predicate is not None:
-            good_verts = [vert for vert in good_verts if predicate(vert)]
+            pairs = [(vert, r) for vert, r in zip(good_verts, good_radiuses) if predicate(vert)]
+            good_verts = [p[0] for p in pairs]
+            good_radiuses = [p[1] for p in pairs]
 
         generated_verts.extend(good_verts)
         generated_radiuses.extend(good_radiuses)

--- a/utils/field/probe.py
+++ b/utils/field/probe.py
@@ -23,8 +23,8 @@ def _check_min_distance(v_new, vs_old, min_r):
     if dist is None:
         return True
     ok = (dist >= min_r)
-    if not ok:
-        print(f"V {v_new} => {nearest}, {dist} >= {min_r}")
+    #if not ok:
+    #    print(f"V {v_new} => {nearest}, {dist} >= {min_r}")
     return ok
 
 def _check_min_radius(point, old_points, old_radiuses, min_r):

--- a/utils/field/probe.py
+++ b/utils/field/probe.py
@@ -22,7 +22,10 @@ def _check_min_distance(v_new, vs_old, min_r):
     nearest, idx, dist = kdt.query(v_new)
     if dist is None:
         return True
-    return (dist >= min_r)
+    ok = (dist >= min_r)
+    if not ok:
+        print(f"V {v_new} => {nearest}, {dist} >= {min_r}")
+    return ok
 
 def _check_min_radius(point, old_points, old_radiuses, min_r):
     if not old_points:
@@ -136,6 +139,7 @@ def field_random_probe(field, bbox, count,
             for candidate in candidates:
                 if _check_min_distance(candidate, generated_verts + good_verts, min_r):
                     good_verts.append(candidate)
+            good_radiuses = [1 for c in good_verts]
 
         if predicate is not None:
             pairs = [(vert, r) for vert, r in zip(good_verts, good_radiuses) if predicate(vert)]

--- a/utils/field/probe.py
+++ b/utils/field/probe.py
@@ -8,20 +8,18 @@
 import random
 import numpy as np
 
-from mathutils.kdtree import KDTree
-
 from sverchok.utils.field.scalar import SvScalarField
 from sverchok.utils.logging import error
+from sverchok.utils.kdtree import SvKdTree
 
 BATCH_SIZE = 50
 MAX_ITERATIONS = 1000
 
 def _check_min_distance(v_new, vs_old, min_r):
-    kdt = KDTree(len(vs_old))
-    for i, v in enumerate(vs_old):
-        kdt.insert(v, i)
-    kdt.balance()
-    nearest, idx, dist = kdt.find(v_new)
+    if not vs_old:
+        return True
+    kdt = SvKdTree.new(SvKdTree.BLENDER, vs_old)
+    nearest, idx, dist = kdt.query(v_new)
     if dist is None:
         return True
     return (dist >= min_r)

--- a/utils/field/probe.py
+++ b/utils/field/probe.py
@@ -16,7 +16,7 @@ from sverchok.utils.logging import error
 BATCH_SIZE = 50
 MAX_ITERATIONS = 1000
 
-def _check_all(v_new, vs_old, min_r):
+def _check_min_distance(v_new, vs_old, min_r):
     kdt = KDTree(len(vs_old))
     for i, v in enumerate(vs_old):
         kdt.insert(v, i)
@@ -26,7 +26,21 @@ def _check_all(v_new, vs_old, min_r):
         return True
     return (dist >= min_r)
 
-def field_random_probe(field, bbox, count, threshold=0, proportional=False, field_min=None, field_max=None, min_r=0, seed=0, predicate=None):
+def _check_min_radius(point, old_points, old_radiuses, min_r):
+    if not old_points:
+        return True
+    old_points = np.array(old_points)
+    old_radiuses = np.array(old_radiuses)
+    point = np.array(point)
+    distances = np.linalg.norm(old_points - point, axis=1)
+    ok = (old_radiuses + min_r < distances).all()
+    return ok
+
+def field_random_probe(field, bbox, count,
+        threshold=0, proportional=False, field_min=None, field_max=None,
+        min_r=0, min_r_field=None,
+        random_radius = False,
+        seed=0, predicate=None):
     """
     Generate random points within bounding box, with distribution controlled (optionally) by a scalar field.
 
@@ -50,16 +64,20 @@ def field_random_probe(field, bbox, count, threshold=0, proportional=False, fiel
     outputs:
         list of vertices.
     """
+    if min_r != 0 and min_r_field is not None:
+        raise Exception("min_r and min_r_field can not be specified simultaneously")
     if seed == 0:
         seed = 12345
-    random.seed(seed)
+    if seed is not None:
+        random.seed(seed)
 
     b1, b2 = bbox
     x_min, y_min, z_min = b1
     x_max, y_max, z_max = b2
 
     done = 0
-    new_verts = []
+    generated_verts = []
+    generated_radiuses = []
     iterations = 0
     while done < count:
         iterations += 1
@@ -99,19 +117,33 @@ def field_random_probe(field, bbox, count, threshold=0, proportional=False, fiel
                     if probe <= value:
                         candidates.append(vert)
 
-        if min_r == 0:
+        good_radiuses = []
+        if min_r == 0 and min_r_field is None:
             good_verts = candidates
-        else:
+        elif min_r_field is not None:
+            xs = np.array([p[0] for p in candidates])
+            ys = np.array([p[1] for p in candidates])
+            zs = np.array([p[2] for p in candidates])
+            min_rs = min_r_field.evaluate_grid(xs, ys, zs).tolist()
+            good_verts = []
+            for candidate, min_r in zip(candidates, min_rs):
+                if random_radius:
+                    min_r = random.uniform(0, min_r)
+                if _check_min_radius(candidate, generated_verts + good_verts, generated_radiuses + good_radiuses, min_r):
+                    good_verts.append(candidate)
+                    good_radiuses.append(min_r)
+        else: # min_r != 0
             good_verts = []
             for candidate in candidates:
-                if _check_all(candidate, new_verts + good_verts, min_r):
-                    good_verts.append(candidate)
+                if _check_min_distance(candidate, generated_verts + good_verts, min_r):
+                    good_verts.append(candidate.tolist())
 
         if predicate is not None:
             good_verts = [vert for vert in good_verts if predicate(vert)]
 
-        new_verts.extend(good_verts)
+        generated_verts.extend(good_verts)
+        generated_radiuses.extend(good_radiuses)
         done += len(good_verts)
 
-    return new_verts
+    return generated_verts, generated_radiuses
 

--- a/utils/field/probe.py
+++ b/utils/field/probe.py
@@ -120,6 +120,7 @@ def field_random_probe(field, bbox, count,
         good_radiuses = []
         if min_r == 0 and min_r_field is None:
             good_verts = candidates
+            good_radiuses = [0 for i in range(len(good_verts))]
         elif min_r_field is not None:
             xs = np.array([p[0] for p in candidates])
             ys = np.array([p[1] for p in candidates])

--- a/utils/field/probe.py
+++ b/utils/field/probe.py
@@ -137,7 +137,7 @@ def field_random_probe(field, bbox, count,
             good_verts = []
             for candidate in candidates:
                 if _check_min_distance(candidate, generated_verts + good_verts, min_r):
-                    good_verts.append(candidate.tolist())
+                    good_verts.append(candidate)
 
         if predicate is not None:
             pairs = [(vert, r) for vert, r in zip(good_verts, good_radiuses) if predicate(vert)]

--- a/utils/geom.py
+++ b/utils/geom.py
@@ -725,6 +725,8 @@ class PlaneEquation(object):
     @classmethod
     def from_normal_and_point(cls, normal, point):
         a, b, c = tuple(normal)
+        if (a*a + b*b + c*c) < 1e-8:
+            raise Exception("Plane normal is (almost) zero!")
         cx, cy, cz = tuple(point)
         d = - (a*cx + b*cy + c*cz)
         return PlaneEquation(a, b, c, d)

--- a/utils/geom.py
+++ b/utils/geom.py
@@ -2181,3 +2181,12 @@ def bounding_sphere(vertices, algorithm=TRIVIAL):
     radius = norms.max()
     return c, radius
 
+def scale_relative(points, center, scale):
+    points = np.asarray(points)
+    center = np.asarray(center)
+    points -= center
+
+    points = points * scale
+
+    return (points + center).tolist()
+

--- a/utils/solid.py
+++ b/utils/solid.py
@@ -486,7 +486,13 @@ def svmesh_to_solid(verts, faces, precision=1e-6, remove_splitter=True, method=F
             face_i = list(face) + [face[0]]
             face_verts = [Base.Vector(verts[i]) for i in face_i]
             wire = Part.makePolygon(face_verts)
-            fc_face = Part.Face(wire)
+            wire.fixTolerance(precision)
+            try:
+                fc_face = Part.Face(wire)
+                #fc_face = Part.makeFilledFace(wire.Edges)
+            except Exception as e:
+                print(f"Face idxs: {face_i}, verts: {face_verts}")
+                raise Exception("Maybe face is not planar?") from e
             fc_faces.append(fc_face)
         shell = Part.makeShell(fc_faces)
         solid = Part.makeSolid(shell)

--- a/utils/solid.py
+++ b/utils/solid.py
@@ -477,3 +477,49 @@ def svmesh_to_solid(verts, faces, precision, remove_splitter=True):
 
     return Part.makeSolid(shape)
 
+def mesh_from_solid_faces(solid):
+    verts = [(v.X, v.Y, v.Z) for v in solid.Vertexes]
+
+    all_fc_verts = {SvSolidTopology.Item(v) : i for i, v in enumerate(solid.Vertexes)}
+    def find_vertex(v):
+        #for i, fc_vert in enumerate(solid.Vertexes):
+        #    if v.isSame(fc_vert):
+        #        return i
+        #return None
+        return all_fc_verts[SvSolidTopology.Item(v)]
+
+    edges = []
+    for fc_edge in solid.Edges:
+        edge = [find_vertex(v) for v in fc_edge.Vertexes]
+        if len(edge) == 2:
+            edges.append(edge)
+
+    faces = []
+    for fc_face in solid.Faces:
+        incident_verts = defaultdict(set)
+        for fc_edge in fc_face.Edges:
+            edge = [find_vertex(v) for v in fc_edge.Vertexes]
+            if len(edge) == 2:
+                i, j = edge
+                incident_verts[i].add(j)
+                incident_verts[j].add(i)
+
+        face = [find_vertex(v) for v in fc_face.Vertexes]
+
+        vert_idx = face[0]
+        correct_face = [vert_idx]
+
+        for i in range(len(face)):
+            incident = list(incident_verts[vert_idx])
+            other_verts = [i for i in incident if i not in correct_face]
+            if not other_verts:
+                break
+            other_vert_idx = other_verts[0]
+            correct_face.append(other_vert_idx)
+            vert_idx = other_vert_idx
+
+        if len(correct_face) > 2:
+            faces.append(correct_face)
+
+    return verts, edges, faces
+

--- a/utils/surface/populate.py
+++ b/utils/surface/populate.py
@@ -171,10 +171,11 @@ def populate_surface(surface, field, count, threshold,
                 good_verts = []
                 good_uvs = []
                 for candidate_uv, candidate in zip(candidate_uvs, candidates):
-                    distance_ok = _check_min_distance(candidate, generated_verts + good_verts, min_r)
+                    distance_ok = _check_min_distance(candidate, old_points + generated_verts + good_verts, min_r)
                     if distance_ok:
                         good_verts.append(tuple(candidate))
                         good_uvs.append(tuple(candidate_uv))
+                        good_radiuses.append(0)
 
             if predicate is not None:
                 results = [(uv, vert, radius) for uv, vert, radius in zip(good_uvs, good_verts, good_radiuses) if predicate(uv, vert)]

--- a/utils/surface/populate.py
+++ b/utils/surface/populate.py
@@ -150,8 +150,8 @@ def populate_surface(surface, field, count, threshold,
         good_radiuses = []
         if len(candidates) > 0:
             if min_r == 0 and min_r_field is None:
-                good_verts = candidates
-                good_uvs = candidate_uvs
+                good_verts = candidates.tolist()
+                good_uvs = candidate_uvs.tolist()
                 good_radiuses = [0 for i in range(len(good_verts))]
             elif min_r_field is not None:
                 xs = np.array([p[0] for p in candidates])

--- a/utils/surface/populate.py
+++ b/utils/surface/populate.py
@@ -52,6 +52,7 @@ def populate_surface(surface, field, count, threshold,
         proportional=False, field_min=None, field_max=None,
         min_r=0, min_r_field = None,
         random_radius = False,
+        avoid_spheres = None,
         seed=0, predicate=None):
     """
     Generate random points on the surface, with distribution controlled (optionally) by scalar field.
@@ -83,6 +84,13 @@ def populate_surface(surface, field, count, threshold,
 
     u_min, u_max = surface.get_u_min(), surface.get_u_max()
     v_min, v_max = surface.get_v_min(), surface.get_v_max()
+
+    if avoid_spheres is not None:
+        old_points = [s[0] for s in avoid_spheres]
+        old_radiuses = [s[1] for s in avoid_spheres]
+    else:
+        old_points = []
+        old_radiuses = []
 
     if seed == 0:
         seed = 12345
@@ -144,6 +152,7 @@ def populate_surface(surface, field, count, threshold,
             if min_r == 0 and min_r_field is None:
                 good_verts = candidates
                 good_uvs = candidate_uvs
+                good_radiuses = [0 for i in range(len(good_verts))]
             elif min_r_field is not None:
                 xs = np.array([p[0] for p in candidates])
                 ys = np.array([p[1] for p in candidates])
@@ -154,7 +163,7 @@ def populate_surface(surface, field, count, threshold,
                 for candidate_uv, candidate, min_r in zip(candidate_uvs, candidates, min_rs):
                     if random_radius:
                         min_r = random.uniform(0, min_r)
-                    if _check_min_radius(candidate, generated_verts + good_verts, generated_radiuses + good_radiuses, min_r):
+                    if _check_min_radius(candidate, old_points + generated_verts + good_verts, old_radiuses + generated_radiuses + good_radiuses, min_r):
                         good_verts.append(candidate)
                         good_uvs.append(candidate_uv)
                         good_radiuses.append(min_r)

--- a/utils/sv_mesh_utils.py
+++ b/utils/sv_mesh_utils.py
@@ -19,7 +19,9 @@
 from sverchok.data_structure import fullList_deep_copy
 from numpy import array, empty, concatenate, unique, sort, int32, ndarray, vectorize
 
+from mathutils import Vector
 
+from sverchok.data_structure import fullList_deep_copy
 
 def mesh_join(vertices_s, edges_s, faces_s):
     '''Given list of meshes represented by lists of vertices, edges and faces,
@@ -142,3 +144,19 @@ def get_unique_faces(faces):
         else:
             uniq_faces.append(face)
     return uniq_faces
+
+def point_inside_mesh(bvh, point):
+    point = Vector(point)
+    axis = Vector((1, 0, 0))
+    outside = False
+    count = 0
+    while True:
+        location, normal, index, distance = bvh.ray_cast(point, axis)
+        if index is None:
+            break
+        count += 1
+        point = location + axis * 0.00001
+    if count % 2 == 0:
+        outside = True
+    return not outside
+


### PR DESCRIPTION
Node |  Comment | Essentially done |  Documentation | Dependencies
--------|-------------------|--------------------------|---------------------------|----------------------
Field Random Probe Mk3  | add "Sphere radius" mode | :heavy_check_mark:  |  :heavy_check_mark:  | none
Populate Solid Mk2 | add "Sphere radius" mode |  :heavy_check_mark:  | :heavy_check_mark:   | FreeCAD
Populate Surface Mk2 | add "Sphere radius" mode |  :heavy_check_mark:  |  :heavy_check_mark:   | none
Voronoi on Mesh | Reworked, moved from Sverchok-Extra | :heavy_check_mark:  |  :heavy_check_mark:  | SciPy
Voronoi on Solid | Reworked, moved from Sverchok-Extra | :heavy_check_mark:  | :heavy_check_mark: | SciPy and FreeCAD

![Screenshot_20201214_212446](https://user-images.githubusercontent.com/284644/102106806-d5caa500-3e52-11eb-805e-73333b35350c.png)


![Screenshot_20201213_222523](https://user-images.githubusercontent.com/284644/102018920-23330d80-3d92-11eb-82ab-0153409aab07.png)

![Screenshot_20201213_202136](https://user-images.githubusercontent.com/284644/102016088-dd217e00-3d80-11eb-85f8-e16c3f4111ff.png)

![Screenshot_20201216_222828](https://user-images.githubusercontent.com/284644/102384062-190d4b00-3fee-11eb-8405-71e8ed383d26.png)


![Screenshot_20201213_203029](https://user-images.githubusercontent.com/284644/102016380-743b0580-3d82-11eb-9bf3-418d88ce6b41.png)
![Screenshot_20201213_203209](https://user-images.githubusercontent.com/284644/102016381-756c3280-3d82-11eb-81c7-85eae815cb26.png)

![Screenshot_20201213_224758](https://user-images.githubusercontent.com/284644/102019410-490de180-3d95-11eb-86e0-78041f749dad.png)

![Screenshot_20201216_230753](https://user-images.githubusercontent.com/284644/102390339-1b73a300-3ff6-11eb-961f-373c98164ced.png)
![Screenshot_20201216_231105](https://user-images.githubusercontent.com/284644/102390341-1ca4d000-3ff6-11eb-90f5-dfa07646f941.png)
![Screenshot_20201216_231218](https://user-images.githubusercontent.com/284644/102390345-1d3d6680-3ff6-11eb-9f33-b004e9ee7e96.png)
![Screenshot_20201216_231511](https://user-images.githubusercontent.com/284644/102390347-1dd5fd00-3ff6-11eb-80a0-5100b7176cbd.png)
![Screenshot_20201216_231804](https://user-images.githubusercontent.com/284644/102390349-1dd5fd00-3ff6-11eb-98d1-6143b5312380.png)
![Screenshot_20201216_232254](https://user-images.githubusercontent.com/284644/102390351-1e6e9380-3ff6-11eb-852d-bc1b41a449d6.png)


## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.


