### PR TITLE
introduce node bound caching (for SNLite at least...)

### DIFF
--- a/nodes/script/script1_lite.py
+++ b/nodes/script/script1_lite.py
@@ -21,6 +21,7 @@ import sys
 import ast
 import json
 import inspect
+import textwrap
 import traceback
 import numpy as np
 
@@ -216,7 +217,7 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
             default_value = socket_description[2]
 
             if socket_description is UNPARSABLE:
-                print(socket_description, idx, 'was unparsable')
+                self.info(f"{socket_description}, {idx}, was unparsable")
                 return
 
             if len(sockets) > 0 and idx in set(range(len(sockets))):
@@ -639,11 +640,15 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
                 if include_name == new_text.name:
                     continue
 
-                print('| in', self.name, 'the importer encountered')
-                print('| an include called', include_name, '. While trying')
-                print('| to write this file to bpy.data.texts another file')
-                print('| with the same name was encountered. The importer')
-                print('| automatically made a datablock called', new_text.name)
+                multi_string_msg = textwrap.dedent(f"""\
+                | in {self.name} the importer encountered
+                | an include called {include_name}. While trying
+                | to write this file to bpy.data.texts another file
+                | with the same name was encountered. The importer
+                | automatically made a datablock called {new_text.name}.
+                """)
+
+                self.info(multi_string_msg)
 
     def load_from_json(self, node_data: dict, import_version: float):
 

--- a/nodes/script/script1_lite.py
+++ b/nodes/script/script1_lite.py
@@ -295,13 +295,6 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
             msg_2 = f"size static cache = {len(nodescript_static_caching)}"
             self.info(f"{msg_1}\n{msg_2}")
 
-    def wipe_responsive_cache(self):
-        try:
-            del nodescript_responsive_caching[self.node_id]
-        except:
-            msg_1 = f"{self.node_id} not found in nodescript_responsive_caching.."
-            msg_2 = f"size responsive cache = {len(nodescript_responsive_caching)}"
-            self.info(f"{msg_1}\n{msg_2}")
 
 
     def get_static_cache(self, function_to_use=None, variables_to_use=None):
@@ -332,6 +325,15 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
 
         return cache
 
+    def wipe_responsive_cache(self):
+        # try:
+        #     del nodescript_responsive_caching[self.node_id]
+        # except:
+        #     msg_1 = f"{self.node_id} not found in nodescript_responsive_caching.."
+        #     msg_2 = f"size responsive cache = {len(nodescript_responsive_caching)}"
+        #     self.info(f"{msg_1}\n{msg_2}")
+        ...
+
     def get_responsive_cache(self, function_to_use=None, variables_to_use=None):
         """
         this functions aims to provide a way to check if a the function or variables that produce your data
@@ -354,6 +356,9 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
             cache = function_to_use(*variables_to_use)
             nodescript_responsive_caching[cache_key] = cache
             self.info('responsive cache created')
+
+            # if any other cache_key is similar except variables, then probably..probably.. want to nuke it.
+            ...
 
         return cache
 

--- a/nodes/script/script1_lite.py
+++ b/nodes/script/script1_lite.py
@@ -31,7 +31,7 @@ from sverchok.utils.sv_update_utils import sv_get_local_path
 from sverchok.utils.snlite_importhelper import (
     UNPARSABLE, set_autocolor, parse_sockets, are_matched)
 
-from sverchok.utils.snlite_utils import vectorize, ddir, CacheMixin
+from sverchok.utils.snlite_utils import vectorize, ddir, range_limit, CacheMixin
 from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata, pydata_from_bmesh
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
@@ -46,6 +46,8 @@ snlite_template_path = os.path.join(sv_path, 'node_scripts', 'SNLite_templates')
 defaults = [0] * 32
 
 template_categories = ['demo', 'bpy_stuff', 'bmesh', 'utils']
+
+
 
 class SNLITE_EXCEPTION(Exception): pass
 
@@ -422,6 +424,7 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode, C
             'bpy': bpy,
             'np': np,
             'ddir': ddir,
+            'range_limit': range_limit,
             'bmesh_from_pydata': bmesh_from_pydata,
             'pydata_from_bmesh': pydata_from_bmesh
         })

--- a/nodes/script/script1_lite.py
+++ b/nodes/script/script1_lite.py
@@ -20,6 +20,7 @@ import os
 import sys
 import ast
 import json
+import inspect
 import traceback
 import numpy as np
 
@@ -338,14 +339,20 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
         - if the function changes significantly (any non whitespace change)  (no point comparing object references)
         - or the variables (works best if the number of variables are relatively small, and not f.ex 100k points)
 
-        [ ] check the function code as a string
-        [ ] check the input variables
+        [x] check the function code as a string
+        [x] check the input variables
 
         """
