### PR TITLE
Nearest Point on Mesh

### DIFF
--- a/docs/nodes/analyzer/analyzer_index.rst
+++ b/docs/nodes/analyzer/analyzer_index.rst
@@ -27,6 +27,7 @@ Analyzers
    select_similar
    proportional
    normals
+   nearest_point_on_mesh
    bvh_overlap_polys
    object_insolation
    path_length_2

--- a/docs/nodes/analyzer/nearest_point_on_mesh.rst
+++ b/docs/nodes/analyzer/nearest_point_on_mesh.rst
@@ -39,10 +39,15 @@ Examples
 --------
 
 Used as skin-wrap modifier:
+
 .. image:: https://user-images.githubusercontent.com/10011941/111774583-f3733480-88af-11eb-9559-78392166b00c.png
 
+
 Determine which polygons are nearer than a distance:
+
 .. image:: https://user-images.githubusercontent.com/10011941/111812010-f255fd80-88d7-11eb-8f48-de67716dd93a.png
 
+
 Placing objects on mesh:
+
 .. image:: https://user-images.githubusercontent.com/10011941/111810852-bf5f3a00-88d6-11eb-9cff-eb2a6c18a01a.png

--- a/docs/nodes/analyzer/nearest_point_on_mesh.rst
+++ b/docs/nodes/analyzer/nearest_point_on_mesh.rst
@@ -38,6 +38,11 @@ Outputs
 Examples
 --------
 
+Used as skin-wrap modifier:
+.. image:: https://user-images.githubusercontent.com/10011941/111774583-f3733480-88af-11eb-9559-78392166b00c.png
 
-.. image:: https://user-images.githubusercontent.com/5783432/30777862-8d369f36-a0cd-11e7-8c8e-a72e7aa8ee7f.png
-https://github.com/nortikin/sverchok/files/1326934/bvhtree-overlap_2017_09_23_23_07.zip
+Determine which polygons are nearer than a distance:
+.. image:: https://user-images.githubusercontent.com/10011941/111812010-f255fd80-88d7-11eb-8f48-de67716dd93a.png
+
+Placing objects on mesh:
+.. image:: https://user-images.githubusercontent.com/10011941/111810852-bf5f3a00-88d6-11eb-9cff-eb2a6c18a01a.png

--- a/docs/nodes/analyzer/nearest_point_on_mesh.rst
+++ b/docs/nodes/analyzer/nearest_point_on_mesh.rst
@@ -1,0 +1,43 @@
+Nearest Point on Mesh
+=====================
+
+Functionality
+-------------
+
+Finds the closest point in a specified mesh.
+
+Inputs
+------
+
+Vertices, Faces: Base mesh for the search
+Points: Points to query
+Distance: Maximum query distance (only for Nearest in Range mode)
+
+Parameters
+----------
+
+*Mode*:
+  - Nearest: Nearest point on the mesh surface
+  - Nearest in range: Nearest points on the mesh within a range (one per face)
+
+*Flat Output*: (only in Nearest in Range) Flattens the list of every vertex to have only a list for every inputted list.
+
+*Safe Check*: (in N-Panel) When disabled polygon indices referring to unexisting points will crash Blender. Not performing this check makes node faster
+
+Outputs
+-------
+
+*Location*: Position of the closest point in the mesh
+
+*Normal*: mesh normal at closets point
+
+*Index*: Face index of the closest point
+
+*Distance*: Distance from the queried point to the closest point
+
+Examples
+--------
+
+
+.. image:: https://user-images.githubusercontent.com/5783432/30777862-8d369f36-a0cd-11e7-8c8e-a72e7aa8ee7f.png
+https://github.com/nortikin/sverchok/files/1326934/bvhtree-overlap_2017_09_23_23_07.zip

--- a/index.md
+++ b/index.md
@@ -284,6 +284,7 @@
     SvKDTreeNodeMK2
     SvKDTreeEdgesNodeMK2
     SvKDTreePathNode
+    SvNearestPointOnMeshNode
     SvBvhOverlapNodeNew
     SvMeshFilterNode
     SvEdgeAnglesNode
@@ -715,7 +716,6 @@
     SvSampleUVColorNode
     SvSubdivideLiteNode
     SvExtrudeSeparateLiteNode
-    SvBVHnearNewNode
     SvUnsubdivideNode
     SvLimitedDissolveMK2
     SvArmaturePropsNode

