### PR TITLE
Fp config from socket

### DIFF
--- a/core/sockets.py
+++ b/core/sockets.py
@@ -1060,6 +1060,9 @@ class SvFilePathSocket(NodeSocket, SvSocketCommon):
 
     color = (0.9, 0.9, 0.3, 1.0)
     quick_link_to_node = 'SvFilePathNode'
+    filepath_node_mode: StringProperty(
+        name="filepath node mode",
+        description="use this property to configure the behaviour of a quicklinked filepath node")
 
 
 class SvSvgSocket(NodeSocket, SvSocketCommon):

--- a/nodes/exchange/FCStd_write.py
+++ b/nodes/exchange/FCStd_write.py
@@ -89,7 +89,7 @@ else:
 
 
         def sv_init(self, context):
-            self.inputs.new('SvFilePathSocket', "File Path")
+            self.sv_new_input('SvFilePathSocket', "File Path", filepath_node_mode="FreeCAD")
 
             if self.obj_format == 'mesh':
                 self.inputs.new('SvVerticesSocket', "Verts")

--- a/nodes/network/file_path.py
+++ b/nodes/network/file_path.py
@@ -38,15 +38,14 @@ class SvFilePathFinder(bpy.types.Operator, SvGenericNodeLocator):
         name="File Path", description="Filepath used for writing files",
         maxlen=1024, default="", subtype='FILE_PATH')
 
+    filename_ext: StringProperty(default="")
+    filter_glob: StringProperty(default="", options={'HIDDEN'})    
+
+    mode: StringProperty(default='')
     def custom_config(self, context):
         if self.mode == "FreeCAD":
             self.filename_ext = ".FCStd"  #  ".tif"
             self.filter_glob = "*.FCStd"  # #*.tif;*.png;"  (if more than one, separate by ;)
-
-    mode: StringProperty(default='', update=custom_config)
-    filename_ext: StringProperty(default="")
-    filter_glob: StringProperty(default="", options={'HIDDEN'})    
-
 
     def sv_execute(self, context, node):
         if self.mode == "FreeCAD":
@@ -56,6 +55,9 @@ class SvFilePathFinder(bpy.types.Operator, SvGenericNodeLocator):
         node.set_data(self.directory, self.files)
 
     def invoke(self, context, event):
+        
+        if self.mode: self.custom_config(context)
+
         wm = context.window_manager
         wm.fileselect_add(self)
         return {'RUNNING_MODAL'}
@@ -74,6 +76,7 @@ class SvFilePathNode(bpy.types.Node, SverchCustomTreeNode):
     files_num: IntProperty(name='files number ', default=0)
     files: CollectionProperty(name="File Path", type=OperatorFileListElement)
     directory: StringProperty(subtype='DIR_PATH', update=updateNode)
+    mode: StringProperty(default='', description="mode determines behaviour of the File Open Dialogue and Operator")
 
     def sv_init(self, context):
 

--- a/nodes/network/file_path.py
+++ b/nodes/network/file_path.py
@@ -34,9 +34,15 @@ class SvFilePathFinder(bpy.types.Operator, SvGenericNodeLocator):
     files: CollectionProperty(name="File Path", type=OperatorFileListElement)
     directory: StringProperty(subtype='DIR_PATH')
 
-    filepath: bpy.props.StringProperty(
-        name="File Path", description="Filepath used for writing waveform files",
+    filepath: StringProperty(
+        name="File Path", description="Filepath used for writing files",
         maxlen=1024, default="", subtype='FILE_PATH')
+
+    filename_ext: StringProperty(default="")#  ".tif"
+    filter_glob: StringProperty(
+        default="", #*.tif;*.png;*.jpeg;*.jpg", 
+        options={'HIDDEN'})    
+
 
     def sv_execute(self, context, node):
         node.set_data(self.directory, self.files)
@@ -61,6 +67,11 @@ class SvFilePathNode(bpy.types.Node, SverchCustomTreeNode):
     files: CollectionProperty(name="File Path", type=OperatorFileListElement)
     directory: StringProperty(subtype='DIR_PATH', update=updateNode)
 
+    filename_ext: StringProperty(default="")#  ".tif"
+    filter_glob: StringProperty(
+        default="", #*.tif;*.png;*.jpeg;*.jpg", 
+        options={'HIDDEN'})  
+
     def sv_init(self, context):
 
         self.outputs.new('SvFilePathSocket', "File Path")
@@ -68,7 +79,10 @@ class SvFilePathNode(bpy.types.Node, SverchCustomTreeNode):
     def draw_buttons(self, context, layout):
 
         op = 'node.sv_file_path'
-        self.wrapper_tracked_ui_draw_op(layout, op, icon='FILE', text='')
+        file_path_operator = self.wrapper_tracked_ui_draw_op(layout, op, icon='FILE', text='')
+        file_path_operator.filename_ext = self.filename_ext
+        file_path_operator.filter_glob = self.filter_glob
+
         if self.files_num == 0:
             layout.label(text=self.directory)
         elif self.files_num == 1:

--- a/nodes/network/file_path.py
+++ b/nodes/network/file_path.py
@@ -38,13 +38,21 @@ class SvFilePathFinder(bpy.types.Operator, SvGenericNodeLocator):
         name="File Path", description="Filepath used for writing files",
         maxlen=1024, default="", subtype='FILE_PATH')
 
