### PR TITLE
Snlite corrections 8

### DIFF
--- a/nodes/script/script1_lite.py
+++ b/nodes/script/script1_lite.py
@@ -107,7 +107,15 @@ class SvScriptNodeLiteTextImport(bpy.types.Operator):
 
 
 class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
-    ''' snl SN Lite /// a lite version of SN '''
+
+    """
+    Triggers: snl
+    Tooltip: Script Node Lite
+    
+    This code represents a conscious weighing of conveniences to the user, vs somewhat harder to understand
+    code under the hood. This code evolved as design specs changed, while providing continued support for
+    previous implementation details.
+    """
 
     bl_idname = 'SvScriptNodeLite'
     bl_label = 'Scripted Node Lite'

--- a/nodes/script/script1_lite.py
+++ b/nodes/script/script1_lite.py
@@ -121,23 +121,20 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
     bl_label = 'Scripted Node Lite'
     bl_icon = 'SCRIPTPLUGINS'
 
-    def custom_enum_func(self, context):
+    def return_enumeration(self, enum_name=""):
         ND = self.node_dict.get(hash(self))
         if ND:
-            enum_list = ND['sockets']['custom_enum']
+            enum_list = ND['sockets'][enum_name]
             if enum_list:
                 return [(ce, ce, '', idx) for idx, ce in enumerate(enum_list)]
 
         return [("A", "A", '', 0), ("B", "B", '', 1)]
+
+    def custom_enum_func(self, context):
+        return self.return_enumeration(enum_name='custom_enum')
 
     def custom_enum_func_2(self, context):
-        ND = self.node_dict.get(hash(self))
-        if ND:
-            enum_list = ND['sockets']['custom_enum_2']
-            if enum_list:
-                return [(ce, ce, '', idx) for idx, ce in enumerate(enum_list)]
-
-        return [("A", "A", '', 0), ("B", "B", '', 1)]
+        return self.return_enumeration(enum_name='custom_enum_2')
 
 
     def custom_callback(self, context, operator):

--- a/nodes/script/script1_lite.py
+++ b/nodes/script/script1_lite.py
@@ -20,6 +20,7 @@ import os
 import sys
 import ast
 import json
+import textwrap
 import traceback
 import numpy as np
 
@@ -210,15 +211,15 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
         for idx, (socket_description) in enumerate(v):
             """
             Socket description at the moment of typing is list of: [
-            socket_type: str, 
-            socket_name: str, 
-            default: int value, float value or None,
-            nested: int]
+                socket_type: str, 
+                socket_name: str, 
+                default: int value, float value or None,
+                nested: int]
             """
             default_value = socket_description[2]
 
             if socket_description is UNPARSABLE:
-                print(socket_description, idx, 'was unparsable')
+                self.info(f"{socket_description}, {idx}, was unparsable")
                 return
 
             if len(sockets) > 0 and idx in set(range(len(sockets))):
@@ -561,11 +562,14 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
                 if include_name == new_text.name:
                     continue
 
-                print('| in', self.name, 'the importer encountered')
-                print('| an include called', include_name, '. While trying')
-                print('| to write this file to bpy.data.texts another file')
-                print('| with the same name was encountered. The importer')
-                print('| automatically made a datablock called', new_text.name)
+                multi_string_msg = textwrap.dedent(f"""\
+                | in {self.name} the importer encountered
+                | an include called {include_name}. While trying
+                | to write this file to bpy.data.texts another file
+                | with the same name was encountered. The importer
+                | automatically made a datablock called {new_text.name}.
+                """)
+                self.info(multi_string_msg)
 
     def load_from_json(self, node_data: dict, import_version: float):
 

--- a/nodes/script/script1_lite.py
+++ b/nodes/script/script1_lite.py
@@ -31,7 +31,7 @@ from sverchok.utils.sv_update_utils import sv_get_local_path
 from sverchok.utils.snlite_importhelper import (
     UNPARSABLE, set_autocolor, parse_sockets, are_matched)
 
-from sverchok.utils.snlite_utils import vectorize, ddir, sv_njit
+from sverchok.utils.snlite_utils import vectorize, ddir, sv_njit, sv_njit_clear
 from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata, pydata_from_bmesh
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
@@ -426,6 +426,7 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
             'np': np,
             'ddir': ddir,
             'sv_njit': sv_njit,
+            'sv_njit_clear': sv_njit_clear,
             'bmesh_from_pydata': bmesh_from_pydata,
             'pydata_from_bmesh': pydata_from_bmesh
         })

--- a/nodes/script/script1_lite.py
+++ b/nodes/script/script1_lite.py
@@ -31,7 +31,7 @@ from sverchok.utils.sv_update_utils import sv_get_local_path
 from sverchok.utils.snlite_importhelper import (
     UNPARSABLE, set_autocolor, parse_sockets, are_matched)
 
