### PR TITLE
separators to in sv-extra addons

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -277,6 +277,7 @@ class SverchNodeItem(object):
             ops.value = setting[1]
 
 class SverchSeparator(object):
+    nodetype = 'separator'
     @staticmethod
     def draw(self, layout, context):
         layout.separator()


### PR DESCRIPTION
Adds the possibility to add separators in the menu.
They have to pass a node bl_idname equal to `'separator'`
- [x] Ready for merge.

