### PR TITLE
Debug print socket bool

### DIFF
--- a/nodes/text/debug_print.py
+++ b/nodes/text/debug_print.py
@@ -35,9 +35,6 @@ class SvDebugPrintNode(bpy.types.Node, SverchCustomTreeNode):
     base_name = 'Data '
     multi_socket_type = 'SvStringsSocket'
 
-    # I wanted to show the bool so you could turn off and on individual sockets
-    # but needs changes in node_s, want to think a bit more before adding an index option to
-    # stringsockets, for now draw_button_ext
     print_socket: BoolVectorProperty(
         name='Print', default=defaults, size=32, update=updateNode)
 

--- a/nodes/text/debug_print.py
+++ b/nodes/text/debug_print.py
@@ -59,14 +59,16 @@ class SvDebugPrintNode(bpy.types.Node, SverchCustomTreeNode):
         icon = ("HIDE_ON", "HIDE_OFF", )[self.print_socket[socket.index]]
         layout.prop(self, "print_socket", icon=icon, index=socket.index, text="")
 
-    def sv_update(self):
-        multi_socket(self, min=1)
-
+    def attach_draw_function_if_needed(self):
         for socket in self.inputs:
             if not socket.custom_draw:
                 socket.custom_draw = "draw_socket_boolean"
 
+    def sv_update(self):
+        multi_socket(self, min=1)
+
     def process(self):
+        self.attach_draw_function_if_needed()
         if not self.print_data:
             return
 

--- a/nodes/text/debug_print.py
+++ b/nodes/text/debug_print.py
@@ -60,7 +60,7 @@ class SvDebugPrintNode(bpy.types.Node, SverchCustomTreeNode):
         text = f"{socket.name}. {SvGetSocketInfo(socket)}"
         layout.label(text=text)
         icon = ("HIDE_ON", "HIDE_OFF", )[self.print_socket[socket.index]]
-        layout.prop(self, "print_socket", icon=icon, index=socket.index, text=socket.name)
+        layout.prop(self, "print_socket", icon=icon, index=socket.index, text="")
 
     def sv_update(self):
         multi_socket(self, min=1)

--- a/nodes/text/debug_print.py
+++ b/nodes/text/debug_print.py
@@ -21,6 +21,7 @@ from bpy.props import BoolProperty, BoolVectorProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import multi_socket, updateNode
+from sverchok.core.socket_data import SvGetSocketInfo
 
 defaults = [True for i in range(32)]
 
@@ -55,8 +56,18 @@ class SvDebugPrintNode(bpy.types.Node, SverchCustomTreeNode):
         for i, socket in enumerate(self.inputs):
             layout.prop(self, "print_socket", index=i, text=socket.name)
 
+    def draw_socket_boolean(self, socket, context, layout):
+        text = f"{socket.name}. {SvGetSocketInfo(socket)}"
+        layout.label(text=text)
+        icon = ("HIDE_ON", "HIDE_OFF", )[self.print_socket[socket.index]]
+        layout.prop(self, "print_socket", icon=icon, index=socket.index, text=socket.name)
+
     def sv_update(self):
         multi_socket(self, min=1)
+
+        for socket in self.inputs:
+            if not socket.custom_draw:
+                socket.custom_draw = "draw_socket_boolean"
 
     def process(self):
         if not self.print_data:


### PR DESCRIPTION
resolves longstanding desire to be able to toggle printing per socket from the node ui,  without `draw_buttons_ext`

![image](https://user-images.githubusercontent.com/619340/126816645-a81cfcb3-9433-42e7-9c19-aa28abefbe2d.png)
