### PR TITLE
Edge split mk3

### DIFF
--- a/docs/nodes/modifier_change/edge_split.rst
+++ b/docs/nodes/modifier_change/edge_split.rst
@@ -4,12 +4,13 @@ Split Edges
 Functionality
 -------------
 
-This node splits each edge of the input mesh. It supports two modes of operation:
+This node splits each edge of the input mesh. It supports the following modes of operation:
 
 * Split each edge in two. Place of split is defined by linear interpolation
   between two vertices of the edge with user-provided factor value.
 * Split each edge in three. The edge is split in two places. Each vertex is
   offset from one of vertices of the edge by user-provided factor value.
+* Split each edge in arbitrary number of pieces, by making several cuts. New vertices are placed evenly.
 
 Inputs
 ------
@@ -23,25 +24,37 @@ This node has the following inputs:
   node splits all edges of the mesh.
 - **Factor**. This defines where each edge must be split. The default value is 0.5.
 
-   * If **Mirror** parameter is not checked, then place of split is defined by
+   * If **Mode** parameter is set to **Simple**, then place of split is defined by
      linear interpolation between two vertices of the edge. Values of Factor
      near 0 mean the split point will be near first vertex of the edge, and
      values near 1 mean the split point will be near the second vertex of the
      edge.
-   * If **Mirror** parameter is checked, then each edge will be split in two
+   * If **Mode** parameter is set to **Mirror**, then each edge will be split in two
      places. Each place is defined by linear interpolation between one of
      vertices of the edge and the middle point of the edge. Values of factor
      near 0 will mean split points will be near vertices of the edge. Values of
      factor near 1 will mean split points will be near the middle of the edge.
+   * Otherwise, this input is not available.
+- **Cuts**. This input is available only when **Mode** parameter is set to
+  **Multiple**. Number of cuts (new vertices) to make at each edge.
+  Correspondingly, number of pieces into which each edge is split is defined as
+  ``Cuts + 1``. Set this to 0 to do not split edges. The default value is 1
+  (split each edge in two equal pieces).
 
 Parameters
 ----------
 
 This node has the following parameter:
 
-- **Mirror**. If not checked, each edge will be split in one place. If checked,
-  each edge will be split in two places, symmetrical with respect to the middle
-  of the edge. Unchecked by default.
+- **Mode**. The following options are available:
+
+  * **Simple**. Each edge will be split in one place.
+  * **Mirror**. Each edge will be split in two places, symmetrical with respect
+    to the middle of the edge.
+  * **Multiple**. Each edge will be split in several places. Number of cuts is
+    defined by **Cuts** input.
+
+  The default option is **Simple**.
 
 Outputs
 -------

--- a/index.md
+++ b/index.md
@@ -387,7 +387,7 @@
     SvExtrudeRegionNode
     SvPokeFacesNode
     SvVertMaskNode
-    SvSplitEdgesMk2Node
+    SvSplitEdgesMk3Node
     SvRigidOrigamiNode
     ---
     SvFollowActiveQuads

--- a/old_nodes/edge_split.py
+++ b/old_nodes/edge_split.py
@@ -44,7 +44,7 @@ class SvSplitEdgesNode(bpy.types.Node, SverchCustomTreeNode):
     sv_icon = 'SV_SPLIT_EDGES'
     # sv_icon = 'SV_EDGE_SPLIT'
 
-    replacement_nodes = [('SvSplitEdgesMk2Node', None, None)]
+    replacement_nodes = [('SvSplitEdgesMk3Node', None, None)]
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'mirror')

--- a/old_nodes/edge_split_mk2.py
+++ b/old_nodes/edge_split_mk2.py
@@ -55,6 +55,8 @@ class SvSplitEdgesMk2Node(bpy.types.Node, SverchCustomTreeNode):
     sv_icon = 'SV_SPLIT_EDGES'
     # sv_icon = 'SV_EDGE_SPLIT'
 