-        cache = nodescript_responsive_caching.get(self.node_id)
+        
+        component_id = self.node_id
+        component_function_text = hash(inspect.getsource(function_to_use))
+        component_variables_hash = hash(str(variables))
+        cache_key = (component_id, component_function_text, component_variables_hash)
+        
+        cache = nodescript_responsive_caching.get(cache_key)
         if not cache:
             cache = function_to_use(*variables_to_use)
-            nodescript_responsive_caching[self.node_id] = cache
+            nodescript_responsive_caching[cache_key] = cache
             self.info('responsive cache created')
 
         return cache

--- a/nodes/script/script1_lite.py
+++ b/nodes/script/script1_lite.py
@@ -325,20 +325,20 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
 
         return cache
 
-    def responsive_cache_key(self, function_to_use=None, variables=None):
-        component_function_text = hash(inspect.getsource(function_to_use))
-        component_variables_hash = hash(str(variables))
-        return (self.node_id, component_function_text, component_variables_hash)
+    def wipe_responsive_cache(self, function_to_use=None):
+        """
+        can wipe the value stored in a key is found where the first two components are (self.node_id, function_str_hash, .......)
 
+        """
+        try:
+            for k in nodescript_responsive_caching.keys():
+                if k[0] == self.node_id and k[1] == hash(inspect.getsource(function_to_use)):
+                    del nodescript_responsive_caching[k]
+                    self.info(f"removed key: {self.nod_id}, function: {function_to_use.__name__}")
+                    # break  maybe 
 
-    def wipe_responsive_cache(self, function_to_use=None, variables=None):
-        # try:
-        #     del nodescript_responsive_caching[self.node_id]
-        # except:
-        #     msg_1 = f"{self.node_id} not found in nodescript_responsive_caching.."
-        #     msg_2 = f"size responsive cache = {len(nodescript_responsive_caching)}"
-        #     self.info(f"{msg_1}\n{msg_2}")
-        ...
+        except Exception as err:
+            self.info(err)
 
     def get_responsive_cache(self, function_to_use=None, variables=None):
         """
@@ -352,7 +352,10 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
 
 
         """
-        cache_key = self.responsive_cache_key(function_to_use, variables)
+        component_function_text = hash(inspect.getsource(function_to_use))
+        component_variables_hash = hash(str(variables))
+        cache_key = (self.node_id, component_function_text, component_variables_hash)
+
         cache = nodescript_responsive_caching.get(cache_key)
 
         if not cache:

--- a/nodes/script/script1_lite.py
+++ b/nodes/script/script1_lite.py
@@ -20,7 +20,6 @@ import os
 import sys
 import ast
 import json
-import inspect
 import textwrap
 import traceback
 import numpy as np
@@ -108,29 +107,34 @@ class SvScriptNodeLiteTextImport(bpy.types.Operator):
 
 
 class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode, CacheMixin):
-    ''' snl SN Lite /// a lite version of SN '''
+
+    """
+    Triggers: snl
+    Tooltip: Script Node Lite
+    
+    This code represents a conscious weighing of conveniences to the user, vs somewhat harder to understand
+    code under the hood. This code evolved as design specs changed, while providing continued support for
+    previous implementation details.
+    """
 
     bl_idname = 'SvScriptNodeLite'
     bl_label = 'Scripted Node Lite'
     bl_icon = 'SCRIPTPLUGINS'
 
-    def custom_enum_func(self, context):
+    def return_enumeration(self, enum_name=""):
         ND = self.node_dict.get(hash(self))
         if ND:
