### PR TITLE
backend cleanups (licence, SvGenericNodeLocator..)

### DIFF
--- a/node_tree.py
+++ b/node_tree.py
@@ -441,7 +441,7 @@ class NodeUtils:
     def wrapper_tracked_ui_draw_op(self, layout_element, operator_idname, **keywords):
         """
         this wrapper allows you to track the origin of a clicked operator, by automatically passing
-        the idname and idtree of the tree.
+        the node_name and tree_name to the operator.
 
         example usage:
 
@@ -450,8 +450,8 @@ class NodeUtils:
 
         """
         op = layout_element.operator(operator_idname, **keywords)
-        op.idname = self.name
-        op.idtree = self.id_data.name
+        op.node_name = self.name
+        op.tree_name = self.id_data.name
         return op
 
     def get_bpy_data_from_name(self, identifier, bpy_data_kind):  # todo, method which have nothing related with nodes

--- a/nodes/exchange/gcode_exporter.py
+++ b/nodes/exchange/gcode_exporter.py
@@ -1,20 +1,9 @@
-# ##### BEGIN GPL LICENSE BLOCK #####
-#
-#  This program is free software; you can redistribute it and/or
-#  modify it under the terms of the GNU General Public License
-#  as published by the Free Software Foundation; either version 2
-#  of the License, or (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software Foundation,
-#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ##### END GPL LICENSE BLOCK #####
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
 
 # made by: Alessandro Zomparelli
 # url: www.alessandrozomparelli.com

--- a/nodes/exchange/nurbs_in.py
+++ b/nodes/exchange/nurbs_in.py
@@ -1,3 +1,9 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
 
 import bpy
 from bpy.props import FloatProperty, EnumProperty, BoolProperty, StringProperty

--- a/nodes/list_mutators/multi_cache.py
+++ b/nodes/list_mutators/multi_cache.py
@@ -25,8 +25,7 @@ class SvvMultiCacheReset(bpy.types.Operator, SvGenericNodeLocator):
 
     def execute(self, context):
         node = self.get_node(context)
-        if not node:
-            return {'CANCELLED'}
+        if not node: return {'CANCELLED'}
         
         node.fill_empty_dict()
         updateNode(node, context)

--- a/nodes/list_mutators/multi_cache.py
+++ b/nodes/list_mutators/multi_cache.py
@@ -1,46 +1,36 @@
-# ##### BEGIN GPL LICENSE BLOCK #####
-#
-#  This program is free software; you can redistribute it and/or
-#  modify it under the terms of the GNU General Public License
-#  as published by the Free Software Foundation; either version 2
-#  of the License, or (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software Foundation,
-#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ##### END GPL LICENSE BLOCK #####
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
 
 import ast
 import inspect
 from itertools import product
-from mathutils.noise import seed_set, random
+
 import bpy
 from bpy.props import FloatVectorProperty, IntVectorProperty, IntProperty, BoolProperty, StringProperty, EnumProperty
-
+from mathutils.noise import seed_set, random
 
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import changable_sockets, dataCorrect, updateNode, zip_long_repeat
+from sverchok.utils.sv_operator_utils import SvGenericNodeLocator
 
 
-class SvvMultiCacheReset(bpy.types.Operator):
+class SvvMultiCacheReset(bpy.types.Operator, SvGenericNodeLocator):
     '''Clear Cache'''
     bl_idname = "node.multy_cache_reset"
     bl_label = "Multi Cache Reset"
 
-    idtree: bpy.props.StringProperty(default='')
-    idname: bpy.props.StringProperty(default='')
-
     def execute(self, context):