--- a/nodes/analyzer/nearest_point_on_mesh.py
+++ b/nodes/analyzer/nearest_point_on_mesh.py
@@ -1,0 +1,155 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+from itertools import cycle
+import bpy
+from bpy.props import EnumProperty, BoolProperty
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import (updateNode, match_long_cycle as C)
+from sverchok.utils.bvh_tree import bvh_tree_from_polygons
+from sverchok.utils.nodes_mixins.recursive_nodes import SvRecursiveNode
+from mathutils.bvhtree import BVHTree
+
+def take_third(elem):
+    return elem[2]
+
+def append_multiple(container, data):
+    for r, rl in zip(container, data):
+        r.append(rl)
+
+def translate_data(data):
+    try:
+        return data[0][:], data[1][:], data[2], data[3]
+    except TypeError:
+        return [], [], -1, -1
+
+
+def svmesh_to_bvh_lists(vsock, fsock, safe_check):
+    for vertices, polygons in zip(vsock, fsock):
+        yield bvh_tree_from_polygons(vertices, polygons, all_triangles=False, epsilon=0.0, safe_check=safe_check)
+
+def nearest_point_in_mesh(verts, faces, points, safe_check=True):
+
+    output = [[] for i in range(4)]
+    for bvh, pts in zip(svmesh_to_bvh_lists(verts, faces, safe_check), points):
+        res_local = list(zip(*[translate_data(bvh.find_nearest(P)) for P in pts]))
+        append_multiple(output, res_local)
+
+    return output
+
+def nearest_in_range(verts, faces, points, distance, safe_check=True, flat_output=True):
+
+    output = [[] for i in range(4)]
+    for bvh, pts, dist in zip(svmesh_to_bvh_lists(verts, faces, safe_check), points, distance):
+        res_local = [[] for i in range(4)]
+        for pt, d in zip(pts, cycle(dist)):
+            res = bvh.find_nearest_range(pt, d)
+
+            res = sorted(res, key=take_third)
+            unique = []
+            if flat_output:
+                for r in res:
+                    if not r[2] in unique:
+                        unique.append(r[2])
+                        append_multiple(res_local, translate_data(r))
+
+            else:
+                sub_res_local = [[] for i in range(4)]
+                for r in res:
+                    if not r[2] in unique:
+                        unique.append(r[2])
+                        append_multiple(sub_res_local, translate_data(r))
+
+                append_multiple(res_local, sub_res_local)
+
+
+        append_multiple(output, res_local)
+
+    return output
+
+
+class SvNearestPointOnMeshNode(bpy.types.Node, SverchCustomTreeNode, SvRecursiveNode):
+    """
+    Triggers: BVH Closest Point
+    Tooltip: Find nearest point on mesh surfaces
+    """
+    bl_idname = 'SvNearestPointOnMeshNode'
+    bl_label = 'Nearest Point on Mesh'
+    bl_icon = 'OUTLINER_OB_EMPTY'
+    sv_icon = 'SV_POINT_ON_MESH'
+
+    modes = [
+            ("find_nearest", "Nearest", "", 0),
+            ("find_nearest_range", "Nearest in range", "", 1),
+        ]
+
+    def update_sockets(self, context):
+        self.inputs['Distance'].hide_safe = self.mode == 'find_nearest'
+        updateNode(self, context)
+    mode: EnumProperty(name="Mode", items=modes, default='find_nearest', update=update_sockets)
+    safe_check: BoolProperty(
+        name='Safe Check',
+        description='When disabled polygon indices refering to unexisting points will crash Blender but makes node faster',
+        default=True)
+    flat_output: BoolProperty(
+        name='Flat Output',
+        description='Ouput a single list for every list in stead of a list of lists',
+        default=True,
+        update=updateNode)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'mode')
+        if self.mode == 'find_nearest_range':
+            layout.prop(self, 'flat_output')
+
+    def draw_buttons_ext(self, context, layout):
+        layout.prop(self, 'mode')
+        layout.prop(self, 'safe_check')
+
+    def sv_init(self, context):
+        si = self.inputs.new
+        so = self.outputs.new
+        si('SvVerticesSocket', 'Verts')
+        si('SvStringsSocket', 'Faces').nesting_level = 3
+        for s in self.inputs[:2]:
+            s.is_mandatory = True
+        si('SvVerticesSocket', 'Points').use_prop = True
+        si('SvStringsSocket', 'Distance').use_prop = True
+        self.inputs['Distance'].hide_safe = True
+
+        so('SvVerticesSocket', 'Location')
+        so('SvVerticesSocket', 'Normal')
+        so('SvStringsSocket', 'Index')
+        so('SvStringsSocket', 'Distance')
+
+
+    def process_data(self, params):
+        verts, faces, points, distance = params
+        if self.mode == 'find_nearest':
+            return nearest_point_in_mesh(verts, faces, points,
+                                         safe_check=self.safe_check)
+        else:
+            return nearest_in_range(verts, faces, points, distance,
+                                    safe_check=self.safe_check,
+                                    flat_output=self.flat_output)
+
+def register():
+    bpy.utils.register_class(SvNearestPointOnMeshNode)
+
+
+def unregister():
+    bpy.utils.unregister_class(SvNearestPointOnMeshNode)

