### PR TITLE
Sv get performance

### DIFF
--- a/core/socket_conversions.py
+++ b/core/socket_conversions.py
@@ -18,7 +18,7 @@
 from copy import deepcopy
 from enum import Enum
 
-from sverchok.data_structure import get_other_socket, get_data_nesting_level, is_ultimately
+from sverchok.data_structure import get_data_nesting_level, is_ultimately
 from sverchok.utils.field.vector import SvVectorField, SvMatrixVectorField, SvConstantVectorField
 from sverchok.utils.field.scalar import SvScalarField, SvConstantScalarField
 from sverchok.utils.curve import SvCurve
@@ -28,48 +28,20 @@ from sverchok.utils.solid_conversion import to_solid_recursive
 from mathutils import Matrix, Quaternion
 from numpy import ndarray
 
-# conversion tests, to be used in sv_get!
+SOCKET_TYPES = {
+    'v': 'SvVerticesSocket',
+    's': 'SvStringsSocket',
+    'm': 'SvMatrixSocket',
+    'q': 'SvQuaternionSocket',
+    'vf': "SvVectorFieldSocket",
+    'sf': 'SvScalarFieldSocket'
+    }
 
-def cross_test_socket(self, A, B):
+def test_socket_type(self, other, A, B):
     """ A is origin type, B is destination type """
-    other = get_other_socket(self)
-    get_type = {'v': 'SvVerticesSocket', 'm': 'SvMatrixSocket', 'q': "SvQuaternionSocket"}
-    return other.bl_idname == get_type[A] and self.bl_idname == get_type[B]
-
-
-def is_vector_to_matrix(self):
-    return cross_test_socket(self, 'v', 'm')
-
-
-def is_matrix_to_vector(self):
-    return cross_test_socket(self, 'm', 'v')
-
-
-def is_matrix_to_quaternion(self):
-    return cross_test_socket(self, 'm', 'q')
-
-
-def is_quaternion_to_matrix(self):
-    return cross_test_socket(self, 'q', 'm')
-
-def is_matrix_to_vfield(socket):
-    other = get_other_socket(socket)
-    return other.bl_idname == 'SvMatrixSocket' and socket.bl_idname == 'SvVectorFieldSocket'
-
-def is_vertex_to_vfield(socket):
-    other = get_other_socket(socket)
-    return other.bl_idname == 'SvVerticesSocket' and socket.bl_idname == 'SvVectorFieldSocket'
-
-def is_string_to_sfield(socket):
-    other = get_other_socket(socket)
-    return other.bl_idname == 'SvStringsSocket' and socket.bl_idname == 'SvScalarFieldSocket'
-
-def is_string_to_vector(socket):
-    other = get_other_socket(socket)
-    return other.bl_idname == 'SvStringsSocket' and socket.bl_idname == 'SvVerticesSocket'
+    return other.bl_idname == SOCKET_TYPES[A] and self.bl_idname == SOCKET_TYPES[B]
 
 # ---
-
 
 def get_matrices_from_locs(data):
     location_matrices = []
@@ -146,10 +118,10 @@ def matrices_to_vfield(data):
     if isinstance(data, Matrix):
         data = deepcopy(data)
         return SvMatrixVectorField(data)
-    elif isinstance(data, (list, tuple)):
+    if isinstance(data, (list, tuple)):
         return [matrices_to_vfield(item) for item in data]
-    else:
-        raise TypeError("Unexpected data type from Matrix socket: %s" % type(data))
+
+    raise TypeError("Unexpected data type from Matrix socket: %s" % type(data))
 
 def vertices_to_vfield(data):
     if isinstance(data, (tuple, list)) and len(data) == 3 and isinstance(data[0], (float, int)):
@@ -183,16 +155,18 @@ class ImplicitConversionProhibited(Exception):
     def __str__(self):
         return self.message
 
-class NoImplicitConversionPolicy(object):
+
+class NoImplicitConversionPolicy():
     """
     Base (empty) implicit conversion policy.
     This prohibits any implicit conversions.
     """
     @classmethod
-    def convert(cls, socket, source_data):
+    def convert(cls, socket, other, source_data):
         raise ImplicitConversionProhibited(socket)
 
