### PR TITLE
Contour 2D Remove Caps property

### DIFF
--- a/docs/nodes/modifier_make/contour2D.rst
+++ b/docs/nodes/modifier_make/contour2D.rst
@@ -6,7 +6,7 @@ Functionality
 
 .. image:: https://user-images.githubusercontent.com/10011941/34644861-37e4c430-f33f-11e7-92e0-d89080effc4b.png
 
-This node creates one or many contours at specified distance. 
+This node creates one or many contours at specified distance.
 
 - It is feeded by sets of vertices and edges.
 - Every set of vertices needs to share the Z coordinate in order to create a valid contour.
@@ -53,6 +53,8 @@ Parameters
 |**List Match**    | Menu          | Long Cycle  |**Long Repeat**: After shortest list repeat last value.      |
 |                  |               |             |**Long Cycle**: After shortest list got to first last value. |
 +------------------+---------------+-------------+-------------------------------------------------------------+
+|**Remove Caps**   | Boolean       | False       | Remove arcs in the vertices with only one edge.             |
++------------------+---------------+-------------+-------------------------------------------------------------+
 
 
 Outputs
@@ -70,22 +72,22 @@ Examples of usage
 In constant mode independent contours will be created (one per distance)
 In Weighted mode will apply each distance to a vertex creating independent contours when there are more distances than vertices
 
-.. image:: https://user-images.githubusercontent.com/10011941/34644863-41eabfde-f33f-11e7-8ed6-6e8fa7a1e6df.png   
- 
+.. image:: https://user-images.githubusercontent.com/10011941/34644863-41eabfde-f33f-11e7-8ed6-6e8fa7a1e6df.png
+
 - When you input different objects independent contours will be created:
 
 .. image:: https://user-images.githubusercontent.com/10011941/34644864-46463d24-f33f-11e7-80c1-bb0718d9966b.png
-  
+
 
 - With the intersection mode on "Circular" the intersection points will be placed as if we were using perfect circles. This will change the edges angles, but the distance between the intersection point and the original points will be maintained. On "Poligonal" the edges angles are preserved but the distance to original vertex will depend on the number of vertices.
 
 .. image:: https://user-images.githubusercontent.com/10011941/35116834-027e2f8c-fc8d-11e7-9cff-35465e3e5e17.png
- 
+
 - Integrated list match function can lead to different results:
 
 .. image:: https://user-images.githubusercontent.com/10011941/34644870-5935b1ee-f33f-11e7-99ba-0c536bf67f91.png
 
-- Different ranges can be used to create a complex contour. 
+- Different ranges can be used to create a complex contour.
 
 .. image:: https://user-images.githubusercontent.com/10011941/35116835-029ea8de-fc8d-11e7-9df0-f044677c059a.png
 
@@ -99,7 +101,6 @@ Notes
 
 - This implementation can get very slow when working with hundreds of inputs and different distances, handle it with patience.
 
-- If the node does not create a closed contour try increasing the vertices number or rising the mask tolerance slowly 
+- If the node does not create a closed contour try increasing the vertices number or rising the mask tolerance slowly
 
 - This is the pull request where this node was added https://github.com/nortikin/sverchok/pull/2001
-


### PR DESCRIPTION
Added Remove Caps property to Contour2D node, allows an easier separation of the contour in two sides removing the arcs where there is only one edge.
![image](https://user-images.githubusercontent.com/10011941/103409908-394e1580-4b69-11eb-84cd-2c2e5d9b7267.png)
Not a full solution but can help with #3802
![image](https://user-images.githubusercontent.com/10011941/103409996-a1046080-4b69-11eb-87b4-4ccadb0a0f15.png)

- [x] Ready for merge.