-        node = bpy.data.node_groups[self.idtree].nodes[self.idname]
-        node.fill_empty_dict()
-        updateNode(node, context)
-        return {'FINISHED'}
+        node = self.get_node(context)
+        if node:
+            node.fill_empty_dict()
+            updateNode(node, context)
+            return {'FINISHED'}
+        return {'CANCELLED'}
+
 
 class SvMultiCacheNode(bpy.types.Node, SverchCustomTreeNode):
     """
@@ -80,11 +70,9 @@ class SvMultiCacheNode(bpy.types.Node, SverchCustomTreeNode):
     memory: StringProperty(default="")
 
     def draw_buttons(self, context, layout):
-
         layout.prop(self, 'pause_recording')
         layout.prop(self, 'unwrap')
         self.wrapper_tracked_ui_draw_op(layout, "node.multy_cache_reset", icon='X', text="RESET")
-
 
     def sv_init(self, context):
         self.inputs.new('SvStringsSocket', 'Data')
@@ -92,7 +80,6 @@ class SvMultiCacheNode(bpy.types.Node, SverchCustomTreeNode):
         self.inputs.new('SvStringsSocket', 'Out Bucket').prop_name = 'out_bucket'
         self.outputs.new('SvStringsSocket', 'Data')
         self.fill_empty_dict()
-
 
     def write_memory_prop(self, data):
         '''write values to string property'''
@@ -117,6 +104,7 @@ class SvMultiCacheNode(bpy.types.Node, SverchCustomTreeNode):
     def process(self):
         if not self.outputs['Data'].is_linked:
             return
+
         in_bucket_s = self.inputs['In Bucket'].sv_get()[0]
         out_bucket_s = self.inputs['Out Bucket'].sv_get()[0]
         if not self.node_id in self.node_mem:

--- a/nodes/list_mutators/multi_cache.py
+++ b/nodes/list_mutators/multi_cache.py
@@ -25,11 +25,12 @@ class SvvMultiCacheReset(bpy.types.Operator, SvGenericNodeLocator):
 
     def execute(self, context):
         node = self.get_node(context)
-        if node:
-            node.fill_empty_dict()
-            updateNode(node, context)
-            return {'FINISHED'}
-        return {'CANCELLED'}
+        if not node:
+            return {'CANCELLED'}
+        
+        node.fill_empty_dict()
+        updateNode(node, context)
+        return {'FINISHED'}
 
 
 class SvMultiCacheNode(bpy.types.Node, SverchCustomTreeNode):

--- a/nodes/logic/evolver.py
+++ b/nodes/logic/evolver.py
@@ -1,20 +1,10 @@
-# ##### BEGIN GPL LICENSE BLOCK #####
-#
-#  This program is free software; you can redistribute it and/or
-#  modify it under the terms of the GNU General Public License
-#  as published by the Free Software Foundation; either version 2
-#  of the License, or (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software Foundation,
-#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ##### END GPL LICENSE BLOCK #####
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
 
 import ast
 import random
@@ -22,15 +12,16 @@ import time
 from collections import namedtuple
 from typing import NamedTuple
 import numpy as np
-import bpy
-from bpy.props import (
-    BoolProperty, StringProperty, EnumProperty, IntProperty, FloatProperty
-    )
 
+import bpy
 from mathutils.noise import seed_set, random
+from bpy.props import (
+    BoolProperty, StringProperty, EnumProperty, IntProperty, FloatProperty)
+
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode
 from sverchok.core.update_system import make_tree_from_nodes, do_update
+from sverchok.utils.sv_operator_utils import SvGenericNodeLocator
 from sverchok.utils.listutils import (
     listinput_getI,
     listinput_getF,
@@ -537,17 +528,14 @@ class Population:
         self.node.info_label = info
 
 
-class SvEvolverRun(bpy.types.Operator):
+class SvEvolverRun(bpy.types.Operator, SvGenericNodeLocator):
 
     bl_idname = "node.evolver_run"
     bl_label = "Evolver Run"
 
-    idtree: bpy.props.StringProperty(default='')
-    idname: bpy.props.StringProperty(default='')
-
     def execute(self, context):
-        tree = bpy.data.node_groups[self.idtree]
-        node = bpy.data.node_groups[self.idtree].nodes[self.idname]
+        node = self.get_node(context)
+        if not node: return {'CANCELLED'}
 
         if not node.inputs[0].is_linked:
             node.info_label = "Stopped - Fitness not linked"
@@ -577,17 +565,15 @@ def set_fittest(tree, genes, agent, update_list):
     finally:
         tree.sv_process = True
 
-class SvEvolverSetFittest(bpy.types.Operator):
+class SvEvolverSetFittest(bpy.types.Operator, SvGenericNodeLocator):
 
     bl_idname = "node.evolver_set_fittest"
     bl_label = "Evolver Run"
 
-    idtree: bpy.props.StringProperty(default='')
-    idname: bpy.props.StringProperty(default='')
-
     def execute(self, context):
-        tree = bpy.data.node_groups[self.idtree]
-        node = bpy.data.node_groups[self.idtree].nodes[self.idname]
+        node = self.get_node(context)
+        if not node: return {'CANCELLED'}
+
         data = evolver_mem[node.node_id]
         genes = data["genes"]
         population = data["population"]
@@ -778,10 +764,6 @@ class SvEvolverNode(bpy.types.Node, SverchCustomTreeNode):
             self.info_label = "Not Executed"
             for s in self.outputs:
                 s.sv_set([])
-
-
-
-
 
 
 classes = [SvEvolverRun, SvEvolverSetFittest, SvEvolverNode]

--- a/nodes/logic/genes_holder.py
+++ b/nodes/logic/genes_holder.py
@@ -1,42 +1,32 @@
-# ##### BEGIN GPL LICENSE BLOCK #####
-#
-#  This program is free software; you can redistribute it and/or
-#  modify it under the terms of the GNU General Public License
-#  as published by the Free Software Foundation; either version 2
-#  of the License, or (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software Foundation,
-#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ##### END GPL LICENSE BLOCK #####
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
 
 import ast
 from itertools import product
+
 from mathutils.noise import seed_set, random
 import bpy
 from bpy.props import FloatVectorProperty, IntVectorProperty, IntProperty, BoolProperty, StringProperty, EnumProperty
 
-
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import dataCorrect, updateNode
+from sverchok.utils.sv_operator_utils import SvGenericNodeLocator
 
 
-class SvGenesHolderReset(bpy.types.Operator):
+class SvGenesHolderReset(bpy.types.Operator, SvGenericNodeLocator):
 
     bl_idname = "node.number_genes_reset"
     bl_label = "Number Genes Reset"
 
-    idtree: bpy.props.StringProperty(default='')
-    idname: bpy.props.StringProperty(default='')
-
     def execute(self, context):
-        node = bpy.data.node_groups[self.idtree].nodes[self.idname]
+        node = self.get_node(context)
+        if not node:
+            return {'CANCELLED'}
+
         if node.number_type == 'vector':
             input_name = 'Vertices'
         else:
@@ -151,7 +141,6 @@ class SvGenesHolderNode(bpy.types.Node, SverchCustomTreeNode):
                     row2 .prop(self, prop[i], index=j, text='XYZ'[j])
 
     def draw_buttons(self, context, layout):
-
 
         col = layout.column(align=True)
         row = col.row(align=True)

--- a/nodes/logic/genes_holder.py
+++ b/nodes/logic/genes_holder.py
@@ -24,8 +24,7 @@ class SvGenesHolderReset(bpy.types.Operator, SvGenericNodeLocator):
 
     def execute(self, context):
         node = self.get_node(context)
-        if not node:
-            return {'CANCELLED'}
+        if not node: return {'CANCELLED'}
 
         if node.number_type == 'vector':
             input_name = 'Vertices'

--- a/nodes/network/file_path.py
+++ b/nodes/network/file_path.py
@@ -40,10 +40,11 @@ class SvFilePathFinder(bpy.types.Operator, SvGenericNodeLocator):
 
     def execute(self, context):
         node = self.get_node(context)
-        if node:
-            node.set_data(self.directory, self.files)
-            return {'FINISHED'}
-        return {'CANCELLED'}
+        if not node:
+            return {'CANCELLED'}
+
+        node.set_data(self.directory, self.files)
+        return {'FINISHED'}
 
     def invoke(self, context, event):
         wm = context.window_manager

--- a/nodes/network/file_path.py
+++ b/nodes/network/file_path.py
@@ -23,29 +23,27 @@ from bpy.types import (
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode, match_long_repeat
 from sverchok.utils.modules import sv_bmesh
+from sverchok.utils.sv_operator_utils import SvGenericNodeLocator
 
-class SvFilePathFinder(bpy.types.Operator):
+
+class SvFilePathFinder(bpy.types.Operator, SvGenericNodeLocator):
     '''Select Files from browser window'''
     bl_idname = "node.sv_file_path"
     bl_label = "Select Files/Folder"
 
-    idtree: StringProperty(default='')
-    idname: StringProperty(default='')
-    files: CollectionProperty(
-            name="File Path",
-            type=OperatorFileListElement,
-            )
-    directory: StringProperty(
-            subtype='DIR_PATH',
-            )
+    files: CollectionProperty(name="File Path", type=OperatorFileListElement)
+    directory: StringProperty(subtype='DIR_PATH')
+
     filepath: bpy.props.StringProperty(
         name="File Path", description="Filepath used for writing waveform files",
         maxlen=1024, default="", subtype='FILE_PATH')
 
     def execute(self, context):
-        node = bpy.data.node_groups[self.idtree].nodes[self.idname]
-        node.set_data(self.directory, self.files)
-        return {'FINISHED'}
+        node = self.get_node(context)
+        if node:
+            node.set_data(self.directory, self.files)
+            return {'FINISHED'}
+        return {'CANCELLED'}
 
     def invoke(self, context, event):
         wm = context.window_manager
@@ -57,22 +55,15 @@ class SvFilePathNode(bpy.types.Node, SverchCustomTreeNode):
     """
     Triggers: OS file path
     Tooltip:  get path file from OS
