### PR TITLE
Fixed `` formatting in line 87 (minor fix)

### DIFF
--- a/docs/nesting.rst
+++ b/docs/nesting.rst
@@ -84,7 +84,7 @@ here with some highlighting of the syntax
 |socket_template_HL|
 
 - The (orange) ``comma`` is what syntactically separates the objects.
-- The inner (green)``Square Brackets`` are what encapsulate the vertices associated with one object.
+- The inner (green) ``Square Brackets`` are what encapsulate the vertices associated with one object.
 - The outer most (blue) ``Square Brackets`` are what collect all sublists into something that we can pass through a socket  
 - The parentheses enclose coordinates of each Vertex. In sverchok can also use square brackets to enclose a Vertex. The following are functionally equivalent in sverchok::
 


### PR DESCRIPTION
## Addressed problem description

Fixed markdown formatting in line 87

## Solution description

Fixed backtick formatting in line 87

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [ ] Code changes complete.
- [ ] Code documentation complete.
- [ ] Documentation for users complete (or not required, if user never sees these changes).
- [ ] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

