### PR TITLE
State tracker graph drawing

### DIFF
--- a/core/update_system.py
+++ b/core/update_system.py
@@ -551,7 +551,10 @@ def reload_sverchok():
     data_structure.RELOAD_EVENT = False
     from sverchok.core import handlers
     handlers.sv_post_load([])
+
     reset_timing_graphs()
+    # for ng in sverchok_trees():
+    #    ng.sv_timing_callbacks_activated = False
 
 def get_update_lists(ng):
     """

--- a/core/update_system.py
+++ b/core/update_system.py
@@ -442,8 +442,8 @@ def build_update_list(ng=None):
     """
     global update_cache
     global partial_update_cache
-    global graphs
-    graphs = []
+    reset_timing_graphs()
+
     if not ng:
         for ng in sverchok_trees():
             build_update_list(ng)
@@ -460,10 +460,8 @@ def process_to_node(node):
     """
     Process nodes upstream until node
     """
-    global graphs
-    graphs = []
-
     ng = node.id_data
+    reset_timing_graphs()
     reset_error_nodes(ng)
 
     if data_structure.RELOAD_EVENT:
@@ -498,9 +496,9 @@ def process_from_node(node):
     """
     global update_cache
     global partial_update_cache
-    global graphs
-    graphs = []
+
     ng = node.id_data
+    reset_timing_graphs()
     reset_error_nodes(ng)
 
     if data_structure.RELOAD_EVENT:
@@ -529,8 +527,7 @@ def sverchok_trees():
 def process_tree(ng=None):
     global update_cache
     global partial_update_cache
-    global graphs
-    graphs = []
+    reset_timing_graphs()
 
     if data_structure.RELOAD_EVENT:
         reload_sverchok()
@@ -554,6 +551,7 @@ def reload_sverchok():
     data_structure.RELOAD_EVENT = False
     from sverchok.core import handlers
     handlers.sv_post_load([])
+    reset_timing_graphs()
 
 def get_update_lists(ng):
     """

--- a/core/update_system.py
+++ b/core/update_system.py
@@ -69,6 +69,7 @@ def reset_timing_graphs():
     graphs = []
     # graph_dicts = {}
 
+
 # cache node group update trees
 update_cache = {}
 # cache for partial update lists

--- a/node_tree.py
+++ b/node_tree.py
@@ -174,6 +174,10 @@ class SverchCustomTree(NodeTree, SvNodeTreeCommon):
     sv_show: BoolProperty(name="Show", default=True, description='Show this layout', update=turn_off_ng)
     sv_show_time_graph: BoolProperty(name="Time Graph", default=False, options=set())
     sv_show_time_nodes: BoolProperty(name="Node times", default=False, options=set())
+    
+    # downside is these are not reset during f8. and not during post save. or post load.
+    sv_timing_callbacks_activated: BoolProperty(
+        default=False, description="internal property used to remember drwing state")
 
     # something related with heat map feature
     # looks like it keeps dictionary of nodes and their user defined colors in string format

--- a/ui/nodeview_operators.py
+++ b/ui/nodeview_operators.py
@@ -6,9 +6,9 @@
 # License-Filename: LICENSE
 
 import bpy
+from sverchok.core.update_system import reset_timing_graphs
 from sverchok.utils.sv_operator_mixins import SvGenericNodeLocator
 from sverchok.ui.bgl_callback_nodeview import callback_disable_filtered
-
 from sverchok.utils.nodeview_time_graph_drawing import (
     start_time_graph, start_node_times)
 
@@ -78,13 +78,17 @@ class SvNodeViewShowTimeInfo(bpy.types.Operator):
         if self.fn_name == "start":
             if ng:
                 self.disable_callbacks()
+                reset_timing_graphs()
                 bpy.ops.node.sverchok_update_current(node_group=self.tree_name)
                 start_time_graph(ng)
                 start_node_times(ng)
+                ng.sv_timing_callbacks_activated = True
             else:
                 print("not found!")
         else:
+            ng.sv_timing_callbacks_activated = False
             self.disable_callbacks()
+            reset_timing_graphs()
 
         return {'FINISHED'}
 

--- a/ui/sv_panels.py
+++ b/ui/sv_panels.py
@@ -93,13 +93,14 @@ class SV_PT_ActiveTreePanel(SverchokPanels, bpy.types.Panel):
             row = col.row()
             cb = "node.nodeview_timeinfo_callback"
 
-            op_start = row.operator(cb, text="start", icon="PREVIEW_RANGE")
-            op_start.fn_name = "start"
-            op_start.tree_name = ng.name
-
-            op_end = row.operator(cb, text="end", icon="CANCEL")
-            op_end.fn_name = "end"
-            op_end.tree_name = ng.name            
+            if not ng.sv_timing_callbacks_activated:
+                op_start = row.operator(cb, text="start", icon="PREVIEW_RANGE")
+                op_start.fn_name = "start"
+                op_start.tree_name = ng.name
+            else:
+                op_end = row.operator(cb, text="end", icon="CANCEL")
+                op_end.fn_name = "end"
+                op_end.tree_name = ng.name            
 
             col.prop(ng, "sv_show_time_nodes")
             col.prop(ng, "sv_show_time_graph")


### PR DESCRIPTION
small test changes.

- does solve:
    - this does solve the stale graph cache after `f8`.  

- does not solve
    - should set `ng.sv_timing_callbacks_activated = False` after f8... that would be cool.
    ```python
    for ng in sverchok_trees():
        ng.sv_timing_callbacks_activated = False
    ```
   