### PR TITLE
Tracked handler streamline

### DIFF
--- a/nodes/exchange/bezier_in.py
+++ b/nodes/exchange/bezier_in.py
@@ -24,17 +24,11 @@ class SvBezierInCallbackOp(bpy.types.Operator, SvGenericNodeLocator):
     bl_label = "Bezier In Callback"
     bl_options = {'INTERNAL'}
 
-    def execute(self, context):
+    def sv_execute(self, context, node):
         """
-        returns the operator's 'self' too to allow the code being called to
-        print from self.report.
+        passes the operator's 'self' too to allow calling self.report()
         """
-        node = self.get_node(context)
-        if node:
-            node.get_objects_from_scene(self)
-            return {'FINISHED'}
-
-        return {'CANCELLED'}
+        node.get_objects_from_scene(self)
 
 
 class SvBezierInNode(Show3DProperties, bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):

--- a/nodes/exchange/nurbs_in.py
+++ b/nodes/exchange/nurbs_in.py
@@ -31,17 +31,13 @@ class SvExNurbsInCallbackOp(bpy.types.Operator, SvGenericNodeLocator):
 
     fn_name: StringProperty(default='')
 
-    def execute(self, context):
+    def sv_execute(self, context, node):
         """
         returns the operator's 'self' too to allow the code being called to
         print from self.report.
         """
-        node = self.get_node(context)
-        if node:        
-            getattr(node, self.fn_name)(self)
-            return {'FINISHED'}
+        getattr(node, self.fn_name)(self)
 
-        return {'CANCELLED'}
 
 class SvExNurbsInNode(Show3DProperties, bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     """

--- a/nodes/list_mutators/multi_cache.py
+++ b/nodes/list_mutators/multi_cache.py
@@ -23,13 +23,9 @@ class SvvMultiCacheReset(bpy.types.Operator, SvGenericNodeLocator):
     bl_idname = "node.multy_cache_reset"
     bl_label = "Multi Cache Reset"
 
-    def execute(self, context):
-        node = self.get_node(context)
-        if not node: return {'CANCELLED'}
-        
+    def sv_execute(self, context, node):
         node.fill_empty_dict()
         updateNode(node, context)
-        return {'FINISHED'}
 
 
 class SvMultiCacheNode(bpy.types.Node, SverchCustomTreeNode):

--- a/nodes/logic/evolver.py
+++ b/nodes/logic/evolver.py
@@ -533,13 +533,11 @@ class SvEvolverRun(bpy.types.Operator, SvGenericNodeLocator):
     bl_idname = "node.evolver_run"
     bl_label = "Evolver Run"
 
-    def execute(self, context):
-        node = self.get_node(context)
-        if not node: return {'CANCELLED'}
+    def sv_execute(self, context, node):
 
         if not node.inputs[0].is_linked:
             node.info_label = "Stopped - Fitness not linked"
-            return {'FINISHED'}
+            return
 
         genotype_frame = node.genotype
         evolver_mem[node.node_id] = {}
@@ -551,7 +549,7 @@ class SvEvolverRun(bpy.types.Operator, SvGenericNodeLocator):
         population.evolve()
         update_list = make_tree_from_nodes([node.name], tree)
         do_update(update_list, tree.nodes)
-        return {'FINISHED'}
+
 
 def set_fittest(tree, genes, agent, update_list):
     '''sets the nodetree with the best value'''
@@ -570,16 +568,13 @@ class SvEvolverSetFittest(bpy.types.Operator, SvGenericNodeLocator):
     bl_idname = "node.evolver_set_fittest"
     bl_label = "Evolver Run"
 
-    def execute(self, context):
-        node = self.get_node(context)
-        if not node: return {'CANCELLED'}
-
+    def sv_execute(self, context, node):
         data = evolver_mem[node.node_id]
         genes = data["genes"]
         population = data["population"]
         update_list = make_tree_from_nodes([g.name for g in genes], tree)
         set_fittest(tree, genes, population[0], update_list)
-        return {'FINISHED'}
+
 
 def get_framenodes(base_node, _):
 

--- a/nodes/logic/genes_holder.py
+++ b/nodes/logic/genes_holder.py
@@ -22,10 +22,7 @@ class SvGenesHolderReset(bpy.types.Operator, SvGenericNodeLocator):
     bl_idname = "node.number_genes_reset"
     bl_label = "Number Genes Reset"
 
-    def execute(self, context):
-        node = self.get_node(context)
-        if not node: return {'CANCELLED'}
-
+    def sv_execute(self, context, node):
         if node.number_type == 'vector':
             input_name = 'Vertices'
         else:
@@ -37,7 +34,6 @@ class SvGenesHolderReset(bpy.types.Operator, SvGenericNodeLocator):
             seed_set(node.r_seed)
             node.fill_empty_dict()
         updateNode(node, context)
-        return {'FINISHED'}
 
 class SvGenesHolderNode(bpy.types.Node, SverchCustomTreeNode):
     """

--- a/nodes/network/file_path.py
+++ b/nodes/network/file_path.py
@@ -38,12 +38,8 @@ class SvFilePathFinder(bpy.types.Operator, SvGenericNodeLocator):
         name="File Path", description="Filepath used for writing waveform files",
         maxlen=1024, default="", subtype='FILE_PATH')
 
