### PR TITLE
Adaptive Polygons mk3

### DIFF
--- a/docs/nodes/modifier_make/adaptive_polygons_mk3.rst
+++ b/docs/nodes/modifier_make/adaptive_polygons_mk3.rst
@@ -250,11 +250,11 @@ This node has some number of parameters, and most of them are accessible only in
   The default value is Tris for Triangular faces, Quads for Quad faces and Frame for NGons.
 
 
-- **Implementation. This defines which algorithm should be used.
+- **Implementation**. This defines which algorithm should be used.
 
- - **NumPy**: Faster when donor has more than 50 vertices for tris or 12 verts for quads.
- - **Mathutils**: Faster when donor has less than 50 vertices for tris or 12 verts for quads.
- - **Auto**: Switched between Mathutils and NumPy implementation depending on donor vert count.
+  - **NumPy**: Faster when donor has more than 50 vertices for tris or 12 verts for quads.
+  - **Mathutils**: Faster when donor has less than 50 vertices for tris or 12 verts for quads.
+  - **Auto**: Switched between Mathutils and NumPy implementation depending on donor vert count.
 
 
 Base area illustrations

--- a/docs/nodes/modifier_make/adaptive_polygons_mk3.rst
+++ b/docs/nodes/modifier_make/adaptive_polygons_mk3.rst
@@ -36,7 +36,7 @@ This node has the following inputs:
 - **PolsR**. Faces of the recipient object. Please have in mind that order of
   indices in each face affect donor object rotation; for example, `[0, 1, 2,
   3]` is one rotation, `[3, 0, 1, 2]` is the same turned by 90 degrees. This
-  input is mandatory. 
+  input is mandatory.
 - **VersD**. Vertices of the donor object. This input is mandatory.
 - **PolsD**. Faces of the donor object.
 - **FaceDataD**. List containing an arbitrary data item for each face of donor
@@ -68,6 +68,9 @@ This node has the following inputs:
 - **Threshold**. Merging threshold for "remove doubles" / "merge by distance"
   function. The default value is 0.0001. This input is only visible if **Remove
   doubles** parameter is checked.
+- **Donor Index**. Determine which donor to use for each face. This input is
+  only visible if **Matching Mode** is set to **Donor per face** and **Donor
+  Matching** is set to **By Index** (see below).
 
 Parameters
 ----------
@@ -82,7 +85,7 @@ This node has some number of parameters, and most of them are accessible only in
   controlled by **Threshold** input / paramter. This parameter is only visible
   if **Join** parameter is checked. Unchecked by default.
 - **Matching mode**. This defines how the list of donor objects is matched with list of recipient objects. Available values are:
-  
+
    - **Match longest**. Each pair of recipient and donor objects will be
      processed. For example, if there are 2 recipient objects and 2 donor
      objects, you will have two outputs: `recipient[1] + donor[1]` and
@@ -95,6 +98,17 @@ This node has some number of parameters, and most of them are accessible only in
      by number of recipient objects.
 
    The default value is **Match longest**.
+
+- **Donor Matching**. This defines how the list of donor objects is matched with
+  list of recipient faces Is only available when *Matching Mode* is set to **Donor per face**.
+  Available values are:
+
+   - **Repeat Last**. The last donor object will be repeated if there are more
+     faces than donors. [1,2] --> [1,2,2,2,..]
+   - **Cycle**.  Cycle the donors list if there are more faces than donors. [1,2] --> [1,2,1,2,..]
+   - **By Index**. Use a supplied list to define the donor that will be used for each face.
+
+   The default value is **Repeat Last**.
 
 - **Normal axis**. Axis of the donor object to be aligned with recipient object
   face normal. Available values are X, Y, and Z. Default value is Z.
@@ -158,7 +172,7 @@ This node has some number of parameters, and most of them are accessible only in
       other axis according to **Normal axis** parameter). The triangle can be
       defined as either equilateral or rectangular, depending on **Bounding
       triangle** parameter.
-  
+
   - **As Is**. The source area is defined as follows:
 
     - For Quad faces, the `[-1/2; 1/2] x [-1/2; 1/2]` unit square is taken.
@@ -188,7 +202,7 @@ This node has some number of parameters, and most of them are accessible only in
     Is**, this will be a triangle with center of it's hypotenuse at `(0, 0, 0)`
     and length of hypotenuse equal to 2. In **Bounds** mode, this will be the
     bounding triangle.
-  
+
   Please see below for the illustrations of bounding triangles.
   The default value is **Equilateral**.
 
@@ -239,13 +253,20 @@ This node has some number of parameters, and most of them are accessible only in
 
   - **As Quads**. Such faces will be processed as if they were quads; only
     first three and the last vertex of the NGon will be used to form a Quad.
-    This can give weird results for such faces. 
+    This can give weird results for such faces.
   - **Skip**. Such faces will be skipped completely, i.e. will not produce any
     vertices and faces.
   - **As Is**. Such faces will be output as they were, i.e. one face will be
     output for each recipient face.
 
   The default value is **As Quads**.
+
+- **Implementation. This defines which algorithm should be used.
+
+ - **NumPy**: Faster when donor has more than 50 vertices for tris or 12 verts for quads.
+ - **Mathutils**: Faster when donor has less than 50 vertices for tris or 12 verts for quads.
+ - **Auto**: Switched between Mathutils and NumPy implementation depending on donor vert count.
+
 
 Base area illustrations
 -----------------------
@@ -331,4 +352,3 @@ Use materials from the recipient object faces for the resulting object:
 .. image:: https://user-images.githubusercontent.com/284644/71734153-0d705500-2e6d-11ea-87aa-8d9a01085645.png
 
 You can also find some more examples `in the development thread <https://github.com/nortikin/sverchok/pull/2651>`_.
-

--- a/docs/nodes/modifier_make/adaptive_polygons_mk3.rst
+++ b/docs/nodes/modifier_make/adaptive_polygons_mk3.rst
@@ -32,14 +32,15 @@ Inputs
 
 This node has the following inputs:
 
-- **VersR**. Vertices of the recipient object. This input is mandatory.
-- **PolsR**. Faces of the recipient object. Please have in mind that order of
+- **Vertices Recipient**. Vertices of the recipient object. This input is mandatory.
+- **Polygons Recipient**. Faces of the recipient object. Please have in mind that order of
   indices in each face affect donor object rotation; for example, `[0, 1, 2,
   3]` is one rotation, `[3, 0, 1, 2]` is the same turned by 90 degrees. This
   input is mandatory.
-- **VersD**. Vertices of the donor object. This input is mandatory.
-- **PolsD**. Faces of the donor object.
-- **FaceDataD**. List containing an arbitrary data item for each face of donor
+- **Vertices Donor**. Vertices of the donor object. This input is mandatory.
+- **Edges Donor**. Vertices of the donor object. This input is mandatory.
+- **Pols Donor**. Faces of the donor object.
+- **FaceData Donor**. List containing an arbitrary data item for each face of donor
   object. For example, this may be used to provide material indexes of donor
   object faces. Optional input.
 - **Width coeff**. Coefficient for donor object width (size along X,Y axis,
@@ -58,11 +59,11 @@ This node has the following inputs:
 - **Z Rotation**. Rotation of donor objects along the normal of recipient
   object face, in radians. Default value is 0.0. The input expects one number
   per each recipient object face.
-- **PolyRotation**. Rotation of each recipient object face indexes. The default
+- **Polygon Rotation**. Rotation of each recipient object face indexes. The default
   value is 0. For example, if recipient face definition is `[3, 4, 5, 6]`, and
-  *PolyRotation* is set to 1, then the face will be interpreted as `[4, 5, 6,
+  *Polygon Rotation* is set to 1, then the face will be interpreted as `[4, 5, 6,
   3]`. This will affect the orientation of donor object.
-- **PolyMask**. Mask for recipient object faces processing. What exactly will
+- **Polygon Mask**. Mask for recipient object faces processing. What exactly will
   be done with faces which are masked out is defined by **Mask Mode** parameter
   (see below).
 - **Threshold**. Merging threshold for "remove doubles" / "merge by distance"
@@ -83,6 +84,11 @@ This node has the following inputs:
     between copies.
 
   The default value is **Map**.
+
+- **Custom Normal**. This vector input will replace the normals of the recipient
+  meshes. It will only work if **Custom Normals** is set to **Normal per Vertex** or
+  **Normal per Face** (see below)
+
 
 Parameters
 ----------
@@ -129,7 +135,7 @@ This node has some number of parameters, and most of them are accessible only in
 
   - **Proportional**. Donor object size along recipient face normal is
     calculated by it's size along Z axis (or other one, defined by **Normal
-    axis** parameter) multiplyed by value from **Z coeff** input.
+    axis** parameter) multiplied by value from **Z coeff** input.
   - **Constant**. Donor object size along recipient face normal is taken from
     **Z Coeff** input.
   - **Auto**. Calculate donor object scale along normal automatically, based on
@@ -138,10 +144,21 @@ This node has some number of parameters, and most of them are accessible only in
 
   The default value is **Proportional**.
 
+- **Custom Normals**: This options allows to rewrite recipient normals before
+  processing them. Available values are:
 
-- **Interpolate normals**. This parameter is available only if **Use normals**
-  is set to **Map**. This defines the method of interpolation between recipient
-  object's vertex normals. Available values are:
+  - **None**: Use recipient normals
+  - **Normal per Vertex**: Overwrite Vertex Normals. It will affect to the faces
+    where **Normal Mode**  is set to **Map* (or 1)
+  - **Normal per Faces**: Overwrite Faces Normals. It will affect to the faces
+    where **Normal Mode**  is set to **Face* (or 0)
+
+  The default value is **None**.
+
+
+- **Interpolate normals**. This parameter will only work in the faces Where
+  **Normal Mode**  is set to **Map** (or 1). This defines the method of interpolation
+  between recipient object's vertex normals. Available values are:
 
   - **Linear**. Linear interpolation will be used.
   - **Unit length**. Linear interpolation will be used, but the resulting
@@ -238,7 +255,7 @@ This node has some number of parameters, and most of them are accessible only in
   -  **As Is**: Output the receiver face
   -  **Tris**: Perform Tris Transform. Barycentric transformation with the first 3 vertices of the face
   -  **Quads**: Perform Quad Transform. Uses first 4 vertices, if the face has less vertices the last one will be repeated
-  -  **Fan**: Perform Fan Transform. Subdivides the face in triangles and performs a barycentric transformation to each
+  -  **Fan**: Perform Fan Transform. Subdivides the face in triangles (Poke) and performs a barycentric transformation to each
   -  **SubQuads**: Divides the face in 4 + Quad Transform
   -  **Frame**: Perform Frame Transform
   -  **Auto Frame Fan**: Perform Frame transform if Frame With is lower than 1 otherwise perform Fan

--- a/docs/nodes/modifier_make/adaptive_polygons_mk3.rst
+++ b/docs/nodes/modifier_make/adaptive_polygons_mk3.rst
@@ -357,4 +357,13 @@ Use materials from the recipient object faces for the resulting object:
 
 .. image:: https://user-images.githubusercontent.com/284644/71734153-0d705500-2e6d-11ea-87aa-8d9a01085645.png
 
-You can also find some more examples `in the development thread <https://github.com/nortikin/sverchok/pull/2651>`_.
+Using custom normals to control the z axis of the donors:
+
+.. image:: https://user-images.githubusercontent.com/10011941/103927917-611a1c00-511b-11eb-94f5-55930829ce29.png
+
+Using edges to create adaptive curves:
+
+.. image:: https://user-images.githubusercontent.com/10011941/103927917-611a1c00-511b-11eb-94f5-55930829ce29.png
+
+You can also find some more examples `in the development thread 1 <https://github.com/nortikin/sverchok/pull/2651>`_
+and `in the development thread 2 <https://github.com/nortikin/sverchok/pull/3798>`_.

--- a/docs/nodes/modifier_make/adaptive_polygons_mk3.rst
+++ b/docs/nodes/modifier_make/adaptive_polygons_mk3.rst
@@ -72,6 +72,18 @@ This node has the following inputs:
   only visible if **Matching Mode** is set to **Donor per face** and **Donor
   Matching** is set to **By Index** (see below).
 
+- **Use normals**. This defines how recipient object normals will be used to
+  transform the donor objects. Available values are:
+
+  - **Map**. Interpolation between recipient object's vertex normals will be
+    used to deform the donor object. While this procuces smoother results, this
+    gives more deformation of donor object.
+  - **Face**. Recipient object's face normal will be used to orient the donor
+    object. While this gives less deformation of donor object, it can give gaps
+    between copies.
+
+  The default value is **Map**.
+
 Parameters
 ----------
 
@@ -86,29 +98,29 @@ This node has some number of parameters, and most of them are accessible only in
   if **Join** parameter is checked. Unchecked by default.
 - **Matching mode**. This defines how the list of donor objects is matched with list of recipient objects. Available values are:
 
-   - **Match longest**. Each pair of recipient and donor objects will be
-     processed. For example, if there are 2 recipient objects and 2 donor
-     objects, you will have two outputs: `recipient[1] + donor[1]` and
-     `recipient[2] + donor[2]`. If one of lists is shorter than another, the
-     last object will be repeated as many times as necessary. For example, if
-     there is 1 recipient object and 2 donor objects, you will have two
-     outputs: `recipient[1] + donor[1]` and `recipient[1] + donor[2]`.
-   - **Donor per face**. The list of donor objects will be treated as "one
-     donor object per recipient object face". Number of outputs will be defined
-     by number of recipient objects.
+  - **Match longest**. Each pair of recipient and donor objects will be
+    processed. For example, if there are 2 recipient objects and 2 donor
+    objects, you will have two outputs: `recipient[1] + donor[1]` and
+    `recipient[2] + donor[2]`. If one of lists is shorter than another, the
+    last object will be repeated as many times as necessary. For example, if
+    there is 1 recipient object and 2 donor objects, you will have two
+    outputs: `recipient[1] + donor[1]` and `recipient[1] + donor[2]`.
+  - **Donor per face**. The list of donor objects will be treated as "one
+    donor object per recipient object face". Number of outputs will be defined
+    by number of recipient objects.
 
-   The default value is **Match longest**.
+  The default value is **Match longest**.
 
 - **Donor Matching**. This defines how the list of donor objects is matched with
   list of recipient faces Is only available when *Matching Mode* is set to **Donor per face**.
   Available values are:
 
-   - **Repeat Last**. The last donor object will be repeated if there are more
-     faces than donors. [1,2] --> [1,2,2,2,..]
-   - **Cycle**.  Cycle the donors list if there are more faces than donors. [1,2] --> [1,2,1,2,..]
-   - **By Index**. Use a supplied list to define the donor that will be used for each face.
+  - **Repeat Last**. The last donor object will be repeated if there are more
+    faces than donors. [1,2] --> [1,2,2,2,..]
+  - **Cycle**.  Cycle the donors list if there are more faces than donors. [1,2] --> [1,2,1,2,..]
+  - **By Index**. Use a supplied list to define the donor that will be used for each face.
 
-   The default value is **Repeat Last**.
+  The default value is **Repeat Last**.
 
 - **Normal axis**. Axis of the donor object to be aligned with recipient object
   face normal. Available values are X, Y, and Z. Default value is Z.
@@ -126,17 +138,6 @@ This node has some number of parameters, and most of them are accessible only in
 
   The default value is **Proportional**.
 
-- **Use normals**. This defines how recipient object normals will be used to
-  transform the donor objects. Available values are:
-
-  - **Map**. Interpolation between recipient object's vertex normals will be
-    used to deform the donor object. While this procuces smoother results, this
-    gives more deformation of donor object.
-  - **Face**. Recipient object's face normal will be used to orient the donor
-    object. While this gives less deformation of donor object, it can give gaps
-    between copies.
-
-  The default value is **Map**.
 
 - **Interpolate normals**. This parameter is available only if **Use normals**
   is set to **Map**. This defines the method of interpolation between recipient
@@ -206,38 +207,6 @@ This node has some number of parameters, and most of them are accessible only in
   Please see below for the illustrations of bounding triangles.
   The default value is **Equilateral**.
 
-- **Frame mode**. This defines when to apply "Frame / Fan" mode. The available values are:
-
-  - **Do not use**. Frame / fan mode will not be used.
-  - **NGons only**. Frame / fan mode will be used for NGons (n > 4) only. Other
-    faces will be processed in simple replacement mode.
-  - **NGons and Quads**. Frame / fan mode will be used for NGons and Quads
-    (i.e. n >= 4) only. Tris will be processed in simple replacement mode.
-  - **Always**. Frame / fan mode will be used for all faces.
-
-  The default value is **Do not use**.
-
-  Note that "Frame / Fan" mode makes either several Quads (when FrameWidth <
-  1.0) or several Tris (when FrameWidth == 1.0) out of each recipient face. How
-  exactly these Quads and Tris will be processed is defined by **Faces mode**
-  parameter.
-
-- **Faces mode**. This defines how deformations of donor object will be
-  calculated for Quad and Tris recipient faces. Available values are:
-
-  - **Quads / Tris Auto**. For Quad faces, the linear transformation will be
-    used. For Tris faces, the barycentric transformation will be used to
-    transform source triangle into the recipient triangle. This method gives
-    good and smooth results for both Quads and Tris.
-  - **Quads Always**. In this mode, Tris faces are processed as if they were
-    (degenerated) Quads with third and fourth vertices coinciding. Such
-    transformation can make one corner of donor object sharper than others, and
-    in some cases produce weird results for Tris. But such results can be
-    interesting in some cases. Note that at the moment the Tissue addon always
-    uses this mode.
-
-  The default value is **Quads / Tris Auto**.
-
 - **Mask mode**. This defines what to do with recipient objectfaces excluded by the
   **PolyMask** input. Available values are:
 
@@ -245,21 +214,41 @@ This node has some number of parameters, and most of them are accessible only in
     vertices and faces.
   - **As Is**. Such faces will be output as they were, i.e. one face will be
     output for each recipient face.
+  - **Transform Control**. In this mode the **PolyMask** input will be used to
+    control the transformation method per face:
+      0 = Skip
+      1 = As Is
+      2 = Tris
+      3 = Quads
+      4 = Fan
+      5 = SubQuads
+      6 = Frame
+      7 = Auto Frame Fan
+      8 = Auto Frame Sub Quads
+      9 = Fan (Quad)
+      10 = Frame (Tri)
+      11 = Sub Quads (Tri)
 
   The default value is **Skip**.
 
-- **NGons**. This defines what to do with NGon recipient object faces (i.e.
-  faces with number of vertices more than 4). Available values are:
+- **Transform**. This defines what method to use in the transformation. In can
+  be different for triangular faces, Quads and Ngons. Available values are:
 
-  - **As Quads**. Such faces will be processed as if they were quads; only
-    first three and the last vertex of the NGon will be used to form a Quad.
-    This can give weird results for such faces.
-  - **Skip**. Such faces will be skipped completely, i.e. will not produce any
-    vertices and faces.
-  - **As Is**. Such faces will be output as they were, i.e. one face will be
-    output for each recipient face.
+  -  **Skip**: Don't Output Anything
+  -  **As Is**: Output the receiver face
+  -  **Tris**: Perform Tris Transform. Barycentric transformation with the first 3 vertices of the face
+  -  **Quads**: Perform Quad Transform. Uses first 4 vertices, if the face has less vertices the last one will be repeated
+  -  **Fan**: Perform Fan Transform. Subdivides the face in triangles and performs a barycentric transformation to each
+  -  **SubQuads**: Divides the face in 4 + Quad Transform
+  -  **Frame**: Perform Frame Transform
+  -  **Auto Frame Fan**: Perform Frame transform if Frame With is lower than 1 otherwise perform Fan
+  -  **Auto Frame Sub Quads**: Frame transform if Frame With is lower than 1 otherwise perform Sub Quads transform
+  -  **Fan (Quad)**: Fan Subdivision + Quad Transform (produces weird but interesting results)
+  -  **Frame (Tri)**: Frame Subdivision + Tri Transform (produces weird but interesting results)
+  -  **Sub Quads (Tri)**: Quads Subdivision + Tri Transform (produces weird but interesting results)
 
-  The default value is **As Quads**.
+  The default value is Tris for Triangular faces, Quads for Quad faces and Frame for NGons.
+
 
 - **Implementation. This defines which algorithm should be used.
 

--- a/docs/nodes/modifier_make/modifier_make_index.rst
+++ b/docs/nodes/modifier_make/modifier_make_index.rst
@@ -12,7 +12,7 @@ Modifier Make
    lathe
    matrix_tube
    pipe_tubes
-   adaptive_polygons_mk2
+   adaptive_polygons_mk3
    solidify
    uv_connect
    wafel

--- a/index.md
+++ b/index.md
@@ -405,7 +405,7 @@
     ---
     SvBevelCurveNode
     SvAdaptiveEdgeNode
-    SvAdaptivePolygonsNodeMk2
+    SvAdaptivePolygonsNodeMk3
     SvDuplicateAlongEdgeNode
     SvFractalCurveNode
     SvFrameworkNode

--- a/json_examples/Design/Adaptive_Voronoi_panel.json
+++ b/json_examples/Design/Adaptive_Voronoi_panel.json
@@ -77,7 +77,7 @@
       "hide": false,
       "label": "",
       "location": [
-        1922.4915771484375,
+        1841.3275146484375,
         387.9793701171875
       ],
       "params": {
@@ -89,7 +89,7 @@
         "tris_as": "FRAME",
         "use_shell_factor": true
       },
-      "width": 140.0
+      "width": 200
     },
     "Fill Holes": {
       "bl_idname": "SvFillsHoleNode",
@@ -651,12 +651,6 @@
       1
     ],
     [
-      "Map Range.001",
-      0,
-      "Mesh Expression",
-      0
-    ],
-    [
       "Plane",
       0,
       "Move.001",
@@ -748,6 +742,12 @@
     ],
     [
       "Adaptive Polygons Mk2",
+      1,
+      "Viewer Draw Mk3",
+      1
+    ],
+    [
+      "Adaptive Polygons Mk2",
       2,
       "Viewer Draw Mk3",
       2
@@ -783,6 +783,12 @@
       0
     ],
     [
+      "Map Range.001",
+      0,
+      "Mesh Expression",
+      0
+    ],
+    [
       "Reroute.001",
       "Output",
       "Adaptive Polygons Mk2",
@@ -802,6 +808,12 @@
     ],
     [
       "Mesh Expression",
+      1,
+      "Adaptive Polygons Mk2",
+      3
+    ],
+    [
+      "Mesh Expression",
       2,
       "Adaptive Polygons Mk2",
       4
@@ -810,7 +822,7 @@
       "Map Range",
       0,
       "Adaptive Polygons Mk2",
-      7
+      8
     ]
   ]
 }

