### PR TITLE
New String Tools Node

### DIFF
--- a/core/sockets.py
+++ b/core/sockets.py
@@ -588,6 +588,7 @@ class SvTextSocket(NodeSocket, SvSocketCommon):
     color = (0.68,  0.85,  0.90, 1)
 
     default_property: StringProperty(update=process_from_socket)
+    default_conversion_name = ConversionPolicies.LENIENT.conversion_name
 
 class SvMatrixSocket(NodeSocket, SvSocketCommon):
     '''4x4 matrix Socket type'''

--- a/docs/nodes/text/string_tools.rst
+++ b/docs/nodes/text/string_tools.rst
@@ -77,11 +77,11 @@ This node has the following parameters:
 +--------------------+-------------------------------------------------------------+-----------------------+-------------+
 |**Right Strip**     | Returns a right trim version of the string                  |                       | String      |
 +--------------------+-------------------------------------------------------------+-----------------------+-------------+
-|**Left Just**       | Returns a left justified version of the string              | 'Length': Line Length | String      |
+|**Left Justify**    | Returns a left justified version of the string              | 'Length': Line Length | String      |
 +--------------------+-------------------------------------------------------------+-----------------------+-------------+
 |**Center**          | Returns a centered string                                   | 'Length': Line Length | String      |
 +--------------------+-------------------------------------------------------------+-----------------------+-------------+
-|**Right Just**      | Returns a right justified version of the string             | 'Length': Line Length | String      |
+|**Right Justify**   | Returns a right justified version of the string             | 'Length': Line Length | String      |
 +--------------------+-------------------------------------------------------------+-----------------------+-------------+
 |**Zeros Fill**      | Fills the string with a specified number of 0 values at     | 'Length': Line Length | String      |
 |                    | the beginning                                               |                       |             |

--- a/docs/nodes/text/string_tools.rst
+++ b/docs/nodes/text/string_tools.rst
@@ -24,7 +24,7 @@ This node has the following parameters:
 +====================+=============================================================+=======================+=============+
 | Function           | Description                                                 | Options               | Output      |
 +--------------------+-------------------------------------------------------------+-----------------------+-------------+
-|**To String**       | Transforms inputs to strings.                               |                       | String      |
+|**To String**       | Transforms inputs to strings.                               | 'Level'               | String      |
 +--------------------+-------------------------------------------------------------+-----------------------+-------------+
 |**To Number**       | Transforms strings to numbers.                              |                       | Number      |
 +--------------------+-------------------------------------------------------------+-----------------------+-------------+
@@ -124,3 +124,14 @@ Outputs
 -------
 
 This node has only one output: it can output Strings or numbers
+
+Examples
+--------
+
+Placing measures:
+
+.. image:: https://user-images.githubusercontent.com/10011941/104808380-0e5cf600-57e6-11eb-9240-3f80df8c21c7.png
+
+Splitting Text:
+
+.. image:: https://user-images.githubusercontent.com/10011941/104808922-98f32480-57e9-11eb-9b43-672a60c5a898.png

--- a/docs/nodes/text/string_tools.rst
+++ b/docs/nodes/text/string_tools.rst
@@ -1,29 +1,19 @@
-Color Mix
-=========
+Strings Tools
+=============
 
 Functionality
 -------------
 
-This node allows you mix colors using many standard methods.
-
-Inputs
-------
-
-**Fac**: Amount of mixture to be applied.
-
-**Color A**: Base color.
-
-**Color B**: Top color.
-
+This node allows operating with strings with many common methods.
 
 Parameters
 ----------
 
 This node has the following parameters:
 
-+====================+=============================================================+=======================+=============+
-| Function           | Description                                                 | Options               | Output      |
 +--------------------+-------------------------------------------------------------+-----------------------+-------------+
+| Function           | Description                                                 | Options               | Output      |
++====================+=============================================================+=======================+=============+
 |**To String**       | Transforms inputs to strings.                               | 'Level'               | String      |
 +--------------------+-------------------------------------------------------------+-----------------------+-------------+
 |**To Number**       | Transforms strings to numbers.                              |                       | Number      |
@@ -97,7 +87,7 @@ This node has the following parameters:
 |                    | the beginning                                               |                       |             |
 +--------------------+-------------------------------------------------------------+-----------------------+-------------+
 
