### PR TITLE
Mesh sel fix 3

### DIFF
--- a/nodes/analyzer/mesh_select_mk2.py
+++ b/nodes/analyzer/mesh_select_mk2.py
@@ -159,7 +159,6 @@ def by_normal(vertices, edges, faces, percent, direction):
     return out_face_mask
 
 def by_outside(vertices, edges, faces, percent, center):
-    # face_normals, _ = calc_mesh_normals(vertices, edges, faces)
     face_normals = pols_normals(vertices, faces, output_numpy=True)
     center = Vector(center[0])
 


### PR DESCRIPTION
fixes #4365 

warning.. If `edges` are not being input into the `mesh select elements` node, this node will not output an `edge mask` in this mode - maybe other modes too. At least `edge mask` can be inferred from face mask.