--- a/json_examples/Design/Adaptive_Voronoi_panel.json
+++ b/json_examples/Design/Adaptive_Voronoi_panel.json
@@ -34,7 +34,7 @@
       "hide": false,
       "label": "Noise Scale",
       "location": [
-        -1697.4852905273438,
+        -1697.4854125976562,
         337.40972900390625
       ],
       "params": {
@@ -49,7 +49,7 @@
       "hide": false,
       "label": "Noise Amplitude",
       "location": [
-        -1700.8305053710938,
+        -1700.8306274414062,
         253.6864471435547
       ],
       "params": {
@@ -63,7 +63,13 @@
         "11": {
           "label": "Polygon Mask"
         },
+        "12": {
+          "label": "Polygon Mask"
+        },
         "14": {
+          "label": "Normal Mode"
+        },
+        "15": {
           "label": "Normal Mode"
         }
       },
@@ -78,8 +84,9 @@
         "frame_width": 1.0,
         "join": true,
         "matching_mode": "PERFACE",
-        "ngons_as": "FRAME",
+        "quads_as": "FRAME",
         "remove_doubles": true,
+        "tris_as": "FRAME",
         "use_shell_factor": true
       },
       "width": 140.0
@@ -253,6 +260,7 @@
         56.73006057739258
       ],
       "params": {
+        "file_pointer": "Donor.json",
         "filename": "Donor.json"
       },
       "width": 140.0
@@ -452,8 +460,8 @@
       "hide": false,
       "label": "",
       "location": [
-        -1296.5253295898438,
-        262.7353973388672
+        -1296.525390625,
+        262.73541259765625
       ],
       "params": {
         "seed": 4
@@ -740,7 +748,7 @@
     ],
     [
       "Adaptive Polygons Mk2",
-      1,
+      2,
       "Viewer Draw Mk3",
       2
     ],
@@ -796,7 +804,7 @@
       "Mesh Expression",
       2,
       "Adaptive Polygons Mk2",
-      3
+      4
     ],
     [
       "Map Range",

--- a/json_examples/Design/Adaptive_Voronoi_panel.json
+++ b/json_examples/Design/Adaptive_Voronoi_panel.json
@@ -58,7 +58,7 @@
       "width": 140.0
     },
     "Adaptive Polygons Mk2": {
-      "bl_idname": "SvAdaptivePolygonsNodeMk2",
+      "bl_idname": "SvAdaptivePolygonsNodeMk3",
       "custom_socket_props": {},
       "height": 100.0,
       "hide": false,

--- a/json_examples/Design/Adaptive_Voronoi_panel.json
+++ b/json_examples/Design/Adaptive_Voronoi_panel.json
@@ -34,8 +34,8 @@
       "hide": false,
       "label": "Noise Scale",
       "location": [
-        -1222.5360221862793,
-        267.6996898651123
+        -1697.4852905273438,
+        337.40972900390625
       ],
       "params": {
         "float_": 2.380000114440918
@@ -49,8 +49,8 @@
       "hide": false,
       "label": "Noise Amplitude",
       "location": [
-        -1225.8812370300293,
-        183.97640800476074
+        -1700.8305053710938,
+        253.6864471435547
       ],
       "params": {
         "float_": 0.6699999570846558
@@ -59,20 +59,26 @@
     },
     "Adaptive Polygons Mk2": {
       "bl_idname": "SvAdaptivePolygonsNodeMk3",
-      "custom_socket_props": {},
+      "custom_socket_props": {
+        "11": {
+          "label": "Polygon Mask"
+        },
+        "14": {
+          "label": "Normal Mode"
+        }
+      },
       "height": 100.0,
       "hide": false,
       "label": "",
       "location": [
-        2397.441162109375,
-        318.2692565917969
+        1922.4915771484375,
+        387.9793701171875
       ],
       "params": {
-        "frame_mode": "ALWAYS",
         "frame_width": 1.0,
         "join": true,
-        "map_mode": "QUADS",
         "matching_mode": "PERFACE",
+        "ngons_as": "FRAME",
         "remove_doubles": true,
         "use_shell_factor": true
       },
@@ -85,8 +91,8 @@
       "hide": false,
       "label": "",
       "location": [
-        380.61968994140625,
-        76.4851303100586
+        -94.32958984375,
+        146.19520568847656
       ],
       "params": {
         "sides": 15
@@ -100,8 +106,8 @@
       "hide": false,
       "label": "",
       "location": [
-        600.6196899414062,
-        112.0316390991211
+        125.67041015625,
+        181.74171447753906
       ],
       "params": {},
       "width": 140.0
@@ -109,12 +115,12 @@
     "Frame": {
       "bl_idname": "NodeFrame",
       "custom_socket_props": {},
-      "height": 319.0199279785156,
+      "height": 321.73004150390625,
       "hide": false,
       "label": "Donor",
       "location": [
-        -38.67843246459961,
-        4.045716762542725
+        -513.6277465820312,
+        73.755859375
       ],
       "params": {},
       "width": 397.815673828125
@@ -122,12 +128,12 @@
     "Frame.001": {
       "bl_idname": "NodeFrame",
       "custom_socket_props": {},
-      "height": 378.7057800292969,
+      "height": 378.4159240722656,
       "hide": false,
       "label": "Donor parameters",
       "location": [
-        -65.60948944091797,
-        110.06001281738281
+        -540.5587768554688,
+        179.7701416015625
       ],
       "params": {},
       "width": 824.3370361328125
@@ -135,12 +141,12 @@
     "Frame.002": {
       "bl_idname": "NodeFrame",
       "custom_socket_props": {},
-      "height": 759.6201171875,
+      "height": 759.3302001953125,
       "hide": false,
       "label": "Recipient (Voronoi pattern)",
       "location": [
-        -307.9476318359375,
-        -91.50511932373047
+        -782.8969116210938,
+        -21.7950439453125
       ],
       "params": {},
       "width": 926.2797241210938
@@ -148,15 +154,15 @@
     "Frame.003": {
       "bl_idname": "NodeFrame",
       "custom_socket_props": {},
-      "height": 692.69970703125,
+      "height": 692.4097290039062,
       "hide": false,
       "label": "Randomize",
       "location": [
-        -30.240001678466797,
-        10.079999923706055
+        -505.18927001953125,
+        79.7900390625
       ],
       "params": {},
-      "width": 1171.5399169921875
+      "width": 1171.5400390625
     },
     "List Math": {
       "bl_idname": "ListFuncNode",
@@ -165,8 +171,8 @@
       "hide": false,
       "label": "",
       "location": [
-        1376.0278396606445,
-        -166.29420471191406
+        901.0785522460938,
+        -96.58407592773438
       ],
       "params": {
         "func_": "MIN"
@@ -180,8 +186,8 @@
       "hide": false,
       "label": "",
       "location": [
-        1374.119758605957,
-        -330.58189392089844
+        899.1704711914062,
+        -260.87176513671875
       ],
       "params": {
         "func_": "MAX"
@@ -195,8 +201,8 @@
       "hide": false,
       "label": "",
       "location": [
-        1602.180305480957,
-        -211.00209045410156
+        1127.2310180664062,
+        -141.29196166992188
       ],
       "params": {
         "new_max": 2.0,
@@ -211,8 +217,8 @@
       "hide": false,
       "label": "",
       "location": [
-        1841.9021339416504,
-        -58.20816659927368
+        1366.9528198242188,
+        11.501976013183594
       ],
       "params": {
         "clamp": false,
@@ -227,8 +233,8 @@
       "hide": false,
       "label": "",
       "location": [
-        184.88937377929688,
-        143.97623443603516
+        -290.0599060058594,
+        213.68630981445312
       ],
       "params": {
         "distance": 0.10000000149011612
@@ -243,8 +249,8 @@
       "hide": false,
       "label": "",
       "location": [
-        2039.7178077697754,
-        -12.980082035064697
+        1564.7684936523438,
+        56.73006057739258
       ],
       "params": {
         "filename": "Donor.json"
@@ -258,8 +264,8 @@
       "hide": false,
       "label": "",
       "location": [
-        -254.34125900268555,
-        190.09525871276855
+        -729.29052734375,
+        259.8052978515625
       ],
       "params": {},
       "width": 140.0
@@ -276,8 +282,8 @@
       "hide": false,
       "label": "",
       "location": [
-        426.72821044921875,
-        299.15601348876953
+        -48.2210693359375,
+        368.8660888671875
       ],
       "params": {
         "n_id": "-8034980455338195246",
@@ -298,8 +304,8 @@
       "hide": false,
       "label": "",
       "location": [
-        112.27020263671875,
-        -147.38931274414062
+        -362.6790771484375,
+        -77.67923736572266
       ],
       "params": {
         "n_id": "-8027588460831181262",
@@ -315,8 +321,8 @@
       "hide": false,
       "label": "",
       "location": [
-        977.8432693481445,
-        -174.8916473388672
+        502.89398193359375,
+        -105.1815185546875
       ],
       "params": {
         "mode": "Faces"
@@ -330,13 +336,32 @@
         0.5,
         0.5
       ],
-      "custom_socket_props": {},
+      "custom_socket_props": {
+        "0": {
+          "label": "Size X"
+        },
+        "1": {
+          "label": "Size Y"
+        },
+        "2": {
+          "label": "Num X"
+        },
+        "3": {
+          "label": "Num Y"
+        },
+        "4": {
+          "label": "Step X"
+        },
+        "5": {
+          "label": "Step Y"
+        }
+      },
       "height": 100.0,
       "hide": false,
       "label": "",
       "location": [
-        -1216.6936149597168,
-        -90.18882179260254
+        -1691.6428833007812,
+        -20.478782653808594
       ],
       "params": {
         "center": true,
@@ -354,8 +379,8 @@
       "hide": false,
       "label": "",
       "location": [
-        787.5957641601562,
-        28.217140197753906
+        312.64642333984375,
+        97.92724609375
       ],
       "params": {},
       "width": 16.0
@@ -367,8 +392,8 @@
       "hide": false,
       "label": "",
       "location": [
-        788.040771484375,
-        71.43331909179688
+        313.09149169921875,
+        141.1434326171875
       ],
       "params": {},
       "width": 16.0
@@ -380,8 +405,8 @@
       "hide": false,
       "label": "",
       "location": [
-        -1003.7809562683105,
-        124.49604606628418
+        -1478.730224609375,
+        194.20608520507812
       ],
       "params": {
         "current_op": "SCALAR",
@@ -396,8 +421,8 @@
       "hide": false,
       "label": "",
       "location": [
-        -638.191478729248,
-        148.20922660827637
+        -1113.1407470703125,
+        217.9192657470703
       ],
       "params": {
         "current_op": "SCALAR",
@@ -412,8 +437,8 @@
       "hide": false,
       "label": "",
       "location": [
-        1151.4094314575195,
-        -204.02647399902344
+        676.4601440429688,
+        -134.31634521484375
       ],
       "params": {
         "out_mode": "SCALAR"
@@ -427,8 +452,8 @@
       "hide": false,
       "label": "",
       "location": [
-        -821.5760612487793,
-        193.02535820007324
+        -1296.5253295898438,
+        262.7353973388672
       ],
       "params": {
         "seed": 4
@@ -442,8 +467,8 @@
       "hide": false,
       "label": "",
       "location": [
-        -429.8031120300293,
-        150.78661918640137
+        -904.7523803710938,
+        220.4966583251953
       ],
       "params": {
         "selected_mode_from": "Scalar"
@@ -462,8 +487,8 @@
       "hide": false,
       "label": "",
       "location": [
-        2595.7626953125,
-        307.5472412109375
+        2120.813232421875,
+        377.25732421875
       ],
       "params": {
         "color_per_edge": true,
@@ -486,8 +511,8 @@
       "hide": false,
       "label": "",
       "location": [
-        198.6109619140625,
-        400.62012481689453
+        -276.33831787109375,
+        470.3302001953125
       ],
       "params": {
         "activate": false
@@ -507,8 +532,8 @@
       "hide": false,
       "label": "",
       "location": [
-        -23.064361572265625,
-        367.53076934814453
+        -498.0136413574219,
+        437.2408447265625
       ],
       "params": {
         "activate": false
@@ -523,8 +548,8 @@
       "hide": false,
       "label": "",
       "location": [
-        -39.55157470703125,
-        51.605140686035156
+        -514.5008544921875,
+        121.31521606445312
       ],
       "params": {
         "clip": 0.3700000047683716
@@ -533,36 +558,6 @@
     }
   },
   "update_lists": [
-    [
-      "Reroute.001",
-      "Output",
-      "Adaptive Polygons Mk2",
-      "VersR"
-    ],
-    [
-      "Reroute",
-      "Output",
-      "Adaptive Polygons Mk2",
-      "PolsR"
-    ],
-    [
-      "Mesh Expression",
-      0,
-      "Adaptive Polygons Mk2",
-      2
-    ],
-    [
-      "Mesh Expression",
-      2,
-      "Adaptive Polygons Mk2",
-      3
-    ],
-    [
-      "Map Range",
-      0,
-      "Adaptive Polygons Mk2",
-      7
-    ],
     [
       "Merge by Distance",
       0,
@@ -738,6 +733,18 @@
       0
     ],
     [
+      "Adaptive Polygons Mk2",
+      0,
+      "Viewer Draw Mk3",
+      0
+    ],
+    [
+      "Adaptive Polygons Mk2",
+      1,
+      "Viewer Draw Mk3",
+      2
+    ],
+    [
       "Voronoi 2D",
       0,
       "Viewer Draw Mk3.001",
@@ -768,16 +775,34 @@
       0
     ],
     [
+      "Reroute.001",
+      "Output",
       "Adaptive Polygons Mk2",
-      0,
-      "Viewer Draw Mk3",
-      0
+      "Vertices Recipient"
     ],
     [
+      "Reroute",
+      "Output",
       "Adaptive Polygons Mk2",
-      1,
-      "Viewer Draw Mk3",
+      "Polygons Recipient"
+    ],
+    [
+      "Mesh Expression",
+      0,
+      "Adaptive Polygons Mk2",
       2
+    ],
+    [
+      "Mesh Expression",
+      2,
+      "Adaptive Polygons Mk2",
+      3
+    ],
+    [
+      "Map Range",
+      0,
+      "Adaptive Polygons Mk2",
+      7
     ]
   ]
 }

--- a/json_examples/Design/Adaptive_per_face.json
+++ b/json_examples/Design/Adaptive_per_face.json
@@ -1,5 +1,5 @@
 {
-  "export_version": "0.079",
+  "export_version": "0.10",
   "framed_nodes": {
     "A Number.002": "Frame.003",
     "A Number.003": "Frame.003",
@@ -30,6 +30,7 @@
   "nodes": {
     "A Number.002": {
       "bl_idname": "SvNumberNode",
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -38,15 +39,13 @@
         209.67471313476562
       ],
       "params": {
-        "float_": 0.06000000238418579,
-        "float_draft_": 0.0,
-        "int_": 0,
-        "int_draft_": 0
+        "float_": 0.06000000238418579
       },
       "width": 140.0
     },
     "A Number.003": {
       "bl_idname": "SvNumberNode",
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -55,15 +54,20 @@
         111.21734619140625
       ],
       "params": {
-        "float_": 0.20000000298023224,
-        "float_draft_": 0.0,
-        "int_": 0,
-        "int_draft_": 0
+        "float_": 0.20000000298023224
       },
       "width": 140.0
     },
     "Adaptive Polygons Mk2": {
       "bl_idname": "SvAdaptivePolygonsNodeMk3",
+      "custom_socket_props": {
+        "11": {
+          "label": "Polygon Mask"
+        },
+        "14": {
+          "label": "Normal Mode"
+        }
+      },
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -72,15 +76,16 @@
         821.8199462890625
       ],
       "params": {
-        "join": 1,
+        "join": true,
         "matching_mode": "PERFACE",
-        "remove_doubles": 1,
+        "remove_doubles": true,
         "z_coef": 0.4000000059604645
       },
       "width": 140.0
     },
     "Assign Materials List": {
       "bl_idname": "SvAssignMaterialListNode",
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -88,16 +93,22 @@
         3180.467041015625,
         956.2824096679688
       ],
-      "materials": [
-        "Edges",
-        "Base"
-      ],
-      "params": {},
+      "params": {
+        "materials": [
+          {
+            "material": "Edges"
+          },
+          {
+            "material": "Base"
+          }
+        ]
+      },
       "width": 200.0
     },
     "Frame": {
       "bl_idname": "NodeFrame",
-      "height": 383.8218994140625,
+      "custom_socket_props": {},
+      "height": 387.03704833984375,
       "hide": false,
       "label": "Buckle Up",
       "location": [
@@ -105,11 +116,12 @@
         1530.1674537658691
       ],
       "params": {},
-      "width": 654.9917602539062
+      "width": 654.8399047851562
     },
     "Frame.001": {
       "bl_idname": "NodeFrame",
-      "height": 384.38909912109375,
+      "custom_socket_props": {},
+      "height": 387.49041748046875,
       "hide": false,
       "label": "Buckle Down",
       "location": [
@@ -117,11 +129,12 @@
         1521.6208229064941
       ],
       "params": {},
-      "width": 654.99169921875
+      "width": 654.83984375
     },
     "Frame.002": {
       "bl_idname": "NodeFrame",
-      "height": 648.3975830078125,
+      "custom_socket_props": {},
+      "height": 651.4228515625,
       "hide": false,
       "label": "Recipient",
       "location": [
@@ -129,11 +142,12 @@
         35.03232192993164
       ],
       "params": {},
-      "width": 1689.3768310546875
+      "width": 1689.933837890625
     },
     "Frame.003": {
       "bl_idname": "NodeFrame",
-      "height": 663.3550415039062,
+      "custom_socket_props": {},
+      "height": 688.2750854492188,
       "hide": false,
       "label": "Donor",
       "location": [
@@ -141,11 +155,12 @@
         519.9917602539062
       ],
       "params": {},
-      "width": 959.7452392578125
+      "width": 960.30224609375
     },
     "Frame.004": {
       "bl_idname": "NodeFrame",
-      "height": 280.3594055175781,
+      "custom_socket_props": {},
+      "height": 282.80242919921875,
       "hide": false,
       "label": "Donor Parameters",
       "location": [
@@ -153,10 +168,11 @@
         123.02684020996094
       ],
       "params": {},
-      "width": 587.983154296875
+      "width": 587.831298828125
     },
     "Map Range": {
       "bl_idname": "SvMapRangeNode",
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -165,7 +181,7 @@
         491.8024139404297
       ],
       "params": {
-        "clamp": 0,
+        "clamp": false,
         "new_max": 0.08999999612569809,
         "new_min": 0.679999828338623,
         "old_max": 1.5,
@@ -175,6 +191,7 @@
     },
     "Matrix In": {
       "bl_idname": "SvMatrixInNodeMK4",
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -183,27 +200,13 @@
         143.91238403320312
       ],
       "params": {
-        "angle": 45.0,
-        "axis": [
-          0.0,
-          0.0,
-          1.0
-        ],
-        "location_": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "scale": [
-          1.0,
-          1.0,
-          1.0
-        ]
+        "angle": 45.0
       },
       "width": 140.0
     },
     "Mesh Expression": {
       "bl_idname": "SvMeshEvalNode",
+      "custom_socket_props": {},
       "geom": "{\n  \"defaults\": {\n    \"CenterClose\": 0.0,\n    \"CenterDown\": 0.0,\n    \"PeriferalDown\": 0.0,\n    \"BaseZ\": 0.1\n  },\n  \"vertices\": [\n    [\n      -1.0,\n      -1.0,\n      \"BaseZ\"\n    ],\n    [\n      1.0,\n      -1.0,\n      \"BaseZ\"\n    ],\n    [\n      0.92176223,\n      -0.92176223,\n      \"BaseZ\"\n    ],\n    [\n      0.0,\n      0.0,\n      \"BaseZ\"\n    ],\n    [\n      -0.75676525,\n      -0.75676525,\n      \"BaseZ\"\n    ],\n    [\n      \"-1.0 + CenterClose\",\n      \"-1.0 + CenterClose\",\n      \"1.0 - CenterDown\",\n      [\n        \"MovingCenter\"\n      ]\n    ],\n    [\n      \"-0.75676525 + CenterClose\",\n      \"-0.75676525 + CenterClose\",\n      \"1.0 - CenterDown\",\n      [\n        \"MovingCenter\"\n      ]\n    ],\n    [\n      0.9,\n      -0.9,\n      \"1.0 - PeriferalDown\",\n      [\n        \"MovingPeriferal\"\n      ]\n    ],\n    [\n      0.8,\n      -0.8,\n      \"1.0 - PeriferalDown\",\n      [\n        \"MovingPeriferal\"\n      ]\n    ],\n    [\n      0.0,\n      0.0,\n      0.0\n    ],\n    [\n      -1.0,\n      -1.0,\n      0.0\n    ],\n    [\n      1.0,\n      -1.0,\n      0.0\n    ]\n  ],\n  \"edges\": [  ],\n  \"faces\": [\n    [\n      4,\n      2,\n      3\n    ],\n    [\n      5,\n      7,\n      8,\n      6\n    ],\n    [\n      1,\n      5,\n      0\n    ],\n    [\n      1,\n      7,\n      5\n    ],\n    [\n      8,\n      2,\n      6\n    ],\n    [\n      2,\n      4,\n      6\n    ],\n    [9, 11, 10]\n  ],\n  \"vertexdata\": [],\n  \"facedata\": [\n    1,\n    0,\n    0,\n    0,\n    0,\n    0,\n    1\n  ]\n}",
       "height": 100.0,
       "hide": false,
@@ -213,18 +216,19 @@
         483.1649169921875
       ],
       "params": {
+        "file_pointer": "Mesh Expression",
         "filename": "Mesh Expression"
       },
       "width": 140.0
     },
     "Mesh viewer": {
       "bl_idname": "SvMeshViewer",
-      "collection": "",
       "color": [
         1.0,
         0.5889999866485596,
         0.21400000154972076
       ],
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -232,14 +236,13 @@
         2981.73095703125,
         944.799072265625
       ],
-      "params": {
-        "base_data_name": "Alpha"
-      },
+      "params": {},
       "use_custom_color": true,
       "width": 140.0
     },
     "Move": {
       "bl_idname": "SvMoveNodeMk3",
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -247,13 +250,12 @@
         679.4505615234375,
         746.8767433166504
       ],
-      "params": {
-        "strength": 1.0
-      },
+      "params": {},
       "width": 140.0
     },
     "Move.002": {
       "bl_idname": "SvMoveNodeMk3",
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -261,13 +263,12 @@
         -47.5662841796875,
         772.3497047424316
       ],
-      "params": {
-        "strength": 1.0
-      },
+      "params": {},
       "width": 140.0
     },
     "Origins": {
       "bl_idname": "SvOrigins",
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -287,6 +288,26 @@
         0.5,
         0.5
       ],
+      "custom_socket_props": {
+        "0": {
+          "label": "Size X"
+        },
+        "1": {
+          "label": "Size Y"
+        },
+        "2": {
+          "label": "Num X"
+        },
+        "3": {
+          "label": "Num Y"
+        },
+        "4": {
+          "label": "Step X"
+        },
+        "5": {
+          "label": "Step Y"
+        }
+      },
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -295,8 +316,7 @@
         1018.4228858947754
       ],
       "params": {
-        "center": 1,
-        "dimension_mode": "SIZE",
+        "center": true,
         "numx": 20,
         "numy": 20
       },
@@ -305,6 +325,7 @@
     },
     "Proportional Edit Falloff": {
       "bl_idname": "SvProportionalEditNode",
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -319,6 +340,7 @@
     },
     "Proportional Edit Falloff.001": {
       "bl_idname": "SvProportionalEditNode",
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -333,6 +355,7 @@
     },
     "Reroute": {
       "bl_idname": "NodeReroute",
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -345,6 +368,7 @@
     },
     "Reroute.001": {
       "bl_idname": "NodeReroute",
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -357,6 +381,7 @@
     },
     "Reroute.002": {
       "bl_idname": "NodeReroute",
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -376,8 +401,7 @@
             0.0,
             0.0,
             1.0
-          ],
-          "use_prop": true
+          ]
         },
         "4": {
           "expanded": true,
@@ -385,8 +409,7 @@
             2.4600000381469727,
             1.709999918937683,
             0.0
-          ],
-          "use_prop": true
+          ]
         }
       },
       "height": 100.0,
@@ -411,8 +434,7 @@
             0.0,
             0.0,
             1.0
-          ],
-          "use_prop": true
+          ]
         },
         "4": {
           "expanded": true,
@@ -420,8 +442,7 @@
             -1.3799999952316284,
             -1.7999999523162842,
             0.0
-          ],
-          "use_prop": true
+          ]
         }
       },
       "height": 100.0,
@@ -439,6 +460,7 @@
     },
     "Symmetrize Mesh": {
       "bl_idname": "SvSymmetrizeNode",
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -453,6 +475,7 @@
     },
     "Symmetrize Mesh.001": {
       "bl_idname": "SvSymmetrizeNode",
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -467,6 +490,7 @@
     },
     "Vector in": {
       "bl_idname": "GenVectorsNode",
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -481,6 +505,7 @@
     },
     "Vector in.001": {
       "bl_idname": "GenVectorsNode",
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -495,6 +520,7 @@
     },
     "Vector out": {
       "bl_idname": "VectorsOutNode",
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -512,6 +538,7 @@
         0.30000001192092896,
         0.0
       ],
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -520,7 +547,7 @@
         112.16677856445312
       ],
       "params": {
-        "activate": 0,
+        "activate": false,
         "selected_draw_mode": "facet"
       },
       "use_custom_color": true,
@@ -533,6 +560,7 @@
         0.30000001192092896,
         0.0
       ],
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -541,7 +569,7 @@
         1050.5684814453125
       ],
       "params": {
-        "activate": 0,
+        "activate": false,
         "selected_draw_mode": "smooth"
       },
       "use_custom_color": true,
