### PR TITLE
socket menus to rclick menu

### DIFF
--- a/core/sockets.py
+++ b/core/sockets.py
@@ -85,8 +85,10 @@ class SV_MT_AllSocketsOptionsMenu(bpy.types.Menu):
 
         for s in node.outputs:
             if hasattr(s, 'draw_menu_items'):
-                layout.label(text=s.name)
-                s.draw_menu_items(context, layout)
+                layout.context_pointer_set("socket", s)
+                layout.context_pointer_set("node", node)
+                layout.menu('SV_MT_SocketOptionsMenu', text=s.name)
+
 
 class SV_MT_SocketOptionsMenu(bpy.types.Menu):
     bl_label = "Socket Options"

--- a/core/sockets.py
+++ b/core/sockets.py
@@ -68,6 +68,25 @@ def update_interface(self, context):
     if input_node:
         group_tree.update_nodes([input_node])
 
+class SV_MT_AllSocketsOptionsMenu(bpy.types.Menu):
+    bl_label = "Sockets Options"
+
+    @classmethod
+    def poll(cls, context):
+        return hasattr(context, 'node')# and hasattr(context, 'socket')
+
+    def draw(self, context):
+        print(dir(context))
+        node = context.active_node
+
+        if not node:
+            return
+        layout = self.layout
+
+        for s in node.outputs:
+            if hasattr(s, 'draw_menu_items'):
+                layout.label(text=s.name)
+                s.draw_menu_items(context, layout)
 
 class SV_MT_SocketOptionsMenu(bpy.types.Menu):
     bl_label = "Socket Options"
@@ -1391,7 +1410,7 @@ class SvInputLinkMenuOp(bpy.types.Operator):
         return {'FINISHED'}
 
 classes = [
-    SV_MT_SocketOptionsMenu,
+    SV_MT_SocketOptionsMenu, SV_MT_AllSocketsOptionsMenu,
     SvVerticesSocket, SvMatrixSocket, SvStringsSocket, SvFilePathSocket,
     SvColorSocket, SvQuaternionSocket, SvDummySocket, SvSeparatorSocket,
     SvTextSocket, SvObjectSocket, SvDictionarySocket, SvChameleonSocket,

--- a/ui/nodeview_rclick_menu.py
+++ b/ui/nodeview_rclick_menu.py
@@ -236,7 +236,9 @@ class SvNodeviewRClickMenu(bpy.types.Menu):
             if hasattr(node, "rclick_menu"):
                 node.rclick_menu(context, layout)
                 layout.separator()
-
+            if len(node.outputs):
+                layout.menu('SV_MT_AllSocketsOptionsMenu', text='Outputs post-process')
+                layout.separator()
             if node.bl_idname in {'ViewerNode2', 'SvBmeshViewerNodeMK2'}:
                 layout.operator("node.sv_deligate_operator", text="Connect IDXViewer").fn = "+idxv"
             else:
@@ -245,7 +247,7 @@ class SvNodeviewRClickMenu(bpy.types.Menu):
                     # layout.operator("node.sv_deligate_operator", text="Connect ViewerDraw + IDX").fn="vdmk2 + idxv"
             if len(node.outputs):
                 layout.operator("node.sv_deligate_operator", text="Connect stethoscope").fn = "stethoscope"
-                layout.menu('SV_MT_AllSocketsOptionsMenu', text='Output post-process')
+
 
 
             layout.separator()

--- a/ui/nodeview_rclick_menu.py
+++ b/ui/nodeview_rclick_menu.py
@@ -245,6 +245,8 @@ class SvNodeviewRClickMenu(bpy.types.Menu):
                     # layout.operator("node.sv_deligate_operator", text="Connect ViewerDraw + IDX").fn="vdmk2 + idxv"
             if len(node.outputs):
                 layout.operator("node.sv_deligate_operator", text="Connect stethoscope").fn = "stethoscope"
+                layout.menu('SV_MT_AllSocketsOptionsMenu', text='Output post-process')
+
 
             layout.separator()
 


### PR DESCRIPTION
On my experience with socket menus I find a couple inconveniences:
Generally In a nodetree I use them in one or two nodes per setup and i don't like how they fill the working space.
Also being a nodetree property makes that you have to enable them per nodetree...

My idea/proposal is to have them accesible in the right-click menu.
![image](https://user-images.githubusercontent.com/10011941/107262495-ea857c80-6a40-11eb-981d-667ebf9d5558.png)

But i cant insert the menus  in the submenu...
I have gotten this far:
![image](https://user-images.githubusercontent.com/10011941/107262661-1dc80b80-6a41-11eb-8e91-e41c7fe88c6c.png)
Which works but is not ideal specially for nodes with many outputs... 

What do you guys think? 

Anyone could give me hint about how to insert each socket menu in a submenu?

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

