### PR TITLE
add usability feature to dupli_mk4

### DIFF
--- a/nodes/scene/dupli_instances_mk4.py
+++ b/nodes/scene/dupli_instances_mk4.py
@@ -92,6 +92,13 @@ class SvDupliInstancesMK4(bpy.types.Node, SverchCustomTreeNode):
                 row4.enabled = ob.use_instance_faces_scale
                 row4.prop(ob, "instance_faces_scale", text="Factor")  #float
 
+                """
+                to hide the child object from the viewport only, use
+                >>> bpy.data.objects['AFUWCR'].hide_set(True)  # toggle bool
+                
+                the child is hidden by default during render
+                """
+
         finally:
             pass
 
@@ -148,6 +155,8 @@ class SvDupliInstancesMK4(bpy.types.Node, SverchCustomTreeNode):
             ob.instance_type = self.mode
             ob.use_instance_faces_scale = self.scale
             child.parent = ob
+            # bpy.data.objects["parent"].show_instancer_for_viewport
+            # bpy.data.objects["parent"].show_instancer_for_render
 
 
 def register():


### PR DESCRIPTION
dupli instancer has a few issues which can be addressed here

i'm in favour of moving a few controls directly onto the node UI, 
- show (parent) in viewport
- show (parent) in render
- show child in viewport

there is no corresponding need to toggle "show child in render" because blender doesn't render the child by default.  