-+====================+=============================================================+
++--------------------+-------------------------------------------------------------+
 | **Booleans**       |                                                             |
 +====================+=============================================================+
 |**Starts With**     | Returns True if the string starts with defined character    |
@@ -123,7 +113,7 @@ This node has the following parameters:
 Outputs
 -------
 
-This node has only one output: it can output Strings or numbers
+This node has only one output: it can output Strings or Numbers or Booleans
 
 Examples
 --------

--- a/docs/nodes/text/string_tools.rst
+++ b/docs/nodes/text/string_tools.rst
@@ -66,8 +66,8 @@ This node has the following parameters:
 |**Count**           | Returns the number of times a specified value occurs in a   |                       | Number      |
 |                    | string                                                      |                       |             |
 +--------------------+-------------------------------------------------------------+-----------------------+-------------+
-|**Replace**         | Returns a string where a specified value is replaced with a |                       | String      |
-|                    | specified value                                             |                       |             |
+|**Replace**         | Returns a string where a specified value is replaced with a | 'Find', 'Replace'     | String      |
+|                    | specified value                                             | 'Count': -1 = all     |             |
 +--------------------+-------------------------------------------------------------+-----------------------+-------------+
 |**Lower**           | Converts a string into lower case                           |                       | String      |
 +--------------------+-------------------------------------------------------------+-----------------------+-------------+

--- a/docs/nodes/text/string_tools.rst
+++ b/docs/nodes/text/string_tools.rst
@@ -1,0 +1,126 @@
+Color Mix
+=========
+
+Functionality
+-------------
+
+This node allows you mix colors using many standard methods.
+
+Inputs
+------
+
+**Fac**: Amount of mixture to be applied.
+
+**Color A**: Base color.
+
+**Color B**: Top color.
+
+
+Parameters
+----------
+
+This node has the following parameters:
+
++====================+=============================================================+=======================+=============+
+| Function           | Description                                                 | Options               | Output      |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**To String**       | Transforms inputs to strings.                               |                       | String      |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**To Number**       | Transforms strings to numbers.                              |                       | Number      |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Join**            | Join two strings.                                           |                       | String      |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Join All**        | Joins a list of strings into one single string              | 'Add Break Lines'     | String      |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Split**           | Split string by a character into a maximum numbers of       | 'Character': Splitter | String List |
+|                    | slices                                                      | 'Max Splits'          |             |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Split Lines**     | Splits the string at line breaks and returns a list         |                       | String List |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Left Partition**  | Returns a tuple where the string is parted into three       |                       | String List |
+|                    | parts. Before defined value, the value (first occurrence),  |                       |             |
+|                    | and the rest of the string                                  |                       |             |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Right Partition** | Returns a tuple where the string is parted into three       |                       | String List |
+|                    | parts. Before defined value, the value (last occurrence),   |                       |             |
+|                    | and the rest of the string                                  |                       |             |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Find First**      | Searches the string for a specified value and returns the   | 'Start': Slice Start  | Number      |
+|                    | first position of where it was found                        | 'End': Slice End      |             |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Find First Slice**| Searches a slice of the string for a specified value and    | 'Start': Slice Start  | Number      |
+|                    | returns the first position of where it was found            | 'End': Slice End      |             |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Find Last**       | Searches the string for a specified value and returns the   |                       | Number      |
+|                    | last position of where it was found                         |                       |             |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Find Last Slice** | Searches a slice of the string for a specified value and    | 'Start': Slice Start  | Number      |
+|                    | returns the last position of where it was found             | 'End': Slice End      |             |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Find All**        | Searches the string for a specified value and returns all   |                       | Number      |
+|                    | the positions of where it was found                         |                       |             |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Find All Slice**  | Searches a slice of the string for a specified value and    | 'Start': Slice Start  | Number      |
+|                    | returns all the positions of where it was found             | 'End': Slice End      |             |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Count**           | Returns the number of times a specified value occurs in a   |                       | Number      |
+|                    | string                                                      |                       |             |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Replace**         | Returns a string where a specified value is replaced with a |                       | String      |
+|                    | specified value                                             |                       |             |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Lower**           | Converts a string into lower case                           |                       | String      |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Upper**           | Converts a string into upper case                           |                       | String      |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Capitalize**      | Converts the first character to upper case                  |                       | String      |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Title**           | Converts the first character of each word to upper case     |                       | String      |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Casefold**        | Converts string into lower case                             |                       | String      |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Swapcase**        | Swaps cases, lower case becomes upper case and vice versa   |                       | String      |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Strip**           | Returns a trimmed version of the string                     |                       | String      |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Left Strip**      | Returns a left trim version of the string                   |                       | String      |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Right Strip**     | Returns a right trim version of the string                  |                       | String      |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Left Just**       | Returns a left justified version of the string              | 'Length': Line Length | String      |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Center**          | Returns a centered string                                   | 'Length': Line Length | String      |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Right Just**      | Returns a right justified version of the string             | 'Length': Line Length | String      |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+|**Zeros Fill**      | Fills the string with a specified number of 0 values at     | 'Length': Line Length | String      |
+|                    | the beginning                                               |                       |             |
++--------------------+-------------------------------------------------------------+-----------------------+-------------+
+
++====================+=============================================================+
+| **Booleans**       |                                                             |
++====================+=============================================================+
+|**Starts With**     | Returns True if the string starts with defined character    |
++--------------------+-------------------------------------------------------------+
+|**Ends With**       | Returns True if the string ends with defined character      |
++--------------------+-------------------------------------------------------------+
+|**Is Alphanumeric** | Returns True if the string is made by letters and numbers   |
++--------------------+-------------------------------------------------------------+
+|**Is Alphabetic**   | Returns True if the string is made by letters               |
++--------------------+-------------------------------------------------------------+
+|**Is Digit**        | Returns True if the string is made by numbers               |
++--------------------+-------------------------------------------------------------+
+|**Is Lower**        | Returns True if all the characters are in lower case        |
++--------------------+-------------------------------------------------------------+
+|**Is Space**        | Returns True if all characters in the string are whitespaces|
++--------------------+-------------------------------------------------------------+
+|**Is Title**        | Returns True if the string follows the rules of a title     |
++--------------------+-------------------------------------------------------------+
+|**Is Upper**        | Returns True if all characters in the string are upper case |
++--------------------+-------------------------------------------------------------+
+
+
+Outputs
+-------
+
+This node has only one output: it can output Strings or numbers

