### PR TITLE
Nurbs Birail: "auto rotate" flag

### DIFF
--- a/docs/nodes/surface/nurbs_birail.rst
+++ b/docs/nodes/surface/nurbs_birail.rst
@@ -25,7 +25,10 @@ path's curve T parameter, at which profile curves must be placed; otherwise,
 the node will place them automatically evenly along T parameter of the path
 curve.
 
-It is supposed that initially th eprovided profile curve(s) lie in XOY plane.
+By default it is supposed that initially the provided profile curve(s) lie in
+XOY plane. However, there is an option to instruct the node to try to figure
+out correct rotation of profile curve(s). Note that this option may result in
+precision loss in some cases.
 
 The node works by placing several copies of profile curve along the path
 curves, and then lofting (skinning) between them.  If several profile curves
@@ -99,6 +102,11 @@ This node has the following parameters:
 * **Scale all axes**. If not checked, profile curves will be scaled along one
   axis only, in order to fill the space between two paths. If checked, profile
   curves will be scaled along all axes uniformly. Checked by default.
+* **Auto rotate profiles**. If not checked, the node will assume that all
+  profile curves lie in the XOY plane. If checked, the node will work with
+  arbitrarily rotated profile curves. Enabled option requires more
+  computations, and so, may make the node slower and less precise. Unchecked by
+  default.
 * **Explicit V Values**. If checked, then the user has the ability to provide
   values of path curves parameter values, at which the provided path curves
   must be placed; otherwise, the node will calculate these parameters

--- a/nodes/surface/nurbs_birail.py
+++ b/nodes/surface/nurbs_birail.py
@@ -100,9 +100,16 @@ class SvNurbsBirailNode(bpy.types.Node, SverchCustomTreeNode):
         default = True,
         update = updateNode)
 
+    auto_rotate_profiles : BoolProperty(
+        name = "Auto rotate profiles",
+        description = "If checked, then the node will try to rotate provided profile curves appropriately. Otherwise, the node expects provided profile curves to lie in XOY plane.",
+        default = False,
+        update = updateNode)
+
     def draw_buttons(self, context, layout):
         layout.prop(self, 'nurbs_implementation', text='')
         layout.prop(self, "scale_uniform")
+        layout.prop(self, "auto_rotate_profiles")
         layout.prop(self, "explicit_v")
 
     def draw_buttons_ext(self, context, layout):
@@ -179,6 +186,7 @@ class SvNurbsBirailNode(bpy.types.Node, SverchCustomTreeNode):
                                     degree_v = degree_v,
                                     metric = self.metric,
                                     scale_uniform = self.scale_uniform,
+                                    auto_rotate = self.auto_rotate_profiles,
                                     implementation = self.nurbs_implementation
                                 )
                 new_surfaces.append(surface)

--- a/utils/geom.py
+++ b/utils/geom.py
@@ -825,7 +825,7 @@ class PlaneEquation(object):
     def get_matrix(self, invert_y=False):
         x = self.second_vector().normalized()
         z = self.normal.normalized()
-        y = z.cross(x)
+        y = z.cross(x).normalized()
         if invert_y:
             y = - y
         return Matrix([x, y, z]).transposed()

--- a/utils/surface/nurbs.py
+++ b/utils/surface/nurbs.py
@@ -1014,7 +1014,7 @@ def nurbs_birail(path1, path2, profiles,
 
     scales = scales.flatten()
     placed_profiles = []
-    for pt1, profile, scale, matrix in zip(points1, profiles, scales, matrices):
+    for pt1, pt2, profile, scale, matrix in zip(points1, points2, profiles, scales, matrices):
         if auto_rotate:
             profile = nurbs_curve_to_xoy(profile)
 
@@ -1034,6 +1034,7 @@ def nurbs_birail(path1, path2, profiles,
                 (0, 0, 1)
             ])
 
+        src_scale = scale
         scale /= pr_length
         if scale_uniform:
             scale_m = np.array([
@@ -1049,6 +1050,7 @@ def nurbs_birail(path1, path2, profiles,
                 ])
         cpts = [matrix @ scale_m @ rotation @ (pt - pr_start) + pt1 for pt in profile.get_control_points()]
         cpts = np.array(cpts)
+
         profile = profile.copy(control_points = cpts)
         placed_profiles.append(profile)
 

--- a/utils/surface/nurbs.py
+++ b/utils/surface/nurbs.py
@@ -8,7 +8,7 @@ from sverchok.utils.nurbs_common import (
         nurbs_divide, from_homogenous
     )
 from sverchok.utils.curve import knotvector as sv_knotvector
-from sverchok.utils.curve.nurbs_algorithms import interpolate_nurbs_curve, unify_curves
+from sverchok.utils.curve.nurbs_algorithms import interpolate_nurbs_curve, unify_curves, nurbs_curve_to_xoy
 from sverchok.utils.curve.algorithms import unify_curves_degree, SvCurveFrameCalculator
 from sverchok.utils.surface.core import UnsupportedSurfaceTypeException
 from sverchok.utils.surface import SvSurface, SurfaceCurvatureCalculator, SurfaceDerivativesData
@@ -903,7 +903,14 @@ def nurbs_sweep(path, profiles, ts, min_profiles, algorithm, knots_u = 'UNIFY', 
                 knots_u=knots_u, metric=metric,
                 implementation=implementation)
 
-def nurbs_birail(path1, path2, profiles, ts1 = None, ts2 = None, min_profiles = 10, knots_u = 'UNIFY', degree_v = None, metric = 'DISTANCE', scale_uniform = True, implementation = SvNurbsSurface.NATIVE):
+def nurbs_birail(path1, path2, profiles,
+        ts1 = None, ts2 = None,
+        min_profiles = 10,
+        knots_u = 'UNIFY',
+        degree_v = None, metric = 'DISTANCE',
+        scale_uniform = True,
+        auto_rotate = False,
+        implementation = SvNurbsSurface.NATIVE):
     """
     NURBS BiRail.
 
@@ -1008,6 +1015,9 @@ def nurbs_birail(path1, path2, profiles, ts1 = None, ts2 = None, min_profiles = 
     scales = scales.flatten()
     placed_profiles = []
     for pt1, profile, scale, matrix in zip(points1, profiles, scales, matrices):
+        if auto_rotate:
+            profile = nurbs_curve_to_xoy(profile)
+
         t_min, t_max = profile.get_u_bounds()
         pr_start = profile.evaluate(t_min)
         pr_end = profile.evaluate(t_max)


### PR DESCRIPTION
Previously, Nurbs Birail node required that profile curves lied in XOY plane.
This PR adds "Auto Rotate Profiles" flag, which instructs the node to work with arbitrarily placed profile curves.
Note: this may result in precision loss in some cases.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [ ] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [ ] Ready for merge.

