### PR TITLE
Remove slowing statement

### DIFF
--- a/core/sockets.py
+++ b/core/sockets.py
@@ -42,7 +42,7 @@ from sverchok.utils.curve import SvCurve
 from sverchok.utils.curve.algorithms import reparametrize_curve
 from sverchok.utils.surface import SvSurface
 
-from sverchok.utils.logging import warning, debug
+from sverchok.utils.logging import warning
 from sverchok.dependencies import FreeCAD
 
 STANDARD_TYPES = SIMPLE_DATA_TYPES + (SvCurve, SvSurface)
@@ -515,7 +515,6 @@ class SvSocketCommon(SvSocketProcessing):
         if not self.needs_data_conversion():
             return source_data
         else:
-            debug(f"Trying to convert data for input socket {self.name} by {implicit_conversions}")
             return implicit_conversions.convert(self, source_data)
 
     def update_objects_number(self):


### PR DESCRIPTION
In this node tree
![image](https://user-images.githubusercontent.com/10011941/102667381-7e497380-4189-11eb-8340-f9abd9732b76.png)
the removed debug statement was causing this nodetree to be executed in 2.54 secs and after removal 0.68 sec  (+1.86 s)  even when debugging was disabled.
Reminder: Use debug statements with caution
#3783
- [X] Ready for merge.