@@ -550,76 +578,82 @@
   },
   "update_lists": [
     [
-      "Plane",
-      0,
-      "Select mesh elements by location",
-      0
+      "Reroute",
+      "Output",
+      "Adaptive Polygons Mk2",
+      "Vertices Recipient"
     ],
     [
-      "Plane",
-      2,
-      "Select mesh elements by location",
-      2
-    ],
-    [
-      "Plane",
-      "Polygons",
       "Reroute.002",
-      "Input"
+      "Output",
+      "Adaptive Polygons Mk2",
+      "Polygons Recipient"
     ],
     [
-      "Plane",
+      "Symmetrize Mesh.001",
       0,
-      "Proportional Edit Falloff",
-      0
-    ],
-    [
-      "Select mesh elements by location",
-      0,
-      "Proportional Edit Falloff",
-      1
-    ],
-    [
-      "Plane",
-      0,
-      "Move.002",
-      0
-    ],
-    [
-      "Vector in",
-      0,
-      "Move.002",
-      1
-    ],
-    [
-      "Proportional Edit Falloff",
-      0,
-      "Move.002",
+      "Adaptive Polygons Mk2",
       2
     ],
     [
-      "Move.002",
-      0,
-      "Select mesh elements by location.001",
-      0
-    ],
-    [
-      "Plane",
+      "Symmetrize Mesh.001",
       2,
-      "Select mesh elements by location.001",
-      2
+      "Adaptive Polygons Mk2",
+      3
     ],
     [
-      "Move.002",
+      "Symmetrize Mesh.001",
+      3,
+      "Adaptive Polygons Mk2",
+      4
+    ],
+    [
+      "Mesh viewer",
       0,
-      "Proportional Edit Falloff.001",
+      "Assign Materials List",
       0
     ],
     [
-      "Select mesh elements by location.001",
+      "Vector out",
+      2,
+      "Map Range",
+      0
+    ],
+    [
+      "Reroute.001",
+      "Output",
+      "Mesh Expression",
+      "CenterClose"
+    ],
+    [
+      "A Number.002",
       0,
-      "Proportional Edit Falloff.001",
-      1
+      "Mesh Expression",
+      2
+    ],
+    [
+      "A Number.003",
+      0,
+      "Mesh Expression",
+      3
+    ],
+    [
+      "Adaptive Polygons Mk2",
+      0,
+      "Mesh viewer",
+      0
+    ],
+    [
+      "Adaptive Polygons Mk2",
+      1,
+      "Mesh viewer",
+      2
+    ],
+    [
+      "Adaptive Polygons Mk2",
+      2,
+      "Mesh viewer",
+      3
     ],
     [
       "Move.002",
@@ -640,10 +674,22 @@
       2
     ],
     [
-      "Move",
-      "Vertices",
-      "Reroute",
-      "Input"
+      "Plane",
+      0,
+      "Move.002",
+      0
+    ],
+    [
+      "Vector in",
+      0,
+      "Move.002",
+      1
+    ],
+    [
+      "Proportional Edit Falloff",
+      0,
+      "Move.002",
+      2
     ],
     [
       "Reroute",
@@ -658,16 +704,34 @@
       "Faces"
     ],
     [
-      "Origins",
+      "Plane",
       0,
-      "Vector out",
+      "Proportional Edit Falloff",
       0
     ],
     [
-      "Vector out",
-      2,
-      "Map Range",
+      "Select mesh elements by location",
+      0,
+      "Proportional Edit Falloff",
+      1
+    ],
+    [
+      "Move.002",
+      0,
+      "Proportional Edit Falloff.001",
       0
+    ],
+    [
+      "Select mesh elements by location.001",
+      0,
+      "Proportional Edit Falloff.001",
+      1
+    ],
+    [
+      "Move",
+      "Vertices",
+      "Reroute",
+      "Input"
     ],
     [
       "Map Range",
@@ -676,22 +740,34 @@
       "Input"
     ],
     [
-      "Reroute.001",
-      "Output",
-      "Mesh Expression",
-      "CenterClose"
+      "Plane",
+      "Polygons",
+      "Reroute.002",
+      "Input"
     ],
     [
-      "A Number.002",
+      "Plane",
       0,
-      "Mesh Expression",
+      "Select mesh elements by location",
+      0
+    ],
+    [
+      "Plane",
+      2,
+      "Select mesh elements by location",
       2
     ],
     [
-      "A Number.003",
+      "Move.002",
       0,
-      "Mesh Expression",
-      3
+      "Select mesh elements by location.001",
+      0
+    ],
+    [
+      "Plane",
+      2,
+      "Select mesh elements by location.001",
+      2
     ],
     [
       "Mesh Expression",
@@ -742,57 +818,9 @@
       4
     ],
     [
-      "Reroute",
-      "Output",
-      "Adaptive Polygons Mk2",
-      "VersR"
-    ],
-    [
-      "Reroute.002",
-      "Output",
-      "Adaptive Polygons Mk2",
-      "PolsR"
-    ],
-    [
-      "Symmetrize Mesh.001",
+      "Origins",
       0,
-      "Adaptive Polygons Mk2",
-      2
-    ],
-    [
-      "Symmetrize Mesh.001",
-      2,
-      "Adaptive Polygons Mk2",
-      3
-    ],
-    [
-      "Symmetrize Mesh.001",
-      3,
-      "Adaptive Polygons Mk2",
-      4
-    ],
-    [
-      "Adaptive Polygons Mk2",
-      0,
-      "Mesh viewer",
-      0
-    ],
-    [
-      "Adaptive Polygons Mk2",
-      1,
-      "Mesh viewer",
-      2
-    ],
-    [
-      "Adaptive Polygons Mk2",
-      2,
-      "Mesh viewer",
-      3
-    ],
-    [
-      "Mesh viewer",
-      0,
-      "Assign Materials List",
+      "Vector out",
       0
     ],
     [

--- a/json_examples/Design/Adaptive_per_face.json
+++ b/json_examples/Design/Adaptive_per_face.json
@@ -64,7 +64,13 @@
         "11": {
           "label": "Polygon Mask"
         },
+        "12": {
+          "label": "Polygon Mask"
+        },
         "14": {
+          "label": "Normal Mode"
+        },
+        "15": {
           "label": "Normal Mode"
         }
       },
@@ -90,20 +96,27 @@
       "hide": false,
       "label": "",
       "location": [
-        3180.467041015625,
-        956.2824096679688
+        3304.39892578125,
+        960.8161010742188
+      ],
+      "params": {},
+      "width": 200.0
+    },
+    "Color in": {
+      "bl_idname": "SvColorsInNodeMK1",
+      "custom_socket_props": {},
+      "height": 100.0,
+      "hide": false,
+      "label": "",
+      "location": [
+        2923.100341796875,
+        420.44476318359375
       ],
       "params": {
-        "materials": [
-          {
-            "material": "Edges"
-          },
-          {
-            "material": "Base"
-          }
-        ]
+        "b_": 1.0,
+        "g_": 0.7300000190734863
       },
-      "width": 200.0
+      "width": 110.0
     },
     "Frame": {
       "bl_idname": "NodeFrame",
@@ -233,10 +246,13 @@
       "hide": false,
       "label": "",
       "location": [
-        2981.73095703125,
-        944.799072265625
+        3084.503662109375,
+        949.332763671875
       ],
-      "params": {},
+      "params": {
+        "selectable_objects": false,
+        "show_objects": false
+      },
       "use_custom_color": true,
       "width": 140.0
     },