-    def execute(self, context):
-        node = self.get_node(context)
-        if not node: return {'CANCELLED'}
-
+    def sv_execute(self, context, node):
         node.set_data(self.directory, self.files)
-        return {'FINISHED'}
 
     def invoke(self, context, event):
         wm = context.window_manager

--- a/nodes/scene/get_objects_data.py
+++ b/nodes/scene/get_objects_data.py
@@ -51,15 +51,10 @@ class SvOB3BItemOperator(bpy.types.Operator, SvGenericNodeLocator):
     fn_name: StringProperty(default='')
     idx: IntProperty()
 
-    def execute(self, context):
-        node = self.get_node(context)
-        if not node: return {'CANCELLED'}
-
+    def sv_execute(self, context, node):
         if self.fn_name == 'REMOVE':
             node.object_names.remove(self.idx)
-
         node.process_node(None)
-        return {'FINISHED'}
 
 
 class SvOB3Callback(bpy.types.Operator, SvGenericNodeLocator):
@@ -70,16 +65,13 @@ class SvOB3Callback(bpy.types.Operator, SvGenericNodeLocator):
 
     fn_name: StringProperty(default='')
 
-    def execute(self, context):
+    def sv_execute(self, context, node):
         """
         returns the operator's 'self' too to allow the code being called to
         print from self.report.
         """
-        node = self.get_node(context)
-        if not node: return {'CANCELLED'}
-
         getattr(node, self.fn_name)(self)
-        return {'FINISHED'}
+
 
 def get_vertgroups(mesh):
     return [k for k,v in enumerate(mesh.vertices) if v.groups.values()]

--- a/nodes/scene/objects_in_lite.py
+++ b/nodes/scene/objects_in_lite.py
@@ -26,15 +26,9 @@ class SvObjLiteCallback(bpy.types.Operator, SvGenericNodeLocator):
 
     cmd: StringProperty()
 
-    def execute(self, context):
-
-        node = self.get_node(context)
-        if node:        
-            getattr(node, self.cmd)()
-            node.process_node(context)
-            return {'FINISHED'}
-
-        return {'CANCELLED'}
+    def sv_execute(self, context, node):
+        getattr(node, self.cmd)()
+        node.process_node(context)
 
 
 class SvObjInLite(bpy.types.Node, SverchCustomTreeNode):

--- a/nodes/svg/svg_document.py
+++ b/nodes/svg/svg_document.py
@@ -60,20 +60,16 @@ class SvSvgServer(bpy.types.Operator, SvGenericNodeLocator):
     bl_idname = "node.sv_svg_server"
     bl_label = "Append"
 
-    def execute(self, context):
-        node = self.get_node(context)
-        if not node: return {'CANCELLED'}
-
+    def sv_execute(self, context, node):
         inputs = node.inputs
         if not (inputs['Folder Path'].is_linked and inputs['SVG Objects'].is_linked):