-from sverchok.utils.snlite_utils import vectorize, ddir
+from sverchok.utils.snlite_utils import vectorize, ddir, sv_njit
 from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata, pydata_from_bmesh
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.utils.nodes_mixins.sv_animatable_nodes import SvAnimatableNode
@@ -425,6 +425,7 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode, SvAnimatableNode):
             'bpy': bpy,
             'np': np,
             'ddir': ddir,
+            'sv_njit': sv_njit,
             'bmesh_from_pydata': bmesh_from_pydata,
             'pydata_from_bmesh': pydata_from_bmesh
         })

--- a/utils/snlite_utils.py
+++ b/utils/snlite_utils.py
@@ -20,11 +20,9 @@
 from logging import info
 
 import bpy
-
-import sverchok
 from sverchok.data_structure import match_long_repeat
 
-sverchok.njit_function_storage = {}
+njit_function_storage = {}
 
 
 def vectorize(all_data):
@@ -51,11 +49,18 @@ def ddir(content, filter_str=None):
 
 def sv_njit(function_to_njit, parameters):
     fn_name = function_to_njit.__name__
-    njit_func = sverchok.njit_function_storage.get(fn_name)
+    njit_func = njit_function_storage.get(fn_name)
     if not njit_func:
         result = function_to_njit(*parameters)
-        sverchok.njit_function_storage[fn_name] = function_to_njit
+        njit_function_storage[fn_name] = function_to_njit
         info(f"caching function: {fn_name}")
     else:
         result = njit_func(*parameters)
     return result
+
+def sv_njit_clear(function_to_njit):
+    fn_name = function_to_njit.__name__
+    njit_func = njit_function_storage.get(fn_name)
+    if njit_func:
+        del njit_function_storage[fn_name]
+        info(f"cleared cached function: {fn_name}")

--- a/utils/snlite_utils.py
+++ b/utils/snlite_utils.py
@@ -17,9 +17,14 @@
 # ##### END GPL LICENSE BLOCK #####
 
 
+from logging import info
+
 import bpy
 
+import sverchok
 from sverchok.data_structure import match_long_repeat
+
+sverchok.njit_function_storage = {}
 
 
 def vectorize(all_data):
@@ -42,3 +47,15 @@ def ddir(content, filter_str=None):
     else:
         vals = [n for n in dir(content) if not n.startswith('__') and filter_str in n]
     return vals
+
+
+def sv_njit(function_to_njit, parameters):
+    fn_name = function_to_njit.__name__
+    njit_func = sverchok.njit_function_storage.get(fn_name)
+    if not njit_func:
+        result = function_to_njit(*parameters)
+        sverchok.njit_function_storage[fn_name] = function_to_njit
+        info(f"caching function: {fn_name}")
+    else:
+        result = njit_func(*parameters)
+    return result


### PR DESCRIPTION
cherrypicking from older commits.

- Functions that can be compiled using `numba` (using `njit`), must be cached for snlite specific reasons. 
- The name of the `function` is the `cache key` _under the hood_

```python
sv_njit_clear(make_hadley3)  # <-- if the cached function needs to be cleaned, comment this out when happy

# here pz are the results of the calculations.
pz = sv_njit(make_hadley3, parameters)
```
allowing this to be written

```python
"""
in  alpha   s d=0.2 n=2
in  beta    s d=4.0 n=2
in  delta   s d=8.0 n=2
in  gamma   s d=1.0 n=2
in  factor  s d=7.0 n=2
in  dif     s d=0.005 n=2
in  t       s d=20000 n=2
in  step    s d=5 n=2
in  mod     s d=4 n=2
out verts   v
""" 

import sverchok
import numba
from numba import njit

@njit
def make_hadley3(alpha=0.2, beta=4.0, delta=8.0, gamma=1.0, factor=7.0, dif=0.005, t=20000, step=5, mod=4):
    Points = []
    p = Points.extend

    x = 0.1
    y = 0.0
    z = 0.0
    AxD = (alpha * delta)
    for i in range(1, t):
        for j in range(step):
            x += dif * (-(y**2) - (z**2) - (alpha*x) + AxD)
            y += dif * ((x*y) - (beta*x*z) - y + gamma)
            z += dif * ((beta*x*y) + (x*z) - z)
        if i % mod == 0:
            p([x*factor, y*factor, z*factor])

    return Points

# sv_njit_clear(make_hadley3)
parameters = (alpha, beta, delta, gamma, factor, dif, t, step, mod)
pz = sv_njit(make_hadley3, parameters)

verts.append(np.array(pz).reshape((-1, 3)).tolist())
```