### PR TITLE
Improve Live update mode

### DIFF
--- a/core/events.py
+++ b/core/events.py
@@ -34,10 +34,11 @@ class TreeEvent:
     FORCE_UPDATE = 'force_update'  # rebuild tree and reevaluate every node
     FRAME_CHANGE = 'frame_change'  # unlike other updates this one should be un-cancellable
 
-    def __init__(self, event_type: str, tree: SverchCustomTree, updated_nodes: Iterable[SvNode] = None):
+    def __init__(self, event_type: str, tree: SverchCustomTree, updated_nodes: Iterable[SvNode] = None, cancel=True):
         self.type = event_type
         self.tree = tree
         self.updated_nodes = updated_nodes
+        self.cancel = cancel
 
 
 class GroupEvent:

--- a/core/main_tree_handler.py
+++ b/core/main_tree_handler.py
@@ -27,7 +27,10 @@ class TreeHandler:
 
         # this should be first other wise other instructions can spoil the node statistic to redraw
         if NodesUpdater.is_running():
-            NodesUpdater.cancel_task()
+            if event.cancel:
+                NodesUpdater.cancel_task()
+            else:
+                return  # ignore the event
 
         # frame update
         if event.type == TreeEvent.FRAME_CHANGE:

--- a/docs/tree_evaluation_system.rst
+++ b/docs/tree_evaluation_system.rst
@@ -140,11 +140,8 @@ Node property / socket property changes
 
 Live update modal operator (:ref:`3d_panel`)
     It makes update some nodes, which read information from Blender objects, via timer with update period
-    about 1/10 second.
-
-.. warning::
-    The operator won't update whole tree if it has too low performance. Next timer event will cancel tree update and
-    cause to start update from the beginning.
+    about 1/10 second. If the tree did not manage to update while this period next event will be ignored.
+    In this case there can be a visible lag between user action and tree response.
 
 Frame changes
     Update upon frame changes. Extra information `Animation`_.

--- a/node_tree.py
+++ b/node_tree.py
@@ -151,9 +151,9 @@ class SverchCustomTree(NodeTree, SvNodeTreeCommon):
         # ideally we would never like to use this method but we live in the real world
         TreeHandler.send(TreeEvent(TreeEvent.FORCE_UPDATE, self))
 
-    def update_nodes(self, nodes):
+    def update_nodes(self, nodes, cancel=True):
         """This method expects to get list of its nodes which should be updated"""
-        return TreeHandler.send(TreeEvent(TreeEvent.NODES_UPDATE, self, nodes))
+        return TreeHandler.send(TreeEvent(TreeEvent.NODES_UPDATE, self, nodes, cancel))
 
     def process_ani(self):
         """

--- a/ui/sv_3d_panel.py
+++ b/ui/sv_3d_panel.py
@@ -447,7 +447,7 @@ class Sv3DViewObjInUpdater(bpy.types.Operator, object):
         objects_nodes_set = {'ObjectsNode', 'ObjectsNodeMK2', 'SvObjectsNodeMK3', 'SvExNurbsInNode', 'SvBezierInNode',
                              'SvGetObjectsData', 'SvObjectsNodeMK3'}
         for ng in BlTrees().sv_main_trees:
-            ng.update_nodes(n for n in ng.nodes if n.bl_idname in objects_nodes_set)
+            ng.update_nodes((n for n in ng.nodes if n.bl_idname in objects_nodes_set), cancel=False)
 
         return {'PASS_THROUGH'}
 


### PR DESCRIPTION
## Addressed problem description

Instead of cancelling tree evaluation the mode should skipp events if evaluation of the tree is still in progress.
It should make the work in this mode to be more pleasant.

As a side effect there is slight unsynchronize between user action and a tree response.

![Live update](https://user-images.githubusercontent.com/28003269/127478047-ca065e57-35df-4277-9e13-312169191f7b.gif)

Closes #4254

## Preflight checklist

- [x] Code changes complete.
- [x] Documentation for users complete.
- [x] Manual testing done. 
- [x] Ready for merge.