-            return {'FINISHED'}
+            return
 
         save_path = node.inputs[0].sv_get()[0][0]
         file_name = node.file_name
         bpy.ops.node.svg_write(tree_name=self.tree_name, node_name=self.node_name)
         spawn_server(save_path, file_name)
 
-        return {'FINISHED'}
 
 def get_template(complete_name):
     old_svg_file = open(complete_name, "r")

--- a/nodes/viz/viewer_waveform_output.py
+++ b/nodes/viz/viewer_waveform_output.py
@@ -141,12 +141,8 @@ class SvWaveformViewerOperator(bpy.types.Operator, SvGenericNodeLocator):
 
     fn_name: bpy.props.StringProperty(default='')
 
-    def execute(self, context):
-        node = self.get_node(context)
-        if not node: return {'CANCELLED'}
-
+    def sv_execute(self, context, node):
         getattr(node, self.fn_name)()
-        return {'FINISHED'}
 
 
 class SvWaveformViewerOperatorDP(bpy.types.Operator, SvGenericNodeLocator):
@@ -157,12 +153,8 @@ class SvWaveformViewerOperatorDP(bpy.types.Operator, SvGenericNodeLocator):
         name="File Path", description="Filepath used for writing waveform files",
         maxlen=1024, default="", subtype='FILE_PATH')
 
-    def execute(self, context):
-        node = self.get_node(context)
-        if not node: return {'CANCELLED'}
-
+    def sv_execute(self, context, node):
         node.set_dir(self.filepath)
-        return {'FINISHED'}
 
     def invoke(self, context, event):
         wm = context.window_manager

--- a/old_nodes/objects_mk3.py
+++ b/old_nodes/objects_mk3.py
@@ -48,15 +48,11 @@ class SvOB3BItemOperator(bpy.types.Operator, SvGenericNodeLocator):
     fn_name: StringProperty(default='')
     idx: IntProperty()
 
-    def execute(self, context):
-        node = self.get_node(context)
-        if not node: return {'CANCELLED'}
-
+    def sv_execute(self, context, node):
         if self.fn_name == 'REMOVE':
             node.object_names.remove(self.idx)
 
         node.process_node(None)
-        return {'FINISHED'}
 
 
 class SvOB3Callback(bpy.types.Operator, SvGenericNodeLocator):
@@ -67,16 +63,12 @@ class SvOB3Callback(bpy.types.Operator, SvGenericNodeLocator):
 
     fn_name: StringProperty(default='')
 
-    def execute(self, context):
+    def sv_execute(self, context, node):
         """
         returns the operator's 'self' too to allow the code being called to
         print from self.report.
         """
-        node = self.get_node(context)
-        if not node: return {'CANCELLED'}
-
         getattr(node, self.fn_name)(self)
-        return {'FINISHED'}
 
 
 class SvObjectsNodeMK3(Show3DProperties, bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):

--- a/ui/nodeview_operators.py
+++ b/ui/nodeview_operators.py
@@ -18,12 +18,7 @@ class SvNodeViewZoomBorder(bpy.types.Operator, SvGenericNodeLocator):
     bl_label = "NodeView Zoom Border Operator"
     bl_options = {'INTERNAL'}
 
-    def execute(self, context):
-
-        node = self.get_node(context)
-        if not node:
-            print("SvNodeViewZoomBorder was not able to locate the node")
-            return {'CANCELLED'}
+    def sv_execute(self, context, node):
 
         for window in bpy.context.window_manager.windows:
             screen = window.screen
@@ -54,8 +49,6 @@ class SvNodeViewZoomBorder(bpy.types.Operator, SvGenericNodeLocator):
                             }
                             bpy.ops.node.view_selected(override)
                             break
-
-        return {'FINISHED'}
 
 def register():
     bpy.utils.register_class(SvNodeViewZoomBorder)

--- a/utils/sv_3dview_tools.py
+++ b/utils/sv_3dview_tools.py
@@ -28,7 +28,7 @@ def get_matrix(socket):
         print(repr(err))
 
 
-def get_center(self, context):
+def get_center(self, context, node):
 
     location = (0, 0, 0)
     matrix = None