+    replacement_nodes = [('SvSplitEdgesMk3Node', None, None)]
+
     def draw_buttons(self, context, layout):
         layout.prop(self, 'mirror')
 

--- a/old_nodes/edge_split_mk2.py
+++ b/old_nodes/edge_split_mk2.py
@@ -5,33 +5,24 @@
 # SPDX-License-Identifier: GPL3
 # License-Filename: LICENSE
 
-import numpy as np
 from collections import defaultdict
 
 import bpy
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import match_long_repeat, rotate_list, repeat_last_for_length, updateNode, throttle_and_update_node
+from sverchok.data_structure import match_long_repeat, rotate_list, repeat_last_for_length, updateNode
 
 import sverchok.utils.handling_nodes as hn
 
-split_modes = [
-        ('SIMPLE', "Simple", "Split each edge in two parts, controlled by factor", 0),
-        ('MIRROR', "Mirror", "Split each edge in two symmetrical parts, controlled by factor", 1),
-        ('MULTI', "Multiple", "Split each edge in several parts, controlled by number of parts", 2)
-    ]
 
 node = hn.WrapNode()
 
 node.props.factor = hn.NodeProperties(bpy.props.FloatProperty(
         name="Factor", description="Split Factor",
         default=0.5, min=0.0, soft_min=0.0, max=1.0))
-node.props.count = hn.NodeProperties(bpy.props.IntProperty(
-        name="Cuts", description="Number of cuts to make at each edge, i.e. number of new vertices at each edge",
-        default = 1, min = 0))
-node.props.mode = hn.NodeProperties(bpy.props.EnumProperty(
-        name="Mode", description = "Edge split mode",
-        items = split_modes, default = 'SIMPLE'))
+node.props.mirror = hn.NodeProperties(bpy.props.BoolProperty(
+        name="Mirror", description="Mirror split",
+        default=False))
 
 node.inputs.verts = hn.SocketProperties(
     name='Vertices', socket_type=hn.SockTypes.VERTICES,
@@ -47,30 +38,25 @@ node.inputs.mask = hn.SocketProperties(
     deep_copy=False, vectorize=False, mandatory=False, default=[[True]])
 node.inputs.factors = hn.SocketProperties(
     name='Factor', socket_type=hn.SockTypes.STRINGS, 
-    prop=node.props.factor, deep_copy=False,
-    show_function = lambda: node.props.mode != 'MULTI')
-node.inputs.count = hn.SocketProperties(
-    name='Cuts', socket_type=hn.SockTypes.STRINGS, 
-    prop=node.props.count, deep_copy=False,
-    show_function = lambda: node.props.mode == 'MULTI')
+    prop=node.props.factor, deep_copy=False)
 
 node.outputs.verts = hn.SocketProperties(name='Vertices', socket_type=hn.SockTypes.VERTICES)
 node.outputs.edges = hn.SocketProperties(name='Edges', socket_type=hn.SockTypes.STRINGS)
 node.outputs.faces = hn.SocketProperties(name='Faces', socket_type=hn.SockTypes.STRINGS)
 
 @hn.initialize_node(node)
-class SvSplitEdgesMk3Node(bpy.types.Node, SverchCustomTreeNode):
+class SvSplitEdgesMk2Node(bpy.types.Node, SverchCustomTreeNode):
     """
     Triggers: Split Edges
     Tooltip: Split each edge of a mesh in two
     """
-    bl_idname = 'SvSplitEdgesMk3Node'
+    bl_idname = 'SvSplitEdgesMk2Node'
     bl_label = 'Split Edges'
     sv_icon = 'SV_SPLIT_EDGES'
     # sv_icon = 'SV_EDGE_SPLIT'
 
     def draw_buttons(self, context, layout):
-        layout.prop(self, 'mode')
+        layout.prop(self, 'mirror')
 
     def process(self):
 
