### PR TITLE
Raycaster checks

### DIFF
--- a/docs/nodes/analyzer/raycaster_lite.rst
+++ b/docs/nodes/analyzer/raycaster_lite.rst
@@ -4,12 +4,12 @@ Raycast
 Functionality
 -------------
 
-Functionality is almost completely analogous to the two built-in blender operators 
-``bpy.context.scene.ray_cast`` and ``object.ray_cast``. 
+Functionality is almost completely analogous to the two built-in blender operators
+``bpy.context.scene.ray_cast`` and ``object.ray_cast``.
 Ray is casted from "start" vector to "end" vector and can hit polygons of input objects.
 
-see docs: 
-`bpy.types.Object.ray_cast <http://www.blender.org/documentation/blender_python_api_2_71_0/bpy.types.Object.html#bpy.types.Object.ray_cast>`_ and 
+see docs:
+`bpy.types.Object.ray_cast <http://www.blender.org/documentation/blender_python_api_2_71_0/bpy.types.Object.html#bpy.types.Object.ray_cast>`_ and
 `bpy.types.Scene.ray_cast <http://www.blender.org/documentation/blender_python_api_2_71_0/bpy.types.Scene.html#bpy.types.Scene.ray_cast>`_
 
 
@@ -41,6 +41,12 @@ Output sockets
 | Success                | ``True`` or ``False`` if ray doesn't hit any polygon.                                  |
 +------------------------+----------------------------------------------------------------------------------------+
 
+Advanced parameters (N-Panel)
+----------------------------
+
+**Safe Check**: Checks the mesh for unreferenced polygons (slows the node but prevents some Blender crashes)
+
+**All Triangles**: Enable if all the incoming faces are triangles to improve the performance of the algorithm
 
 Usage
 -----

--- a/nodes/analyzer/raycaster_lite.py
+++ b/nodes/analyzer/raycaster_lite.py
@@ -25,7 +25,10 @@ from sverchok.utils.bvh_tree import bvh_tree_from_polygons
 # airlifted from Kosvor's Raycast nodes..
 
 class SvRaycasterLiteNode(bpy.types.Node, SverchCustomTreeNode):
-    ''' svmesh to Raycast '''
+    """
+    Triggers: Raycast on Mesh
+    Tooltip: Cast rays from arbitrary points on to a mesh a determine hiting location, normal at hitpoint, ray legngth and index of the hitted face.
+    """
     bl_idname = 'SvRaycasterLiteNode'
     bl_label = 'Raycaster'
     bl_icon = 'OUTLINER_OB_EMPTY'
@@ -69,7 +72,8 @@ class SvRaycasterLiteNode(bpy.types.Node, SverchCustomTreeNode):
     def process(self):
         L, N, I, D, S = self.outputs
         RL = []
-
+        if not any([s.is_linked for s in self.outputs]):
+            return
         vert_in, face_in, start_in, direction_in = C([sock.sv_get(deepcopy=False) for sock in self.inputs])
 
         for bvh, st, di in zip(*[self.svmesh_to_bvh_lists(vert_in, face_in, self.all_triangles, self.safe_check), start_in, direction_in]):


### PR DESCRIPTION
A couple of toggles for the raycaster node:

**Safe Check**: Checks the mesh for un-referenced polygons (slows the node but prevents some Blender crashes)

**All Triangles**: Enable if all the incoming faces are triangles to improve the performance of the algorithm


- [x] Ready for merge.

