### PR TITLE
Svg doc autowrite with framenum

### DIFF
--- a/nodes/svg/svg_document.py
+++ b/nodes/svg/svg_document.py
@@ -211,7 +211,7 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
         self.inputs.new('SvFilePathSocket', 'Folder Path')
         self.inputs.new('SvFilePathSocket', 'Template Path')
         self.inputs.new('SvSvgSocket', 'SVG Objects')
-        self.inputs.new('SvStringsSocket', "File Name").prop_name = "file_name"
+        self.inputs.new('SvTextSocket', "File Name").prop_name = "file_name"
         self.outputs.new('SvVerticesSocket', 'Canvas Vertices')
         self.outputs.new('SvStringsSocket', 'Canvas Edges')
 

--- a/nodes/svg/svg_document.py
+++ b/nodes/svg/svg_document.py
@@ -152,7 +152,7 @@ class SvSVGWrite(bpy.types.Operator, SvGenericNodeLocator):
         if hasattr(node, "suffix_filename_with_framenumber"):
             if node.suffix_filename_with_framenumber:
                 frame_number = bpy.context.scene.frame_current
-                file_name = f"{file_name}_{frame_number:04}_"
+                file_name = f"{file_name}_{frame_number:04}"
         
         complete_name = os.path.join(save_path, file_name+".svg")
         svg_file = open(complete_name, "w")
@@ -201,7 +201,9 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
     file_name: StringProperty(name="Name", default="Sv_svg")
     live_update: BoolProperty(name='Live Update', description="Automatically write file when input changes")
 
-    suffix_filename_with_framenumber: BoolProperty(name="Suffix with Frame Number")
+    suffix_filename_with_framenumber: BoolProperty(
+        name="Suffix with Frame Number", 
+        description="adds the frame number to the end of the filename, useful for animations")
 
     def sv_init(self, context):
         self.width = 200

--- a/nodes/svg/svg_document.py
+++ b/nodes/svg/svg_document.py
@@ -147,6 +147,13 @@ class SvSVGWrite(bpy.types.Operator, SvGenericNodeLocator):
         svg_defs += '</defs>\n'
         svg_end = '</svg>'
         file_name = node.file_name
+
+        # for animation this is the code that changes the local file_name before writing.
+        if hasattr(node, "suffix_filename_with_framenumber"):
+            if node.suffix_filename_with_framenumber:
+                frame_number = bpy.context.scene.frame_current
+                file_name = f"{file_name}_{frame_number:04}_"
+        
         complete_name = os.path.join(save_path, file_name+".svg")
         svg_file = open(complete_name, "w")
         svg = svg_head + svg_defs + svg_shapes + svg_end
@@ -192,7 +199,9 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
         update=updateNode)
 
     file_name: StringProperty(name="Name", default="Sv_svg")
-    live_update: BoolProperty(name='Live Update')
+    live_update: BoolProperty(name='Live Update', description="Automatically write file when input changes")
+
+    suffix_filename_with_framenumber: BoolProperty(name="Suffix with Frame Number")
 
     def sv_init(self, context):
         self.width = 200
@@ -213,6 +222,9 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
         layout.prop(self, "doc_height")
         layout.prop(self, "doc_scale")
         self.wrapper_tracked_ui_draw_op(layout, "node.svg_write", icon='RNA_ADD', text="Write")
+    
+    def draw_buttons_ext(self, context, layout):
+        layout.prop(self, "suffix_filename_with_framenumber")
 
     def process(self):
 

--- a/nodes/svg/svg_document.py
+++ b/nodes/svg/svg_document.py
@@ -217,10 +217,17 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
 
     def draw_filename_socket(self, socket, context, layout):
         text = f"{socket.name}. {str(socket.objects_number) if socket.is_linked else ''}"
-        layout.label(text=text)
+
         if not socket.is_linked:
-            layout.prop(self, "file_name", text="")
-        layout.prop(self, "suffix_filename_with_framenumber", icon="SEQUENCE", text='')
+            col = layout.column()
+            col.label(text="File Name:")
+            row_below = col.row(align=True)
+            row_below.prop(self, "file_name", text='')
+            row_below.prop(self, "suffix_filename_with_framenumber", icon="SEQUENCE", text='')
+        else:
+            layout.label(text=text)
+            #layout.prop(self, "file_name", text="")
+            layout.prop(self, "suffix_filename_with_framenumber", icon="SEQUENCE", text='')
 
 
     def draw_buttons(self, context, layout):

--- a/nodes/svg/svg_document.py
+++ b/nodes/svg/svg_document.py
@@ -216,7 +216,7 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
         self.outputs.new('SvStringsSocket', 'Canvas Edges')
 
     def draw_filename_socket(self, socket, context, layout):
