### PR TITLE
Map range sensitive clamp

### DIFF
--- a/nodes/number/range_map.py
+++ b/nodes/number/range_map.py
@@ -39,7 +39,11 @@ def map_range(params, constant, matching_f):
         res = new_min + (val - old_min) * ((new_max - new_min)/(old_max - old_min))
 
         if clamp and not auto_limits:
-            res = np.clip(res, new_min, new_max)
+            mask = new_min < new_max
+            invert_mask = np.invert(mask)
+            res[mask] = np.clip(res[mask], new_min[mask], new_max[mask])
+            res[invert_mask] = np.clip(res[invert_mask], new_max[invert_mask], new_min[invert_mask])
+
         result.append(res if out_numpy else res.tolist())
 
     return result


### PR DESCRIPTION
Clamp option was not working properly when the New Max was lower than the New Min.
This PR fixes that 
![image](https://user-images.githubusercontent.com/10011941/105634290-9170f280-5e5d-11eb-97e4-0b107c2175b6.png)

- [x] Ready for merge.

