### PR TITLE
Oldnodes parser retrofit

### DIFF
--- a/old_nodes/formula.py
+++ b/old_nodes/formula.py
@@ -16,11 +16,11 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
-import parser
 
 import bpy
 from bpy.props import StringProperty
 
+from sverchok.utils.modules.parser_subset import parser
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode
 from math import cos, sin, pi, tan

--- a/old_nodes/formula2.py
+++ b/old_nodes/formula2.py
@@ -16,7 +16,6 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
-import parser
 from math import (
     acos, acosh, asin, asinh, atan, atan2,
     atanh, ceil, copysign, cos, cosh, degrees, e,
@@ -29,6 +28,7 @@ from math import (
 import bpy
 from bpy.props import BoolProperty, StringProperty
 
+from sverchok.utils.modules.parser_subset import parser
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import (
     updateNode, multi_socket, changable_sockets,

--- a/old_nodes/profile_mk2.py
+++ b/old_nodes/profile_mk2.py
@@ -22,7 +22,7 @@ import re
 import json
 from string import ascii_lowercase
 
-import parser
+from sverchok.utils.modules.parser_subset import parser
 from ast import literal_eval
 
 import bpy

--- a/utils/modules/parser_subset.py
+++ b/utils/modules/parser_subset.py
@@ -1,0 +1,26 @@
+"""
+in Python 3.10 the parser module has been removed. some old nodes 
+(namely: formula.py / formula2.py / profile_mk2.py) make light use of that module.
+
+The main goal of this module is to suppress a startup import exception caused by 
+the missing parser module, and at the same time offer the basic features of that
+module as used by these nodes.
+"""
+
+try:
+    import parser
+
+except (ImportError, ModuleNotFoundError) as err:
+
+    from dataclasses import dataclass
+
+    @dataclass
+    class Expr(str):
+        str_formula: str
+        def compile(self):
+            # print('use mock')
+            return compile(self.str_formula, '<string>', mode='eval')
+
+    parser = lambda: None
+    parser.expr = lambda str_formula: Expr(str_formula)
+


### PR DESCRIPTION
in the unlikely event that anyone is still using these nodes in old `.json` or blends..