-
     """
 
     bl_idname = "SvFilePathNode"
     bl_label = "File Path"
     bl_icon = "FILE"
 
-    files_num: bpy.props.IntProperty(name='files number ', default=0)
-
-    files: CollectionProperty(
-        name="File Path",
-        type=OperatorFileListElement,
-        )
-    directory: StringProperty(
-        subtype='DIR_PATH',
-        update=updateNode)
+    files_num: IntProperty(name='files number ', default=0)
+    files: CollectionProperty(name="File Path", type=OperatorFileListElement)
+    directory: StringProperty(subtype='DIR_PATH', update=updateNode)
 
     def sv_init(self, context):
 

--- a/nodes/network/file_path.py
+++ b/nodes/network/file_path.py
@@ -40,8 +40,7 @@ class SvFilePathFinder(bpy.types.Operator, SvGenericNodeLocator):
 
     def execute(self, context):
         node = self.get_node(context)
-        if not node:
-            return {'CANCELLED'}
+        if not node: return {'CANCELLED'}
 
         node.set_data(self.directory, self.files)
         return {'FINISHED'}

--- a/nodes/scene/obj_edit.py
+++ b/nodes/scene/obj_edit.py
@@ -1,20 +1,9 @@
-# ##### BEGIN GPL LICENSE BLOCK #####
-#
-#  This program is free software; you can redistribute it and/or
-#  modify it under the terms of the GNU General Public License
-#  as published by the Free Software Foundation; either version 2
-#  of the License, or (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software Foundation,
-#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ##### END GPL LICENSE BLOCK #####
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
 
 import bpy
 from bpy.props import BoolProperty, StringProperty, EnumProperty

--- a/nodes/scene/objects_in_lite.py
+++ b/nodes/scene/objects_in_lite.py
@@ -1,20 +1,9 @@
-# ##### BEGIN GPL LICENSE BLOCK #####
-#
-#  This program is free software; you can redistribute it and/or
-#  modify it under the terms of the GNU General Public License
-#  as published by the Free Software Foundation; either version 2
-#  of the License, or (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software Foundation,
-#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ##### END GPL LICENSE BLOCK #####
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
 
 import bpy
 from bpy.props import BoolProperty, StringProperty, EnumProperty

--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -43,7 +43,7 @@ class SVOB3B_UL_NamesList(bpy.types.UIList):
 class SvOB3BItemOperator(bpy.types.Operator, SvGenericNodeLocator):
 
     bl_idname = "node.sv_ob3b_collection_operator"
-    bl_label = "bladibla"
+    bl_label = "generic bladibla"
 
     fn_name: StringProperty(default='')
     idx: IntProperty()

--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -1,20 +1,9 @@
-# ##### BEGIN GPL LICENSE BLOCK #####
-#
-#  This program is free software; you can redistribute it and/or
-#  modify it under the terms of the GNU General Public License
-#  as published by the Free Software Foundation; either version 2
-#  of the License, or (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software Foundation,
-#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ##### END GPL LICENSE BLOCK #####
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
 
 import bpy
 from bpy.props import BoolProperty, StringProperty

--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -268,8 +268,9 @@ class SvObjectsNodeMK3(Show3DProperties, bpy.types.Node, SverchCustomTreeNode, S
             mtrx = []
             materials = []
 
-            # events inside this function can trigger dependancy graph updates, 
-            # it is necessary to call throttle here to prevent recursive sverchok tree updates.
+            # code inside this context can trigger dependancy graph update events, 
+            # it is necessary to call throttle here to prevent Sverchok from responding to these updates:
+            # not doing so would trigger recursive updates and Blender would likely become unresponsive.
             with self.sv_throttle_tree_update():
 
                 mtrx = obj.matrix_world

--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -289,7 +289,6 @@ class SvObjectsNodeMK3(Show3DProperties, bpy.types.Node, SverchCustomTreeNode, S
                     else:
 
                         if self.modifiers:
-
                             obj = sv_depsgraph.objects[obj.name]
                             obj_data = obj.to_mesh(preserve_all_data_layers=True, depsgraph=sv_depsgraph)
                         else:

--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -50,8 +50,7 @@ class SvOB3BItemOperator(bpy.types.Operator, SvGenericNodeLocator):
 
     def execute(self, context):
         node = self.get_node(context)
-        if not node:
-            return {'CANCELLED'}
+        if not node: return {'CANCELLED'}
 
         if self.fn_name == 'REMOVE':
             node.object_names.remove(self.idx)
@@ -74,8 +73,7 @@ class SvOB3Callback(bpy.types.Operator, SvGenericNodeLocator):
         print from self.report.
         """
         node = self.get_node(context)
