### PR TITLE
New update system fixes 1

### DIFF
--- a/node_tree.py
+++ b/node_tree.py
@@ -124,7 +124,7 @@ class SverchCustomTree(NodeTree, SvNodeTreeCommon):
     sv_animate: BoolProperty(name="Animate", default=True, description='Animate this layout', options=set())
     sv_show: BoolProperty(name="Show", default=True, description='Show this layout', update=turn_off_ng, options=set())
     sv_show_time_graph: BoolProperty(name="Time Graph", default=False, options=set())  # todo is not used now
-    sv_show_time_nodes: BoolProperty(name="Node times", default=True, options=set(), update=lambda s, c: s.update_ui())
+    sv_show_time_nodes: BoolProperty(name="Node times", default=False, options=set(), update=lambda s, c: s.update_ui())
     show_time_mode: EnumProperty(
         items=[(n, n, '') for n in ["Per node", "Cumulative"]],
         options=set(),

--- a/ui/nodeview_keymaps.py
+++ b/ui/nodeview_keymaps.py
@@ -164,6 +164,12 @@ def add_keymap():
 
         # F5 | Trigger update of context node tree
         kmi = km.keymap_items.new('node.sverchok_update_context', 'F5', 'PRESS')
+        kmi.properties.force_mode = False
+        nodeview_keymaps.append((km, kmi))
+
+        # Ctrl-F5 | Trigger update of context node tree
+        kmi = km.keymap_items.new('node.sverchok_update_context', 'F5', 'PRESS', ctrl=True)
+        kmi.properties.force_mode = True
         nodeview_keymaps.append((km, kmi))
 
         # F6 | Toggle processing mode of the active node tree

--- a/ui/nodeview_keymaps.py
+++ b/ui/nodeview_keymaps.py
@@ -162,6 +162,10 @@ def add_keymap():
         kmi = km.keymap_items.new('node.sv_extra_search', 'SPACE', 'PRESS', alt=True)
         nodeview_keymaps.append((km, kmi))
 
+        # F5 | Trigger update of context node tree
+        kmi = km.keymap_items.new('node.sverchok_update_context', 'F5', 'PRESS')
+        nodeview_keymaps.append((km, kmi))
+
         # F6 | Toggle processing mode of the active node tree
         kmi = km.keymap_items.new('node.sv_toggle_process', 'F6', 'PRESS')
         nodeview_keymaps.append((km, kmi))

--- a/ui/sv_panels.py
+++ b/ui/sv_panels.py
@@ -261,6 +261,25 @@ class SverchokUpdateCurrent(bpy.types.Operator):
             bpy.context.window.cursor_set("DEFAULT")
         return {'FINISHED'}
 
+class SverchokUpdateContext(bpy.types.Operator):
+    """Update current Sverchok node tree"""
+    bl_idname = "node.sverchok_update_context"
+    bl_label = "Update current node tree"
+    bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
+
+    @classmethod
+    def poll(cls, context):
+        return displaying_sverchok_nodes(context)
+
+    def execute(self, context):
+        node_tree = context.space_data.node_tree
+        if node_tree:
+            try:
+                bpy.context.window.cursor_set("WAIT")
+                node_tree.force_update()
+            finally:
+                bpy.context.window.cursor_set("DEFAULT")
+        return {'FINISHED'}
 
 class SvSwitchToLayout(bpy.types.Operator):
     """Switch to exact layout, user friendly way"""
@@ -325,6 +344,7 @@ sv_tools_classes = [
     SverchokUpdateAll,
     SverchokBakeAll,
     SverchokUpdateCurrent,
+    SverchokUpdateContext,
     SvSwitchToLayout
 ]
 

--- a/ui/sv_panels.py
+++ b/ui/sv_panels.py
@@ -267,6 +267,8 @@ class SverchokUpdateContext(bpy.types.Operator):
     bl_label = "Update current node tree"
     bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
 
+    force_mode: bpy.props.BoolProperty(default=False)
+
     @classmethod
     def poll(cls, context):
         return displaying_sverchok_nodes(context)
@@ -274,11 +276,12 @@ class SverchokUpdateContext(bpy.types.Operator):
     def execute(self, context):
         node_tree = context.space_data.node_tree
         if node_tree:
-            try:
-                bpy.context.window.cursor_set("WAIT")
-                node_tree.force_update()
-            finally:
-                bpy.context.window.cursor_set("DEFAULT")
+            if self.force_mode or node_tree.sv_process:
+                try:
+                    bpy.context.window.cursor_set("WAIT")
+                    node_tree.force_update()
+                finally:
+                    bpy.context.window.cursor_set("DEFAULT")
         return {'FINISHED'}
 
 class SvSwitchToLayout(bpy.types.Operator):


### PR DESCRIPTION
Was discussed in #4221.

* Node timings display is disabled by default.
* F5 and Ctrl-F5 shortcuts are re-enabled.