### PR TITLE
Svg doc framenum and filenamesocket

### DIFF
--- a/core/sockets.py
+++ b/core/sockets.py
@@ -648,6 +648,7 @@ class SvTextSocket(NodeSocket, SvSocketCommon):
     bl_label = "Text Socket"
 
     color = (0.68,  0.85,  0.90, 1)
+    quick_link_to_node: StringProperty()
 
     default_property: StringProperty(update=process_from_socket)
     default_conversion_name = ConversionPolicies.LENIENT.conversion_name

--- a/nodes/svg/svg_document.py
+++ b/nodes/svg/svg_document.py
@@ -152,7 +152,7 @@ class SvSVGWrite(bpy.types.Operator, SvGenericNodeLocator):
         if hasattr(node, "suffix_filename_with_framenumber"):
             if node.suffix_filename_with_framenumber:
                 frame_number = bpy.context.scene.frame_current
-                file_name = f"{file_name}_{frame_number:04}_"
+                file_name = f"{file_name}_{frame_number:04}"
         
         complete_name = os.path.join(save_path, file_name+".svg")
         svg_file = open(complete_name, "w")
@@ -201,7 +201,9 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
     file_name: StringProperty(name="Name", default="Sv_svg")
     live_update: BoolProperty(name='Live Update', description="Automatically write file when input changes")
 
-    suffix_filename_with_framenumber: BoolProperty(name="Suffix with Frame Number")
+    suffix_filename_with_framenumber: BoolProperty(
+        name="Suffix with Frame Number", 
+        description="adds the frame number to the end of the filename, useful for animations")
 
     def sv_init(self, context):
         self.width = 200

--- a/nodes/svg/svg_document.py
+++ b/nodes/svg/svg_document.py
@@ -147,6 +147,13 @@ class SvSVGWrite(bpy.types.Operator, SvGenericNodeLocator):
         svg_defs += '</defs>\n'
         svg_end = '</svg>'
         file_name = node.file_name
+
+        # for animation this is the code that changes the local file_name before writing.
+        if hasattr(node, "suffix_filename_with_framenumber"):
+            if node.suffix_filename_with_framenumber:
+                frame_number = bpy.context.scene.frame_current
+                file_name = f"{file_name}_{frame_number:04}_"
+        
         complete_name = os.path.join(save_path, file_name+".svg")
         svg_file = open(complete_name, "w")
         svg = svg_head + svg_defs + svg_shapes + svg_end
@@ -192,7 +199,9 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
         update=updateNode)
 
     file_name: StringProperty(name="Name", default="Sv_svg")
-    live_update: BoolProperty(name='Live Update')
+    live_update: BoolProperty(name='Live Update', description="Automatically write file when input changes")
+
+    suffix_filename_with_framenumber: BoolProperty(name="Suffix with Frame Number")
 
     def sv_init(self, context):
         self.width = 200
@@ -213,6 +222,9 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
         layout.prop(self, "doc_height")
         layout.prop(self, "doc_scale")
         self.wrapper_tracked_ui_draw_op(layout, "node.svg_write", icon='RNA_ADD', text="Write")
+    
+    def draw_buttons_ext(self, context, layout):
+        layout.prop(self, "suffix_filename_with_framenumber")
 
     def process(self):
 

--- a/nodes/svg/svg_document.py
+++ b/nodes/svg/svg_document.py
@@ -198,7 +198,8 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
         name='Scale', description='Iterations',
         update=updateNode)
 
-    file_name: StringProperty(name="Name", default="Sv_svg")
+    file_name: StringProperty(name="Name", default="Sv_svg",
+        description="this variable holds the name of the file only, the file extension will be added automatically by sverchok")
     live_update: BoolProperty(name='Live Update', description="Automatically write file when input changes")
 
     suffix_filename_with_framenumber: BoolProperty(
@@ -210,6 +211,7 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
         self.inputs.new('SvFilePathSocket', 'Folder Path')
         self.inputs.new('SvFilePathSocket', 'Template Path')
         self.inputs.new('SvSvgSocket', 'SVG Objects')
+        self.sv_new_input('SvTextSocket', 'File Name', prop_name="file_name", quick_link_to_node="NoteNode")
         self.outputs.new('SvVerticesSocket', 'Canvas Vertices')
         self.outputs.new('SvStringsSocket', 'Canvas Edges')
 
@@ -219,7 +221,7 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
         mode_row = layout.split(factor=0.4, align=False)
         mode_row.label(text="Units:")
         mode_row.prop(self, "units", text="")
-        layout.prop(self, "file_name")
+        #layout.prop(self, "file_name")
         layout.prop(self, "doc_width")
         layout.prop(self, "doc_height")
         layout.prop(self, "doc_scale")
@@ -229,6 +231,10 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
         row.prop(self, "suffix_filename_with_framenumber", icon="SEQUENCE", text='')
     
     def process(self):
+
+        filename_socket = self.inputs.get('File Name')
+        if filename_socket and filename_socket.is_linked:
+            self.file_name = filename_socket.sv_get()[0][0]
 
         x = self.doc_width / (self.doc_scale)
         y = self.doc_height / (self.doc_scale)

--- a/nodes/svg/svg_document.py
+++ b/nodes/svg/svg_document.py
@@ -225,6 +225,7 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
         layout.prop(self, "doc_scale")
         row = layout.row(align=True)
         self.wrapper_tracked_ui_draw_op(row, "node.svg_write", icon='RNA_ADD', text="Write")
+        row.separator()
         row.prop(self, "suffix_filename_with_framenumber", icon="SEQUENCE", text='')
     
     def process(self):

--- a/nodes/svg/svg_document.py
+++ b/nodes/svg/svg_document.py
@@ -223,11 +223,10 @@ class SvSvgDocumentNode(bpy.types.Node, SverchCustomTreeNode):
         layout.prop(self, "doc_width")
         layout.prop(self, "doc_height")
         layout.prop(self, "doc_scale")
-        self.wrapper_tracked_ui_draw_op(layout, "node.svg_write", icon='RNA_ADD', text="Write")
+        row = layout.row(align=True)
+        self.wrapper_tracked_ui_draw_op(row, "node.svg_write", icon='RNA_ADD', text="Write")
+        row.prop(self, "suffix_filename_with_framenumber", icon="SEQUENCE", text='')
     
-    def draw_buttons_ext(self, context, layout):
-        layout.prop(self, "suffix_filename_with_framenumber")
-
     def process(self):
 
         x = self.doc_width / (self.doc_scale)


### PR DESCRIPTION
adds filesocket.

this exposes an incompleted feature of SvTextSocket class.  
- quick_link_to_node is not implemented/ignored

this also brings up a new issue,
- maybe quick_link should be allowed to pass a string reference to a `post_node_placement_function`, to allow the quick_link to place the added node in a specific state which is most useful to the user. right now we are at the mercy of the default state of a node.
- maybe it's time to create an additional simple text node, like NoteNode but with SvTextSocket in/out (or user changable per socket)
