### PR TITLE
Renamed json_examples/Shapes/Buddha_Lotus.json + typo fix within 

### DIFF
--- a/json_examples/Shapes/Buddha_Lotus.json
+++ b/json_examples/Shapes/Buddha_Lotus.json
@@ -118,7 +118,7 @@
       "bl_idname": "NodeFrame",
       "height": 286.68707275390625,
       "hide": false,
-      "label": "buddah",
+      "label": "buddha",
       "location": [
         -57.046142578125,
         -49.86566162109375


### PR DESCRIPTION
Correct spelling of 'Buddha'