@@ -531,6 +547,30 @@
       "params": {},
       "width": 140.0
     },
+    "Viewer Draw": {
+      "bl_idname": "SvViewerDrawMk4",
+      "color": [
+        1.0,
+        0.5889999866485596,
+        0.21400000154972076
+      ],
+      "custom_socket_props": {},
+      "height": 100.0,
+      "hide": false,
+      "label": "",
+      "location": [
+        3080.2822265625,
+        601.79150390625
+      ],
+      "params": {
+        "color_per_polygon": true,
+        "display_edges": false,
+        "display_verts": false,
+        "selected_draw_mode": "facet"
+      },
+      "use_custom_color": true,
+      "width": 140.0
+    },
     "Viewer Draw Mk3": {
       "bl_idname": "SvViewerDrawMk4",
       "color": [
@@ -578,42 +618,6 @@
   },
   "update_lists": [
     [
-      "Reroute",
-      "Output",
-      "Adaptive Polygons Mk2",
-      "Vertices Recipient"
-    ],
-    [
-      "Reroute.002",
-      "Output",
-      "Adaptive Polygons Mk2",
-      "Polygons Recipient"
-    ],
-    [
-      "Symmetrize Mesh.001",
-      0,
-      "Adaptive Polygons Mk2",
-      2
-    ],
-    [
-      "Symmetrize Mesh.001",
-      2,
-      "Adaptive Polygons Mk2",
-      3
-    ],
-    [
-      "Symmetrize Mesh.001",
-      3,
-      "Adaptive Polygons Mk2",
-      4
-    ],
-    [
-      "Mesh viewer",
-      0,
-      "Assign Materials List",
-      0
-    ],
-    [
       "Vector out",
       2,
       "Map Range",
@@ -635,24 +639,6 @@
       "A Number.003",
       0,
       "Mesh Expression",
-      3
-    ],
-    [
-      "Adaptive Polygons Mk2",
-      0,
-      "Mesh viewer",
-      0
-    ],
-    [
-      "Adaptive Polygons Mk2",
-      1,
-      "Mesh viewer",
-      2
-    ],
-    [
-      "Adaptive Polygons Mk2",
-      2,
-      "Mesh viewer",
       3
     ],
     [
@@ -834,6 +820,84 @@
       "Output",
       "Viewer Draw Mk3.001",
       "Polygons"
+    ],
+    [
+      "Reroute",
+      "Output",
+      "Adaptive Polygons Mk2",
+      "Vertices Recipient"
+    ],
+    [
+      "Reroute.002",
+      "Output",
+      "Adaptive Polygons Mk2",
+      "Polygons Recipient"
+    ],
+    [
+      "Symmetrize Mesh.001",
+      0,
+      "Adaptive Polygons Mk2",
+      2
+    ],
+    [
+      "Symmetrize Mesh.001",
+      2,
+      "Adaptive Polygons Mk2",
+      4
+    ],
+    [
+      "Symmetrize Mesh.001",
+      3,
+      "Adaptive Polygons Mk2",
+      5
+    ],
+    [
+      "Adaptive Polygons Mk2",
+      0,
+      "Viewer Draw",
+      0
+    ],
+    [
+      "Adaptive Polygons Mk2",
+      2,
+      "Viewer Draw",
+      2
+    ],
+    [
+      "Color in",
+      0,
+      "Viewer Draw",
+      6
+    ],
+    [
+      "Adaptive Polygons Mk2",
+      3,
+      "Color in",
+      0
+    ],
+    [
+      "Adaptive Polygons Mk2",
+      0,
+      "Mesh viewer",
+      0
+    ],
+    [
+      "Adaptive Polygons Mk2",
+      2,
+      "Mesh viewer",
+      2
+    ],
+    [
+      "Adaptive Polygons Mk2",
+      3,
+      "Mesh viewer",
+      3
+    ],
+    [
+      "Mesh viewer",
+      0,
+      "Assign Materials List",
+      0
     ]
   ]
 }

--- a/json_examples/Design/Adaptive_per_face.json
+++ b/json_examples/Design/Adaptive_per_face.json
@@ -63,7 +63,7 @@
       "width": 140.0
     },
     "Adaptive Polygons Mk2": {
-      "bl_idname": "SvAdaptivePolygonsNodeMk2",
+      "bl_idname": "SvAdaptivePolygonsNodeMk3",
       "height": 100.0,
       "hide": false,
       "label": "",

--- a/json_examples/Design/Adaptive_per_face.json
+++ b/json_examples/Design/Adaptive_per_face.json
@@ -99,7 +99,16 @@
         3304.39892578125,
         960.8161010742188
       ],
-      "params": {},
+      "params": {
+        "materials": [
+          {
+            "material": "edges"
+          },
+          {
+            "material": "base"
+          }
+        ]
+      },
       "width": 200.0
     },
     "Color in": {
@@ -250,8 +259,7 @@
         949.332763671875
       ],
       "params": {
-        "selectable_objects": false,
-        "show_objects": false
+        "base_data_name": "Beta"
       },
       "use_custom_color": true,
       "width": 140.0
@@ -618,27 +626,69 @@
   },
   "update_lists": [
     [
+      "Reroute",
+      "Output",
+      "Adaptive Polygons Mk2",
+      "Vertices Recipient"
+    ],
+    [
+      "Reroute.002",
+      "Output",
+      "Adaptive Polygons Mk2",
+      "Polygons Recipient"
+    ],
+    [
+      "Symmetrize Mesh.001",
+      0,
+      "Adaptive Polygons Mk2",
+      2
+    ],
+    [
+      "Symmetrize Mesh.001",
+      2,
+      "Adaptive Polygons Mk2",
+      4
+    ],
+    [
+      "Symmetrize Mesh.001",
+      3,
+      "Adaptive Polygons Mk2",
+      5
+    ],
+    [
+      "Mesh viewer",
+      0,
+      "Assign Materials List",
+      0
+    ],
+    [
+      "Adaptive Polygons Mk2",
+      3,
+      "Color in",
+      0
+    ],
+    [
       "Vector out",
       2,
       "Map Range",
       0
     ],
     [
-      "Reroute.001",
-      "Output",
-      "Mesh Expression",
-      "CenterClose"
+      "Adaptive Polygons Mk2",
+      0,
+      "Mesh viewer",
+      0
     ],
     [
-      "A Number.002",
-      0,
-      "Mesh Expression",
+      "Adaptive Polygons Mk2",
+      2,
+      "Mesh viewer",
       2
     ],
     [
-      "A Number.003",
-      0,
-      "Mesh Expression",
+      "Adaptive Polygons Mk2",
+      3,
+      "Mesh viewer",
       3
     ],
     [
@@ -810,48 +860,6 @@
       0
     ],
     [
-      "Reroute",
-      "Output",
-      "Viewer Draw Mk3.001",
-      "Vertices"
-    ],
-    [
-      "Reroute.002",
-      "Output",
-      "Viewer Draw Mk3.001",
-      "Polygons"
-    ],
-    [
-      "Reroute",
-      "Output",
-      "Adaptive Polygons Mk2",
-      "Vertices Recipient"
-    ],
-    [
-      "Reroute.002",
-      "Output",
-      "Adaptive Polygons Mk2",
-      "Polygons Recipient"
-    ],
-    [
-      "Symmetrize Mesh.001",
-      0,
-      "Adaptive Polygons Mk2",
-      2
-    ],
-    [
-      "Symmetrize Mesh.001",
-      2,
-      "Adaptive Polygons Mk2",
-      4
-    ],
-    [
-      "Symmetrize Mesh.001",
-      3,
-      "Adaptive Polygons Mk2",
-      5
-    ],
-    [
       "Adaptive Polygons Mk2",
       0,
       "Viewer Draw",
@@ -870,34 +878,34 @@
       6
     ],
     [
-      "Adaptive Polygons Mk2",
-      3,
-      "Color in",
-      0
+      "Reroute",
+      "Output",
+      "Viewer Draw Mk3.001",
+      "Vertices"
     ],
     [
-      "Adaptive Polygons Mk2",
+      "Reroute.002",
+      "Output",
+      "Viewer Draw Mk3.001",
+      "Polygons"
+    ],
+    [
+      "Reroute.001",
+      "Output",
+      "Mesh Expression",
+      "CenterClose"
+    ],
+    [
+      "A Number.002",
       0,
-      "Mesh viewer",
-      0
-    ],
-    [
-      "Adaptive Polygons Mk2",
-      2,
-      "Mesh viewer",
+      "Mesh Expression",
       2
     ],
     [
-      "Adaptive Polygons Mk2",
-      3,
-      "Mesh viewer",
-      3
-    ],
-    [
-      "Mesh viewer",
+      "A Number.003",
       0,
-      "Assign Materials List",
-      0
+      "Mesh Expression",
+      3
     ]
   ]
 }

--- a/json_examples/Introduction/Adaptive_Spread.json
+++ b/json_examples/Introduction/Adaptive_Spread.json
@@ -1,5 +1,5 @@
 {
-  "export_version": "0.079",
+  "export_version": "0.10",
   "framed_nodes": {
     "Objects in": "Frame",
     "Objects in.001": "Frame.001"
@@ -8,6 +8,14 @@
   "nodes": {
     "Adaptive Polygons Mk2": {
       "bl_idname": "SvAdaptivePolygonsNodeMk3",
+      "custom_socket_props": {
+        "12": {
+          "label": "Polygon Mask"
+        },
+        "15": {
+          "label": "Normal Mode"
+        }
+      },
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -16,14 +24,15 @@
         162.041748046875
       ],
       "params": {
-        "join": 1,
-        "remove_doubles": 1
+        "join": true,
+        "remove_doubles": true
       },
       "width": 140.0
     },
     "Frame": {
       "bl_idname": "NodeFrame",
-      "height": 298.25439453125,
+      "custom_socket_props": {},
+      "height": 322.3343811035156,
       "hide": false,
       "label": "RECIPIENT",
       "location": [
@@ -31,11 +40,12 @@
         184.05665588378906
       ],
       "params": {},
-      "width": 200.47998046875
+      "width": 200.0
     },
     "Frame.001": {
       "bl_idname": "NodeFrame",
-      "height": 295.2027587890625,
+      "custom_socket_props": {},
+      "height": 319.2827453613281,
       "hide": false,
       "label": "DONOR",
       "location": [
@@ -43,7 +53,7 @@
         60.0
       ],
       "params": {},
-      "width": 200.47998046875
+      "width": 200.0
     },
     "Objects in": {
       "bl_idname": "SvObjectsNodeMK3",
@@ -52,6 +62,7 @@
         0.5,
         0.20000000298023224
       ],
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "recepient",
@@ -71,6 +82,7 @@
         0.5,
         0.20000000298023224
       ],
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "donor",
@@ -91,6 +103,7 @@
         1.0
       ],
       "current_text": "Cube",
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -99,6 +112,9 @@
         -85.90300750732422
       ],
       "params": {
+        "current_text": "Cube",
+        "is_animatable": false,
+        "n_id": "-8575430288870586118",
         "text": "Cube",
         "textmode": "JSON"
       },
@@ -208,6 +224,7 @@
         1.0
       ],
       "current_text": "Plane",
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -216,6 +233,9 @@
         165.29104614257812
       ],
       "params": {
+        "current_text": "Plane",
+        "is_animatable": false,
+        "n_id": "-8575430288870582472",
         "text": "Plane",
         "textmode": "JSON"
       },
@@ -3736,6 +3756,7 @@
         0.30000001192092896,
         0.0
       ],
+      "custom_socket_props": {},
       "height": 100.0,
       "hide": false,
       "label": "",
@@ -3773,7 +3794,7 @@
       "Text in+",
       0,
       "Adaptive Polygons Mk2",
-      3
+      4
     ],
     [
       "Adaptive Polygons Mk2",
@@ -3783,7 +3804,7 @@
     ],
     [
       "Adaptive Polygons Mk2",
-      1,
+      2,
       "Viewer Draw Mk3",
       2
     ]

--- a/json_examples/Introduction/Adaptive_Spread.json
+++ b/json_examples/Introduction/Adaptive_Spread.json
@@ -7,7 +7,7 @@
   "groups": {},
   "nodes": {
     "Adaptive Polygons Mk2": {
-      "bl_idname": "SvAdaptivePolygonsNodeMk2",
+      "bl_idname": "SvAdaptivePolygonsNodeMk3",
       "height": 100.0,
       "hide": false,
       "label": "",

--- a/nodes/modifier_make/adaptive_polygons_mk3.py
+++ b/nodes/modifier_make/adaptive_polygons_mk3.py
@@ -27,8 +27,7 @@ from numpy import (array as np_array,
                    float64 as np_float64,
                    dot as np_dot,
                    max as np_max,
-                   min as np_min,
-                   concatenate as np_concatenate)
+                   min as np_min)
 from numpy.linalg import (norm as np_norm,
                           inv as np_inv)
 import bpy
@@ -47,10 +46,9 @@ from sverchok.data_structure import (updateNode, throttle_and_update_node,
 from sverchok.ui.sv_icons import custom_icon
 from sverchok.ui.utils import enum_split
 from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata, remove_doubles
-from sverchok.utils.sv_mesh_utils import mesh_join
 from sverchok.utils.geom import diameter, LineEquation2D, center
 from sverchok.utils.math import np_normalize_vectors
-from sverchok.utils.mesh_functions import join_meshes, meshes_py, to_elements, meshes_np
+from sverchok.utils.mesh_functions import join_meshes, meshes_py, to_elements
 # "coauthor": "Alessandro Zomparelli (sketchesofcode)"
 
 cos_pi_6 = cos(pi/6)

--- a/nodes/modifier_make/adaptive_polygons_mk3.py
+++ b/nodes/modifier_make/adaptive_polygons_mk3.py
@@ -106,7 +106,7 @@ def barycentric_transform_np(verts, src_verts, dst_verts):
 
 
 def donor_by_index(verts_donor, edges_donor, faces_donor, face_data_donor, donor_index, n_faces_recpt):
-    verts_donor_m, edges_donor_m, faces_donor_m, face_data_m = [], [], []
+    verts_donor_m, edges_donor_m, faces_donor_m, face_data_m = [], [], [], []
     if not face_data_donor[0]:
         face_data_m = cycle([[]])
     for i, idx in zip(range(n_faces_recpt), cycle(donor_index)):
@@ -199,7 +199,9 @@ class OutputData():
         else:
             self.face_recpt_idx_out = None
         if rem_doubles:
-            doubles_res = remove_doubles(self.verts_out[0], self.edges_out[0], self.faces_out[0],
+            doubles_res = remove_doubles(self.verts_out[0],
+                                         self.edges_out[0] if self.edges_out else [],
+                                         self.faces_out[0] if self.faces_out else [],
                                          threshold,
                                          face_data=self.face_data_out,
                                          vert_data=self.vert_recpt_idx_out,
@@ -1397,7 +1399,6 @@ class SvAdaptivePolygonsNodeMk3(bpy.types.Node, SverchCustomTreeNode):
 
         objects, single_donor = self.get_data()
         output = OutputData(self)
-
 
         for verts_recpt, faces_recpt, verts_donor,\
             edges_donor, faces_donor, face_data_donor,\

--- a/nodes/modifier_make/adaptive_polygons_mk3.py
+++ b/nodes/modifier_make/adaptive_polygons_mk3.py
@@ -853,7 +853,7 @@ class SvAdaptivePolygonsNodeMk3(bpy.types.Node, SverchCustomTreeNode):
                 if self.xy_mode == 'BOUNDS':
                     print(X)
                     verts[:, X] = self.map_bounds(donor.min_x, donor.max_x, verts[:, X])
-                    verts[:, Y] = self.map_bounds(donor.min_x, donor.max_x, verts[:, Y])
+                    verts[:, Y] = self.map_bounds(donor.min_y, donor.max_y, verts[:, Y])
                 new_verts = self.interpolate_quad_3d_np(recpt_face_data, verts,
                                                         wcoef, zcoef, zoffset,
                                                         [i0, i1, i2, i3])
@@ -884,11 +884,11 @@ class SvAdaptivePolygonsNodeMk3(bpy.types.Node, SverchCustomTreeNode):
 
             if is_fan:
                 tri_faces = [(recpt_face_data.vertices_co[i],
-                                recpt_face_data.vertices_co[i+1],
-                                recpt_face_data.center) for i in range(n-1)]
+                              recpt_face_data.vertices_co[i+1],
+                              recpt_face_data.center) for i in range(n-1)]
                 tri_faces.append((recpt_face_data.vertices_co[-1],
-                                    recpt_face_data.vertices_co[0],
-                                    recpt_face_data.center))
+                                  recpt_face_data.vertices_co[0],
+                                  recpt_face_data.center))
 
                 if self.use_shell_factor:
                     face_normal = sum(recpt_face_data.vertices_normal, Vector()) / n
@@ -909,29 +909,29 @@ class SvAdaptivePolygonsNodeMk3(bpy.types.Node, SverchCustomTreeNode):
                     self._process_face(sub_map_mode, output, sub_recpt, donor, zcoef, zoffset, angle, wcoef, facerot)
             else:
                 inner_verts = [vert.lerp(recpt_face_data.center, recpt_face_data.frame_width)
-                                    for vert in recpt_face_data.vertices_co]
+                               for vert in recpt_face_data.vertices_co]
                 if self.use_shell_factor:
                     inner_normals = [normal.lerp(recpt_face_data.normal, recpt_face_data.frame_width)
-                                        for normal in recpt_face_data.vertices_normal]
+                                     for normal in recpt_face_data.vertices_normal]
                 else:
                     face_normal = sum(recpt_face_data.vertices_normal, Vector()) / n
                     inner_normals = [normal.lerp(face_normal, recpt_face_data.frame_width)
-                                        for normal in recpt_face_data.vertices_normal]
+                                     for normal in recpt_face_data.vertices_normal]
 
                 quad_faces = [(recpt_face_data.vertices_co[i],
-                                recpt_face_data.vertices_co[i+1],
-                                inner_verts[i+1], inner_verts[i])
-                                    for i in range(n-1)]
+                               recpt_face_data.vertices_co[i+1],
+                               inner_verts[i+1], inner_verts[i])
+                              for i in range(n-1)]
                 quad_faces.append((recpt_face_data.vertices_co[-1],
-                                    recpt_face_data.vertices_co[0],
-                                    inner_verts[0], inner_verts[-1]))
+                                   recpt_face_data.vertices_co[0],
+                                   inner_verts[0], inner_verts[-1]))
                 quad_normals = [(recpt_face_data.vertices_normal[i],
-                                recpt_face_data.vertices_normal[i+1],
-                                inner_normals[i+1], inner_normals[i])
-                                    for i in range(n-1)]
+                                 recpt_face_data.vertices_normal[i+1],
+                                 inner_normals[i+1], inner_normals[i])
+                                for i in range(n-1)]
                 quad_normals.append((recpt_face_data.vertices_normal[-1],
-                                    recpt_face_data.vertices_normal[0],
-                                    inner_normals[0], inner_normals[-1]))
+                                     recpt_face_data.vertices_normal[0],
+                                     inner_normals[0], inner_normals[-1]))
 
                 for quad_face, quad_normal in zip(quad_faces, quad_normals):
                     sub_recpt = recpt_face_data.copy()
