### PR TITLE
Component Analyzer Vertex normal modes

### DIFF
--- a/docs/nodes/analyzer/component_analyzer.rst
+++ b/docs/nodes/analyzer/component_analyzer.rst
@@ -25,7 +25,9 @@ This node has the following parameters:
 
   * For **Vertices** supported criteria are:
 
-    * **Normal**. Vertices normal vector.
+    * **Normal**. Vertices normal vector. Offers different calculation methods:
+        Bmesh (standard Blender),Mean Weighted Equally (Faster), Mean Weighted Based on Triangle Area
+        Mean Weighted Edge Length Reciprocal and Mean Weighted by Sine
     * **Matrix ZY**: Matrix aligned with normal.
     * **Sharpness**: Curvature of mesh in vertex.
     * **Adjacent Edges**: Adjacent edges.

--- a/nodes/analyzer/component_analyzer.py
+++ b/nodes/analyzer/component_analyzer.py
@@ -55,6 +55,7 @@ op_dict = { #signature : (prop_name, e for enum and b for boolean)
     'n': ('matrix_normal', 'e'),
     't': ('tangent_mode', 'e'),
     'a': ('output_numpy', 'b'),
+    'v': ('vertex_normal_mode', 'e'),
 }
 
 
@@ -99,7 +100,13 @@ class SvComponentAnalyzerNode(bpy.types.Node, SverchCustomTreeNode, SvRecursiveN
         ("X", "X", "Aligned with X", 0),
         ("Z", "Z", "Aligned with Z", 2),
     ]
-
+    vertex_normal_modes = [
+        ('BMESH', 'Bmesh', 'Slower (Legacy)', 0),
+        ('MWE', 'Mean Weighted Equally', 'Faster', 1),
+        ('MWELR','Mean Weighted Edge Length Reciprocal', '', 2),
+        ('MWAT', 'Mean Weighted Area Triangle', '', 3),
+        ('MWS', 'Mean Weighted by Sine', '', 4)
+    ]
 
     @throttle_and_update_node
     def update_mode(self, context):
@@ -192,6 +199,12 @@ class SvComponentAnalyzerNode(bpy.types.Node, SverchCustomTreeNode, SvRecursiveN
         name="Origin",
         items=pols_origin_modes,
         default="Median_Center",
+        update=update_mode)
+
+    vertex_normal_mode: EnumProperty(
+        name="Method",
+        items=vertex_normal_modes,
+        default="MWE",
         update=update_mode)
 
     matrix_track: EnumProperty(
@@ -362,6 +375,7 @@ class SvComponentAnalyzerNode(bpy.types.Node, SverchCustomTreeNode, SvRecursiveN
                 'u': self.matrix_normal_up,
                 'n': self.matrix_normal,
                 't': self.tangent_mode,
+                'v': self.vertex_normal_mode,
                 'a': self.output_numpy
             }
             special_op = []

--- a/utils/modules/vertex_utils.py
+++ b/utils/modules/vertex_utils.py
@@ -108,7 +108,7 @@ def np_faces_normals(v_pols):
     np_normalize_vectors(f_normals)
 
     return f_normals
-
+# based in this article https://www.researchgate.net/publication/220067106_A_comparison_of_algorithms_for_vertex_normal_computation
 def add_faces_normals(v_pols, np_faces_g, algorithm, pol_sides, v_normals):
     if algorithm in ('MWE', 'MWAT'):
         if algorithm == 'MWE': #weighted equally


### PR DESCRIPTION
Adds back the old bmesh method  and adds other four different algorithms to calculate them with different valid outputs
Mean Weighted Equally (Faster)
Mean Weighted Based on Triangle Area 
Mean Weighted Edge Length Reciprocal 
Mean Weighted by Sine

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