-            enum_list = ND['sockets']['custom_enum']
+            enum_list = ND['sockets'][enum_name]
             if enum_list:
                 return [(ce, ce, '', idx) for idx, ce in enumerate(enum_list)]
 
         return [("A", "A", '', 0), ("B", "B", '', 1)]
+
+    def custom_enum_func(self, context):
+        return self.return_enumeration(enum_name='custom_enum')
 
     def custom_enum_func_2(self, context):
-        ND = self.node_dict.get(hash(self))
-        if ND:
-            enum_list = ND['sockets']['custom_enum_2']
-            if enum_list:
-                return [(ce, ce, '', idx) for idx, ce in enumerate(enum_list)]
-
-        return [("A", "A", '', 0), ("B", "B", '', 1)]
+        return self.return_enumeration(enum_name='custom_enum_2')
 
 
     def custom_callback(self, context, operator):
@@ -206,10 +210,10 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode, C
         for idx, (socket_description) in enumerate(v):
             """
             Socket description at the moment of typing is list of: [
-            socket_type: str, 
-            socket_name: str, 
-            default: int value, float value or None,
-            nested: int]
+                socket_type: str, 
+                socket_name: str, 
+                default: int value, float value or None,
+                nested: int]
             """
             default_value = socket_description[2]
 

--- a/nodes/script/script1_lite.py
+++ b/nodes/script/script1_lite.py
@@ -289,7 +289,7 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
         try:
             del nodescript_static_caching[self.node_id]
         except:
-            msg_1 = f"{self.node_id} not found in node_script_static_caching.."
+            msg_1 = f"{self.node_id} not found in nodescript_static_caching.."
             msg_2 = f"size static cache = {len(nodescript_static_caching)}"
             self.info(f"{msg_1}\n{msg_2}")
 