-        text = f"{socket.name}. {str(socket.objects_number)}"
+        text = f"{socket.name}. {str(socket.objects_number) if socket.is_linked else ''}"
         layout.label(text=text)
         if not socket.is_linked:
             layout.prop(self, "file_name", text="")

--- a/nodes/svg/svg_document.py
+++ b/nodes/svg/svg_document.py
@@ -223,11 +223,10 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
         layout.prop(self, "doc_width")
         layout.prop(self, "doc_height")
         layout.prop(self, "doc_scale")
-        self.wrapper_tracked_ui_draw_op(layout, "node.svg_write", icon='RNA_ADD', text="Write")
+        row = layout.row(align=True)
+        self.wrapper_tracked_ui_draw_op(row, "node.svg_write", icon='RNA_ADD', text="Write")
+        row.prop(self, "suffix_filename_with_framenumber", icon="SEQUENCE", text='')
     
-    def draw_buttons_ext(self, context, layout):
-        layout.prop(self, "suffix_filename_with_framenumber")
-
     def process(self):
 
         x = self.doc_width / (self.doc_scale)

--- a/nodes/svg/svg_document.py
+++ b/nodes/svg/svg_document.py
@@ -211,9 +211,17 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
         self.inputs.new('SvFilePathSocket', 'Folder Path')
         self.inputs.new('SvFilePathSocket', 'Template Path')
         self.inputs.new('SvSvgSocket', 'SVG Objects')
-        self.inputs.new('SvTextSocket', "File Name").prop_name = "file_name"
+        self.sv_new_input('SvTextSocket', "File Name", prop_name="file_name", custom_draw="draw_filename_socket")
         self.outputs.new('SvVerticesSocket', 'Canvas Vertices')
         self.outputs.new('SvStringsSocket', 'Canvas Edges')
+
+    def draw_filename_socket(self, socket, context, layout):
+        text = f"{socket.name}. {str(socket.objects_number)}"
+        layout.label(text=text)
+        if not socket.is_linked:
+            layout.prop(self, "file_name", text="")
+        layout.prop(self, "suffix_filename_with_framenumber", icon="SEQUENCE", text='')
+
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "live_update")
@@ -221,13 +229,10 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
         mode_row = layout.split(factor=0.4, align=False)
         mode_row.label(text="Units:")
         mode_row.prop(self, "units", text="")
-        # layout.prop(self, "file_name")
         layout.prop(self, "doc_width")
         layout.prop(self, "doc_height")
         layout.prop(self, "doc_scale")
-        row = layout.row(align=True)
-        self.wrapper_tracked_ui_draw_op(row, "node.svg_write", icon='RNA_ADD', text="Write")
-        row.prop(self, "suffix_filename_with_framenumber", icon="SEQUENCE", text='')
+        self.wrapper_tracked_ui_draw_op(layout, "node.svg_write", icon='RNA_ADD', text="Write")
     
     def process(self):
 

--- a/nodes/svg/svg_document.py
+++ b/nodes/svg/svg_document.py
@@ -202,6 +202,7 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
     live_update: BoolProperty(name='Live Update', description="Automatically write file when input changes")
 
     suffix_filename_with_framenumber: BoolProperty(
+        default=False,
         name="Suffix with Frame Number", 
         description="adds the frame number to the end of the filename, useful for animations")
 
@@ -210,6 +211,7 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
         self.inputs.new('SvFilePathSocket', 'Folder Path')
         self.inputs.new('SvFilePathSocket', 'Template Path')
         self.inputs.new('SvSvgSocket', 'SVG Objects')
+        self.inputs.new('SvStringsSocket', "File Name").prop_name = "file_name"
         self.outputs.new('SvVerticesSocket', 'Canvas Vertices')
         self.outputs.new('SvStringsSocket', 'Canvas Edges')
 
@@ -219,7 +221,7 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
         mode_row = layout.split(factor=0.4, align=False)
         mode_row.label(text="Units:")
         mode_row.prop(self, "units", text="")
-        layout.prop(self, "file_name")
+        # layout.prop(self, "file_name")
         layout.prop(self, "doc_width")
         layout.prop(self, "doc_height")
         layout.prop(self, "doc_scale")
@@ -238,6 +240,10 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
             (x, y, 0),
             (0, y, 0)
         ]
+
+        filename_socket = self.inputs.get("File Name")
+        if filename_socket and filename_socket.is_linked:
+            self.file_name = filename_socket.sv_get()[0][0]
 
         self.outputs['Canvas Vertices'].sv_set([verts])
         self.outputs['Canvas Edges'].sv_set([[(0, 1),(1, 2), (2, 3), (3, 0)]])


### PR DESCRIPTION
adds a switch that can be enabled if the user wants the current frame to be included in the filename

![image](https://user-images.githubusercontent.com/619340/166252892-1461e643-1f9d-4e87-af87-789c4066e5b7.png)


resolves #4448