-    filename_ext: StringProperty(default="")#  ".tif"
-    filter_glob: StringProperty(
-        default="", #*.tif;*.png;*.jpeg;*.jpg", 
-        options={'HIDDEN'})    
+    def custom_config(self, context):
+        if self.mode == "FreeCAD":
+            self.filename_ext = ".FCStd"  #  ".tif"
+            self.filter_glob = "*.FCStd"  # #*.tif;*.png;"  (if more than one, separate by ;)
+
+    mode: StringProperty(default='', update=custom_config)
+    filename_ext: StringProperty(default="")
+    filter_glob: StringProperty(default="", options={'HIDDEN'})    
 
 
     def sv_execute(self, context, node):
+        if self.mode == "FreeCAD":
+            print("can do something here")
+            # if len self.files == 1 , and it doesn't end in FCStd/FCStd1 set it.
+
         node.set_data(self.directory, self.files)
 
     def invoke(self, context, event):
@@ -67,11 +75,6 @@ class SvFilePathNode(bpy.types.Node, SverchCustomTreeNode):
     files: CollectionProperty(name="File Path", type=OperatorFileListElement)
     directory: StringProperty(subtype='DIR_PATH', update=updateNode)
 
-    filename_ext: StringProperty(default="")#  ".tif"
-    filter_glob: StringProperty(
-        default="", #*.tif;*.png;*.jpeg;*.jpg", 
-        options={'HIDDEN'})  
-
     def sv_init(self, context):
 
         self.outputs.new('SvFilePathSocket', "File Path")
@@ -80,8 +83,7 @@ class SvFilePathNode(bpy.types.Node, SverchCustomTreeNode):
 
         op = 'node.sv_file_path'
         file_path_operator = self.wrapper_tracked_ui_draw_op(layout, op, icon='FILE', text='')
-        file_path_operator.filename_ext = self.filename_ext
-        file_path_operator.filter_glob = self.filter_glob
+        file_path_operator.mode = self.mode
 
         if self.files_num == 0:
             layout.label(text=self.directory)

--- a/nodes/network/file_path.py
+++ b/nodes/network/file_path.py
@@ -117,13 +117,11 @@ class SvFilePathNode(bpy.types.Node, SverchCustomTreeNode):
         only call this mode if the output(s) .is_linked returns true
         """
         socket = self.outputs[0]
+        self.mode = ""
         if socket.is_linked:
             other_socket = socket.other
             if hasattr(other_socket, "filepath_node_mode"):
-                print("YES!", other_socket.filepath_node_mode)
                 self.mode = other_socket.filepath_node_mode
-            else:
-                self.mode = ''
 
     def process(self):
         # return if no outputs are connected

--- a/nodes/network/file_path.py
+++ b/nodes/network/file_path.py
@@ -49,8 +49,10 @@ class SvFilePathFinder(bpy.types.Operator, SvGenericNodeLocator):
 
     def sv_execute(self, context, node):
         if self.mode == "FreeCAD":
-            print("can do something here")
-            # if len self.files == 1 , and it doesn't end in FCStd/FCStd1 set it.
+            # This is triggered after the file is selected or typed in by the user in the Text Field of path
+            if self.directory and len(self.files) == 1:
+                if self.files[0].name and not self.files[0].name.endswith(".FCStd"):
+                    self.files[0].name = self.files[0].name + ".FCStd" 
 
         node.set_data(self.directory, self.files)
 

--- a/nodes/network/file_path.py
+++ b/nodes/network/file_path.py
@@ -112,10 +112,26 @@ class SvFilePathNode(bpy.types.Node, SverchCustomTreeNode):
         else:
             self.files_num = len(files)
 
+    def get_linked_socket_mode_and_set_operator(self):
+        """
+        only call this mode if the output(s) .is_linked returns true
+        """
+        socket = self.outputs[0]
+        if socket.is_linked:
+            other_socket = socket.other
+            if hasattr(other_socket, "filepath_node_mode"):
+                print("YES!", other_socket.filepath_node_mode)
+                self.mode = other_socket.filepath_node_mode
+            else:
+                self.mode = ''
+
     def process(self):
         # return if no outputs are connected
         if not any(s.is_linked for s in self.outputs):
             return
+
+        self.get_linked_socket_mode_and_set_operator()
+
         directory = self.directory
         if self.files:
             files = []

--- a/nodes/network/file_path.py
+++ b/nodes/network/file_path.py
@@ -42,6 +42,7 @@ class SvFilePathFinder(bpy.types.Operator, SvGenericNodeLocator):
     filter_glob: StringProperty(default="", options={'HIDDEN'})    
 
     mode: StringProperty(default='')
+
     def custom_config(self, context):
         if self.mode == "FreeCAD":
             self.filename_ext = ".FCStd"  #  ".tif"


### PR DESCRIPTION
This makes it possible to configure a FilePath Node as a function of the kind of FilePath socket with which it is linked.
- this introduces a new property (StringProperty) of the `SvFilePathSocket` called `filepath_node_mode`, upstream the FilePath Node will look at the `filepath_node_mode` and use the mode to configure the `SvFilePathFinder` Operator.

`SvFilePathFinder` Operator can behave according to the kind of files it's used for.

i'm not sure this is the best way to do it, because this while this makes some functionality easier, it may interfere with flexibility in its current state. Another path is to add features to `draw_buttons` function of the SfFilePathFinder Operator, as a fail safe incase the automatic mode resulted in something undesirable.