@@ -91,16 +77,15 @@ class SvSplitEdgesMk3Node(bpy.types.Node, SverchCustomTreeNode):
 
         # sanitize the input
         input_f = list(map(lambda factor: min(1, max(0, factor)), node.inputs.factors))
-        counts = repeat_last_for_length(node.inputs.count, len(node.inputs.edges))
 
         mask = repeat_last_for_length(node.inputs.mask, len(node.inputs.edges))
-        params = match_long_repeat([node.inputs.edges, mask, input_f, counts])
+        params = match_long_repeat([node.inputs.edges, mask, input_f])
 
         offset = len(node.inputs.verts)
         new_verts = list(node.inputs.verts)
         new_edges = []
         i = 0
-        for edge, ok, factor, count in zip(*params):
+        for edge, ok, factor in zip(*params):
             if not ok:
                 new_edges.append(edge)
                 continue
@@ -110,7 +95,7 @@ class SvSplitEdgesMk3Node(bpy.types.Node, SverchCustomTreeNode):
             v0 = node.inputs.verts[i0]
             v1 = node.inputs.verts[i1]
 
-            if node.props.mode == 'MIRROR':
+            if node.props.mirror:
                 factor = factor / 2
 
                 vx = v0[0] * (1 - factor) + v1[0] * factor
@@ -139,7 +124,7 @@ class SvSplitEdgesMk3Node(bpy.types.Node, SverchCustomTreeNode):
 
                 i = i + 2
 
-            elif node.props.mode == 'SIMPLE':
+            else:
                 vx = v0[0] * (1 - factor) + v1[0] * factor
                 vy = v0[1] * (1 - factor) + v1[1] * factor
                 vz = v0[2] * (1 - factor) + v1[2] * factor
@@ -156,38 +141,6 @@ class SvSplitEdgesMk3Node(bpy.types.Node, SverchCustomTreeNode):
                         insert_after(new_faces[face_idx], vert_idx, offset+i)
 
                 i = i + 1
-
-            else: # MULTI
-                if count > 0:
-                    new_vert_idxs = []
-                    j = offset + i
-                    for p in np.linspace(0.0, 1.0, num=count+1, endpoint=False)[1:]:
-                        vx = v0[0] * (1 - p) + v1[0] * p
-                        vy = v0[1] * (1 - p) + v1[1] * p
-                        vz = v0[2] * (1 - p) + v1[2] * p
-                        va = [vx, vy, vz]
-                        new_verts.append(va)
-                        new_vert_idxs.append(j)
-                        j += 1
-
-                    if new_vert_idxs:
-                        vert_idxs = [i0] + new_vert_idxs[:]
-                        edges = list(zip(vert_idxs, vert_idxs[1:]))
-                        edges.append((vert_idxs[-1], i1))
-                        new_edges.extend(edges)
-                        
-                        for vert_idx, before, face_idx in faces_per_edge[tuple(edge)]:
-                            prev_vert_idx = vert_idx
-                            for new_vert_idx in new_vert_idxs:
-                                if before:
-                                    insert_before(new_faces[face_idx], prev_vert_idx, new_vert_idx)
-                                else:
-                                    insert_after(new_faces[face_idx], prev_vert_idx, new_vert_idx)
-                                prev_vert_idx = new_vert_idx
-                else:
-                    new_edges.append(edge)
-
-                i = i + count
 
         node.outputs.verts = new_verts
         node.outputs.edges = new_edges


### PR DESCRIPTION
This provides Mk3 of "Edge Split" node.

"Mirror" option is replaced with "Mode" parameter:

* Simple - corresponds to  old "mirror" parameter unchecked, this is the default option
* Mirror - corresponds to old "mirror" parameter checked
* Multiple - divides each edge in arbitrary number of pieces, defined by new "Cuts" input.

![Screenshot_20210114_224155](https://user-images.githubusercontent.com/284644/104628407-043dd900-56ba-11eb-8535-afae0e4f666d.png)


## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