-        if not node:
-            return {'CANCELLED'}
+        if not node: return {'CANCELLED'}
 
         getattr(node, self.fn_name)(self)
         return {'FINISHED'}

--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -287,7 +287,7 @@ class SvObjectsNodeMK3(Show3DProperties, bpy.types.Node, SverchCustomTreeNode, S
                     else:
 
                         """
-                        in a throttled tree update state we can aquire a depsgraph if
+                        in a throttled tree update state we can acquire a depsgraph if
                         - modifiers
                         - or vertex groups are desired
                         """

--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -6,7 +6,7 @@
 # License-Filename: LICENSE
 
 import bpy
-from bpy.props import BoolProperty, StringProperty
+from bpy.props import BoolProperty, StringProperty, IntProperty
 import bmesh
 
 import sverchok
@@ -40,14 +40,13 @@ class SVOB3B_UL_NamesList(bpy.types.UIList):
         action.idx = index
 
 
-
 class SvOB3BItemOperator(bpy.types.Operator, SvGenericNodeLocator):
 
     bl_idname = "node.sv_ob3b_collection_operator"
     bl_label = "bladibla"
 
-    fn_name: bpy.props.StringProperty(default='')
-    idx: bpy.props.IntProperty()
+    fn_name: StringProperty(default='')
+    idx: IntProperty()
 
     def execute(self, context):
         node = self.get_node(context)

--- a/nodes/scene/objects_mk3.py
+++ b/nodes/scene/objects_mk3.py
@@ -268,6 +268,8 @@ class SvObjectsNodeMK3(Show3DProperties, bpy.types.Node, SverchCustomTreeNode, S
             mtrx = []
             materials = []
 
+            # events inside this function can trigger dependancy graph updates, 
+            # it is necessary to call throttle here to prevent recursive sverchok tree updates.
             with self.sv_throttle_tree_update():
 
                 mtrx = obj.matrix_world
@@ -284,12 +286,6 @@ class SvObjectsNodeMK3(Show3DProperties, bpy.types.Node, SverchCustomTreeNode, S
                         materials = self.get_materials_from_bmesh(bm)
                         del bm
                     else:
-
-                        """
-                        in a throttled tree update state we can acquire a depsgraph if
-                        - modifiers
-                        - or vertex groups are desired
-                        """
 
                         if self.modifiers:
 

--- a/nodes/solid/export_solid.py
+++ b/nodes/solid/export_solid.py
@@ -4,6 +4,7 @@ from bpy.props import StringProperty, EnumProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import flatten_data, map_recursive
+from sverchok.utils.sv_operator_utils import SvGenericNodeLocator
 from sverchok.utils.curve.core import SvCurve
 from sverchok.utils.surface.core import SvSurface
 from sverchok.utils.logging import debug
@@ -18,18 +19,16 @@ else:
 
     from sverchok.utils.solid import to_solid
 
-    class SvExportSolidOperator(bpy.types.Operator):
+    class SvExportSolidOperator(bpy.types.Operator, SvGenericNodeLocator):
 
         bl_idname = "node.sv_export_solid_mk2"
         bl_label = "Export Solid"
         bl_options = {'INTERNAL', 'REGISTER'}
 
-        idtree: StringProperty(default='')
-        idname: StringProperty(default='')
-
         def execute(self, context):
-            tree = bpy.data.node_groups[self.idtree]
-            node = bpy.data.node_groups[self.idtree].nodes[self.idname]
+            node = self.get_node(context)
+            if not node:
+                return {'CANCELLED'}
 
             if not node.inputs['Folder Path'].is_linked:
                 self.report({'WARNING'}, "Folder path is not specified")

--- a/nodes/solid/export_solid.py
+++ b/nodes/solid/export_solid.py
@@ -1,3 +1,9 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
 
 import bpy
 from bpy.props import StringProperty, EnumProperty

--- a/nodes/solid/export_solid.py
+++ b/nodes/solid/export_solid.py
@@ -33,8 +33,7 @@ else:
 
         def execute(self, context):
             node = self.get_node(context)
-            if not node:
-                return {'CANCELLED'}
+            if not node: return {'CANCELLED'}
 
             if not node.inputs['Folder Path'].is_linked:
                 self.report({'WARNING'}, "Folder path is not specified")

--- a/nodes/solid/solid_viewer.py
+++ b/nodes/solid/solid_viewer.py
@@ -398,7 +398,7 @@ else:
         def bake(self):
             with self.sv_throttle_tree_update():
                 bpy.ops.node.sverchok_mesh_baker_mk3(
-                    idname=self.name, idtree=self.id_data.name
+                    node_name=self.name, tree_name=self.id_data.name
                 )
 
         def rclick_menu(self, context, layout):

--- a/nodes/svg/svg_document.py
+++ b/nodes/svg/svg_document.py
@@ -70,7 +70,7 @@ class SvSvgServer(bpy.types.Operator, SvGenericNodeLocator):
 
         save_path = node.inputs[0].sv_get()[0][0]
         file_name = node.file_name
-        bpy.ops.node.svg_write(idtree=self.idtree, idname=self.idname)
+        bpy.ops.node.svg_write(tree_name=self.tree_name, node_name=self.node_name)
         spawn_server(save_path, file_name)
 
         return {'FINISHED'}
@@ -233,7 +233,7 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
         self.outputs['Canvas Vertices'].sv_set([verts])
         self.outputs['Canvas Edges'].sv_set([[(0, 1),(1, 2), (2, 3), (3, 0)]])
         if self.live_update:
-            bpy.ops.node.svg_write(idtree=self.id_data.name, idname=self.name)
+            bpy.ops.node.svg_write(tree_name=self.id_data.name, node_name=self.name)
 
 
 classes = [SvSvgServer, SvSVGWrite, SvSvgDocumentNode]

--- a/nodes/svg/svg_document.py
+++ b/nodes/svg/svg_document.py
@@ -17,14 +17,16 @@
 # ##### END GPL LICENSE BLOCK #####
 import os
 import webbrowser
-import sverchok
+
 import bpy
 from bpy.props import (
     BoolProperty, StringProperty, EnumProperty, FloatProperty
     )
 
+import sverchok
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode
+from sverchok.utils.sv_operator_utils import SvGenericNodeLocator
 
 evolver_mem = {}
 
@@ -51,22 +53,19 @@ def spawn_server(save_path, file_name):
     webbrowser.open(path2)
 
 
-class SvSvgServer(bpy.types.Operator):
+class SvSvgServer(bpy.types.Operator, SvGenericNodeLocator):
     """
     Opens in web browser a html file that updates frecuently showing the changes in the SVG file
     """
     bl_idname = "node.sv_svg_server"
     bl_label = "Append"
 
-    idtree: bpy.props.StringProperty(default='')
-    idname: bpy.props.StringProperty(default='')
-
     def execute(self, context):
-        tree = bpy.data.node_groups[self.idtree]
-        node = bpy.data.node_groups[self.idtree].nodes[self.idname]
+        node = self.get_node(context)
+        if not node: return {'CANCELLED'}
+
         inputs = node.inputs
         if not (inputs['Folder Path'].is_linked and inputs['SVG Objects'].is_linked):
-
             return {'FINISHED'}
 
         save_path = node.inputs[0].sv_get()[0][0]
@@ -104,20 +103,17 @@ def draw_svg_defs(document, defs_list, all_defs_list):
         svg_defs += draw_svg_defs(document, new_def_list, all_defs_list)
     return svg_defs
 
-class SvSVGWrite(bpy.types.Operator):
+class SvSVGWrite(bpy.types.Operator, SvGenericNodeLocator):
 
     bl_idname = "node.svg_write"
     bl_label = "Write"
 
-    idtree: bpy.props.StringProperty(default='')
-    idname: bpy.props.StringProperty(default='')
-
     def execute(self, context):
-        node = bpy.data.node_groups[self.idtree].nodes[self.idname]
+        node = self.get_node(context)
+        if not node: return {'CANCELLED'}
 
         inputs = node.inputs
         if not (inputs['Folder Path'].is_linked and inputs['SVG Objects'].is_linked):
-
             return {'FINISHED'}
 
         save_path = inputs[0].sv_get()[0][0]
@@ -157,7 +153,7 @@ class SvSVGWrite(bpy.types.Operator):
         file_name = node.file_name
         complete_name = os.path.join(save_path, file_name+".svg")
         svg_file = open(complete_name, "w")
-        svg = svg_head + svg_defs +svg_shapes + svg_end
+        svg = svg_head + svg_defs + svg_shapes + svg_end
         svg_file.write(svg)
 
         svg_file.close()
@@ -224,16 +220,16 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
 
     def process(self):
 
-        x = self.doc_width/(self.doc_scale)
-        y = self.doc_height/(self.doc_scale)
+        x = self.doc_width / (self.doc_scale)
+        y = self.doc_height / (self.doc_scale)
+
         verts =[
             (0, 0, 0),
             (x, 0, 0),
             (x, y, 0),
-            (0, y, 0),
-
-
+            (0, y, 0)
         ]
+
         self.outputs['Canvas Vertices'].sv_set([verts])
         self.outputs['Canvas Edges'].sv_set([[(0, 1),(1, 2), (2, 3), (3, 0)]])
         if self.live_update:

--- a/nodes/text/text_in_mk2.py
+++ b/nodes/text/text_in_mk2.py
@@ -1,20 +1,9 @@
-# ##### BEGIN GPL LICENSE BLOCK #####
-#
-#  This program is free software; you can redistribute it and/or
-#  modify it under the terms of the GNU General Public License
-#  as published by the Free Software Foundation; either version 2
-#  of the License, or (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software Foundation,
-#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ##### END GPL LICENSE BLOCK #####
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
 
 # made by: Linus Yng, haxed by zeffii to mk2
 # pylint: disable=c0326

--- a/nodes/text/text_out_mk2.py
+++ b/nodes/text/text_out_mk2.py
@@ -1,20 +1,9 @@
-# ##### BEGIN GPL LICENSE BLOCK #####
-#
-#  This program is free software; you can redistribute it and/or
-#  modify it under the terms of the GNU General Public License
-#  as published by the Free Software Foundation; either version 2
-#  of the License, or (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software Foundation,
-#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ##### END GPL LICENSE BLOCK #####
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
 
 # made by: Linus Yng, haxed by zeffii to mk2
 # pylint: disable=c0326

--- a/nodes/viz/viewer_draw_mk4.py
+++ b/nodes/viz/viewer_draw_mk4.py
@@ -1,31 +1,22 @@
-# ##### BEGIN GPL LICENSE BLOCK #####
-#
-#  This program is free software; you can redistribute it and/or
-#  modify it under the terms of the GNU General Public License
-#  as published by the Free Software Foundation; either version 2
-#  of the License, or (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software Foundation,
-#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ##### END GPL LICENSE BLOCK #####
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
 
 from itertools import cycle
+
 from mathutils import Vector, Matrix
 from mathutils.geometry import tessellate_polygon as tessellate, normal
 from mathutils.noise import random, seed_set
 import bpy
 from bpy.props import StringProperty, FloatProperty, IntProperty, EnumProperty, BoolProperty, FloatVectorProperty
-
 import bgl
 import gpu
 from gpu_extras.batch import batch_for_shader
+
 import sverchok
 from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata
 from sverchok.utils.sv_mesh_utils import polygons_to_edges_np

--- a/nodes/viz/viewer_draw_mk4.py
+++ b/nodes/viz/viewer_draw_mk4.py
@@ -710,7 +710,7 @@ class SvViewerDrawMk4(bpy.types.Node, SverchCustomTreeNode):
     def bake(self):
         with self.sv_throttle_tree_update():
             bpy.ops.node.sverchok_mesh_baker_mk3(
-                idname=self.name, idtree=self.id_data.name
+                node_name=self.name, tree_name=self.id_data.name
             )
 
     def sv_init(self, context):

--- a/nodes/viz/viewer_waveform_output.py
+++ b/nodes/viz/viewer_waveform_output.py
@@ -142,9 +142,9 @@ class SvWaveformViewerOperator(bpy.types.Operator, SvGenericNodeLocator):
     fn_name: bpy.props.StringProperty(default='')
 
     def execute(self, context):
-        node = self.get_node()
+        node = self.get_node(context)
         if not node: return {'CANCELLED'}
-        
+
         getattr(node, self.fn_name)()
         return {'FINISHED'}
 
@@ -158,7 +158,7 @@ class SvWaveformViewerOperatorDP(bpy.types.Operator, SvGenericNodeLocator):
         maxlen=1024, default="", subtype='FILE_PATH')
 
     def execute(self, context):
-        node = self.get_node()
+        node = self.get_node(context)
         if not node: return {'CANCELLED'}
 
         node.set_dir(self.filepath)

--- a/nodes/viz/viewer_waveform_output.py
+++ b/nodes/viz/viewer_waveform_output.py
@@ -20,10 +20,10 @@ from gpu_extras.batch import batch_for_shader
 from mathutils import Vector
 
 from sverchok.utils.context_managers import sv_preferences
+from sverchok.utils.sv_operator_utils import SvGenericNodeLocator
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode, node_id
 from sverchok.ui import bgl_callback_nodeview as nvBGL
-
 
 DATA_SOCKET = 'SvStringsSocket'
 
@@ -134,16 +134,8 @@ def advanced_grid_xy(context, args, xy):
     config.line_shader.uniform_float("y_offset", y)
     config.line_batch.draw(config.line_shader)
 
-class NodeTreeGetter():
-    __annotations__ = {}
-    __annotations__['idname'] = bpy.props.StringProperty(default='')
-    __annotations__['idtree'] = bpy.props.StringProperty(default='')
 
-    def get_node(self):
-        return bpy.data.node_groups[self.idtree].nodes[self.idname]
-
-
-class SvWaveformViewerOperator(bpy.types.Operator, NodeTreeGetter):
+class SvWaveformViewerOperator(bpy.types.Operator, SvGenericNodeLocator):
     bl_idname = "node.waveform_viewer_callback"
     bl_label = "Waveform Viewer Operator"
 
@@ -151,11 +143,13 @@ class SvWaveformViewerOperator(bpy.types.Operator, NodeTreeGetter):
 
     def execute(self, context):
         node = self.get_node()
+        if not node: return {'CANCELLED'}
+        
         getattr(node, self.fn_name)()
         return {'FINISHED'}
 
 
-class SvWaveformViewerOperatorDP(bpy.types.Operator, NodeTreeGetter):
+class SvWaveformViewerOperatorDP(bpy.types.Operator, SvGenericNodeLocator):
     bl_idname = "node.waveform_viewer_dirpick"
     bl_label = "Waveform Viewer Directory Picker"
 
@@ -165,6 +159,8 @@ class SvWaveformViewerOperatorDP(bpy.types.Operator, NodeTreeGetter):
 
     def execute(self, context):
         node = self.get_node()
+        if not node: return {'CANCELLED'}
+
         node.set_dir(self.filepath)
         return {'FINISHED'}
 

--- a/old_nodes/vd_draw_experimental.py
+++ b/old_nodes/vd_draw_experimental.py
@@ -414,7 +414,7 @@ class SvVDExperimental(bpy.types.Node, SverchCustomTreeNode):
     def bake(self):
         with self.sv_throttle_tree_update():
             bpy.ops.node.sverchok_mesh_baker_mk3(
-                idname=self.name, idtree=self.id_data.name
+                node_name=self.name, tree_name=self.id_data.name
             )
 
     def rclick_menu(self, context, layout):

--- a/utils/sv_3dview_tools.py
+++ b/utils/sv_3dview_tools.py
@@ -1,20 +1,9 @@
-# ##### BEGIN GPL LICENSE BLOCK #####
-#
-#  This program is free software; you can redistribute it and/or
-#  modify it under the terms of the GNU General Public License
-#  as published by the Free Software Foundation; either version 2
-#  of the License, or (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software Foundation,
-#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ##### END GPL LICENSE BLOCK #####
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
 
 import sys
 

--- a/utils/sv_3dview_tools.py
+++ b/utils/sv_3dview_tools.py
@@ -12,6 +12,7 @@ from mathutils import Matrix, Vector
 
 from sverchok.core.socket_conversions import is_matrix
 from sverchok.utils.modules import geom_utils
+from sverchok.utils.sv_operator_utils import SvGenericNodeLocator
 
 
 def get_matrix(socket):
@@ -34,10 +35,7 @@ def get_center(self, context):
 
     try:
 
-        # we must now pass the origin node/tree in 2.80  ( this code does not interpret that yet )
-
-        node_group = bpy.data.node_groups[self.idtree]
-        node = node_group.nodes[self.idname]
+        node = self.get_node(context)
         print('node:', node)
 
         inputs = node.inputs
@@ -65,7 +63,7 @@ def get_center(self, context):
                     location = (Matrix(matrix) @ Vector(location))[:]
 
         else:
-            self.report({'INFO'}, 'viewer has no get_center function')
+            self.report({'INFO'}, 'viewer has no get_center function, or node not found')
 
     except Exception as err:
         self.report({'INFO'}, 'no active node found')
@@ -79,22 +77,12 @@ def get_center(self, context):
 
 
 
-class Sv3DviewAlign(bpy.types.Operator):
+class Sv3DviewAlign(bpy.types.Operator, SvGenericNodeLocator):
     """ Zoom to viewer output """
     bl_idname = "node.view3d_align_from"
     bl_label = "Align 3dview to Viewer"
 
     fn_name: bpy.props.StringProperty(default='')
-
-    idname: bpy.props.StringProperty(
-        name='idname',
-        description='name of parent node',
-        default='')
-
-    idtree: bpy.props.StringProperty(
-        name='idtree',
-        description='name of parent tree',
-        default='')
 
     def execute(self, context):
 

--- a/utils/sv_obj_baker.py
+++ b/utils/sv_obj_baker.py
@@ -11,6 +11,7 @@ from bpy.props import StringProperty
 from mathutils import Vector, Matrix
 
 from sverchok.data_structure import node_id, dataCorrect, dataCorrect_np
+from sverchok.utils.sv_operator_utils import SvGenericNodeLocator
 
 cache_viewer_baker = {}
 
@@ -28,26 +29,17 @@ def fill_cache_from_node_reference(node):
     cache_viewer_baker[matrix_ref] = data[4]
 
 
-class SvObjBakeMK3(bpy.types.Operator):
+class SvObjBakeMK3(bpy.types.Operator, SvGenericNodeLocator):
     """ B A K E   OBJECTS """
     bl_idname = "node.sverchok_mesh_baker_mk3"
     bl_label = "Sverchok mesh baker mk3"
     bl_options = {'REGISTER', 'UNDO'}
 
-    idname: StringProperty(
-        name='idname',
-        description='name of parent node',
-        default='')
-
-    idtree: StringProperty(
-        name='idtree',
-        description='name of parent tree',
-        default='')
-
     def execute(self, context):
+        node = self.get_node(context)
+        if not node:
+            return {'CANCELLED'}
 
-        node_group = bpy.data.node_groups[self.idtree]
-        node = node_group.nodes[self.idname]
         nid = node_id(node)
 
         if not node.inputs[0].is_linked:
@@ -141,26 +133,17 @@ if FreeCAD is not None:
         cache_viewer_baker[matrix_ref] = []
 
 
-    class SvSolidBake(bpy.types.Operator):
+    class SvSolidBake(bpy.types.Operator, SvGenericNodeLocator):
         """ B A K E   OBJECTS """
         bl_idname = "node.sverchok_solid_baker_mk3"
         bl_label = "Sverchok solid baker mk3"
         bl_options = {'REGISTER', 'UNDO'}
 
-        idname: StringProperty(
-            name='idname',
-            description='name of parent node',
-            default='')
-
-        idtree: StringProperty(
-            name='idtree',
-            description='name of parent tree',
-            default='')
-
         def execute(self, context):
+            node = self.get_node(context)
+            if not node:
+                return {'CANCELLED'}
 
-            node_group = bpy.data.node_groups[self.idtree]
-            node = node_group.nodes[self.idname]
             nid = node_id(node)
 
             if not node.inputs[0].is_linked:

--- a/utils/sv_operator_utils.py
+++ b/utils/sv_operator_utils.py
@@ -1,20 +1,10 @@
-# ##### BEGIN GPL LICENSE BLOCK #####
-#
-#  This program is free software; you can redistribute it and/or
-#  modify it under the terms of the GNU General Public License
-#  as published by the Free Software Foundation; either version 2
-#  of the License, or (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software Foundation,
-#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ##### END GPL LICENSE BLOCK #####
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
 
 import bpy
 from bpy.props import StringProperty

--- a/utils/sv_operator_utils.py
+++ b/utils/sv_operator_utils.py
@@ -20,13 +20,13 @@ import bpy
 from bpy.props import StringProperty
 
 class SvGenericNodeLocator():
-    idtree: StringProperty(default='')
-    idname: StringProperty(default='')
+    tree_name: StringProperty(default='', description="name of the node tree")
+    node_name: StringProperty(default='', description="name of the node")
 
     def get_node(self, context):
         """ context.node is usually provided, else tree_name/node_name must be passed """
-        if self.idtree and self.idname:
-            return bpy.data.node_groups[self.idtree].nodes[self.idname]
+        if self.tree_name and self.node_name:
+            return bpy.data.node_groups[self.tree_name].nodes[self.node_name]
 
         if hasattr(context, "node"):
             return context.node
@@ -35,7 +35,7 @@ class SvGenericNodeLocator():
         return None
 
     def get_tree(self):
-        return bpy.data.node_groups.get(self.idtree)
+        return bpy.data.node_groups.get(self.tree_name)
 
 
 class SvGenericCallbackOldOp(bpy.types.Operator):

--- a/utils/sv_operator_utils.py
+++ b/utils/sv_operator_utils.py
@@ -31,7 +31,8 @@ class SvGenericNodeLocator():
         if hasattr(context, "node"):
             return context.node
 
-        print("treename and nodename not supplied, or node not found in nodetree")
+        print("treename or nodename not supplied, node not found in available trees")
+        print(f"received tree_name: {tree_name} and node_name: {node_name}")
         return None
 
     def get_tree(self):


### PR DESCRIPTION
Some operators are called from buttons which are located in a Blender UI space which does not track the `context.node`, (the origin of the click is undefined). The `node.wrapper_tracked_ui_draw_op` wrapper is an alternative for those nodes that do need extra origin tracking - the wrapper passes the node's `node.id_data.name` and `node.name` behind the scenes. Most nodes don't need this, until they do.

This PR commits a few backend cleanups

- makes operators that do need to track the click-origin use `SvGenericNodeLocator` mixin, this simplifies the transition away from `idtree` and `idname`. These are some of the oldest variable names in sverchok :) it's time they get more obvious names
```
self.idtree    -> self.tree_name
self.idname    -> self.node_name
```

along the way i'll also change a few node license blurbs to the abbreviated version.

-----

- [x] ...sverchok\nodes\list_mutators\multi_cache.py
- [x] ...sverchok\nodes\logic\evolver.py
- [x] ...sverchok\nodes\logic\genes_holder.py
- [x] ...sverchok\nodes\network\file_path.py
- [x] ...sverchok\nodes\scene\objects_mk3.py
- [x] ...sverchok\nodes\solid\export_solid.py
- [x] ...sverchok\nodes\svg\svg_document.py
- [x] ...sverchok\nodes\viz\viewer_waveform_output.py
- [x] ...sverchok\utils\sv_3dview_tools.py
- [x] ...sverchok\utils\sv_obj_baker.py
- [x] ...sverchok\utils\sv_operator_utils.py
- [ ] extensively tested