@@ -84,12 +84,12 @@ class Sv3DviewAlign(bpy.types.Operator, SvGenericNodeLocator):
 
     fn_name: bpy.props.StringProperty(default='')
 
-    def execute(self, context):
+    def sv_execute(self, context, node):
 
-        vector_3d = get_center(self, context)
+        vector_3d = get_center(self, context, node)
         if not vector_3d:
             print(vector_3d)
-            return {'CANCELLED'}
+            return
 
         print(vector_3d)
         context.scene.cursor.location = vector_3d[:]
@@ -101,16 +101,6 @@ class Sv3DviewAlign(bpy.types.Operator, SvGenericNodeLocator):
                 ctx['region'] = area.regions[-1]
                 bpy.ops.view3d.view_center_cursor(ctx)
 
-        return {'FINISHED'}
-
-
 
 classes = [Sv3DviewAlign,]
-
-
-def register():
-    _ = [bpy.utils.register_class(cls) for cls in classes]
-
-
-def unregister():
-    _ = [bpy.utils.unregister_class(cls) for cls in classes[::-1]]
+register, unregister = bpy.utils.register_classes_factory(classes)

--- a/utils/sv_3dview_tools.py
+++ b/utils/sv_3dview_tools.py
@@ -85,7 +85,7 @@ class Sv3DviewAlign(bpy.types.Operator, SvGenericNodeLocator):
         vector_3d = get_center(self, context, node)
         if not vector_3d:
             print(vector_3d)
-            return
+            return {'CANCELLED'}
 
         print(vector_3d)
         context.scene.cursor.location = vector_3d[:]

--- a/utils/sv_3dview_tools.py
+++ b/utils/sv_3dview_tools.py
@@ -32,7 +32,7 @@ def get_center(self, context, node):
 
     location = (0, 0, 0)
     matrix = None
-    print('node:', node)
+    print('node:', node.name)
 
     try:
         inputs = node.inputs

--- a/utils/sv_3dview_tools.py
+++ b/utils/sv_3dview_tools.py
@@ -32,12 +32,9 @@ def get_center(self, context, node):
 
     location = (0, 0, 0)
     matrix = None
+    print('node:', node)
 
     try:
-
-        node = self.get_node(context)
-        print('node:', node)
-
         inputs = node.inputs
 
         if node.bl_idname in {'SvViewerDrawMk4'}:
@@ -71,7 +68,6 @@ def get_center(self, context, node):
         sys.stderr.write('ERROR: %s\n' % str(err))
         print(sys.exc_info()[-1].tb_frame.f_code)
         print('Error on line {}'.format(sys.exc_info()[-1].tb_lineno))
-
 
     return location
 

--- a/utils/sv_obj_baker.py
+++ b/utils/sv_obj_baker.py
@@ -35,16 +35,12 @@ class SvObjBakeMK3(bpy.types.Operator, SvGenericNodeLocator):
     bl_label = "Sverchok mesh baker mk3"
     bl_options = {'REGISTER', 'UNDO'}
 
-    def execute(self, context):
-        node = self.get_node(context)
-        if not node:
-            return {'CANCELLED'}
+    def sv_execute(self, context, node):
 
         nid = node_id(node)
-
         if not node.inputs[0].is_linked:
             self.report({"WARNING"}, "Vertex socket of Draw node must be connected")
-            return {'CANCELLED'}
+            return
 
         fill_cache_from_node_reference(node)
         matrix_cache = cache_viewer_baker[nid + 'm']
@@ -53,7 +49,7 @@ class SvObjBakeMK3(bpy.types.Operator, SvGenericNodeLocator):
         pol_cache = cache_viewer_baker[nid + 'p']
 
         if matrix_cache and not vertex_cache:
-            return {'CANCELLED'}
+            return
 
         v = dataCorrect_np(vertex_cache)
         e = self.dataCorrect3(edg_cache)
@@ -61,7 +57,7 @@ class SvObjBakeMK3(bpy.types.Operator, SvGenericNodeLocator):
         m = self.dataCorrect2(matrix_cache, v)
         self.config = node
         self.makeobjects(v, e, p, m)
