### PR TITLE
objects in Lite, can optionally create json-stored object as a Scene object

### DIFF
--- a/nodes/scene/objects_in_lite.py
+++ b/nodes/scene/objects_in_lite.py
@@ -59,6 +59,10 @@ class SvObjInLite(bpy.types.Node, SverchCustomTreeNode):
         description='Apply modifier geometry to import (original untouched)',
         name='Modifiers', default=False, update=updateNode)
 
+    do_not_add_obj_to_scene: BoolProperty(
+        default=False,
+        description="Do not add the object to the scene if this node is imported from elsewhere") 
+    
     currently_storing: BoolProperty()
     obj_name: StringProperty(update=updateNode)
     node_dict = {}
@@ -129,6 +133,7 @@ class SvObjInLite(bpy.types.Node, SverchCustomTreeNode):
 
         row.prop(self, 'modifiers', text='', icon='MODIFIER')
         layout.label(text=display_text)
+        layout.row().prop(self, "do_not_add_obj_to_scene", text="do not add to scene")
 
 
     def pass_data_to_sockets(self):
@@ -167,6 +172,9 @@ class SvObjInLite(bpy.types.Node, SverchCustomTreeNode):
         materials = unrolled_geom.get('MaterialIdx', [])
         matrix = unrolled_geom['Matrix']
 
+        if self.do_not_add_obj_to_scene:
+            return
+
         with self.sv_throttle_tree_update():
             bm = bmesh_from_pydata(verts, edges, polygons)
             if materials:
@@ -188,7 +196,9 @@ class SvObjInLite(bpy.types.Node, SverchCustomTreeNode):
             self.error('failed to obtain local geometry, can not add to json')
             return
 
-        node_data['geom'] = json.dumps(flatten(obj))
+       self. nodo_not_add_obj_to_scene:
+        return
+        de_data['geom'] = json.dumps(flatten(obj))
 
 
 def register():

--- a/nodes/scene/objects_in_lite.py
+++ b/nodes/scene/objects_in_lite.py
@@ -198,9 +198,6 @@ class SvObjInLite(bpy.types.Node, SverchCustomTreeNode):
             self.error('failed to obtain local geometry, can not add to json')
             return
 
-        # if self.do_not_add_obj_to_scene:
-        #    return
-        
         node_data['geom'] = json.dumps(flatten(obj))
 
 

--- a/nodes/scene/objects_in_lite.py
+++ b/nodes/scene/objects_in_lite.py
@@ -174,7 +174,7 @@ class SvObjInLite(bpy.types.Node, SverchCustomTreeNode):
 
         if self.do_not_add_obj_to_scene:
             self.node_dict[hash(self)] = unrolled_geom
-            self.obj_name = "placeholder"
+            self.obj_name = name
             return
 
         with self.sv_throttle_tree_update():

--- a/nodes/scene/objects_in_lite.py
+++ b/nodes/scene/objects_in_lite.py
@@ -196,8 +196,8 @@ class SvObjInLite(bpy.types.Node, SverchCustomTreeNode):
             self.error('failed to obtain local geometry, can not add to json')
             return
 
-        if self.do_not_add_obj_to_scene:
-            return
+        # if self.do_not_add_obj_to_scene:
+        #    return
         
         node_data['geom'] = json.dumps(flatten(obj))
 

--- a/nodes/scene/objects_in_lite.py
+++ b/nodes/scene/objects_in_lite.py
@@ -196,10 +196,10 @@ class SvObjInLite(bpy.types.Node, SverchCustomTreeNode):
             self.error('failed to obtain local geometry, can not add to json')
             return
 
-        self.do_not_add_obj_to_scene:
+        if self.do_not_add_obj_to_scene:
             return
         
-        de_data['geom'] = json.dumps(flatten(obj))
+        node_data['geom'] = json.dumps(flatten(obj))
 
 
 def register():

--- a/nodes/scene/objects_in_lite.py
+++ b/nodes/scene/objects_in_lite.py
@@ -173,6 +173,8 @@ class SvObjInLite(bpy.types.Node, SverchCustomTreeNode):
         matrix = unrolled_geom['Matrix']
 
         if self.do_not_add_obj_to_scene:
+            self.node_dict[has(self)] = geom
+            self.obj_name = "placeholder"
             return
 
         with self.sv_throttle_tree_update():

--- a/nodes/scene/objects_in_lite.py
+++ b/nodes/scene/objects_in_lite.py
@@ -196,8 +196,9 @@ class SvObjInLite(bpy.types.Node, SverchCustomTreeNode):
             self.error('failed to obtain local geometry, can not add to json')
             return
 
-       self. nodo_not_add_obj_to_scene:
-        return
+        self.do_not_add_obj_to_scene:
+            return
+        
         de_data['geom'] = json.dumps(flatten(obj))
 
 

--- a/nodes/scene/objects_in_lite.py
+++ b/nodes/scene/objects_in_lite.py
@@ -173,7 +173,7 @@ class SvObjInLite(bpy.types.Node, SverchCustomTreeNode):
         matrix = unrolled_geom['Matrix']
 
         if self.do_not_add_obj_to_scene:
-            self.node_dict[has(self)] = geom
+            self.node_dict[hash(self)] = unrolled_geom
             self.obj_name = "placeholder"
             return
 


### PR DESCRIPTION
make it possible to not automatically add a stored object to the scene.
resolves #4044 