-class LenientImplicitConversionPolicy(object):
+
+class LenientImplicitConversionPolicy():
     """
     Lenient implicit conversion policy.
     Does not actually convert anything, but passes any
@@ -202,32 +176,32 @@ class LenientImplicitConversionPolicy(object):
     nodes).
     """
     @classmethod
-    def convert(cls, socket, source_data):
+    def convert(cls, socket, other, source_data):
         return source_data
+
 
 class DefaultImplicitConversionPolicy(NoImplicitConversionPolicy):
     """
     Default implicit conversion policy.
     """
+
     @classmethod
-    def convert(cls, socket, source_data):
-        # let policy to decide if deep copy of data is needed
-        if is_vector_to_matrix(socket):
-            return cls.vectors_to_matrices(socket, source_data)
-        elif is_matrix_to_vector(socket):
-            return cls.matrices_to_vectors(socket, source_data)
-        elif is_quaternion_to_matrix(socket):
-            return cls.quaternions_to_matrices(socket, source_data)
-        elif is_matrix_to_quaternion(socket):
-            return cls.matrices_to_quaternions(socket, source_data)
-        elif is_string_to_vector(socket):
-            return cls.string_to_vector(socket, source_data)
-        elif socket.bl_idname in cls.get_lenient_socket_types():
+    def convert(cls, socket, other, source_data):
+        test = [
+            ['v', 'm', cls.vectors_to_matrices],
+            ['m', 'v', cls.matrices_to_vectors],
+            ['q', 'm', cls.quaternions_to_matrices],
+            ['m', 'q', cls.matrices_to_quaternions],
+            ['s', 'v', cls.string_to_vector]]
+        for t in test:
+            if test_socket_type(socket, other, t[0], t[1]):
+                return t[2](socket, source_data)
+        if socket.bl_idname in cls.get_lenient_socket_types():
             return source_data
-        elif cls.data_type_check(socket, source_data):
+        if cls.data_type_check(socket, other, source_data):
             return source_data
-        else:
-            super().convert(socket, source_data)
+
+        return super().convert(socket, other, source_data)
 
     @classmethod
     def get_lenient_socket_types(cls):
@@ -249,12 +223,12 @@ class DefaultImplicitConversionPolicy(NoImplicitConversionPolicy):
         return ['SvStringsSocket']
 
     @classmethod
-    def data_type_check(cls, socket, source_data):
+    def data_type_check(cls, socket, other, source_data):
         checking_sockets = cls.get_data_type_checking_socket_types()
         expected_type = checking_sockets.get(socket.bl_idname)
         if expected_type is None:
             return False
-        if not get_other_socket(socket).bl_idname in cls.get_arbitrary_type_socket_types():
+        if not other.bl_idname in cls.get_arbitrary_type_socket_types():
             return False
         return is_ultimately(source_data, expected_type)
 
@@ -288,27 +262,29 @@ class DefaultImplicitConversionPolicy(NoImplicitConversionPolicy):
 
 class FieldImplicitConversionPolicy(DefaultImplicitConversionPolicy):
     @classmethod
-    def convert(cls, socket, source_data):
+    def convert(cls, socket, other, source_data):
         # let policy to decide if deep copy of data is needed
-        if is_matrix_to_vfield(socket):
-            return matrices_to_vfield(source_data) 
-        elif is_vertex_to_vfield(socket):
+        if test_socket_type(socket, other, 'm', 'vf'):
+            return matrices_to_vfield(source_data)
+        if test_socket_type(socket, other, 'v', 'vf'):
             return vertices_to_vfield(source_data)
-        elif is_string_to_sfield(socket):
+        if test_socket_type(socket, other, 's', 'sf'):
             level = get_data_nesting_level(source_data)
             if level > 2:
                 raise TypeError("Too high data nesting level for Number -> Scalar Field conversion: %s" % level)
             return numbers_to_sfield(source_data)
-        else:
-            super().convert(socket, source_data)
+
+        return super().convert(socket, other, source_data)
+
 
 class SolidImplicitConversionPolicy(NoImplicitConversionPolicy):
     @classmethod