--- a/docs/nodes/text/text_index.rst
+++ b/docs/nodes/text/text_index.rst
@@ -14,3 +14,4 @@ Text
    viewer_text_mk3
    stethoscope_v28
    gtext
+   string_tools

--- a/index.md
+++ b/index.md
@@ -603,6 +603,8 @@
     ---
     NoteNode
     SvGTextNode
+    ---
+    SvStringsToolsNode
 
 ## BPY Data
     SvGetPropNode

--- a/nodes/text/string_tools.py
+++ b/nodes/text/string_tools.py
@@ -83,7 +83,7 @@ func_dict = {
     "find_all":   (24,  find_all,                            ('tc s'),   "Find All",         ('Character', 'Start', 'End')),
     "find_all_sl":(25,  find_all_slice,                      ('tcsn s'), "Find All Slice",   ('Character', 'Start', 'End')),
     "count":      (30,  lambda x, c: x.count(c),             ('tt s'),   "Count"),
-    "replace":    (40,  lambda x, c, c2: x.replace(c, c2),   ('tcd t'),  "Replace",          ('Find', 'Replace')),
+    "replace":    (40,  lambda x, c, c2, n: x.replace(c, c2, n),('tcds t'),  "Replace",          ('Find', 'Replace', 'Count')),
 
     "lower":      (50,  lambda x: x.lower(),                 ('t t'),    "Lower"),
     "upper":      (51,  lambda x: x.upper(),                 ('t t'),    "Upper"),

--- a/nodes/text/string_tools.py
+++ b/nodes/text/string_tools.py
@@ -124,8 +124,11 @@ mode_items = generate_node_items()
 
 def string_tools(params, constant, matching_f):
     result = []
-    func = constant
+    func, inputs_signature = constant
     params = matching_f(params)
+    for idx, signature in enumerate(inputs_signature):
+        if signature in 'tcd' and type(params[idx][0]) != str:
+            params[idx]=[str(p) for p in params[idx]]
 
     for props in zip(*params):
         result.append(func(*props))
@@ -274,8 +277,9 @@ class SvStringsToolsNode(bpy.types.Node, SverchCustomTreeNode):
             params = [si.sv_get(default=[[]], deepcopy=False) for si in self.inputs]
             matching_f = list_match_func[self.list_match]
             desired_levels = [2 if self.current_op=='join_all' else 1]*len(params)
-
-            result = recurse_f_level_control(params, current_func, string_tools, matching_f, desired_levels)
+            inputs_signature = self.sockets_signature.split(' ')[0]
+            ops = [current_func, inputs_signature]
+            result = recurse_f_level_control(params, ops, string_tools, matching_f, desired_levels)
 
             self.outputs[0].sv_set(result)
 

--- a/nodes/text/string_tools.py
+++ b/nodes/text/string_tools.py
@@ -93,9 +93,9 @@ func_dict = {
     "strip":      (60,  lambda x, c: x.strip(c),             ('tc t'),   "Strip"),
     "lstrip":     (61,  lambda x, c: x.lstrip(c),            ('tc t'),   "Left Strip"),
     "rstrip":     (62,  lambda x, c: x.rstrip(c),            ('tc t'),   "Right Strip"),
-    "ljust":      (63,  lambda x, l, c: x.ljust(l, c),       ('tsc t'),  "Left Just"),
+    "ljust":      (63,  lambda x, l, c: x.ljust(l, c),       ('tsc t'),  "Left Justify"),
     "center":     (64,  lambda x,l,c: x.center(l, c),        ('tst t'),  "Center",          ('Length', 'Character')),
-    "rjust":      (65,  lambda x, l, c: x.rjust(l, c),       ('tsc t'),  "Right Just"),
+    "rjust":      (65,  lambda x, l, c: x.rjust(l, c),       ('tsc t'),  "Right Justify"),
     "zfill":      (66,  lambda x,l: x.zfill(l),              ('ts t'),   "Zeros Fill"),
 
     "startswith": (70,  lambda x, c: x.startswith(c),        ('tc s'),   "Starts With"),

--- a/nodes/text/string_tools.py
+++ b/nodes/text/string_tools.py
@@ -1,0 +1,283 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+from math import pi, e
+
+import bpy
+from bpy.props import EnumProperty, FloatProperty, IntProperty, BoolProperty, StringProperty
+
+from sverchok.ui.sv_icons import custom_icon
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode, list_match_func, numpy_list_match_modes, numpy_list_match_func, no_space
+from sverchok.utils.sv_itertools import (recurse_fx, recurse_fxy, recurse_f_level_control)
+import numpy as np
+# pylint: disable=C0326
+
+# Rules for modification:
+#     1) Keep 4 items per column, 5 for socket labels
+#     2) only add new function with unique number
+
+def split(x, c, max_num):
+    return x.split(c, max_num) if c else x.split(' ', max_num)
+
+def join(x, add_breaks):
+    print('add_breaks', add_breaks)
+    if add_breaks[0]:
+        return [''.join([l+'\n' for l in x])]
+    else:
+        return[''.join(x)]
+def find_all(text, chars):
+    out =[]
+    index=0
+    while index < len(text):
+        f = text.find(chars, index, len(text))
+
+        if f==-1:
+            break
+        else:
+            out.append(f)
+            index=f+1
+    return out
+def find_all_slice(text, chars, start, end):
+    out =[]
+    index=start
+    while index < end+1:
+        f = text.find(chars, index, end)
+
+        if f==-1:
+            break
+        else:
+            out.append(f)
+            index=f+1
+    return out
+
+func_dict = {
+    "---------------OPS" : "#---------------------------------------------------#",
+    "to_string":  (0,   str,                                 ('t t'),    "To String"),
+    "to_number":  (1,   eval,                                ('t s'),    "To Number"),
+    "join":       (5,   lambda x, y: ''.join([x,y]),         ('tt t'),   "Join"),
+    "join_all":   (6,   join,                                ('tb t'),   "Join All",         ('Add Break Lines',)),
+    "split":      (10,  split,                               ('tcs t'),  "Split",            ('Spliter', 'Max Split')),
+    "splitlines": (11,  lambda x,b: x.splitlines(b),         ('tb t'),   "Splitlines"),
+    "partition":  (12,  lambda x, c: x.partition(c),         ('tc t'),   "Left Partition"),
+    "rpartition": (13,  lambda x, c: x.rpartition(c),        ('tc t'),   "Right Partition"),
+    "find_f_all": (20,  lambda x, c: x.find(c),              ('tc s'),   "Find First",       ('Character', 'Start', 'End')),
+    "find_f_sli": (21,  lambda x, c, s, e: x.find(c, s, e),  ('tcsn s'), "Find First Slice", ('Character', 'Start', 'End')),
+    "find_l_all": (22,  lambda x, c: x.rfind(c),             ('tc s'),   "Find Last",        ('Character', 'Start', 'End')),
+    "find_l_sli": (23,  lambda x, c, s, e: x.rfind(c, s, e), ('tcsn s'), "Find Last Slice",  ('Character', 'Start', 'End')),
+    "find_all":   (24,  find_all,                            ('tc s'),   "Find All",         ('Character', 'Start', 'End')),
+    "find_all_sl":(25,  find_all_slice,                      ('tcsn s'), "Find All Slice",   ('Character', 'Start', 'End')),
+    "count":      (30,  lambda x, c: x.count(c),             ('tt s'),   "Count"),
+    "replace":    (40,  lambda x, c, c2: x.replace(c, c2),   ('tcd t'),  "Replace",          ('Find', 'Replace')),
+
+    "lower":      (50,  lambda x: x.lower(),                 ('t t'),    "Lower"),
+    "upper":      (51,  lambda x: x.upper(),                 ('t t'),    "Upper"),
+    "capitalize": (52,  lambda x : x.capitalize(),           ('t t'),    "Capitalize"),
+    "title":      (53,  lambda x: x.title(),                 ('t t'),    "Title"),
+    "casefold":   (54,  lambda x : x.casefold(),             ('t t'),    "Casefold"),
+    "swapcase":   (55,  lambda x: x.swapcase(),              ('t t'),    "Swapcase"),
+
+    "strip":      (60,  lambda x, c: x.strip(c),             ('tc t'),   "Strip"),
+    "lstrip":     (61,  lambda x, c: x.lstrip(c),            ('tc t'),   "Left Strip"),
+    "rstrip":     (62,  lambda x, c: x.rstrip(c),            ('tc t'),   "Right Strip"),
+    "ljust":      (63,  lambda x, l, c: x.ljust(l, c),       ('tsc t'),  "Left Just"),
+    "center":     (64,  lambda x,l,c: x.center(l, c),        ('tst t'),  "Center",          ('Length', 'Character')),
+    "rjust":      (65,  lambda x, l, c: x.rjust(l, c),       ('tsc t'),  "Right Just"),
+    "zfill":      (66,  lambda x,l: x.zfill(l),              ('ts t'),   "Zeros Fill"),
+
+    "startswith": (70,  lambda x, c: x.startswith(c),        ('tc s'),   "Starts With"),
+    "endswith":   (71,  lambda x, c: x.endswith(c),          ('tc s'),   "Ends With"),
+    "isalnum":    (72,  lambda x: x.isalnum(),               ('t s'),    "Is Alphanumeric"),
+    "isalpha":    (73,  lambda x: x.isalpha(),               ('t s'),    "Is Alphabetic"),
+    "isdigit":    (74,  lambda x: x.isdigit(),               ('t s'),    "Is Digit"),
+    "islower":    (75,  lambda x: x.islower(),               ('t s'),    "Is Lower"),
+    "isspace":    (76,  lambda x: x.isspace(),               ('t s'),    "Is Space"),
+    "istitle":    (77,  lambda x: x.istitle(),               ('t s'),    "Is Title"),
+    "isupper":    (78,  lambda x: x.isupper(),               ('t s'),    "Is Upper"),
+
+}
+
+
+def func_from_mode(mode):
+    return func_dict[mode][1]
+
+def generate_node_items():
+    prefilter = {k: v for k, v in func_dict.items() if not k.startswith('---')}
+    return [(k, params[3], '', params[0]) for k, params in sorted(prefilter.items(), key=lambda k: k[1][0])]
+
+mode_items = generate_node_items()
+
+def string_tools(params, constant, matching_f):
+    result = []
+    func = constant
+    params = matching_f(params)
+
+    for props in zip(*params):
+        result.append(func(*props))
+
+    return result
+
+class SvStringsToolsNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: Text modifier
+    Tooltip: Strings operations as split, to uppecase, find characters...
+    """
+
+    bl_idname = 'SvStringsToolsNode'
+    bl_label = 'Strings Tools'
+    sv_icon = 'SV_SCALAR_MATH'
+
+    def mode_change(self, context):
+        self.update_sockets()
+        updateNode(self, context)
+
+
+    current_op: EnumProperty(
+        name="Function", description="Function choice", default="join",
+        items=mode_items, update=mode_change)
+
+    xi_: IntProperty(default=1, name='x', update=updateNode)
+    yi_: IntProperty(default=1, name='y', update=updateNode)
+
+
+    list_match: EnumProperty(
+        name="List Match",
+        description="Behavior on different list lengths",
+        items=numpy_list_match_modes, default="REPEAT",
+        update=updateNode)
+
+    text: StringProperty(
+        name='Text',
+        description='Text to modify',
+        default='', update=updateNode)
+
+    text2: StringProperty(
+        name='Text',
+        description='Text to modify',
+        default='', update=updateNode)
+
+    chars: StringProperty(
+        name='Characters',
+        description='Text to modify',
+        default='', update=updateNode)
+
+    chars2: StringProperty(
+        name='Characters',
+        description='Text to modify',
+        default='', update=updateNode)
+    keep_brakes:BoolProperty(
+        name='Keep breaks',
+        description='Text to modify',
+        default=False, update=updateNode)
+
+    sockets_signature: StringProperty(
+        name='Characters',
+        default='tt t',
+        )
+
+    def draw_label(self):
+        num_inputs = len(self.inputs)
+        label = [self.current_op]
+        if self.hide:
+            return " ".join(label).title()
+        else:
+            return str(self.bl_label)
+
+    def draw_buttons(self, ctx, layout):
+        row = layout.row(align=True)
+        row.prop(self, "current_op", text="", icon_value=custom_icon("SV_FUNCTION"))
+
+    def rclick_menu(self, context, layout):
+        layout.prop_menu_enum(self, "current_op", text="Function")
+
+    def sv_init(self, context):
+        self.inputs.new('SvTextSocket', "Text").prop_name = 'text'
+        self.inputs.new('SvTextSocket', "Text 2").prop_name = 'text2'
+        for socket in self.inputs:
+            socket.custom_draw = 'draw_prop_socket'
+            socket.label = socket.name
+        self.outputs.new('SvTextSocket', "Out")
+
+    def draw_prop_socket(self, socket, context, layout):
+        if socket.is_linked:
+            layout.label(text=socket.label + f". {socket.objects_number or ''}")
+        elif socket.prop_name:
+            layout.prop(self, socket.prop_name, text=socket.label)
+        else:
+            layout.label(text=socket.label)
+
+    def update_sockets(self):
+        data =  func_dict.get(self.current_op)
+        socket_info = func_dict.get(self.current_op)[2]
+        if self.sockets_signature == socket_info:
+            return
+        t_inputs, t_outputs = socket_info.split(' ')
+        old_inputs, old_outputs = self.sockets_signature.split(' ')
+        self.sockets_signature = socket_info
+        for s in range(len(self.inputs[1:])):
+            self.inputs.remove(self.inputs[-1])
+        for idx, s in enumerate(t_inputs[1:]):
+            if s=="t":
+                socket = self.inputs.new('SvTextSocket', 'Text 2')
+                socket.prop_name = 'text2'
+            elif s=="c":
+                socket = self.inputs.new('SvTextSocket', 'Characters')
+                socket.prop_name = 'chars'
+            elif s=="d":
+                socket = self.inputs.new('SvTextSocket', 'Characters 2')
+                socket.prop_name = 'chars2'
+            elif s=="s":
+                socket = self.inputs.new('SvStringsSocket', 'Number')
+                socket.prop_name = 'xi_'
+
+            elif s=="n":
+                socket = self.inputs.new('SvStringsSocket', 'Number 2')
+                socket.prop_name = 'yi_'
+                socket.custom_draw = 'draw_prop_socket'
+                socket.label = socket.name
+            elif s=="b":
+                socket = self.inputs.new('SvTextSocket', 'Keep Breaks')
+                socket.prop_name = 'keep_brakes'
+            socket.custom_draw = 'draw_prop_socket'
+            if len(data)>4:
+                print(data[4], idx)
+                socket.label = data[4][idx]
+            else:
+                socket.label = socket.name
+
+        if t_outputs != old_outputs:
+            self.outputs.remove(self.outputs[0])
+            if t_outputs == 't':
+                self.outputs.new('SvTextSocket', "Out")
+            else:
+                self.outputs.new('SvStringsSocket', 'Out')
+
+    def process(self):
+
+        if self.outputs[0].is_linked:
+            current_func = func_from_mode(self.current_op)
+            params = [si.sv_get(default=[[]], deepcopy=False) for si in self.inputs]
+            matching_f = list_match_func[self.list_match]
+            desired_levels = [2 if self.current_op=='join_all' else 1]*len(params)
+
+            result = recurse_f_level_control(params, current_func, string_tools, matching_f, desired_levels)
+
+            self.outputs[0].sv_set(result)
+
+classes = [SvStringsToolsNode]
+register, unregister = bpy.utils.register_classes_factory(classes)

--- a/nodes/text/text_out_mk2.py
+++ b/nodes/text/text_out_mk2.py
@@ -105,14 +105,20 @@ def format_to_text(data):
             out += str(d)+'\n'
     return out
 
+def get_text_data(node):
+    out = []
+    if node.inputs['Text'].links:
+        data = node.inputs['Text'].sv_get(deepcopy=False)
+        out = format_to_text(data)
+
+    return out
+
 def get_sv_data(node):
     out = []
     if node.inputs['Data'].links:
         data = node.inputs['Data'].sv_get(deepcopy=False)
         if node.sv_mode == 'pretty':
             out = pprint.pformat(data)
-        elif node.sv_mode == 'text':
-            out = format_to_text(data)
         else:
             out = str(data)
 
@@ -130,8 +136,7 @@ class SvTextOutNodeMK2(bpy.types.Node, SverchCustomTreeNode):
 
     sv_modes = [
         ('compact',     'Compact',      'Using str()',        1),
-        ('pretty',      'Pretty',       'Using pretty print', 2),
-        ('text',        'Text',       'Using pretty print', 3)]
+        ('pretty',      'Pretty',       'Using pretty print', 2)]
 
     json_modes = [
         ('compact',     'Compact',      'Minimal',            1),
@@ -153,6 +158,8 @@ class SvTextOutNodeMK2(bpy.types.Node, SverchCustomTreeNode):
             self.base_name = 'Data '
         elif self.text_mode == 'SV':
             self.inputs.new('SvStringsSocket', 'Data')
+        elif self.text_mode == 'TEXT':
+            self.inputs.new('SvStringsSocket', 'Text')
 
     def pointer_update(self, context):
         if self.file_pointer:
@@ -241,6 +248,8 @@ class SvTextOutNodeMK2(bpy.types.Node, SverchCustomTreeNode):
             out = get_json_data(node=self)
         elif self.text_mode == 'SV':
             out = get_sv_data(node=self)
+        elif self.text_mode == 'TEXT':
+            out = get_text_data(node=self)
         return out
 
     def set_pointer_from_filename(self):

--- a/utils/sv_obj_helper.py
+++ b/utils/sv_obj_helper.py
@@ -34,7 +34,7 @@ def enum_from_list(*item_list):
     """
     usage:   var = enum_from_list('TOP_BASELINE', 'TOP')
     produces:  [('TOP_BASELINE', 'TOP_BASELINE', '', 0), ('TOP', 'TOP', '', 1)]
-    """    
+    """
     return [(item, item, "", idx) for idx, item in enumerate(item_list)]
 
 def enum_from_list_idx(*item_list):
@@ -65,7 +65,7 @@ def get_random_init_v3():
 def tracked_operator(node, layout_element, fn_name='', text='', icon=None):
     """
     this is a wrapper around the layout.operator(CALLBACK_OP....), it allows
-    us to track the nodetree and nodename origins of the callback. 
+    us to track the nodetree and nodename origins of the callback.
 
     // Without treename and nodename it's not possible to tell where the button press comes from
     // and now you can just press the button, without first making a node selected or active.
@@ -78,7 +78,7 @@ def tracked_operator(node, layout_element, fn_name='', text='', icon=None):
     button = layout_element.operator(CALLBACK_OP, **operator_props)
     button.fn_name = fn_name
     button.node_name = node.name
-    button.tree_name = node.id_data.name    
+    button.tree_name = node.id_data.name
 
 
 class SvObjectsHelperCallback(bpy.types.Operator):
@@ -214,14 +214,14 @@ class SvObjHelper():
             if not self.parent_name in bpy.data.objects:
                 empty = bpy.data.objects.new(self.parent_name, None)
                 collection.objects.link(empty)
-                scene.update()        
+                scene.update()
 
     def to_parent(self, objs):
         for obj in objs:
             if self.parent_to_empty:
                 obj.parent = bpy.data.objects[self.parent_name]
             elif obj.parent:
-                obj.parent = None        
+                obj.parent = None
 
     layer_choice: BoolVectorProperty(
         subtype='LAYER', size=20, name="Layer Choice",
@@ -240,7 +240,7 @@ class SvObjHelper():
         default='Alpha',
         description="which base name the object and data will use",
         update=updateNode
-    )    
+    )
 
     # most importantly, what kind of base data are we making?
     data_kind: StringProperty(name='data kind', default='MESH')
@@ -261,19 +261,19 @@ class SvObjHelper():
     use_smooth: BoolProperty(name='use smooth', default=True, update=updateNode)
 
     parent_to_empty: BoolProperty(name='parent to empty', default=False, update=updateNode)
-    parent_name: StringProperty(name='parent name')  # calling updateNode would recurse.    
-    
+    parent_name: StringProperty(name='parent name')  # calling updateNode would recurse.
+
     custom_collection_name: StringProperty(
         name='collection name', update=updateNode,
         description='custom collection name, will default to the basename of the node first')
 
     def sv_init_helper_basedata_name(self):
-        """ 
+        """
         this is to be used in sv_init, at the top
         """
-        dname = get_random_init_v3()
+        dname = bpy.context.scene.sv_object_names.get_available_name()
         self.basedata_name = dname
-        self.use_custom_color = True        
+        self.use_custom_color = True
 
 
     def icons(self, TYPE):
@@ -290,7 +290,7 @@ class SvObjHelper():
         row = col.row(align=True)
         row.column().prop(self, "activate", text="LIVE", toggle=True)
 
-        for op_name in common_ops: 
+        for op_name in common_ops:
             tracked_operator(self, row, fn_name=op_name, icon=self.icons(op_name))
 
     def draw_object_buttons(self, context, layout):
@@ -333,6 +333,9 @@ class SvObjHelper():
             kinds = bpy.data.curves
         elif self.data_kind == 'META':
             kinds = bpy.data.metaballs
+        elif self.data_kind == 'FONT':
+            kinds = bpy.data.curves
+
 
         objects = bpy.data.objects
         collection = bpy.context.scene.collection
@@ -353,7 +356,7 @@ class SvObjHelper():
 
         # delete associated meshes/curves etc
         for object_name in obj_names:
-            kinds.remove(kinds[object_name])        
+            kinds.remove(kinds[object_name])
 
     def create_object(self, object_name, obj_index, data):
         """
@@ -408,10 +411,10 @@ class SvObjHelper():
 
     def push_custom_matrix_if_present(self, sv_object, matrix):
         if matrix:
-            # matrix = matrix_sanitizer(matrix)    
+            # matrix = matrix_sanitizer(matrix)
             sv_object.matrix_local = matrix
         else:
-            sv_object.matrix_local = Matrix.Identity(4)    
+            sv_object.matrix_local = Matrix.Identity(4)
 
 
 def register():

--- a/utils/sv_text_io_common.py
+++ b/utils/sv_text_io_common.py
@@ -30,7 +30,8 @@ READY_COLOR = (0.5, 0.7, 1)
 text_modes = [
     ("CSV",         "Csv",          "Csv data",           1),
     ("SV",          "Sverchok",     "Python data",        2),
-    ("JSON",        "JSON",         "Sverchok JSON",      3)]
+    ("JSON",        "JSON",         "Sverchok JSON",      3),
+    ("TEXT",        "Text",         "Sverchok JSON",      4)]
 
 name_dict = {'m': 'Matrix', 's': 'Data', 'v': 'Vertices'}
 


### PR DESCRIPTION
New Strings Tools node with common python strings routines 
![image](https://user-images.githubusercontent.com/10011941/104808393-32203c00-57e6-11eb-906f-e1c4b063a034.png)

![image](https://user-images.githubusercontent.com/10011941/104808380-0e5cf600-57e6-11eb-9240-3f80df8c21c7.png)
 Also covers the functionality of #3619
![image](https://user-images.githubusercontent.com/10011941/104808922-98f32480-57e9-11eb-9b43-672a60c5a898.png)
Added a Text mode to Text Out+ and Text In+ input text data as strings:
![image](https://user-images.githubusercontent.com/10011941/104808847-31d57000-57e9-11eb-8050-eac442870372.png)

And added a bugfix on typography viewer when deleting objects 
- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

