### PR TITLE
add poll to node.sv_quicklink_new_node_input

### DIFF
--- a/core/sockets.py
+++ b/core/sockets.py
@@ -1232,6 +1232,10 @@ class SvLinkNewNodeInput(bpy.types.Operator):
     bl_idname = "node.sv_quicklink_new_node_input"
     bl_label = "Add a new node to the left"
 
+    @classmethod
+    def poll(cls, context):
+        return hasattr(context, 'socket')    
+
     def execute(self, context):
         tree, node, socket = context.node.id_data, context.node, context.socket
 


### PR DESCRIPTION
## Addressed problem description

the node properties panel has a different context than the `quick_link` Operator expects, and will throw an error when used. The only sensible place to use this button is directly from the Node ui at the moment.

## Solution

Adding a poll to the Operator makes it visible, but not clickable. Removing it entirely from the properties panel is maybe possible, but is it worth it?

![image](https://user-images.githubusercontent.com/619340/111687670-d6e0e900-882a-11eb-833e-386e10a3ac80.png)



resolves #3976 