### PR TITLE
Changing from fraction import gcd (obsolete) from math import gcd pyt…

### DIFF
--- a/nodes/number/scalar_mk4.py
+++ b/nodes/number/scalar_mk4.py
@@ -16,8 +16,7 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
-from math import pi, e
-from fractions import gcd
+from math import pi, e, gcd
 
 import bpy
 from bpy.props import EnumProperty, FloatProperty, IntProperty, BoolProperty


### PR DESCRIPTION
…hon 3.9

## Addressed problem description
`from fractions import gcd` in /nodes/number/scalar_mk4.py breaking the sverchok installation on blender 2.9.1 with python 3.9

## Solution description
Changing to  `from math import gcd` solved the problem 