@@ -308,7 +308,7 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
 
             # here you set the cache, and obtain the data.
             my_data = self.get_static_cache(
-                my_useful_function,    # any kind of function, should return a useful product of calcuation
+                my_useful_function,    # any kind of function, should return the useful product of calculation
                 my_variables           # must be a tuple of variables (if single variable use (variable,))
                                        # if no variables use () : f.ex:  self.get_static_cache(some_func, ())
         

--- a/utils/snlite_utils.py
+++ b/utils/snlite_utils.py
@@ -148,7 +148,7 @@ class CacheMixin():
 
     def get_size_of_responsive_cache(self, this_node_only=False):
         if this_node_only:
-            return len([k for k in static_caching.keys() if k[0] == self.node_id])
+            return len([k for k in responsive_caching.keys() if k[0] == self.node_id])
         return len(responsive_caching)
 
     # user should not modify existing cache manually. my guess is very few people will ever use this except me.

--- a/utils/snlite_utils.py
+++ b/utils/snlite_utils.py
@@ -124,8 +124,6 @@ class CacheMixin():
 
         [x] check the function code as a string
         [x] check the input variables
-        [ ] testing
-
 
         """
         component_function_text = hash(inspect.getsource(function_to_use))
@@ -133,7 +131,7 @@ class CacheMixin():
         cache_key = (self.node_id, component_function_text, component_variables_hash)
 
         if auto_wipe:
-            # maybe?
+            # maybe? this will wipe any references in cache that come from this "node_id" and this "function_to_use.str"
             self.wipe_responsive_cache(function_to_use)
 
         cache = responsive_caching.get(cache_key)

--- a/utils/snlite_utils.py
+++ b/utils/snlite_utils.py
@@ -115,7 +115,7 @@ class CacheMixin():
         except Exception as err:
             self.info(err)
 
-    def get_responsive_cache(self, function_to_use=None, variables=None):
+    def get_responsive_cache(self, function_to_use=None, variables=None, auto_wipe=True):
         """
         this functions aims to provide a way to check if a the function or variables that produce 
         your data has changed, before deciding to re-execute the function with your variables.
@@ -132,14 +132,15 @@ class CacheMixin():
         component_variables_hash = hash(str(variables))
         cache_key = (self.node_id, component_function_text, component_variables_hash)
 
+        if auto_wipe:
+            # maybe?
+            self.wipe_responsive_cache(function_to_use)
+
         cache = responsive_caching.get(cache_key)
 
         if not cache:
             cache = function_to_use(*variables_to_use)
             responsive_caching[cache_key] = cache
             self.info('responsive cache created')
-
-            # if any other cache_key is similar except variables, then probably..probably.. want to nuke it.
-            ...
 
         return cache

--- a/utils/snlite_utils.py
+++ b/utils/snlite_utils.py
@@ -42,3 +42,94 @@ def ddir(content, filter_str=None):
     else:
         vals = [n for n in dir(content) if not n.startswith('__') and filter_str in n]
     return vals
+
+
+
+static_caching = {}
+responsive_caching = {}
+
+
+class CacheMixin():
+
+
+    def wipe_static_cache(self):
+        try:
+            del static_caching[self.node_id]
+        except Exception as err:
+            msg_1 = f"{self.node_id} not found in static_caching.."
+            msg_2 = f"size static cache = {len(static_caching)}"
+            self.info(f"{msg_1}\n{msg_2}")
+            self.info(f"{err}")
+
+
+
+    def get_static_cache(self, function_to_use=None, variables=None):
+        """
+        This function provides a relatively convenient way to do Static Caching
+
+        - lets you cache one off calculations for this node
+        - reset the cache if your (input) data changes.
+
+        How to make an initial cache for a tested function with known input data:
+
+            # if you need to reset, do it above the caching.
+            self.wipe_static_cache()
+
+            # here you set the cache, and obtain the data.
+            my_data = self.get_static_cache(
+                my_useful_function,    # any kind of function, should return the useful product of calculation
+                my_variables           # must be a tuple of variables (if single variable use (variable,))
+                                       # if no variables use () : f.ex:  self.get_static_cache(some_func, ())
+        
+        """
+      
+        cache = static_caching.get(self.node_id)
+        if not cache:
+            cache = function_to_use(*variables)
+            static_caching[self.node_id] = cache
+            self.info('static cache created')
+
+        return cache
+
+    def wipe_responsive_cache(self, function_to_use=None):
+        """
+        can wipe the value stored in a key is found where the first two components are (self.node_id, function_str_hash, .......)
+
+        """
+        try:
+            for k in responsive_caching.keys():
+                if k[0] == self.node_id and k[1] == hash(inspect.getsource(function_to_use)):
+                    del responsive_caching[k]
+                    self.info(f"removed key: {self.nod_id}, function: {function_to_use.__name__}")
+                    # break  maybe 
+
+        except Exception as err:
+            self.info(err)
+
+    def get_responsive_cache(self, function_to_use=None, variables=None):
+        """
+        this functions aims to provide a way to check if a the function or variables that produce your data
+        has changed, before deciding to re-execute the function with your variables.
+        - if the function changes significantly (any non whitespace change)  (no point comparing object references)
+        - or the variables (works best if the number of variables are relatively small, and not f.ex 100k points)
+
+        [x] check the function code as a string
+        [x] check the input variables
+
+
+        """
+        component_function_text = hash(inspect.getsource(function_to_use))
+        component_variables_hash = hash(str(variables))
+        cache_key = (self.node_id, component_function_text, component_variables_hash)
+
+        cache = responsive_caching.get(cache_key)
+
+        if not cache:
+            cache = function_to_use(*variables_to_use)
+            responsive_caching[cache_key] = cache
+            self.info('responsive cache created')
+
+            # if any other cache_key is similar except variables, then probably..probably.. want to nuke it.
+            ...
+
+        return cache

--- a/utils/snlite_utils.py
+++ b/utils/snlite_utils.py
@@ -100,9 +100,10 @@ class CacheMixin():
 
     def wipe_responsive_cache(self, function_to_use=None):
         """
-        can wipe the value stored in a key is found where the first two components are:
-
-             (self.node_id, function_str_hash, .......)
+        to avoid infinitely growing cache, it's useful to be able to wipe storage of all other reference
+        to this node and this function. Any cached key that starts with these components can be wiped.
+        
+            (self.node_id, function_str_hash, .......)
 
         """
         try:
@@ -110,7 +111,6 @@ class CacheMixin():
                 if k[0] == self.node_id and k[1] == hash(inspect.getsource(function_to_use)):
                     del responsive_caching[k]
                     self.info(f"removed key: {self.nod_id}, function: {function_to_use.__name__}")
-                    # break  maybe 
 
         except Exception as err:
             self.info(err)
@@ -131,7 +131,7 @@ class CacheMixin():
         cache_key = (self.node_id, component_function_text, component_variables_hash)
 
         if auto_wipe:
-            # maybe? this will wipe any references in cache that come from this "node_id" and this "function_to_use.str"
+            # this will wipe any references in cache that come from this "node_id" and this "function_to_use.str"
             self.wipe_responsive_cache(function_to_use)
 
         cache = responsive_caching.get(cache_key)
@@ -142,3 +142,19 @@ class CacheMixin():
             self.info('responsive cache created')
 
         return cache
+
+    def get_size_of_static_cache(self):
+        return len(static_caching)
+
+    def get_size_of_responsive_cache(self, this_node_only=False):
+        if this_node_only:
+            return len([k for k in static_caching.keys() if k[0] == self.node_id])
+        return len(responsive_caching)
+
+    # user should not modify existing cache manually. my guess is very few people will ever use this except me.
+
+    def get_static_cache(self):
+        return static_caching
+
+    def get_responsive_cache(self):
+        return responsive_caching

--- a/utils/snlite_utils.py
+++ b/utils/snlite_utils.py
@@ -153,8 +153,8 @@ class CacheMixin():
 
     # user should not modify existing cache manually. my guess is very few people will ever use this except me.
 
-    def get_static_cache(self):
+    def get_static_cache_dict(self):
         return static_caching
 
-    def get_responsive_cache(self):
+    def get_responsive_cache_dict(self):
         return responsive_caching

--- a/utils/snlite_utils.py
+++ b/utils/snlite_utils.py
@@ -16,6 +16,7 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
+import inspect
 
 import bpy
 
@@ -42,6 +43,12 @@ def ddir(content, filter_str=None):
     else:
         vals = [n for n in dir(content) if not n.startswith('__') and filter_str in n]
     return vals
+
+
+def range_limit(low, high, x):
+    if x < low: return low
+    elif x > high: return high
+    return x
 
 
 
@@ -93,7 +100,9 @@ class CacheMixin():
 
     def wipe_responsive_cache(self, function_to_use=None):
         """
-        can wipe the value stored in a key is found where the first two components are (self.node_id, function_str_hash, .......)
+        can wipe the value stored in a key is found where the first two components are:
+
+             (self.node_id, function_str_hash, .......)
 
         """
         try:
@@ -108,13 +117,14 @@ class CacheMixin():
 
     def get_responsive_cache(self, function_to_use=None, variables=None):
         """
-        this functions aims to provide a way to check if a the function or variables that produce your data
-        has changed, before deciding to re-execute the function with your variables.
+        this functions aims to provide a way to check if a the function or variables that produce 
+        your data has changed, before deciding to re-execute the function with your variables.
         - if the function changes significantly (any non whitespace change)  (no point comparing object references)
         - or the variables (works best if the number of variables are relatively small, and not f.ex 100k points)
 
         [x] check the function code as a string
         [x] check the input variables
+        [ ] testing
 
 
         """


### PR DESCRIPTION
- [x] static_caching  (basic, one per node)
- [ ] responsive_caching
     - some kind of combination tuple as hashmap key:

         ```python
            component_id = self.node_id
            component_function_text = hash(inspect.getsource(function_to_use))
            component_variables_hash = hash(str(variables))

            cache_key = (component_id, component_function_text, component_variables_hash)
         ```

     - so if the cache is invalidated if 
         - user has code changes to the input function
         - user changes input variables
     
     - considerations:
         - do i want automatic cache culling?
             - include function name as part of the hash key so as to make it more convenient to delete cache's where keys contains the first two components
- [x] make it a mixin
     - altho, because not all scripts will use this maybe having it as a default mixin is not a good idea...

and see how that goes