-    def convert(cls, socket, source_data):
+    def convert(cls, socket, other, source_data):
         try:
             return to_solid_recursive(source_data)
         except TypeError as e:
             raise ImplicitConversionProhibited(socket, msg=f"Cannot perform implicit socket conversion for socket {socket.name}: {e}")
+
 
 class ConversionPolicies(Enum):
     """It should keeps all policy classes"""
@@ -332,4 +308,3 @@ class ConversionPolicies(Enum):
                 return enum.conversion
         raise LookupError(f"Conversion policy with name={conversion_name} was not found,"
                           f"Available names: {[e.conversion_name for e in cls]}")
-

--- a/core/socket_data.py
+++ b/core/socket_data.py
@@ -87,9 +87,11 @@ def SvSetSocket(socket, out):
 
     s_id = socket.socket_id
     s_ng = socket.id_data.tree_id
-    if s_ng not in socket_data_cache:
+    try:
+        socket_data_cache[s_ng][s_id] = out
+    except KeyError:
         socket_data_cache[s_ng] = {}
-    socket_data_cache[s_ng][s_id] = out
+        socket_data_cache[s_ng][s_id] = out
 
 
 def SvGetSocket(socket, other=None, deepcopy=True):
@@ -106,7 +108,7 @@ def SvGetSocket(socket, other=None, deepcopy=True):
         if deepcopy:
             return sv_deep_copy(out)
         return out
-        
+
     except Exception as e:
         if data_structure.DEBUG_MODE:
             debug(f"cache miss: {socket.node.name} -> {socket.name} from: {other.node.name} -> {other.name}")