@@ -972,8 +972,6 @@ class SvAdaptivePolygonsNodeMk3(bpy.types.Node, SverchCustomTreeNode):
         bm_verts = bm.verts
         bm_verts.ensure_lookup_table()
 
-        # single_donor = self.matching_mode == 'LONG'
-        # frame_level = get_data_nesting_level(frame_widths)
         if single_donor:
             # Original (unrotated) donor vertices
             donor_verts_o = [Vector(v) for v in verts_donor]
@@ -1037,7 +1035,9 @@ class SvAdaptivePolygonsNodeMk3(bpy.types.Node, SverchCustomTreeNode):
 
             donor.faces_i = donor_faces_i
             donor.face_data_i = donor_face_data_i
+
             map_mode = self.get_map_mode(len(recpt_face), m)
+
             if self.implementation == 'Auto':
                 is_fan = abs(frame_width - 1.0) < 1e-6
                 numpy_candidate = len(donor_verts_i) > (50 if map_mode == "TRIS" or (map_mode=='FRAME' and is_fan) else 12)
@@ -1076,39 +1076,6 @@ class SvAdaptivePolygonsNodeMk3(bpy.types.Node, SverchCustomTreeNode):
                 else:
                     zcoef = zcoef / z_size
 
-            # Define TRI/QUAD mode based on node settings.
-
-
-            # if not m:
-            #     map_mode = self.mask_mode
-            # else:
-            #     if n == 3:
-            #         if self.frame_mode == 'ALWAYS':
-            #             map_mode = 'FRAME'
-            #         else:
-            #             if self.map_mode == 'QUADTRI':
-            #                 map_mode = 'TRI'
-            #             else: # self.map_mode == 'QUADS':
-            #                 map_mode = 'QUAD'
-            #     elif n == 4:
-            #         if self.frame_mode in ['ALWAYS', 'NGONQUAD']:
-            #             map_mode = 'FRAME'
-            #         else:
-            #             map_mode = 'QUAD'
-            #     else:
-            #         if self.frame_mode in ['ALWAYS', 'NGONQUAD', 'NGONS']:
-            #             map_mode = 'FRAME'
-            #         else:
-            #             if self.ngon_mode == 'QUADS':
-            #                 map_mode = 'QUAD'
-            #             elif self.ngon_mode == 'ASIS':
-            #                 map_mode = 'ASIS'
-            #             else:
-            #                 map_mode = 'SKIP'
-            #
-            # if map_mode == 'SKIP':
-            #     # Skip this recipient's face - do not produce any vertices/faces for it
-            #     continue
 
             self._process_face(map_mode, output, recpt_face_data, donor, zcoef, zoffset, angle, wcoef, facerot)
             recpt_face_idx += 1

--- a/nodes/modifier_make/adaptive_polygons_mk3.py
+++ b/nodes/modifier_make/adaptive_polygons_mk3.py
@@ -147,11 +147,11 @@ class DonorData():
 
 class SvAdaptivePolygonsNodeMk3(bpy.types.Node, SverchCustomTreeNode):
     """
-    Triggers: Adaptive Polygons Tessellate Tissue
+    Triggers: Tessellate Tissue
     Tooltip: Generate an adapted copy of donor object along each face of recipient object.
     """
     bl_idname = 'SvAdaptivePolygonsNodeMk3'
-    bl_label = 'Adaptive Polygons Mk2'
+    bl_label = 'Adaptive Polygons'
     bl_icon = 'OUTLINER_OB_EMPTY'
     sv_icon = 'SV_ADAPTATIVE_POLS'
 

--- a/nodes/modifier_make/adaptive_polygons_mk3.py
+++ b/nodes/modifier_make/adaptive_polygons_mk3.py
@@ -76,7 +76,6 @@ def matrix_def(triangle):
 
 def prepare_source_data(src_verts):
     '''Create the inverted Transformation Matrix and 4th point of the tetrahedron'''
-
     matrix_trasform_s, tri3_src = matrix_def(src_verts)
     inverted_matrix_s = np_inv(matrix_trasform_s).T
 
@@ -85,9 +84,7 @@ def prepare_source_data(src_verts):
 
 def prepare_dest_data(dst_verts):
     '''Create Transformation Matrix and 4th point of the tetrahedron'''
-
     matrix_trasform, tri3_dest = matrix_def(dst_verts)
-
 
     return matrix_trasform, tri3_dest
 
@@ -361,7 +358,7 @@ class SvAdaptivePolygonsNodeMk3(bpy.types.Node, SverchCustomTreeNode):
     ngons_as: EnumProperty(
         name="Ngons Transform",
         description="How to transform on triangular faces",
-        items=transform_modes, default="QUAD",
+        items=transform_modes, default="FRAME",
         update=update_sockets
     )
 

