### PR TITLE
bug fixes in graph/time drawing

### DIFF
--- a/utils/nodeview_time_graph_drawing.py
+++ b/utils/nodeview_time_graph_drawing.py
@@ -9,6 +9,7 @@
 import bgl
 import blf
 import bpy
+from mathutils import Vector
 import gpu
 from gpu_extras.batch import batch_for_shader
 
@@ -95,6 +96,11 @@ def draw_node_time_infos(*data):
         
         x, y = get_xy_for_bgl_drawing(node)
         x, y = int(x), int(y)
+
+        if node.hide and isinstance(node.dimensions, Vector):
+            # just in case we are still overriding node.dimensions anywhere.
+            # this is not exact, but it's better than the alternative
+            y += (node.dimensions[1] / 2) - 10
 
         show_str = string_from_duration(node_data['duration'])
         draw_text(font_id, (x, y), show_str, (r, g, b))


### PR DESCRIPTION
addresses a few toothing issues in graph/timing display

note to self, it might be more useful to make a separate `graphs_dict` which will map 
```python
{"tree_name": {only most_recent_events for that tree}, ...}
or
{"tree_name": [event_dict, event_dict, .....], ...}
```
because right now there is no distinction in `graphs` between updates from various trees.