### PR TITLE
no edges required for new calc_mesh_normals(bmesh)

### DIFF
--- a/old_nodes/mesh_select.py
+++ b/old_nodes/mesh_select.py
@@ -137,7 +137,7 @@ class SvMeshSelectNode(bpy.types.Node, SverchCustomTreeNode):
         return result
 
     def by_normal(self, vertices, edges, faces):
-        vertex_normals, face_normals = calc_mesh_normals(vertices, edges, faces)
+        vertex_normals, face_normals = calc_mesh_normals(vertices, faces)
         percent = self.inputs['Percent'].sv_get(default=[1.0])[0][0]
         direction = self.inputs['Direction'].sv_get()[0][0]
         values = [Vector(n).dot(direction) for n in face_normals]


### PR DESCRIPTION
resolves api change in calc_mesh_normals_bmesh imported as calc_mesh_normals 
closes #4340 

also outputs edge mask, but edges must be passed in .