-        return {'FINISHED'}
+        return
 
     def dataCorrect2(self, destination, obj):
         if destination:
@@ -139,16 +135,11 @@ if FreeCAD is not None:
         bl_label = "Sverchok solid baker mk3"
         bl_options = {'REGISTER', 'UNDO'}
 
-        def execute(self, context):
-            node = self.get_node(context)
-            if not node:
-                return {'CANCELLED'}
-
+        def sv_execute(self, context, node):
             nid = node_id(node)
-
             if not node.inputs[0].is_linked:
                 self.report({"WARNING"}, "Solid socket of Viewer node must be connected")
-                return {'CANCELLED'}
+                return
 
             fill_cache_from_solid_node_reference(node)
             matrix_cache = cache_viewer_baker[nid + 'm']
@@ -156,14 +147,14 @@ if FreeCAD is not None:
             pol_cache = cache_viewer_baker[nid + 'p']
 
             if matrix_cache and not vertex_cache:
-                return {'CANCELLED'}
+                return
 
             v = vertex_cache
             p = pol_cache
             m = self.dataCorrect2(matrix_cache, v)
             self.config = node
             self.makeobjects(v, p, m)
-            return {'FINISHED'}
+            return
 
         def dataCorrect2(self, destination, obj):
             if destination:

--- a/utils/sv_obj_baker.py
+++ b/utils/sv_obj_baker.py
@@ -154,7 +154,7 @@ if FreeCAD is not None:
             m = self.dataCorrect2(matrix_cache, v)
             self.config = node
             self.makeobjects(v, p, m)
-            return
+
 
         def dataCorrect2(self, destination, obj):
             if destination:

--- a/utils/sv_obj_baker.py
+++ b/utils/sv_obj_baker.py
@@ -40,7 +40,7 @@ class SvObjBakeMK3(bpy.types.Operator, SvGenericNodeLocator):
         nid = node_id(node)
         if not node.inputs[0].is_linked:
             self.report({"WARNING"}, "Vertex socket of Draw node must be connected")
-            return
+            return {'CANCELLED'}
 
         fill_cache_from_node_reference(node)
         matrix_cache = cache_viewer_baker[nid + 'm']
@@ -49,7 +49,7 @@ class SvObjBakeMK3(bpy.types.Operator, SvGenericNodeLocator):
         pol_cache = cache_viewer_baker[nid + 'p']
 
         if matrix_cache and not vertex_cache:
-            return
+            return {'CANCELLED'}
 
         v = dataCorrect_np(vertex_cache)
         e = self.dataCorrect3(edg_cache)
@@ -57,7 +57,7 @@ class SvObjBakeMK3(bpy.types.Operator, SvGenericNodeLocator):
         m = self.dataCorrect2(matrix_cache, v)
         self.config = node
         self.makeobjects(v, e, p, m)
-        return
+
 
     def dataCorrect2(self, destination, obj):
         if destination:
@@ -139,7 +139,7 @@ if FreeCAD is not None:
             nid = node_id(node)
             if not node.inputs[0].is_linked:
                 self.report({"WARNING"}, "Solid socket of Viewer node must be connected")
-                return
+                return {'CANCELLED'}
 
             fill_cache_from_solid_node_reference(node)
             matrix_cache = cache_viewer_baker[nid + 'm']
@@ -147,7 +147,7 @@ if FreeCAD is not None:
             pol_cache = cache_viewer_baker[nid + 'p']
 
             if matrix_cache and not vertex_cache:
-                return
+                return {'CANCELLED'}
 
             v = vertex_cache
             p = pol_cache

--- a/utils/sv_operator_mixins.py
+++ b/utils/sv_operator_mixins.py
@@ -49,7 +49,9 @@ class SvGenericNodeLocator():
         node = self.get_node(context)
         if node:
             response = self.sv_execute(context, node)
-            # we could add something like  ..  if response: return response
+            if response:
+                # you can explicitely return {'CANCELLED', ..'FINISHED', etc } from sv_execute
+                return response
             return {'FINISHED'}
 
         msg = f'{self.bl_idname} was unable to locate the node <{self.tree_name}|{self.node_name}>'