--- a/core/sockets.py
+++ b/core/sockets.py
@@ -35,6 +35,7 @@ from sverchok.data_structure import (
 
 from sverchok.settings import get_params
 
+from sverchok.utils.socket_utils import format_bpy_property, setup_new_node_location
 from sverchok.utils.field.scalar import SvScalarField
 from sverchok.utils.field.vector import SvVectorField
 from sverchok.utils.curve import SvCurve
@@ -265,14 +266,6 @@ class SvSocketProcessing():
         if self.can_wrap():
             layout.prop(self, 'use_wrap')
 
-def format_property(prop):
-    if isinstance(prop, (str, int, float)):
-        return [[prop]]
-    if hasattr(prop, '__len__'):
-        # it looks like as some BLender property array - convert to tuple
-        return [[prop[:]]]
-
-    return [prop]
 
 class SvSocketCommon(SvSocketProcessing):
     """
@@ -388,12 +381,12 @@ class SvSocketCommon(SvSocketProcessing):
         prop_name = self.get_prop_name()
         if prop_name:
             prop = getattr(self.node, prop_name)
-            return format_property(prop)
+            return format_bpy_property(prop)
 
         if self.use_prop and hasattr(self, 'default_property') and self.default_property is not None:
             default_property = self.default_property
-            return format_property(default_property)
-            
+            return format_bpy_property(default_property)
+
         if default is not sentinel:
             return default
 
@@ -1193,13 +1186,6 @@ class SvSocketHelpOp(bpy.types.Operator):
                 col.label(text=line)
         bpy.context.window_manager.popup_menu(draw, title="Socket description", icon='QUESTION')
         return {'FINISHED'}
-
-def setup_new_node_location(new_node, old_node):
-    links_number = len([s for s in old_node.inputs if s.is_linked])
-    new_node.location = (old_node.location[0] - 200, old_node.location[1] - 100 * links_number)
-    if old_node.parent:
-        new_node.parent = old_node.parent
-        new_node.location = new_node.absolute_location
 
 class SvInputLinkMenuOp(bpy.types.Operator):
     "Opens a menu"

--- a/core/sockets.py
+++ b/core/sockets.py
@@ -22,22 +22,21 @@ import bpy
 from bpy.props import StringProperty, BoolProperty, FloatVectorProperty, IntProperty, FloatProperty, EnumProperty
 from bpy.types import NodeTree, NodeSocket
 
-from sverchok.core.socket_conversions import ConversionPolicies, is_vector_to_matrix, FieldImplicitConversionPolicy
+from sverchok.core.socket_conversions import ConversionPolicies
 from sverchok.core.socket_data import (
     SvGetSocketInfo, SvGetSocket, SvSetSocket, SvForgetSocket,
     SvNoDataError, sentinel)
 
 from sverchok.data_structure import (
     get_other_socket,
-    socket_id,
     replace_socket,
     SIMPLE_DATA_TYPES,
     flatten_data, graft_data, map_at_level, wrap_data, unwrap_data)
 
 from sverchok.settings import get_params
 
-from sverchok.utils.field.scalar import SvScalarField, SvConstantScalarField
-from sverchok.utils.field.vector import SvVectorField, SvMatrixVectorField, SvConstantVectorField
+from sverchok.utils.field.scalar import SvScalarField
+from sverchok.utils.field.vector import SvVectorField
 from sverchok.utils.curve import SvCurve
 from sverchok.utils.curve.algorithms import reparametrize_curve
 from sverchok.utils.surface import SvSurface
@@ -49,6 +48,8 @@ STANDARD_TYPES = SIMPLE_DATA_TYPES + (SvCurve, SvSurface)
 if FreeCAD is not None:
     import Part
     STANDARD_TYPES = STANDARD_TYPES + (Part.Shape,)
+
+DEFAULT_CONVERSION = ConversionPolicies.DEFAULT.conversion
 
 def process_from_socket(self, context):
     """Update function of exposed properties in Sockets"""
@@ -82,7 +83,7 @@ class SV_MT_SocketOptionsMenu(bpy.types.Menu):
         if hasattr(context.socket, 'draw_menu_items'):
             context.socket.draw_menu_items(context, layout)
 
-class SvSocketProcessing(object):
+class SvSocketProcessing():
     """
     Mixin class for data processing logic of a socket.
     """
@@ -264,6 +265,15 @@ class SvSocketProcessing(object):
         if self.can_wrap():
             layout.prop(self, 'use_wrap')
 
+def format_property(prop):
+    if isinstance(prop, (str, int, float)):
+        return [[prop]]
+    if hasattr(prop, '__len__'):
+        # it looks like as some BLender property array - convert to tuple
+        return [[prop[:]]]
+
+    return [prop]
+
 class SvSocketCommon(SvSocketProcessing):
     """
     Base class for all Sockets
@@ -302,16 +312,16 @@ class SvSocketCommon(SvSocketProcessing):
         Name can be replaced by twin property name in draft mode of a tree
         If does not have 'missing_dependecy' attribute it can return empty list, reasons unknown
         """
-        if hasattr(self.node, 'missing_dependecy'):
+        node = self.node
+        if hasattr(node, 'missing_dependecy'):
             return []
-        if self.node and hasattr(self.node, 'does_support_draft_mode') and self.node.does_support_draft_mode() and hasattr(self.node.id_data, 'sv_draft') and self.node.id_data.sv_draft:
+        if node and hasattr(node, 'does_support_draft_mode') and node.does_support_draft_mode() and hasattr(node.id_data, 'sv_draft') and node.id_data.sv_draft:
             prop_name_draft = self.node.draft_properties_mapping.get(self.prop_name, None)
             if prop_name_draft:
                 return prop_name_draft
-            else:
-                return self.prop_name
-        else:
             return self.prop_name
+
+        return self.prop_name
 
     @property
     def other(self):
@@ -364,36 +374,30 @@ class SvSocketCommon(SvSocketProcessing):
         :param implicit_conversions: if needed automatic conversion data from one socket type to another
         :return: data bound to the socket
         """
-        if implicit_conversions is None:
-            if hasattr(self, 'default_conversion_name'):
-                implicit_conversions = ConversionPolicies.get_conversion(self.default_conversion_name)
-            else:
-                implicit_conversions = ConversionPolicies.DEFAULT.conversion
 
         if self.is_linked and not self.is_output:
-            return self.convert_data(SvGetSocket(self, deepcopy), implicit_conversions)
-        elif self.get_prop_name():
-            prop = getattr(self.node, self.get_prop_name())
-            if isinstance(prop, (str, int, float)):
-                return [[prop]]
-            elif hasattr(prop, '__len__'):
-                # it looks like as some BLender property array - convert to tuple
-                return [[prop[:]]]
-            else:
-                return [prop]
-        elif self.use_prop and hasattr(self, 'default_property') and self.default_property is not None:
+            other = self.other
+            if implicit_conversions is None:
+                if hasattr(self, 'default_conversion_name'):
+                    implicit_conversions = ConversionPolicies.get_conversion(self.default_conversion_name)
+                else:
+                    implicit_conversions = DEFAULT_CONVERSION
+
+            return self.convert_data(SvGetSocket(self, other, deepcopy), implicit_conversions, other)
+
+        prop_name = self.get_prop_name()
+        if prop_name:
+            prop = getattr(self.node, prop_name)
+            return format_property(prop)
+
+        if self.use_prop and hasattr(self, 'default_property') and self.default_property is not None:
             default_property = self.default_property
-            if isinstance(default_property, (str, int, float)):
-                return [[default_property]]
-            elif hasattr(default_property, '__len__'):
-                # it looks like as some BLender property array - convert to tuple
-                return [[default_property[:]]]
-            else:
-                return [default_property]
-        elif default is not sentinel:
+            return format_property(default_property)
+            
+        if default is not sentinel:
             return default
-        else:
-            raise SvNoDataError(self)
+
+        raise SvNoDataError(self)
 
     def sv_set(self, data):
         """Set output data"""
@@ -472,19 +476,20 @@ class SvSocketCommon(SvSocketProcessing):
             draw_label(self.label or text)
 
         else:  # unlinked INPUT
-            if self.get_prop_name():  # has property
+            prop_name = self.get_prop_name()
+            if prop_name:  # has property
                 if menu_option == 'ALL':
                     self.draw_link_input_menu(context, layout, node)
-                self.draw_property(layout, prop_origin=node, prop_name=self.get_prop_name())
+                self.draw_property(layout, prop_origin=node, prop_name=prop_name)
 
-            elif self.node.bl_idname == 'SvGroupTreeNode' and hasattr(self, 'draw_group_property'):  # group node
-                if self.node.node_tree:  # when tree is removed from node sockets still exist
-                    interface_socket = self.node.node_tree.inputs[self.index]
+            elif node.bl_idname == 'SvGroupTreeNode' and hasattr(self, 'draw_group_property'):  # group node
+                if node.node_tree:  # when tree is removed from node sockets still exist
+                    interface_socket = node.node_tree.inputs[self.index]
                     self.draw_group_property(layout, text, interface_socket)
 
-            elif self.node.bl_idname == 'NodeGroupOutput' and hasattr(self, 'draw_group_property'):  # group out node
-                if self.index < len(self.id_data.outputs):  # in case of last socket of the node which is virtual
-                    interface_socket = self.id_data.outputs[self.index]
+            elif node.bl_idname == 'NodeGroupOutput' and hasattr(self, 'draw_group_property'):  # group out node
+                if self.index < len(node.outputs):  # in case of last socket of the node which is virtual
+                    interface_socket = node.outputs[self.index]
                     self.draw_group_property(layout, text, interface_socket)
 
             elif self.use_prop:  # no property but use default prop
@@ -505,17 +510,12 @@ class SvSocketCommon(SvSocketProcessing):
     def draw_color(self, context, node):
         return self.color
 
-    def needs_data_conversion(self):
-        """True if other socket has got different type"""
-        if not self.is_linked:
-            return False
-        return self.other.bl_idname != self.bl_idname
+    def convert_data(self, source_data, implicit_conversions=DEFAULT_CONVERSION, other=None):
 
-    def convert_data(self, source_data, implicit_conversions=ConversionPolicies.DEFAULT.conversion):
-        if not self.needs_data_conversion():
+        if other.bl_idname == self.bl_idname:
             return source_data
-        else:
-            return implicit_conversions.convert(self, source_data)
+
+        return implicit_conversions.convert(self, other, source_data)
 
     def update_objects_number(self):
         """
@@ -541,7 +541,7 @@ class SvObjectSocket(NodeSocket, SvSocketCommon):
     bl_idname = "SvObjectSocket"
     bl_label = "Object Socket"
 
-    def filter_kinds(self, object):
+    def filter_kinds(self, objs):
         """
         object_kinds could be any of these:
          [‘MESH’, ‘CURVE’, ‘SURFACE’, ‘META’, ‘FONT’, ‘VOLUME’, ‘ARMATURE’, ‘LATTICE’,
@@ -560,9 +560,9 @@ class SvObjectSocket(NodeSocket, SvSocketCommon):
         kind = self.object_kinds
         if "," in kind:
             kinds = kind.split(',')
-            if object.type in set(kinds):
+            if objs.type in set(kinds):
                 return True
-        if object.type == kind:
+        if objs.type == kind:
             return True
 
     color = (0.69, 0.74, 0.73, 1.0)
@@ -804,10 +804,10 @@ class SvStringsSocket(NodeSocket, SvSocketCommon):
 
     color = (0.6, 1.0, 0.6, 1.0)
 
-    use_graft_2 : BoolProperty(
-            name = "Graft Topology",
-            default = False,
-            update = process_from_socket)
+    use_graft_2: BoolProperty(
+        name="Graft Topology",
+        default=False,
+        update=process_from_socket)
 
     def get_mode_flags(self):
         flags = super().get_mode_flags()
@@ -816,8 +816,9 @@ class SvStringsSocket(NodeSocket, SvSocketCommon):
         return flags
 
     def get_prop_data(self):
-        if self.get_prop_name():
-            return {"prop_name": self.get_prop_name()}
+        prop_name = self.get_prop_name()
+        if prop_name:
+            return {"prop_name": prop_name}
         elif self.prop_type:
             return {"prop_type": self.prop_type,
                     "prop_index": self.prop_index}
@@ -833,8 +834,7 @@ class SvStringsSocket(NodeSocket, SvSocketCommon):
     def get_link_parameter_node(self):
         if self.quick_link_to_node:
             return self.quick_link_to_node
-        else:
-            return 'SvNumberNode'
+        return 'SvNumberNode'
 
     def does_support_link_input_menu(self, context, layout, node):
         ok = super().does_support_link_input_menu(context, layout, node)
@@ -1002,10 +1002,10 @@ class SvSvgSocket(NodeSocket, SvSocketCommon):
     def quick_link_to_node(self):
         if "Fill / Stroke" in self.name:
             return "SvSvgFillStrokeNodeMk2"
-        elif "Pattern" in self.name:
+        if "Pattern" in self.name:
             return "SvSvgPatternNode"
-        else:
-            return
+
+        return
 
 
 class SvPulgaForceSocket(NodeSocket, SvSocketCommon):

--- a/utils/socket_utils.py
+++ b/utils/socket_utils.py
@@ -1,0 +1,24 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+# this functions are used in core.sockets
+
+def format_bpy_property(prop):
+    if isinstance(prop, (str, int, float)):
+        return [[prop]]
+    if hasattr(prop, '__len__'):
+        # it looks like as some BLender property array - convert to tuple
+        return [[prop[:]]]
+
+    return [prop]
+
+def setup_new_node_location(new_node, old_node):
+    links_number = len([s for s in old_node.inputs if s.is_linked])
+    new_node.location = (old_node.location[0] - 200, old_node.location[1] - 100 * links_number)
+    if old_node.parent:
+        new_node.parent = old_node.parent
+        new_node.location = new_node.absolute_location


### PR DESCRIPTION
Optimisation of sv_get:
From profiling this nodetree:
![image](https://user-images.githubusercontent.com/10011941/102699836-5a009c00-4248-11eb-849b-72298fc8b1e4.png)
I discover some performance leaks:
socket.other (get_other_socket) was being called 2-6 times every sv_get.
also the basic concept _every dot pays a price_  becomes  obvious when the function is triggered 8000 times every update.
So I have rewritten some parts of the sv_get functionality including implicit conversions.

With this make up changes sv_get was boosted 2x (from 0.2s to 0.1 s for 9053 calls), this will be hard to appreciate on a simple tree but reduces the distance between the nodes.
#3783
- [x] Ready for merge.

