### PR TITLE
resolve Python changes to AST module

### DIFF
--- a/nodes/object_nodes/getsetprop_mk2.py
+++ b/nodes/object_nodes/getsetprop_mk2.py
@@ -85,13 +85,15 @@ def apply_alias(eval_str, nodetree=None):
     - will raise error if it isn't an bpy path
     '''
     if not eval_str.startswith("bpy."):
+
+        # special case for the nodes alias, end early
+        if eval_str.startswith("nodes") and nodetree:
+            string_path_to_current_tree = f'bpy.data.node_groups["{nodetree.name}"].nodes'
+            eval_str = eval_str.replace("nodes", string_path_to_current_tree, 1)
+            return eval_str
+
+        # all other aliases
         for alias, expanded in aliases.items():
-
-            if eval_str.startswith("nodes") and nodetree:
-                string_path_to_current_tree = f'bpy.data.node_groups["{nodetree.name}"].nodes'
-                eval_str = eval_str.replace("nodes", string_path_to_current_tree, 1)
-                break
-
             if eval_str.startswith(alias):
                 eval_str = eval_str.replace(alias, expanded, 1)
                 break

--- a/nodes/object_nodes/getsetprop_mk2.py
+++ b/nodes/object_nodes/getsetprop_mk2.py
@@ -169,10 +169,7 @@ class SvPropNodeMixin():
     @property
     def obj(self):
         eval_str = apply_alias(self.prop_name)
-        ast_path = ast.parse(eval_str) # , mode='exec|func_type|eval')
-
-        # print("SvPropNodeMixin:obj - parsing : ", eval_str)
-
+        ast_path = ast.parse(eval_str)
         path = parse_to_path(ast_path.body[0].value)
         return get_object(path)
     

--- a/nodes/object_nodes/getsetprop_mk2.py
+++ b/nodes/object_nodes/getsetprop_mk2.py
@@ -158,7 +158,7 @@ aliases = {
     "meshes": "bpy.data.meshes",
     "texts": "bpy.data.texts",
     "ng": "bpy.data.node_groups"
-    # nodes: <current_nodetree>.nodes  <-- handled in the alias function
+    # "nodes": None
 }
 
 types = {

--- a/nodes/object_nodes/getsetprop_mk2.py
+++ b/nodes/object_nodes/getsetprop_mk2.py
@@ -84,7 +84,6 @@ def apply_alias(eval_str):
     - apply standard aliases
     - will raise error if it isn't an bpy path
     '''
-    print(globals())
     if not eval_str.startswith("bpy."):
         for alias, expanded in aliases.items():
             if eval_str.startswith(alias):

--- a/nodes/object_nodes/getsetprop_mk2.py
+++ b/nodes/object_nodes/getsetprop_mk2.py
@@ -282,6 +282,9 @@ class SvSetPropNodeMK2(bpy.types.Node, SverchCustomTreeNode, SvPropNodeMixin):
 
     def process(self):
 
+        if len(self.inputs) == 0:
+            return
+
         data = self.inputs[0].sv_get()
         eval_str = apply_alias(self.prop_name)
         ast_path = ast.parse(eval_str)

--- a/nodes/object_nodes/getsetprop_mk2.py
+++ b/nodes/object_nodes/getsetprop_mk2.py
@@ -160,7 +160,7 @@ aliases = {
     "meshes": "bpy.data.meshes",
     "texts": "bpy.data.texts",
     "ng": "bpy.data.node_groups"
-    # "nodes": None
+    # "nodes": None , this is directly handled in the apply_alias function
 }
 
 types = {


### PR DESCRIPTION
## Addressed problem description

The Set/Get Property MK2 node relies on Python's AST module, which received major upgrades between Python 3.7 (Blender 2.92) and Python 3.9+ ( Blender 2.93). The upgrades to AST module broke the way this nodes parses attributes, because internally certain classes of ast have been depreciated.

## Solution description

The solution provides two extra clauses in the if-else logic of the "parse_to_path" function, these clauses show the simplified approach now permitted by the AST module.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Manual testing done. 
- [x] Ready for merge.

resolves https://github.com/nortikin/sverchok/issues/3946