--- a/nodes/modifier_make/adaptive_polygons_mk3.py
+++ b/nodes/modifier_make/adaptive_polygons_mk3.py
@@ -1,0 +1,1222 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+from math import sin, cos, pi, sqrt, pow
+from functools import reduce
+from itertools import cycle
+from numpy import (array as np_array,
+                   newaxis as np_newaxis,
+                   cross as np_cross,
+                   zeros as np_zeros,
+                   sqrt as np_sqrt,
+                   float64 as np_float64,
+                   dot as np_dot,
+                   max as np_max,
+                   min as np_min)
+from numpy.linalg import (norm as np_norm,
+                          inv as np_inv)
+import bpy
+from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty
+from mathutils import Vector, Matrix
+from mathutils.geometry import barycentric_transform
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import (updateNode, throttle_and_update_node,
+                                     match_long_repeat,
+                                     numpy_list_match_modes,
+                                     cycle_for_length, make_repeaters, make_cyclers,
+                                     get_data_nesting_level,
+                                     rotate_list)
+
+from sverchok.ui.sv_icons import custom_icon
+from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata, remove_doubles
+from sverchok.utils.sv_mesh_utils import mesh_join
+from sverchok.utils.geom import diameter, LineEquation2D, center
+
+# "coauthor": "Alessandro Zomparelli (sketchesofcode)"
+
+cos_pi_6 = cos(pi/6)
+sin_pi_6 = sin(pi/6)
+sqrt_3 = sqrt(3)
+sqrt_3_6 = sqrt_3/6
+sqrt_3_3 = sqrt_3/3
+sqrt_3_2 = sqrt_3/2
+
+def matrix_def(triangle):
+    '''Creation of Transform matrix from triangle'''
+    tri0, tri1, tri2 = triangle[0, :], triangle[1, :], triangle[2, :]
+    tri_normal = np_cross(tri1 - tri0, tri2 - tri0)
+    magnitude = np_norm(tri_normal)
+    tri_area = 0.5 * magnitude
+    tri3 = tri0+ (tri_normal / magnitude)* np_sqrt(tri_area)
+
+    transform_matrix = np_zeros([3, 3], dtype=np_float64)
+    transform_matrix[0, :] = tri0 - tri3
+    transform_matrix[1, :] = tri1 - tri3
+    transform_matrix[2, :] = tri2 - tri3
+
+    return transform_matrix, tri3
+
+def prepare_source_data(src_verts):
+    '''Create the inverted Transformation Matrix and 4th point of the tetrahedron'''
+
+    matrix_trasform_s, tri3_src = matrix_def(src_verts)
+    inverted_matrix_s = np_inv(matrix_trasform_s).T
+
+    return inverted_matrix_s, tri3_src
+
+
+def prepare_dest_data(dst_verts):
+    '''Create Transformation Matrix and 4th point of the tetrahedron'''
+
+    matrix_trasform, tri3_dest = matrix_def(dst_verts)
+
+
+    return matrix_trasform, tri3_dest
+
+def barycentric_transform_np(verts, src_verts, dst_verts):
+    '''NumPy Implementation of a barycentric transform'''
+
+    inverted_matrix_s, tri3_src = prepare_source_data(src_verts)
+    matrix_transform_d, tri3_dest = prepare_dest_data(dst_verts)
+
+
+    barycentric_co = np_dot(inverted_matrix_s, (verts - tri3_src).T)
+    cartesian_co = np_dot(barycentric_co.T, matrix_transform_d) + tri3_dest
+
+    return cartesian_co
+
+
+class OutputData():
+    def __init__(self):
+        self.verts_out = []
+        self.faces_out = []
+        self.face_data_out = []
+        self.vert_recpt_idx_out = []
+        self.face_recpt_idx_out = []
+
+class RecptFaceData():
+    def __init__(self):
+        self.vertices_co = []
+        self.vertices_normal = []
+        self.vertices_idxs = []
+        self.index = 0
+        self.normal = None
+        self.center = None
+        self.frame_width = None
+
+    def copy(self):
+        r = RecptFaceData()
+        r.vertices_co = self.vertices_co[:]
+        r.vertices_normal = self.vertices_normal[:]
+        r.vertices_idxs = self.vertices_idxs[:]
+        r.normal = self.normal
+        r.center = self.center
+        r.frame_width = self.frame_width
+        r.index = self.index
+        return r
+
+class DonorData():
+    def __init__(self):
+        self.min_x = None
+        self.max_x = None
+        self.min_y = None
+        self.max_y = None
+        self.tri_vert_1 = None
+        self.tri_vert_2 = None
+        self.tri_vert_3 = None
+        self.verts_v = []
+        self.faces_i = []
+        self.face_data_i = []
+
+
+class SvAdaptivePolygonsNodeMk3(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: Adaptive Polygons Tessellate Tissue
+    Tooltip: Generate an adapted copy of donor object along each face of recipient object.
+    """
+    bl_idname = 'SvAdaptivePolygonsNodeMk3'
+    bl_label = 'Adaptive Polygons Mk2'
+    bl_icon = 'OUTLINER_OB_EMPTY'
+    sv_icon = 'SV_ADAPTATIVE_POLS'
+
+    axes = [
+            ("X", "X", "Orient donor's X axis along normal", 0),
+            ("Y", "Y", "Orient donor's Y axis along normal", 1),
+            ("Z", "Z", "Orient donor's Z axis along normal", 2)
+        ]
+
+    normal_axis: EnumProperty(
+        name="Normal axis",
+        description="Donor object axis to be oriented along recipient face normal",
+        items=axes,
+        default='Z',
+        update=updateNode)
+
+    width_coef: FloatProperty(
+        name='Width coeff',
+        description="Donor object width coefficient",
+        default=1.0, max=3.0, min=0.5, update=updateNode)
+
+    frame_width: FloatProperty(
+        name='Frame width',
+        description="Frame width coefficient for Frame / Fan mode",
+        default=0.5, max=1.0, min=0.0, update=updateNode)
+
+    z_coef: FloatProperty(
+        name='Z coeff',
+        default=1.0, max=3.0, min=0.0, update=updateNode)
+
+    z_offset: FloatProperty(
+        name="Z offet",
+        default=0.0,
+        update=updateNode)
+
+    normal_interp_modes = [
+            ("LINEAR", "Linear", "Exact / linear normals interpolation", 0),
+            ("SMOOTH", "Unit length", "Use normals of unit length", 1)
+        ]
+
+    normal_interp_mode: EnumProperty(
+        name="Interpolate normals",
+        description="Normals interpolation mode",
+        items=normal_interp_modes, default="LINEAR",
+        update=updateNode)
+
+    normal_modes = [
+            ("MAP", "Map", "Interpolate from donor vertex normals", 0),
+            ("FACE", "Face", "Use donor face normals", 1)
+        ]
+    implementation_modes = [
+            ("NumPy", "NumPy", "Faster when donor has more than 50 vertices for tris or 12 verts for quads", 0),
+            ("Mathutils", "Mathutils", "Faster when donor has less than 50 vertices for tris or 12 verts for quads ", 1),
+            ("Auto", "Auto", "Switched between Mathutils and NumPy implementation depending on donor vert count", 2)
+        ]
+
+    normal_mode: EnumProperty(
+        name="Use normals",
+        description="Normals mapping mode",
+        items=normal_modes, default="MAP",
+        update=updateNode)
+
+    use_shell_factor: BoolProperty(
+        name="Use shell factor",
+        description="Use shell factor to make shell thickness constant",
+        default=False,
+        update=updateNode)
+
+    implementation: EnumProperty(
+        name="Implementation",
+        description="Algorithm used for computation",
+        items=implementation_modes, default="Auto",
+        update=updateNode)
+
+    z_scale_modes = [
+            ("PROP", "Proportional", "Scale along normal proportionally with the donor object", 0),
+            ("CONST", "Constant", "Constant scale along normal", 1),
+            ("AUTO", "Auto", "Try to calculate the correct scale automatically", 2)
+        ]
+
+    z_scale: EnumProperty(
+        name="Z Scale",
+        description="Mode of scaling along the normals",
+        items=z_scale_modes, default="PROP",
+        update=updateNode)
+
+    z_rotation: FloatProperty(
+        name="Z Rotation",
+        description="Rotate donor object around recipient's face normal",
+        min=0, max=2*pi, default=0,
+        update=updateNode)
+
+    poly_rotation: IntProperty(
+        name="Polygons rotation",
+        description="Rotate indexes in polygons definition",
+        min=0, default=0,
+        update=updateNode)
+
+    donor_index: IntProperty(
+        name="Donor Index",
+        description="Donor index to use",
+        min=0, default=0,
+        update=updateNode)
+
+    xy_modes = [
+            ("BOUNDS", "Bounds", "Map donor object bounds to recipient face", 0),
+            ("PLAIN", "As Is", "Map donor object's coordinate space to recipient face as-is", 1)
+        ]
+
+    xy_mode: EnumProperty(
+        name="Coordinates",
+        description="Donor object coordinates mapping",
+        items=xy_modes, default="BOUNDS",
+        update=updateNode)
+
+    tri_bound_modes = [
+            ("EQUILATERAL", "Equilateral", "Use unit-sided equilateral triangle as a base area",
+                custom_icon("SV_EQUILATERAL_TRIANGLE"), 0),
+            ("RECTANGULAR", "Rectangular", "Use rectangular triangle with hypotenuse of 2 as a base area",
+                custom_icon("SV_RECTANGULAR_TRIANGLE"), 1)
+        ]
+
+    tri_bound_mode: EnumProperty(
+        name="Bounding triangle",
+        description="Type of triangle to use as a bounding triangle",
+        items=tri_bound_modes,
+        default="EQUILATERAL",
+        update=updateNode)
+
+    map_modes = [
+            ("QUADTRI", "Quads / Tris Auto", "Use Quads or Tris mapping automatically", 0),
+            ("QUADS", "Quads Always", "Use Quads mapping even for the Tris", 1)
+        ]
+
+    map_mode: EnumProperty(
+        name="Faces mode",
+        description="Donor object mapping mode",
+        items=map_modes, default="QUADTRI",
+        update=updateNode)
+
+    skip_modes = [
+            ("SKIP", "Skip", "Do not output anything", 0),
+            ("ASIS", "As Is", "Output these faces as is", 1)
+        ]
+
+    mask_mode: EnumProperty(
+        name="Mask mode",
+        description="What to do with masked out faces",
+        items=skip_modes, default="SKIP",
+        update=updateNode)
+
+    ngon_modes = [
+            ("QUADS", "As Quads", "Try to process as Quads", 0),
+            ("SKIP", "Skip", "Do not output anything", 1),
+            ("ASIS", "As Is", "Output these faces as is", 2)
+        ]
+
+    ngon_mode: EnumProperty(
+        name="NGons",
+        description="What to do with NGons",
+        items=ngon_modes, default="QUADS",
+        update=updateNode)
+
+    @throttle_and_update_node
+    def update_sockets(self, context):
+        show_width = self.frame_mode != 'NEVER'
+        self.inputs['FrameWidth'].hide_safe = not show_width
+        self.inputs['Threshold'].hide_safe = not self.join or not self.remove_doubles
+        self.inputs['Donor Index'].hide_safe = self.donor_matching_mode != "INDEX"
+
+    frame_modes = [
+            ("NEVER", "Do not use", "Do not use Frame / Fan mode", 0),
+            ("NGONS", "NGons only", "Use Frame / Fan mode for NGons (n > 4) only", 1),
+            ("NGONQUAD", "NGons and Quads", "Use Frame / Fan mode for NGons and Quads (n >= 4)", 2),
+            ("ALWAYS", "Always", "Use Frame / Fan mode for all faces", 3)
+        ]
+
+    frame_mode: EnumProperty(
+        name="Frame mode",
+        description="When to use Frame / Fan mode",
+        items=frame_modes, default='NEVER',
+        update=update_sockets)
+
+    matching_modes = [
+            ("LONG", "Match longest", "Make an iteration for each donor or recipient object - depending on which list is longer", 0),
+            ("PERFACE", "Donor per face", "If there are many donor objects, match each donor object with corresponding recipient object face", 1)
+        ]
+
+    matching_mode: EnumProperty(
+        name="Matching",
+        description="How to match list of recipient objects with list of donor objects",
+        items=matching_modes, default="LONG",
+        update=update_sockets)
+    donor_matching_modes = numpy_list_match_modes[1:] + [("INDEX",  "By Index",  "Match shortest List",    4)]
+    donor_matching_mode: EnumProperty(
+        name="Donor Matching",
+        description="How to match list of recipient objects with list of donor objects",
+        items=donor_matching_modes, default="REPEAT",
+        update=update_sockets)
+
+    join: BoolProperty(
+        name="Join",
+        description="Output one joined mesh",
+        default=False,
+        update=updateNode)
+
+    remove_doubles: BoolProperty(
+        name="Remove doubles",
+        description="Merge vertices at the same location",
+        default=False,
+        update=update_sockets)
+
+    threshold: FloatProperty(
+        name="Threshold",
+        description="Threshold for vertices to be considered as identical",
+        precision=4, min=0,
+        default=1e-4,
+        update=updateNode)
+
+    output_numpy: BoolProperty(
+        name="Output Numpy",
+        description="Output Arrays",
+        default=False,
+        update=update_sockets)
+
+    tri_vert_idxs = [0, 1, 2]
+    quad_vert_idxs = [0, 1, 2, -1]
+
+    def sv_init(self, context):
+        self.inputs.new('SvVerticesSocket', "VersR")
+        self.inputs.new('SvStringsSocket', "PolsR")
+        self.inputs.new('SvVerticesSocket', "VersD")
+        self.inputs.new('SvStringsSocket', "PolsD")
+        self.inputs.new('SvStringsSocket', "FaceDataD")
+        self.inputs.new('SvStringsSocket', "W_Coef").prop_name = 'width_coef'
+        self.inputs.new('SvStringsSocket', "FrameWidth").prop_name = 'frame_width'
+        self.inputs.new('SvStringsSocket', "Z_Coef").prop_name = 'z_coef'
+        self.inputs.new('SvStringsSocket', "Z_Offset").prop_name = 'z_offset'
+        self.inputs.new('SvStringsSocket', "Z_Rotation").prop_name = 'z_rotation'
+        self.inputs.new('SvStringsSocket', "PolyRotation").prop_name = 'poly_rotation'
+        self.inputs.new('SvStringsSocket', "PolyMask")
+        self.inputs.new('SvStringsSocket', "Threshold").prop_name = 'threshold'
+        self.inputs.new('SvStringsSocket', "Donor Index").prop_name = 'donor_index'
+
+        self.outputs.new('SvVerticesSocket', "Vertices")
+        self.outputs.new('SvStringsSocket', "Polygons")
+        self.outputs.new('SvStringsSocket', "FaceData")
+        self.outputs.new('SvStringsSocket', "VertRecptIdx")
+        self.outputs.new('SvStringsSocket', "FaceRecptIdx")
+
+        self.update_sockets(context)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "join")
+        if self.join:
+            layout.prop(self, "remove_doubles")
+        layout.prop(self, "matching_mode")
+        if self.matching_mode == 'PERFACE':
+            layout.prop(self, "donor_matching_mode")
+
+    def draw_buttons_ext(self, context, layout):
+        self.draw_buttons(context, layout)
+
+        layout.label(text="Normal axis:")
+        layout.prop(self, "normal_axis", expand=True)
+        layout.prop(self, "z_scale")
+        layout.prop(self, "normal_mode")
+        if self.normal_mode == 'MAP':
+            layout.prop(self, "normal_interp_mode")
+        layout.prop(self, "use_shell_factor")
+        layout.prop(self, "xy_mode")
+        layout.label(text="Bounding triangle:")
+        layout.prop(self, "tri_bound_mode", expand=True)
+        layout.prop(self, "frame_mode")
+        layout.prop(self, "map_mode")
+        layout.prop(self, "mask_mode")
+        layout.prop(self, "ngon_mode")
+        layout.prop(self, "implementation")
+        if not self.join:
+            layout.prop(self, "output_numpy")
+
+    def get_triangle_directions(self):
+        """
+        Three normal of unit triangle's edges.
+        This is not constant just because the normal can be X or Y or Z.
+        """
+        if self.tri_bound_mode == 'EQUILATERAL':
+            triangle_direction_1 = Vector((cos_pi_6, sin_pi_6, 0))
+            triangle_direction_2 = Vector((-cos_pi_6, sin_pi_6, 0))
+            triangle_direction_3 = Vector((0, -1, 0))
+        else:
+            triangle_direction_1 = Vector((1, 1, 0))
+            triangle_direction_2 = Vector((-1, 1, 0))
+            triangle_direction_3 = Vector((0, -1, 0))
+
+        if self.normal_axis == 'X':
+            return triangle_direction_1.zxy, triangle_direction_2.zxy, triangle_direction_3.zxy
+
+        if self.normal_axis == 'Y':
+            return triangle_direction_1.xzy, triangle_direction_2.xzy, triangle_direction_3.xzy
+
+        return triangle_direction_1, triangle_direction_2, triangle_direction_3
+
+    def to2d(self, vec):
+        """
+        Convert vector to 2D.
+        Remove the coordinate which is responsible for normal axis.
+        """
+        if self.normal_axis == 'X':
+            return vec.yz
+        if self.normal_axis == 'Y':
+            return vec.xz
+
+        return vec.xy
+
+    def from2d(self, x_co, y_co):
+        """
+        Make 3D vector from X and Y.
+        Add zero for the coordinate which is responsible for normal axis.
+        """
+        if self.normal_axis == 'X':
+            return Vector((0, x_co, y_co))
+        if self.normal_axis == 'Y':
+            return Vector((x_co, 0, y_co))
+
+        return Vector((x_co, y_co, 0))
+
+    def bounding_triangle(self, vertices):
+        """
+        Return three vertices of a triangle with equal sides / rectangular triangle,
+        which contains all provided vertices.
+        """
+        X, Y = self.get_other_axes()
+
+        triangle_direction_1, triangle_direction_2, triangle_direction_3 = self.get_triangle_directions()
+        max_1 = self.to2d(max(vertices, key=lambda vertex: triangle_direction_1.dot(vertex)))
+        max_2 = self.to2d(max(vertices, key=lambda vertex: triangle_direction_2.dot(vertex)))
+        max_3 = self.to2d(min(vertices, key=lambda vertex: vertex[Y]))
+
+        side_1 = LineEquation2D.from_normal_and_point(self.to2d(triangle_direction_1), max_1)
+        side_2 = LineEquation2D.from_normal_and_point(self.to2d(triangle_direction_2), max_2)
+        side_3 = LineEquation2D.from_normal_and_point(self.to2d(triangle_direction_3), max_3)
+
+        p1 = side_2.intersect_with_line(side_3)
+        p2 = side_1.intersect_with_line(side_3)
+        p3 = side_1.intersect_with_line(side_2)
+
+        p1 = self.from2d(p1[0], p1[1])
+        p2 = self.from2d(p2[0], p2[1])
+        p3 = self.from2d(p3[0], p3[1])
+
+        return p1, p2, p3
+
+    def interpolate_quad_2d(self, dst_vert_1, dst_vert_2, dst_vert_3, dst_vert_4, v, x_coef, y_coef):
+        """
+        Map the provided `v` vertex, considering only two of it's coordinates,
+        from the [-1/2; 1/2] x [-1/2; 1/2] square to the face defined by
+        four `dst_vert_n` vertices.
+        """
+        X, Y = self.get_other_axes()
+        v12 = dst_vert_1 + (dst_vert_2 - dst_vert_1) * v[X] * x_coef + ((dst_vert_2 - dst_vert_1) / 2)
+        v43 = dst_vert_4 + (dst_vert_3 - dst_vert_4) * v[X] * x_coef + ((dst_vert_3 - dst_vert_4) / 2)
+        return v12 + (v43 - v12) * v[Y] * y_coef + ((v43 - v12) / 2)
+
+    def interpolate_quad_3d(self, dst_vert_1, dst_vert_2, dst_vert_3, dst_vert_4, dst_normal_1, dst_normal_2, dst_normal_3, dst_normal_4, face_normal, v, x_coef, y_coef, z_coef, z_offset):
+        """
+        Map the provided `v` vertex from the source
+        [-1/2; 1/2] x [-1/2; 1/2] x [-1/2; 1/2] cube
+        to the space defined by `dst_vert_n` vertices.
+        """
+        loc = self.interpolate_quad_2d(dst_vert_1,
+                                       dst_vert_2,
+                                       dst_vert_3,
+                                       dst_vert_4,
+                                       v, x_coef, y_coef)
+        if self.normal_mode == 'MAP':
+            if self.normal_interp_mode == 'SMOOTH':
+                normal = self.interpolate_quad_2d(dst_normal_1,
+                                                  dst_normal_2,
+                                                  dst_normal_3,
+                                                  dst_normal_4,
+                                                  v, x_coef, y_coef)
+                normal.normalize()
+            else:
+                normal = self.interpolate_quad_2d(dst_vert_1 + dst_normal_1,
+                                                  dst_vert_2 + dst_normal_2,
+                                                  dst_vert_3 + dst_normal_3,
+                                                  dst_vert_4 + dst_normal_4,
+                                                  v, x_coef, y_coef)
+                normal = normal - loc
+        else:
+
+            normal = face_normal
+        Z = self.normal_axis_idx()
+        return loc + normal * (v[Z] * z_coef + z_offset)
+
+    def interpolate_quad_2d_np(self, dst_verts, verts, x_coef, y_coef):
+        """
+        Map the provided `v` vertex, considering only two of it's coordinates,
+        from the [-1/2; 1/2] x [-1/2; 1/2] square to the face defined by
+        four `dst_vert_n` vertices.
+        """
+        dst_vert_1, dst_vert_2, dst_vert_3, dst_vert_4 = dst_verts
+        X, Y = self.get_other_axes()
+        v10 = dst_vert_1 + ((dst_vert_2-dst_vert_1)/2)
+        v02 = (dst_vert_2 - dst_vert_1)[np_newaxis] * (verts[:, X] * x_coef)[:, np_newaxis]
+        v12 = v10 + v02
+
+
+        v40 = dst_vert_4 + ((dst_vert_3-dst_vert_4)/2)
+        v03 = (dst_vert_3 - dst_vert_4)[np_newaxis] * (verts[:, X] * x_coef)[:, np_newaxis]
+        v43 = v40 + v03
+
+        return v12  + ((v43-v12)/2) + (v43-v12) * (verts[:, Y] * y_coef)[:, np_newaxis]
+
+    def interpolate_quad_3d_np(self, recpt_face_data, verts, w_coef, z_coef, z_offset, indexes):
+        """
+        Map the provided `v` vertex from the source
+        [-1/2; 1/2] x [-1/2; 1/2] x [-1/2; 1/2] cube
+        to the space defined by `dst_vert_n` vertices.
+        """
+        dst_verts = np_array(recpt_face_data.vertices_co)[indexes]
+        dst_normals = np_array(recpt_face_data.vertices_normal)[indexes]
+        face_normal = np_array(recpt_face_data.normal)
+        x_coef = y_coef = w_coef
+        loc = self.interpolate_quad_2d_np(dst_verts, verts, x_coef, y_coef)
+        if self.normal_mode == 'MAP':
+            if self.normal_interp_mode == 'SMOOTH':
+                normal = self.interpolate_quad_2d_np(dst_normals, verts, x_coef, y_coef)
+                normal.normalize()
+            else:
+                normal = self.interpolate_quad_2d_np(dst_verts + dst_normals, verts, x_coef, y_coef)
+                normal = normal - loc
+        else:
+
+            normal = face_normal[np_newaxis, :]
+        Z = self.normal_axis_idx()
+
+        return loc + normal * (verts[:, Z] * z_coef + z_offset)[:, np_newaxis]
+
+    def interpolate_tri_2d(self, dst_vert_1, dst_vert_2, dst_vert_3, src_vert_1, src_vert_2, src_vert_3, v):
+        """
+        Map the provided `v` vertex, considering only two of it's coordinates,
+        from the source triangle (defined by `src_vert_n` vertices) to the face defined by
+        three `dst_vert_n` vertices.
+        """
+        X, Y = self.get_other_axes()
+        v = self.from2d(v[X], v[Y])
+        return barycentric_transform(v, src_vert_1, src_vert_2, src_vert_3,
+                                        dst_vert_1, dst_vert_2, dst_vert_3)
+
+    def interpolate_tri_3d(self, dst_vert_1, dst_vert_2, dst_vert_3, dst_normal_1, dst_normal_2, dst_normal_3, src_vert_1, src_vert_2, src_vert_3, face_normal, v, z_coef, z_offset):
+        """
+        Map the provided `v` vertex from the source triangle
+        to the space defined by `dst_vert_n` vertices.
+        """
+        v_at_triangle = self.interpolate_tri_2d(dst_vert_1, dst_vert_2, dst_vert_3,
+                                                src_vert_1, src_vert_2, src_vert_3,
+                                                v)
+        if self.normal_mode == 'MAP':
+            if self.normal_interp_mode == 'SMOOTH':
+                normal = self.interpolate_tri_2d(dst_normal_1, dst_normal_2, dst_normal_3,
+                                                 src_vert_1, src_vert_2, src_vert_3,
+                                                 v)
+                normal.normalize()
+            else:
+                normal = self.interpolate_tri_2d(dst_vert_1 + dst_normal_1,
+                                                 dst_vert_2 + dst_normal_2,
+                                                 dst_vert_3 + dst_normal_3,
+                                                 src_vert_1, src_vert_2, src_vert_3,
+                                                 v)
+                normal = normal - v_at_triangle
+        else:
+            normal = face_normal
+        Z = self.normal_axis_idx()
+        return (v_at_triangle + normal * (v[Z] * z_coef + z_offset))[:]
+
+    def interpolate_tri_2d_np(self, dst_verts, src_verts, verts):
+        """
+        Map the provided `v` vertex, considering only two of it's coordinates,
+        from the source triangle (defined by `src_vert_n` vertices) to the face defined by
+        three `dst_vert_n` vertices.
+        """
+        Z = self.normal_axis_idx()
+        v2d = np_array(verts)
+        v2d[:, Z] *= 0
+        return barycentric_transform_np(v2d, src_verts, dst_verts)
+
+    def interpolate_tri_3d_np(self, recpt_face_data, donor, wcoef, z_coef, z_offset, indexes):
+        """
+        Map the provided `vecs` vertex from the source triangle
+        to the space defined by `dst_vert_n` vertices.
+        """
+        dst_verts = np_array(recpt_face_data.vertices_co)[indexes]
+        src_verts = np_array([donor.tri_vert_1, donor.tri_vert_2, donor.tri_vert_3])/wcoef
+        vecs = donor.verts_v
+        v_at_triangle = self.interpolate_tri_2d_np(dst_verts,
+                                                   src_verts,
+                                                   vecs)
+        if self.normal_mode == 'MAP':
+            dst_normals = np_array(recpt_face_data.vertices_normal)[indexes]
+            if self.normal_interp_mode == 'SMOOTH':
+                normal = self.interpolate_tri_2d_np(dst_normals,
+                                                    src_verts,
+                                                    vecs)
+                normal.normalize()
+            else:
+                normal = self.interpolate_tri_2d_np(dst_verts + dst_normals,
+                                                    src_verts,
+                                                    vecs)
+                normal = normal - v_at_triangle
+        else:
+            normal = np_array(recpt_face_data.normal)
+
+        Z = self.normal_axis_idx()
+        return v_at_triangle + normal * (vecs[:, Z] * z_coef + z_offset)[:, np_newaxis]
+
+    def get_other_axes(self):
+        if self.normal_axis == 'X':
+            return 1, 2
+        if self.normal_axis == 'Y':
+            return 0, 2
+
+        return 0, 1
+
+    def normal_axis_idx(self):
+        return "XYZ".index(self.normal_axis)
+
+    def map_bounds(self, min_v, max_v, x):
+        c = (min_v + max_v) / 2.0
+        k = 1.0 / (max_v - min_v)
+        return (x - c) * k
+
+    def rotate_z(self, verts, angle):
+        if abs(angle) < 1e-6:
+            return verts
+        projection = [self.to2d(v) for v in verts]
+        x0, y0 = center(projection)
+        c = self.from2d(x0, y0)
+        rot = Matrix.Rotation(angle, 4, self.normal_axis)
+        result = [(rot @ (v - c)) + c for v in verts]
+        return result
+
+    def calc_z_scale(self, dst_verts, src_verts):
+        src_lens = []
+        for v1, v2 in zip(src_verts, src_verts[1:]):
+            src_lens.append((v1 - v2).length)
+        src_lens.append((src_verts[-1] - src_verts[0]).length)
+
+        dst_lens = []
+        for v1, v2 in zip(dst_verts, dst_verts[1:]):
+            dst_lens.append((v1 - v2).length)
+        dst_lens.append((dst_verts[-1] - dst_verts[0]).length)
+
+        scales = [dst_len / src_len for src_len,dst_len in zip(src_lens, dst_lens) if abs(src_len) > 1e-6 and abs(dst_len) > 1e-6]
+        n = len(scales)
+        prod = reduce(lambda x,y: x*y, scales, 1.0)
+        return pow(prod, 1.0/n)
+
+    def interpolate_quads(self, recpt_face_data, donor, wcoef, zcoef, zoffset, X, Y, Z, i0, i1, i2, i3):
+        new_verts=[]
+
+        for v in donor.verts_v:
+            if self.xy_mode == 'BOUNDS':
+                # Map the `v` vertex's X, Y coordinates
+                # from it's bounding square to
+                # [-1/2; 1/2] square.
+                # Leave Z coordinate as it was.
+                x = self.map_bounds(donor.min_x, donor.max_x, v[X])
+                y = self.map_bounds(donor.min_y, donor.max_y, v[Y])
+                z = v[Z]
+
+                v = Vector((0, 0, 0))
+                v[X] = x
+                v[Y] = y
+                v[Z] = z
+
+            new_verts.append(self.interpolate_quad_3d(
+                                recpt_face_data.vertices_co[i0],
+                                recpt_face_data.vertices_co[i1],
+                                recpt_face_data.vertices_co[i2],
+                                recpt_face_data.vertices_co[i3],
+                                recpt_face_data.vertices_normal[i0],
+                                recpt_face_data.vertices_normal[i1],
+                                recpt_face_data.vertices_normal[i2],
+                                recpt_face_data.vertices_normal[i3],
+                                recpt_face_data.normal,
+                                v,
+                                wcoef, wcoef,
+                                zcoef, zoffset)[:])
+        return new_verts
+
+    def interpolate_tris(self, recpt_face_data, donor, wcoef, zcoef, zoffset, i0, i1, i2):
+        new_verts = []
+        for v in donor.verts_v:
+            new_verts.append(self.interpolate_tri_3d(
+                                recpt_face_data.vertices_co[i0],
+                                recpt_face_data.vertices_co[i1],
+                                recpt_face_data.vertices_co[i2],
+                                recpt_face_data.vertices_normal[i0],
+                                recpt_face_data.vertices_normal[i1],
+                                recpt_face_data.vertices_normal[i2],
+                                donor.tri_vert_1/wcoef, donor.tri_vert_2/wcoef, donor.tri_vert_3/wcoef,
+                                recpt_face_data.normal,
+                                v, zcoef, zoffset))
+        return new_verts
+
+    def verts_of_unit_triangle(self, donor):
+        # Vertices of the unit triangle.
+        # In case xy_mode != BOUNDS, we will never
+        # have to recalculate these.
+        if self.tri_bound_mode == 'EQUILATERAL':
+            donor.tri_vert_1 = self.from2d(-0.5, -sqrt_3_6)
+            donor.tri_vert_2 = self.from2d(0.5, -sqrt_3_6)
+            donor.tri_vert_3 = self.from2d(0, sqrt_3_3)
+        else:
+            donor.tri_vert_1 = self.from2d(-1, 0)
+            donor.tri_vert_2 = self.from2d(1, 0)
+            donor.tri_vert_3 = self.from2d(0, 1)
+
+    def _process_face(self, map_mode, output, recpt_face_data, donor, zcoef, zoffset, angle, wcoef, facerot):
+
+        X, Y = self.get_other_axes()
+        Z = self.normal_axis_idx()
+        #self.info(f"Face: {len(recpt_face_data.vertices_co)}, mode: {map_mode}")
+        output_numpy = self.output_numpy and not self.join
+        if map_mode == 'ASIS':
+            # Leave this recipient's face as it was - as a single face.
+            verts = recpt_face_data.vertices_co[:]
+            n = len(verts)
+            output.verts_out.append(verts)
+            output.faces_out.append([list(range(n))])
+            output.vert_recpt_idx_out.append([recpt_face_data.index for i in verts])
+            output.face_recpt_idx_out.append([recpt_face_data.index for i in range(n)])
+
+        elif map_mode == 'TRI':
+            # Tris processing mode.
+            #
+            # As interpolate_tri_3d is based on barycentric_transform,
+            # here we do not have to manually map donor vertices to the
+            # unit triangle.
+
+            i0, i1, i2 = rotate_list(self.tri_vert_idxs, facerot)
+            if self.z_scale == 'AUTO':
+                zcoef = self.calc_z_scale(
+                                    [recpt_face_data.vertices_co[i0],
+                                     recpt_face_data.vertices_co[i1],
+                                     recpt_face_data.vertices_co[i2]],
+                                    [donor.tri_vert_1/wcoef, donor.tri_vert_2/wcoef, donor.tri_vert_3/wcoef]
+                                ) * zcoef
+
+            if self.implementation == 'NumPy' or (self.implementation == 'Auto' and len(donor.verts_v) > 50):
+                new_verts = self.interpolate_tri_3d_np(recpt_face_data, donor,
+                                                       wcoef, zcoef, zoffset,
+                                                       [i0, i1, i2])
+                output.verts_out.append(new_verts if output_numpy else new_verts.tolist())
+            else:
+                new_verts = self.interpolate_tris(recpt_face_data, donor,
+                                                  wcoef, zcoef, zoffset,
+                                                  i0, i1, i2)
+                output.verts_out.append(np_array(new_verts) if output_numpy else new_verts)
+            output.faces_out.append(donor.faces_i)
+            output.face_data_out.append(donor.face_data_i)
+            output.vert_recpt_idx_out.append([recpt_face_data.index for i in new_verts])
+            output.face_recpt_idx_out.append([recpt_face_data.index for i in donor.faces_i])
+
+        elif map_mode == 'QUAD':
+            # Quads processing mode.
+            #
+            # It can process Tris, but it will look strange:
+            # triangle will be processed as degenerated Quad,
+            # where third and fourth vertices coincide.
+            # In Tissue addon, this is the only mode possible for Quads.
+            # Someone may like that behaivour, so we allow it with setting...
+            #
+            # This can process NGons in even worse way:
+            # it will take first three vertices and the last one
+            # and consider that as a Quad.
+
+            i0, i1, i2, i3 = rotate_list(self.quad_vert_idxs, facerot)
+            if self.z_scale == 'AUTO':
+                corner1 = self.from2d(donor.min_x, donor.min_y)
+                corner2 = self.from2d(donor.min_x, donor.max_y)
+                corner3 = self.from2d(donor.max_x, donor.max_y)
+                corner4 = self.from2d(donor.max_x, donor.min_y)
+
+                zcoef = self.calc_z_scale(
+                                [recpt_face_data.vertices_co[i0],
+                                 recpt_face_data.vertices_co[i1],
+                                 recpt_face_data.vertices_co[i2],
+                                 recpt_face_data.vertices_co[i3]],
+                                [corner1, corner2, corner3, corner4]
+                            ) * zcoef
+
+            new_verts = []
+            #self.info("Donor: %s", len(donor.=))
+            if self.implementation == 'NumPy' or (self.implementation == 'Auto' and len(donor.verts_v) > 12):
+                verts = donor.verts_v
+                if self.xy_mode == 'BOUNDS':
+                    print(X)
+                    verts[:, X] = self.map_bounds(donor.min_x, donor.max_x, verts[:, X])
+                    verts[:, Y] = self.map_bounds(donor.min_x, donor.max_x, verts[:, Y])
+                new_verts = self.interpolate_quad_3d_np(recpt_face_data, verts,
+                                                        wcoef, zcoef, zoffset,
+                                                        [i0, i1, i2, i3])
+
+                output.verts_out.append(new_verts if output_numpy else new_verts.tolist())
+            else:
+                new_verts = self.interpolate_quads(recpt_face_data, donor,
+                                                   wcoef, zcoef, zoffset,
+                                                   X, Y, Z,
+                                                   i0, i1, i2, i3)
+                output.verts_out.append(np_array(new_verts) if output_numpy else new_verts)
+
+            output.faces_out.append(donor.faces_i)
+            output.face_data_out.append(donor.face_data_i)
+            output.vert_recpt_idx_out.append([recpt_face_data.index for i in new_verts])
+            output.face_recpt_idx_out.append([recpt_face_data.index for i in donor.faces_i])
+
+        elif map_mode == 'FRAME':
+            is_fan = abs(recpt_face_data.frame_width - 1.0) < 1e-6
+            n = len(recpt_face_data.vertices_co)
+            if self.map_mode == 'QUADS':
+                sub_map_mode = 'QUAD'
+            else:
+                if is_fan:
+                    sub_map_mode = 'TRI'
+                else:
+                    sub_map_mode = 'QUAD'
+
+            if is_fan:
+                tri_faces = [(recpt_face_data.vertices_co[i],
+                                recpt_face_data.vertices_co[i+1],
+                                recpt_face_data.center) for i in range(n-1)]
+                tri_faces.append((recpt_face_data.vertices_co[-1],
+                                    recpt_face_data.vertices_co[0],
+                                    recpt_face_data.center))
+
+                if self.use_shell_factor:
+                    face_normal = sum(recpt_face_data.vertices_normal, Vector()) / n
+                else:
+                    face_normal = recpt_face_data.normal
+                tri_normals = [(recpt_face_data.vertices_normal[i],
+                                recpt_face_data.vertices_normal[i+1],
+                                face_normal) for i in range(n-1)]
+                tri_normals.append((recpt_face_data.vertices_normal[-1],
+                                    recpt_face_data.vertices_normal[0],
+                                    face_normal))
+
+                for tri_face, tri_normal in zip(tri_faces, tri_normals):
+                    sub_recpt = recpt_face_data.copy()
+                    sub_recpt.vertices_co = tri_face
+                    sub_recpt.vertices_normal = tri_normal
+                    sub_recpt.vertices_idxs = [0, 1, 2]
+                    self._process_face(sub_map_mode, output, sub_recpt, donor, zcoef, zoffset, angle, wcoef, facerot)
+            else:
+                inner_verts = [vert.lerp(recpt_face_data.center, recpt_face_data.frame_width)
+                                    for vert in recpt_face_data.vertices_co]
+                if self.use_shell_factor:
+                    inner_normals = [normal.lerp(recpt_face_data.normal, recpt_face_data.frame_width)
+                                        for normal in recpt_face_data.vertices_normal]
+                else:
+                    face_normal = sum(recpt_face_data.vertices_normal, Vector()) / n
+                    inner_normals = [normal.lerp(face_normal, recpt_face_data.frame_width)
+                                        for normal in recpt_face_data.vertices_normal]
+
+                quad_faces = [(recpt_face_data.vertices_co[i],
+                                recpt_face_data.vertices_co[i+1],
+                                inner_verts[i+1], inner_verts[i])
+                                    for i in range(n-1)]
+                quad_faces.append((recpt_face_data.vertices_co[-1],
+                                    recpt_face_data.vertices_co[0],
+                                    inner_verts[0], inner_verts[-1]))
+                quad_normals = [(recpt_face_data.vertices_normal[i],
+                                recpt_face_data.vertices_normal[i+1],
+                                inner_normals[i+1], inner_normals[i])
+                                    for i in range(n-1)]
+                quad_normals.append((recpt_face_data.vertices_normal[-1],
+                                    recpt_face_data.vertices_normal[0],
+                                    inner_normals[0], inner_normals[-1]))
+
+                for quad_face, quad_normal in zip(quad_faces, quad_normals):
+                    sub_recpt = recpt_face_data.copy()
+                    sub_recpt.vertices_co = quad_face
+                    sub_recpt.vertices_normal = quad_normal
+                    sub_recpt.vertices_idxs = [0, 1, 2, 3]
+                    self._process_face(sub_map_mode, output, sub_recpt, donor, zcoef, zoffset, angle, wcoef, facerot)
+
+    def get_map_mode(self, mask, sides_n):
+
+        if not mask:
+            return  self.mask_mode
+
+        if sides_n == 3:
+            if self.frame_mode == 'ALWAYS':
+                return 'FRAME'
+            if self.map_mode == 'QUADTRI':
+                return 'TRI'
+            return 'QUAD'
+
+        if sides_n == 4:
+            if self.frame_mode in ['ALWAYS', 'NGONQUAD']:
+                return 'FRAME'
+            return 'QUAD'
+
+        if self.frame_mode in ['ALWAYS', 'NGONQUAD', 'NGONS']:
+            return 'FRAME'
+
+        if self.ngon_mode == 'QUADS':
+            return 'QUAD'
+        if self.ngon_mode == 'ASIS':
+            return 'ASIS'
+
+        return 'SKIP'
+
+    def _process(self, verts_recpt, faces_recpt, verts_donor, faces_donor, face_data_donor, frame_widths, zcoefs, zoffsets, zrotations, wcoefs, facerots, mask, single_donor, donor_index):
+        bm = bmesh_from_pydata(verts_recpt, [], faces_recpt, normal_update=True)
+        bm_verts = bm.verts
+        bm_verts.ensure_lookup_table()
+
+        # single_donor = self.matching_mode == 'LONG'
+        # frame_level = get_data_nesting_level(frame_widths)
+        if single_donor:
+            # Original (unrotated) donor vertices
+            donor_verts_o = [Vector(v) for v in verts_donor]
+
+            verts_donor = [verts_donor]
+            faces_donor = [faces_donor]
+            face_data_donor = [face_data_donor]
+
+        if self.matching_mode == 'LONG':
+            verts_donor_match, faces_donor_match, face_data_match = make_repeaters([verts_donor, faces_donor, face_data_donor])
+        else:
+            if self.donor_matching_mode == 'REPEAT':
+                verts_donor_match, faces_donor_match, face_data_match = make_repeaters([verts_donor, faces_donor, face_data_donor])
+            elif  self.donor_matching_mode == 'CYCLE':
+                verts_donor_match, faces_donor_match, face_data_match = make_cyclers([verts_donor, faces_donor, face_data_donor])
+            else:
+                verts_donor_match, faces_donor_match, face_data_match = [], [], []
+                if not face_data_donor[0]:
+                    face_data_match = cycle([[]])
+                n_faces_recpt = len(faces_recpt)
+                for i, idx in zip(range(n_faces_recpt), cycle(donor_index)):
+                    idx_f = idx%(n_faces_recpt-1)
+                    verts_donor_match.append(verts_donor[idx % len(verts_donor)])
+                    faces_donor_match.append(faces_donor[idx % len(faces_donor)])
+                    if face_data_donor[0]:
+                        face_data_match.append(face_data_donor[idx % len(face_data_donor)])
+
+
+
+        X, Y = self.get_other_axes()
+        Z = self.normal_axis_idx()
+
+        donor = DonorData()
+        self.verts_of_unit_triangle(donor)
+
+        if single_donor:
+            # We will be rotating the donor object around Z axis,
+            # so it's size along Z is not going to change.
+            z_size = diameter(donor_verts_o, Z)
+
+        output = OutputData()
+
+        prev_angle = None
+        face_data = zip(faces_recpt, bm.faces, frame_widths, verts_donor_match, faces_donor_match, face_data_match, zcoefs, zoffsets, zrotations, wcoefs, facerots, mask)
+        recpt_face_idx = 0
+        for recpt_face, recpt_face_bm, frame_width, donor_verts_i, donor_faces_i, donor_face_data_i, zcoef, zoffset, angle, wcoef, facerot, m in face_data:
+
+            recpt_face_data = RecptFaceData()
+            recpt_face_data.index = recpt_face_idx
+            recpt_face_data.normal = recpt_face_bm.normal
+            recpt_face_data.center = recpt_face_bm.calc_center_median()
+            recpt_face_data.vertices_co = [bm_verts[i].co for i in recpt_face]
+            if self.use_shell_factor:
+                recpt_face_data.vertices_normal = [bm_verts[i].normal * bm_verts[i].calc_shell_factor() for i in recpt_face]
+            else:
+                recpt_face_data.vertices_normal = [bm_verts[i].normal for i in recpt_face]
+            recpt_face_data.vertices_idxs = recpt_face[:]
+            if not isinstance(frame_width, (int, float)):
+                raise Exception(f"Unexpected data type for frame_width: {frame_width}")
+            recpt_face_data.frame_width = frame_width
+
+            donor.faces_i = donor_faces_i
+            donor.face_data_i = donor_face_data_i
+            map_mode = self.get_map_mode(len(recpt_face), m)
+            if self.implementation == 'Auto':
+                is_fan = abs(frame_width - 1.0) < 1e-6
+                numpy_candidate = len(donor_verts_i) > (50 if map_mode == "TRIS" or (map_mode=='FRAME' and is_fan) else 12)
+            else:
+                numpy_candidate = False
+            if not single_donor:
+                # Original (unrotated) donor vertices
+                donor_verts_o = [Vector(v) for v in donor_verts_i]
+                z_size = diameter(donor_verts_o, Z)
+
+            # We have to recalculate rotated vertices only if
+            # the rotation angle have changed.
+            if prev_angle is None or angle != prev_angle or not single_donor:
+                verts_v = self.rotate_z(donor_verts_o, angle)
+                np_verts = np_array(verts_v)
+                if self.implementation == 'NumPy' or (numpy_candidate):
+                    donor.verts_v = np_verts
+                else:
+                    donor.verts_v = verts_v
+
+                if self.xy_mode == 'BOUNDS' or self.z_scale == 'AUTO' :
+                    donor.max_x = np_max(np_verts[:, X])
+                    donor.min_x = np_min(np_verts[:, X])
+
+                    donor.max_y = np_max(np_verts[:, Y])
+                    donor.min_y = np_min(np_verts[:, Y])
+
+                if self.xy_mode == 'BOUNDS':
+                    donor.tri_vert_1, donor.tri_vert_2, donor.tri_vert_3 = self.bounding_triangle(verts_v)
+
+            prev_angle = angle
+
+            if self.z_scale == 'CONST':
+                if abs(z_size) < 1e-6:
+                    zcoef = 0
+                else:
+                    zcoef = zcoef / z_size
+
+            # Define TRI/QUAD mode based on node settings.
+
+
+            # if not m:
+            #     map_mode = self.mask_mode
+            # else:
+            #     if n == 3:
+            #         if self.frame_mode == 'ALWAYS':
+            #             map_mode = 'FRAME'
+            #         else:
+            #             if self.map_mode == 'QUADTRI':
+            #                 map_mode = 'TRI'
+            #             else: # self.map_mode == 'QUADS':
+            #                 map_mode = 'QUAD'
+            #     elif n == 4:
+            #         if self.frame_mode in ['ALWAYS', 'NGONQUAD']:
+            #             map_mode = 'FRAME'
+            #         else:
+            #             map_mode = 'QUAD'
+            #     else:
+            #         if self.frame_mode in ['ALWAYS', 'NGONQUAD', 'NGONS']:
+            #             map_mode = 'FRAME'
+            #         else:
+            #             if self.ngon_mode == 'QUADS':
+            #                 map_mode = 'QUAD'
+            #             elif self.ngon_mode == 'ASIS':
+            #                 map_mode = 'ASIS'
+            #             else:
+            #                 map_mode = 'SKIP'
+            #
+            # if map_mode == 'SKIP':
+            #     # Skip this recipient's face - do not produce any vertices/faces for it
+            #     continue
+
+            self._process_face(map_mode, output, recpt_face_data, donor, zcoef, zoffset, angle, wcoef, facerot)
+            recpt_face_idx += 1
+
+        bm.free()
+
+        return output
+
+    def process(self):
+        if not any(output.is_linked for output in self.outputs):
+            return
+
+        verts_recpt_s = self.inputs['VersR'].sv_get(deepcopy=False)
+        faces_recpt_s = self.inputs['PolsR'].sv_get(default=[[]], deepcopy=False)
+        verts_donor_s = self.inputs['VersD'].sv_get(deepcopy=False)
+        faces_donor_s = self.inputs['PolsD'].sv_get(deepcopy=False)
+        face_data_donor_s = self.inputs['FaceDataD'].sv_get(default=[[]], deepcopy=False)
+        zcoefs_s = self.inputs['Z_Coef'].sv_get(deepcopy=False)
+        zoffsets_s = self.inputs['Z_Offset'].sv_get(deepcopy=False)
+        zrotations_s = self.inputs['Z_Rotation'].sv_get(deepcopy=False)
+        wcoefs_s = self.inputs['W_Coef'].sv_get(deepcopy=False)
+        frame_widths_s = self.inputs['FrameWidth'].sv_get(deepcopy=False)
+        facerots_s = self.inputs['PolyRotation'].sv_get(default=[[0]], deepcopy=False)
+        mask_s = self.inputs['PolyMask'].sv_get(default=[[1]], deepcopy=False)
+        thresholds_s = self.inputs['Threshold'].sv_get(deepcopy=False)
+        donor_index_s = self.inputs['Donor Index'].sv_get(deepcopy=False)
+
+
+        output = OutputData()
+
+        single_donor = self.matching_mode == 'LONG' or len(verts_donor_s) < 2
+        if not single_donor:
+        # if self.matching_mode == 'PERFACE':
+            verts_donor_s = [verts_donor_s]
+            faces_donor_s = [faces_donor_s]
+            face_data_donor_s = [face_data_donor_s]
+            #self.info("FW: %s", frame_widths_s)
+            #frame_widths_s = [frame_widths_s]
+        objects = match_long_repeat([verts_recpt_s, faces_recpt_s,
+                                     verts_donor_s, faces_donor_s, face_data_donor_s,
+                                     frame_widths_s,
+                                     zcoefs_s, zoffsets_s, zrotations_s,
+                                     wcoefs_s, facerots_s, mask_s,
+                                     thresholds_s,
+                                     donor_index_s])
+        #self.info("N objects: %s", len(list(zip(*objects))))
+        for verts_recpt, faces_recpt, verts_donor, faces_donor, face_data_donor, frame_widths, zcoefs, zoffsets, zrotations, wcoefs, facerots, mask, threshold, donor_index in zip(*objects):
+            n_faces_recpt = len(faces_recpt)
+
+            if get_data_nesting_level(frame_widths) < 1:
+                frame_widths = [frame_widths]
+
+            zcoefs, zoffsets, zrotations, frame_widths, wcoefs, facerots = make_repeaters([zcoefs, zoffsets, zrotations, frame_widths, wcoefs, facerots])
+            mask = cycle_for_length(mask, n_faces_recpt)
+
+            if isinstance(threshold, (list, tuple)):
+                threshold = threshold[0]
+
+            new = self._process(verts_recpt, faces_recpt,
+                                verts_donor, faces_donor,
+                                face_data_donor,
+                                frame_widths,
+                                zcoefs, zoffsets, zrotations,
+                                wcoefs, facerots,
+                                mask, single_donor,
+                                donor_index)
+
+            output.verts_out.extend(new.verts_out)
+            output.faces_out.extend(new.faces_out)
+            output.face_data_out.extend(new.face_data_out)
+            output.vert_recpt_idx_out.extend(new.vert_recpt_idx_out)
+            output.face_recpt_idx_out.extend(new.face_recpt_idx_out)
+
+            # output.verts_out = Vector_degenerate(output.verts_out)
+            if self.join:
+                output.verts_out, _, output.faces_out = mesh_join(output.verts_out, [], output.faces_out)
+                output.face_data_out = sum(output.face_data_out, [])
+                output.vert_recpt_idx_out = sum(output.vert_recpt_idx_out, [])
+                output.face_recpt_idx_out = sum(output.face_recpt_idx_out, [])
+
+                if self.remove_doubles:
+                    doubles_res = remove_doubles(output.verts_out, [], output.faces_out, threshold, face_data=output.face_data_out, vert_data=output.vert_recpt_idx_out)
+                    if len(doubles_res) == 4:
+                        output.verts_out, _, output.faces_out, data_out = doubles_res
+                    else:
+                        output.verts_out, _, output.faces_out = doubles_res
+                        data_out = dict()
+                    output.vert_recpt_idx_out = data_out.get('verts', [])
+                    if output.face_recpt_idx_out:
+                        output.face_recpt_idx_out = [output.face_recpt_idx_out[idx] for idx in data_out['face_init_index']]
+
+                output.verts_out = [output.verts_out]
+                output.faces_out = [output.faces_out]
+                output.face_data_out = [output.face_data_out]
+                output.vert_recpt_idx_out = [output.vert_recpt_idx_out]
+                output.face_recpt_idx_out = [output.face_recpt_idx_out]
+
+            self.outputs['Vertices'].sv_set(output.verts_out)
+            self.outputs['Polygons'].sv_set(output.faces_out)
+            if 'FaceData' in self.outputs:
+                self.outputs['FaceData'].sv_set(output.face_data_out)
+            if 'VertRecptIdx' in self.outputs:
+                self.outputs['VertRecptIdx'].sv_set(output.vert_recpt_idx_out)
+            if 'FaceRecptIdx' in self.outputs:
+                self.outputs['FaceRecptIdx'].sv_set(output.face_recpt_idx_out)
+
+def register():
+    bpy.utils.register_class(SvAdaptivePolygonsNodeMk3)
+
+def unregister():
+    bpy.utils.unregister_class(SvAdaptivePolygonsNodeMk3)

--- a/nodes/modifier_make/adaptive_polygons_mk3.py
+++ b/nodes/modifier_make/adaptive_polygons_mk3.py
@@ -286,26 +286,20 @@ class SvAdaptivePolygonsNodeMk3(bpy.types.Node, SverchCustomTreeNode):
         update=updateNode)
 
     transform_modes = [("SKIP", "Skip", "Don't Output Anything", 0),
-                       ("ASIS", "As Is", "Output the reciever face", 1),
-                       ("TRI", "Tris", "Perform Tris Transfrom", 2),
-                       ("QUAD", "Quads", "Perform Quad Transfrom", 3),
-                       ("FAN", "Fan", "Perform Fan Transfrom", 4),
-                       ("SUB_QUADS", "SubQuads", "Divides the face in 4 + Quad Transfrom", 5),
-                       ("FRAME", "Frame", "Perform Frame Transfrom", 6),
+                       ("ASIS", "As Is", "Output the receiver face", 1),
+                       ("TRI", "Tris", "Perform Tris Transform", 2),
+                       ("QUAD", "Quads", "Perform Quad Transform", 3),
+                       ("FAN", "Fan", "Perform Fan Transform", 4),
+                       ("SUB_QUADS", "SubQuads", "Divides the face in 4 + Quad Transform", 5),
+                       ("FRAME", "Frame", "Perform Frame Transform", 6),
                        ("FRAME_FAN", "Auto Frame Fan", "Perform Frame transform if Frame With is lower than 1 otherwise perform Fan", 7),
                        ("FRAME_QUADS", "Auto Frame Sub Quads", "Frame transform if Frame With is lower than 1 otherwise perform Sub Quads transform", 8),
-                       ("FAN_QUAD", "Fan (Quad)", "Fan Subdividision + Quad Transform", 9),
-                       ("FRAME_TRI", "Frame (Tri)", "Frame Subdividision + Tri Transform", 10),
-                       ("SUB_QUADS_TRI", "Sub Quads (Tri)", "Quads Subdividision + Tri Transform", 11),
+                       ("FAN_QUAD", "Fan (Quad)", "Fan Subdivision + Quad Transform", 9),
+                       ("FRAME_TRI", "Frame (Tri)", "Frame Subdivision + Tri Transform", 10),
+                       ("SUB_QUADS_TRI", "Sub Quads (Tri)", "Quads Subdivision + Tri Transform", 11),
                        ]
-    transform_description = 'Use the mask to control how transformation is done\n' \
-                            '0 = Skip\n1 = As Is\n'\
-                            '2 = Tris\n3 = Quads\n'\
-                            '4 = Fan\n5 = SubQuads\n'\
-                            '6 = Frame\n7 = Auto Frame Fan\n'\
-                            '8 = Auto Frame Sub Quads\n9 = Fan (Quad)\n'\
-                            '10 = Frame (Tri)\n11 = Sub Quads (Tri)'
-    td = ''.join([f'{p[3]} = {p[1]} ({p[2]})\n' for p in transform_modes])
+
+    transform_description = ''.join([f'{p[3]} = {p[1]} ({p[2]})\n' for p in transform_modes])
     transform_dict = {p[0]: p[3] for p in transform_modes}
 
     @throttle_and_update_node
@@ -324,7 +318,7 @@ class SvAdaptivePolygonsNodeMk3(bpy.types.Node, SverchCustomTreeNode):
     skip_modes = [
             ("SKIP", "Skip", "Do not output anything", 0),
             ("ASIS", "As Is", "Output these faces as is", 1),
-            ("TRANSFORM", "Transform Control", td, 2)
+            ("TRANSFORM", "Transform Control", transform_description, 2)
         ]
 
     mask_mode: EnumProperty(
@@ -373,7 +367,7 @@ class SvAdaptivePolygonsNodeMk3(bpy.types.Node, SverchCustomTreeNode):
 
     transform_mask: EnumProperty(
         name="Transform",
-        description="Transform method:\n"+ td + 'Selected',
+        description="Transform method:\n"+ transform_description + 'Selected',
         items=transform_modes, default="QUAD",
         update=update_sockets
     )

--- a/old_nodes/adaptive_polygons_mk2.py
+++ b/old_nodes/adaptive_polygons_mk2.py
@@ -98,7 +98,7 @@ class SvAdaptivePolygonsNodeMk2(bpy.types.Node, SverchCustomTreeNode):
     bl_label = 'Adaptive Polygons Mk2'
     bl_icon = 'OUTLINER_OB_EMPTY'
     sv_icon = 'SV_ADAPTATIVE_POLS'
-
+    replacement_nodes = [('SvAdaptivePolygonsNodeMk3', None, None)]
     axes = [
             ("X", "X", "Orient donor's X axis along normal", 0),
             ("Y", "Y", "Orient donor's Y axis along normal", 1),
@@ -116,12 +116,12 @@ class SvAdaptivePolygonsNodeMk2(bpy.types.Node, SverchCustomTreeNode):
         name='Width coeff',
         description = "Donor object width coefficient",
         default=1.0, max=3.0, min=0.5, update=updateNode)
-    
+
     frame_width: FloatProperty(
         name='Frame width',
         description = "Frame width coefficient for Frame / Fan mode",
         default=0.5, max=1.0, min=0.0, update=updateNode)
-    
+
     z_coef: FloatProperty(
         name='Z coeff',
         default=1.0, max=3.0, min=0.0, update=updateNode)
@@ -158,7 +158,7 @@ class SvAdaptivePolygonsNodeMk2(bpy.types.Node, SverchCustomTreeNode):
         description = "Use shell factor to make shell thickness constant",
         default = False,
         update = updateNode)
-    
+
     z_scale_modes = [
             ("PROP", "Proportional", "Scale along normal proportionally with the donor object", 0),
             ("CONST", "Constant", "Constant scale along normal", 1),
@@ -176,7 +176,7 @@ class SvAdaptivePolygonsNodeMk2(bpy.types.Node, SverchCustomTreeNode):
         description = "Rotate donor object around recipient's face normal",
         min = 0, max = 2*pi, default = 0,
         update = updateNode)
-    
+
     poly_rotation: IntProperty(
         name = "Polygons rotation",
         description = "Rotate indexes in polygons definition",
@@ -256,7 +256,7 @@ class SvAdaptivePolygonsNodeMk2(bpy.types.Node, SverchCustomTreeNode):
             ("NGONQUAD", "NGons and Quads", "Use Frame / Fan mode for NGons and Quads (n >= 4)", 2),
             ("ALWAYS", "Always", "Use Frame / Fan mode for all faces", 3)
         ]
-    
+
     frame_mode: EnumProperty(
         name = "Frame mode",
         description = "When to use Frame / Fan mode",
@@ -945,4 +945,3 @@ def register():
 
 def unregister():
     bpy.utils.unregister_class(SvAdaptivePolygonsNodeMk2)
-

--- a/old_nodes/adaptive_polygons_mk2.py
+++ b/old_nodes/adaptive_polygons_mk2.py
@@ -98,7 +98,12 @@ class SvAdaptivePolygonsNodeMk2(bpy.types.Node, SverchCustomTreeNode):
     bl_label = 'Adaptive Polygons Mk2'
     bl_icon = 'OUTLINER_OB_EMPTY'
     sv_icon = 'SV_ADAPTATIVE_POLS'
-    replacement_nodes = [('SvAdaptivePolygonsNodeMk3', None, None)]
+    replacement_nodes = [('SvAdaptivePolygonsNodeMk3',
+                        dict(VersR='Vertices Recipient',
+                             PolsR='Polygons Recipient',
+                             VersD='Vertices Donor',
+                             PolsD='Polygons Donor',
+                             FaceDataD='FaceData Donor'), None)]
     axes = [
             ("X", "X", "Orient donor's X axis along normal", 0),
             ("Y", "Y", "Orient donor's Y axis along normal", 1),

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -25,3 +25,7 @@ def message_on_layout(layout, text, width=140, **kwargs):
         box.label(text=line)
     return box
 
+def enum_split(layout, node, prop_name, label, factor):
+    enum_row = layout.split(factor=factor, align=False)
+    enum_row.label(text=label)
+    enum_row.prop(node, prop_name, text="")

--- a/utils/math.py
+++ b/utils/math.py
@@ -310,6 +310,20 @@ def np_vectors_angle(v1, v2):
     dot = np.dot(v1, v2)
     return np.arccos(dot)
 
+def np_normalized_vectors(vecs):
+    '''Returns new array with normalized vectors'''
+    result = np.zeros(vecs.shape)
+    norms = np.linalg.norm(vecs, axis=1)
+    nonzero = (norms > 0)
+    result[nonzero] = vecs[nonzero] / norms[nonzero][:,np.newaxis]
+    return result
+
+def np_normalize_vectors(vecs):
+    '''Does normalization in-place'''
+    norms = np.linalg.norm(vecs, axis=1)
+    nonzero = (norms > 0)
+    vecs[nonzero] = vecs[nonzero] / norms[nonzero][:,np.newaxis]
+
 def weighted_center(verts, field=None):
     if field is None:
         return np.mean(verts, axis=0)
@@ -321,4 +335,3 @@ def weighted_center(verts, field=None):
         wpoints = weights[:,np.newaxis] * verts
         result = wpoints.sum(axis=0) / weights.sum()
         return result
-

--- a/utils/sv_bmesh_utils.py
+++ b/utils/sv_bmesh_utils.py
@@ -356,7 +356,7 @@ def bmesh_join(list_of_bmeshes, normal_update=False):
 
     return bm
 
-def remove_doubles(vertices, edges, faces, d, face_data=None, vert_data=None):
+def remove_doubles(vertices, edges, faces, d, face_data=None, vert_data=None, edge_data=None):
     """
     This is a wrapper for bmesh.ops.remove_doubles.
 
@@ -366,41 +366,51 @@ def remove_doubles(vertices, edges, faces, d, face_data=None, vert_data=None):
     vert_data: arbitrary data per mesh vertex.
 
     output:
-        if face_data or vert_data was specified, this outputs 4-tuple:
+        if face_data, vert_data or edge_data was specified, this outputs 4-tuple:
             * vertices
             * edges
             * faces
             * data: a dictionary with following keys:
                 * 'vert_init_index': indexes of the output vertices in the original mesh
+                * 'edge_init_index': indexes of the output edges in the original mesh
                 * 'face_init_index': indexes of the output faces in the original mesh
-                * 'faces': correctly reordered face_data (if present)
                 * 'verts': correclty reordered vert_data (if present)
+                * 'edges': correctly reordered edge_data (if present)
+                * 'faces': correctly reordered face_data (if present)
     """
-    has_face_data = bool(face_data)
     has_vert_data = bool(vert_data)
-    bm = bmesh_from_pydata(vertices, edges, faces, normal_update=True, markup_face_data = True, markup_vert_data = True)
+    has_edge_data = bool(edge_data)
+    has_face_data = bool(face_data)
+    bm = bmesh_from_pydata(vertices, edges, faces, normal_update=True, markup_face_data=True, markup_edge_data=True, markup_vert_data=True)
     bmesh.ops.remove_doubles(bm, verts=bm.verts[:], dist=d)
     bm.verts.index_update()
     bm.edges.index_update()
     bm.faces.index_update()
     verts, edges, faces = pydata_from_bmesh(bm)
-    if has_face_data or has_vert_data:
-        data = dict()
-        vert_layer = bm.verts.layers.int.get("initial_index")
-        face_layer = bm.faces.layers.int.get("initial_index")
-        if vert_layer:
-            data['vert_init_index'] = [vert[vert_layer] for vert in bm.verts]
-        if face_layer:
-            data['face_init_index'] = [face[face_layer] for face in bm.faces]
-        if has_face_data:
-            data['faces'] = face_data_from_bmesh_faces(bm, face_data)
-        if has_vert_data:
-            data['verts'] = vert_data_from_bmesh_verts(bm, vert_data)
-        bm.free()
-        return verts, edges, faces, data
-    else:
+    if not (has_face_data or has_vert_data or has_edge_data):
         bm.free()
         return verts, edges, faces
+
+    data = dict()
+    vert_layer = bm.verts.layers.int.get("initial_index")
+    edge_layer = bm.edges.layers.int.get("initial_index")
+    face_layer = bm.faces.layers.int.get("initial_index")
+    if vert_layer:
+        data['vert_init_index'] = [vert[vert_layer] for vert in bm.verts]
+    if edge_layer:
+        data['edge_init_index'] = [edge[edge_layer] for edge in bm.edges]
+    if face_layer:
+        data['face_init_index'] = [face[face_layer] for face in bm.faces]
+    if has_vert_data:
+        data['verts'] = vert_data_from_bmesh_verts(bm, vert_data)
+    if has_edge_data:
+        data['edges'] = edge_data_from_bmesh_edges(bm, vert_data)
+    if has_face_data:
+        data['faces'] = face_data_from_bmesh_faces(bm, face_data)
+    bm.free()
+    return verts, edges, faces, data
+
+
 
 def dual_mesh(bm, recalc_normals=True):
     # Make vertices of dual mesh by finding
@@ -818,4 +828,3 @@ def recalc_normals(verts, edges, faces, loop=False):
         verts, edges, faces = pydata_from_bmesh(bm)
         bm.free()
         return verts, edges, faces
-

--- a/utils/sv_bmesh_utils.py
+++ b/utils/sv_bmesh_utils.py
@@ -381,7 +381,10 @@ def remove_doubles(vertices, edges, faces, d, face_data=None, vert_data=None, ed
     has_vert_data = bool(vert_data)
     has_edge_data = bool(edge_data)
     has_face_data = bool(face_data)
-    bm = bmesh_from_pydata(vertices, edges, faces, normal_update=True, markup_face_data=True, markup_edge_data=True, markup_vert_data=True)
+    bm = bmesh_from_pydata(vertices, edges, faces, normal_update=True,
+                           markup_face_data=has_face_data, 
+                           markup_edge_data=has_edge_data,
+                           markup_vert_data=has_vert_data)
     bmesh.ops.remove_doubles(bm, verts=bm.verts[:], dist=d)
     bm.verts.index_update()
     bm.edges.index_update()


### PR DESCRIPTION
Numpy implementation for the Adaptive polygons node.
In this scenario: 
![image](https://user-images.githubusercontent.com/10011941/103181475-b5163c80-48a1-11eb-9d1d-814f3b387e32.png)
Before 0.793 seconds. Now 0.058 seconds (13X)
I left the previous implementation because is faster when the donor has less than 12 vertices for quad transform and 50 for tris transform. (approx.)
The default is a Auto mode that switches implementation depending on the donor vert count.
Also added a Donor Matching property that can be Repeat Last, Cycle or By Index (controlled by input)
![image](https://user-images.githubusercontent.com/10011941/103181636-9a44c780-48a3-11eb-8dd3-aa1d51f709cc.png)

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

