### PR TITLE
Commit log printing

### DIFF
--- a/utils/sv_update_utils.py
+++ b/utils/sv_update_utils.py
@@ -231,6 +231,7 @@ class SvPrintCommits(bpy.types.Operator):
         print("author | commit details")
         print("--- | ---")
 
+        messages = [f"The {self.num_commits} most recent commits to Sverchok (master)"]
         for i in range(self.num_commits):
             commit = json_obj[i]['commit']
             sha = os.path.basename(commit['url'])[:7]
@@ -241,7 +242,10 @@ class SvPrintCommits(bpy.types.Operator):
 
             message = f'{author} | {comment} sha: {sha}'
             print(message)
-            self.report({'INFO'}, message)
+            messages.append(message)
+
+        multiline_string_of_messages = "\n".join(messages)
+        self.report({'INFO'}, multiline_string_of_messages)
 
         return {'FINISHED'}
 

--- a/utils/sv_update_utils.py
+++ b/utils/sv_update_utils.py
@@ -221,27 +221,28 @@ class SvPrintCommits(bpy.types.Operator):
     bl_idname = "node.sv_show_latest_commits"
     bl_label = "Show latest commits"
     commits_link: bpy.props.StringProperty(default=COMMITS_LINK)
+    num_commits: bpy.props.IntProperty(default=30)
 
     def execute(self, context):
         r = requests.get(self.commits_link)
         json_obj = r.json()
-        for i in range(5):
+
+        # some table printing for github markdown
+        print("author | commit details")
+        print("--- | ---")
+
+
+        for i in range(self.num_commits):
             commit = json_obj[i]['commit']
-            comment = commit['message'].split('\n')
+            sha = os.path.basename(commit['url'])[:7]
 
-            # display on report window
-            message_dict = {
-                'sha': os.path.basename(json_obj[i]['commit']['url'])[:7],
-                'user': commit['committer']['name'],
-                'comment': comment[0] + '...' if len(comment) else ''
-            }
+            author = commit['author']['name']
+            comments = commit['message'].split('\n')
+            comment = comments[0] + '...' if len(comments) else ''
 
-            self.report({'INFO'}, '{sha} : by {user}  :  {comment}'.format(**message_dict))
-
-            # display on terminal
-            print('{sha} : by {user}'.format(**message_dict))
-            for line in comment:
-                print('    ' + line)
+            message = f'{author} | {comment} sha: {sha}'
+            print(message)
+            self.report({'INFO'}, message)
 
         return {'FINISHED'}
 

--- a/utils/sv_update_utils.py
+++ b/utils/sv_update_utils.py
@@ -231,7 +231,6 @@ class SvPrintCommits(bpy.types.Operator):
         print("author | commit details")
         print("--- | ---")
 
-
         for i in range(self.num_commits):
             commit = json_obj[i]['commit']
             sha = os.path.basename(commit['url'])[:7]

--- a/utils/sv_update_utils.py
+++ b/utils/sv_update_utils.py
@@ -229,11 +229,12 @@ class SvPrintCommits(bpy.types.Operator):
 
         rewrite_date = lambda date: f'{date[:10]}' #  @ {date[11:16]}'
 
-        # some table printing for github markdown
-        print("author | commit details")
-        print("--- | ---")
+        # table boilerplate for github markdown
+        print("author | commit details\n--- | ---")
 
+        # intro message for Info printing
         messages = [f"The {self.num_commits} most recent commits to Sverchok (master)"]
+
         for i in range(self.num_commits):
             commit = json_obj[i]['commit']
             sha = os.path.basename(commit['url'])[:7]

--- a/utils/sv_update_utils.py
+++ b/utils/sv_update_utils.py
@@ -237,6 +237,7 @@ class SvPrintCommits(bpy.types.Operator):
             sha = os.path.basename(commit['url'])[:7]
 
             author = commit['author']['name']
+            ## date = commit['author']['date'] #  format : '2021-04-03T10:44:59Z'
             comments = commit['message'].split('\n')
             comment = comments[0] + '...' if len(comments) else ''
 

--- a/utils/sv_update_utils.py
+++ b/utils/sv_update_utils.py
@@ -227,6 +227,8 @@ class SvPrintCommits(bpy.types.Operator):
         r = requests.get(self.commits_link)
         json_obj = r.json()
 
+        rewrite_date = lambda date: f'{date[:10]}' #  @ {date[11:16]}'
+
         # some table printing for github markdown
         print("author | commit details")
         print("--- | ---")
@@ -237,11 +239,11 @@ class SvPrintCommits(bpy.types.Operator):
             sha = os.path.basename(commit['url'])[:7]
 
             author = commit['author']['name']
-            ## date = commit['author']['date'] #  format : '2021-04-03T10:44:59Z'
+            date = commit['author']['date'] #  format : '2021-04-03T10:44:59Z'
             comments = commit['message'].split('\n')
             comment = comments[0] + '...' if len(comments) else ''
 
-            message = f'{author} | {comment} sha: {sha}'
+            message = f'{author} | {comment} {sha} on {rewrite_date(date)}'
             print(message)
             messages.append(message)
 


### PR DESCRIPTION
A feature update for displaying commit logs of last n commits, where:
- n is not hardcoded anymore
- terminal printout includes github flavoured markdown to automate table creation (for stable releases)
- self.report are now done in a single call to .report, all messages will be in one `Info` (multiline)..
   
![image](https://user-images.githubusercontent.com/619340/113478029-8bfbde00-9486-11eb-8788-e847346ef9f6.png)