--- a/nodes/analyzer/nearest_point_on_mesh.py
+++ b/nodes/analyzer/nearest_point_on_mesh.py
@@ -117,6 +117,7 @@ class SvNearestPointOnMeshNode(bpy.types.Node, SverchCustomTreeNode, SvRecursive
             layout.prop(self, 'flat_output')
 
     def draw_buttons_ext(self, context, layout):
+        layout.prop(self, 'list_match')
         layout.prop(self, 'mode')
         layout.prop(self, 'safe_check')
 
@@ -128,8 +129,10 @@ class SvNearestPointOnMeshNode(bpy.types.Node, SverchCustomTreeNode, SvRecursive
         for s in self.inputs[:2]:
             s.is_mandatory = True
         si('SvVerticesSocket', 'Points').use_prop = True
-        si('SvStringsSocket', 'Distance').use_prop = True
-        self.inputs['Distance'].hide_safe = True
+        d = si('SvStringsSocket', 'Distance')
+        d.use_prop = True
+        d.default_property = 10.0
+        d.hide_safe = True
 
         so('SvVerticesSocket', 'Location')
         so('SvVerticesSocket', 'Normal')

--- a/old_nodes/bvh_nearest_new.py
+++ b/old_nodes/bvh_nearest_new.py
@@ -29,7 +29,7 @@ class SvBVHnearNewNode(bpy.types.Node, SverchCustomTreeNode):
     bl_label = 'bvh_nearest'
     bl_icon = 'OUTLINER_OB_EMPTY'
     sv_icon = 'SV_POINT_ON_MESH'
-
+    replacement_nodes =[('SvNearestPointOnMeshNode', None, None)]
     modes = [
             ("find_nearest", "nearest", "", 0),
             ("find_nearest_range", "nearest in range", "", 1),

--- a/tests/docs_tests.py
+++ b/tests/docs_tests.py
@@ -153,7 +153,6 @@ mesh_separate_mk2.py
 symmetrize.py
 vd_attr_node_mk2.py
 scalar_field_point.py
-bvh_nearest_new.py
 quads_to_nurbs.py
 location.py
 sun_position.py""".split("\n")

--- a/utils/bvh_tree.py
+++ b/utils/bvh_tree.py
@@ -1,0 +1,20 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+from mathutils.bvhtree import BVHTree
+
+def bvh_safe_check(verts, pols):
+    len_v = len(verts)
+    for p in pols:
+        for c in p:
+            if c > len_v:
+                raise Exception(f"Index {c} should be less than vertices length ({len_v})")
+
+def bvh_tree_from_polygons(vertices, polygons, all_triangles=False, epsilon=0.0, safe_check=True):
+    if safe_check:
+        bvh_safe_check(vertices, polygons)
+    return BVHTree.FromPolygons(vertices, polygons, all_triangles=all_triangles, epsilon=epsilon)


### PR DESCRIPTION
Nearest Point on Mesh New node that replaces bvh_nearest, with:
More stability: a safe check added to prevent blender to crash,
Distance input for nearest in range mode.
Nearest in range mode auto cleaning results.
Multilevel recursion node.

Used as skin-wrap modifier
![image](https://user-images.githubusercontent.com/10011941/111774583-f3733480-88af-11eb-9559-78392166b00c.png)
Determine which polygons are nearer than a distance:
![image](https://user-images.githubusercontent.com/10011941/111812010-f255fd80-88d7-11eb-8f48-de67716dd93a.png)
Placing objects on mesh
![image](https://user-images.githubusercontent.com/10011941/111810852-bf5f3a00-88d6-11eb-9cff-eb2a6c18a01a.png)

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

