### PR TITLE
Cached sv extra search

### DIFF
--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -184,7 +184,17 @@ class SvExtraSearch(bpy.types.Operator):
 
     def invoke(self, context, event):
         context.space_data.cursor_location_from_region(event.mouse_region_x, event.mouse_region_y)
-        loop['results'] = gather_items(context)
+        
+        if not loop.get('results'):
+            loop['results'] = gather_items(context)
+            print(":) extra search results cached")
+        else:
+            # line_1 = "using cached items! clear cache by doing\n"
+            # line_2 = ">>> import sverchok\n"
+            # line_3 = ">>> sverchok.utils.sv_extra_search.loop[\"results\"] = None"
+            # print(line_1 + line_2 + line_3)
+            pass
+        
         wm = context.window_manager
         wm.invoke_search_popup(self)
         return {'FINISHED'}

--- a/utils/sv_extra_search.py
+++ b/utils/sv_extra_search.py
@@ -187,13 +187,6 @@ class SvExtraSearch(bpy.types.Operator):
         
         if not loop.get('results'):
             loop['results'] = gather_items(context)
-            print(":) extra search results cached")
-        else:
-            # line_1 = "using cached items! clear cache by doing\n"
-            # line_2 = ">>> import sverchok\n"
-            # line_3 = ">>> sverchok.utils.sv_extra_search.loop[\"results\"] = None"
-            # print(line_1 + line_2 + line_3)
-            pass
         
         wm = context.window_manager
         wm.invoke_search_popup(self)


### PR DESCRIPTION
addresses a massive waste of resources by caching the enum gathering/compilation step.
User can reset this process, for whatever reason by doing
```python
>>> import sverchok
>>> sverchok.utils.sv_extra_search.loop["results"] = None
```

this might resolve #4294 