--- a/utils/sv_operator_mixins.py
+++ b/utils/sv_operator_mixins.py
@@ -42,10 +42,24 @@ class SvGenericNodeLocator():
         return bpy.data.node_groups.get(self.tree_name)
 
     def sv_execute(self, context, node):
-        # you overwrite this, this is the code you want to execute if the locator finds a node
-        # - if you return (False) early, it is considered 'FINISHED'
-        # - you can explicitely return {'CANCELLED', ..'FINISHED', etc }
-        ...
+        """ 
+        you override this, inside this function you place the code you want to execute 
+        if the locator finds the node.
+        
+        - you can use a return statement to end the sv_execute function early.
+        - return can be one of two things. success or failure
+
+            success:  (these are all equal)
+                return False,
+                return 0
+                return None
+                return
+                return {'FINISHED'}
+
+            failure:
+                return {'CANCELLED'} as a regular execute function
+        """
+        pass
 
     def execute(self, context):
         node = self.get_node(context)

--- a/utils/sv_operator_mixins.py
+++ b/utils/sv_operator_mixins.py
@@ -41,6 +41,20 @@ class SvGenericNodeLocator():
     def get_tree(self):
         return bpy.data.node_groups.get(self.tree_name)
 
+    def sv_execute(self, context, node):
+        # you overwrite this, this is the code you want to execute if the locator finds a node
+        ...
+
+    def execute(self, context)
+        node = self.get_node(context)
+        if node:
+            response = self.sv_execute(context, node)
+            # we could add something like  ..  if response: return response
+            return {'FINISHED'}
+
+        msg = f'{self.bl_idname} was unable to locate the node <{self.tree_name}|{self.node_name}>'
+        self.report({'ERROR'}, msg)
+        return {'CANCELLED'}
 
 class SvGenericCallbackWithParams():
 

--- a/utils/sv_operator_mixins.py
+++ b/utils/sv_operator_mixins.py
@@ -45,7 +45,7 @@ class SvGenericNodeLocator():
         # you overwrite this, this is the code you want to execute if the locator finds a node
         ...
 
-    def execute(self, context)
+    def execute(self, context):
         node = self.get_node(context)
         if node:
             response = self.sv_execute(context, node)

--- a/utils/sv_operator_mixins.py
+++ b/utils/sv_operator_mixins.py
@@ -43,6 +43,8 @@ class SvGenericNodeLocator():
 
     def sv_execute(self, context, node):
         # you overwrite this, this is the code you want to execute if the locator finds a node
+        # - if you return (False) early, it is considered 'FINISHED'
+        # - you can explicitely return {'CANCELLED', ..'FINISHED', etc }
         ...
 
     def execute(self, context):
@@ -50,7 +52,6 @@ class SvGenericNodeLocator():
         if node:
             response = self.sv_execute(context, node)
             if response:
-                # you can explicitely return {'CANCELLED', ..'FINISHED', etc } from sv_execute
                 return response
             return {'FINISHED'}
 


### PR DESCRIPTION
features. 
- introduces `sv_execute(self, context, node)` to Operators that use mixin `SvGenericNodeLocator`
- if you still want to write the full `def execute(self, context)` you can, i've left some of the more elaborate `execute` implementations unchanged.
- in `sv_execute` you can always return early. Using `return` will always result in `return {"FINISHED"}`, 
     - you can `return {"CANCELLED"}` explicitely if you want. (or any other of the accepted Set values

a typical SvGenericNodeLocator operator would change from 
```python
    ...

    def execute(self, context):
        """
        passes the operator's 'self' too to allow calling self.report()
        """
        node = self.get_node(context)
        if node:
            node.get_objects_from_scene(self)
            return {'FINISHED'}

        return {'CANCELLED'}
```
to this
```python
    def sv_execute(self, context, node):
        """
        passes the operator's 'self' too to allow calling self.report()
        """
        node.get_objects_from_scene(self)
```

as you can see, the node locating is entirely taken care of.