### PR TITLE
Decorator test

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,6 +2,7 @@ import importlib
 import sverchok
 from sverchok.core.socket_data import clear_all_socket_cache
 
+color_terminal = False
 reload_event = False
 
 root_modules = [

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,7 +2,6 @@ import importlib
 import sverchok
 from sverchok.core.socket_data import clear_all_socket_cache
 
-color_terminal = False
 reload_event = False
 
 root_modules = [

--- a/utils/ascii_print.py
+++ b/utils/ascii_print.py
@@ -1,10 +1,14 @@
 import os
 import sys
 from sverchok.utils.development import get_version_string
-import sverchok
+
 # pylint: disable=c0304
 # pylint: disable=c0326
 # pylint: disable=w1401
+
+color_terminal = False
+
+
 
 def logo():
 
@@ -22,7 +26,7 @@ def logo():
     except:
         ...
 
-    sverchok.core.color_terminal = can_paint
+    sverchok.utils.ascii_print.color_terminal = can_paint
 
     with_color = "\033[1;31m{0}\033[0m" if can_paint else "{0}"
     for line in lines:

--- a/utils/ascii_print.py
+++ b/utils/ascii_print.py
@@ -21,11 +21,17 @@ def is_terminal_color_capable():
 
 def str_color(text, color):
     """
-    text must be a string
-    color must be any of https://github.com/nortikin/sverchok/pull/4511#issuecomment-1151478312
-    30 = black, 31 = red, 32 = green, 33 = yellow, 34 = blue, 35 = purple, 36 = ilghtblue, 37 = white-ish
-    90 = grey,  91 = red+,92 = green+,93 = yellow+,94 = blue+,95 = purple+,96 = lightblue+,97 = white
-    """
+    input:
+    - text  : should be a string
+    - color : must be any of https://github.com/nortikin/sverchok/pull/4511#issuecomment-1151478312
+    output:
+    - a str : the text is returned with additional color-markup if the terminal can display colors.
+ 
+    available colors:
+        30 = black, 31 = red, 32 = green, 33 = yellow, 34 = blue, 35 = purple, 36 = ilghtblue, 37 = white-ish
+        90 = grey,  91 = red+,92 = green+,93 = yellow+,94 = blue+,95 = purple+,96 = lightblue+,97 = white
+    
+       """
     if color_terminal['displays_colors']:
         return f"\033[1;{color}m{text}\033[0m"
     return text

--- a/utils/ascii_print.py
+++ b/utils/ascii_print.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from sverchok.utils.development import get_version_string
-
+import sverchok
 # pylint: disable=c0304
 # pylint: disable=c0326
 # pylint: disable=w1401
@@ -21,6 +21,8 @@ def logo():
                 can_paint = True
     except:
         ...
+
+    sverchok.core.color_terminal = can_paint
 
     with_color = "\033[1;31m{0}\033[0m" if can_paint else "{0}"
     for line in lines:

--- a/utils/ascii_print.py
+++ b/utils/ascii_print.py
@@ -6,9 +6,18 @@ from sverchok.utils.development import get_version_string
 # pylint: disable=c0326
 # pylint: disable=w1401
 
-color_terminal = False
+color_terminal = {'displays_colors': False}
 
+def is_terminal_color_capable():
+    can_paint = os.name in {'posix'}
+    try:
+        if hasattr(sys, 'getwindowsversion'):
+            if sys.getwindowsversion().major == 10:
+                can_paint = True
+    except:
+        ...
 
+    color_terminal['displays_colors'] = can_paint
 
 def logo():
 
@@ -18,20 +27,11 @@ def logo():
     l4 = r"initialized."
     lines = [l1, l2, l3, l4]
 
-    can_paint = os.name in {'posix'}
-    try:
-        if hasattr(sys, 'getwindowsversion'):
-            if sys.getwindowsversion().major == 10:
-                can_paint = True
-    except:
-        ...
-
-    sverchok.utils.ascii_print.color_terminal = can_paint
-
-    with_color = "\033[1;31m{0}\033[0m" if can_paint else "{0}"
+    with_color = "\033[1;31m{0}\033[0m" if color_terminal['displays_colors'] else "{0}"
     for line in lines:
         print(with_color.format(line))
 
 def show_welcome():
+    is_terminal_color_capable()
     logo()
     print("\nsv: version:", get_version_string())

--- a/utils/ascii_print.py
+++ b/utils/ascii_print.py
@@ -19,6 +19,18 @@ def is_terminal_color_capable():
 
     color_terminal['displays_colors'] = can_paint
 
+def str_color(text, color):
+    """
+    text must be a string
+    color must be any of https://github.com/nortikin/sverchok/pull/4511#issuecomment-1151478312
+    30 = black, 31 = red, 32 = green, 33 = yellow, 34 = blue, 35 = purple, 36 = ilghtblue, 37 = white-ish
+    90 = grey,  91 = red+,92 = green+,93 = yellow+,94 = blue+,95 = purple+,96 = lightblue+,97 = white
+    """
+    if color_terminal['displays_colors']:
+        return f"\033[1;{color}m{text}\033[0m"
+    return text
+
+
 def logo():
 
     l1 = r" ______ _    _ _______  ______ _______ _     _  _____  _     _"
@@ -27,9 +39,7 @@ def logo():
     l4 = r"initialized."
     lines = [l1, l2, l3, l4]
 
-    with_color = "\033[1;31m{0}\033[0m" if color_terminal['displays_colors'] else "{0}"
-    for line in lines:
-        print(with_color.format(line))
+    for line in lines: print(str_color(line, 31))
 
 def show_welcome():
     is_terminal_color_capable()

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -110,15 +110,19 @@ def duration(func):
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
         start_time = time.time()
-        
         result = func(*args, **kwargs)
+        duration = (time.time() - start_time) * 1000
 
         display_args = (f"\n    {args=}" if args else "")
         display_kwargs = (f"\n    {kwargs=}" if kwargs else "")
         func_name = func.__name__
-        func_name = f"\033[1;31m{func_name}\033[0m" if color_terminal else f"{func_name}"
 
-        duration = (time.time() - start_time) * 1000
+        if color_terminal:
+            func_name = f"\033[1;31m{func_name}\033[0m"
+
+        if color_terminal:
+            duration = f"\033[1;32m{duration}\033[0m"
+        
         msg = f"\n{func_name}: {duration:.5g} ms" + display_args + display_kwargs
         # print(msg)
         info(msg)

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -20,6 +20,8 @@ import time
 import functools
 import inspect
 import warnings
+from sverchok.utils.logging import info
+
 
 string_types = (type(b''), type(u''))
 
@@ -111,7 +113,7 @@ def duration(func):
         display_args = (f"\n    {args=}" if args else "")
         display_kwargs = (f"\n    {kwargs=}" if kwargs else "")
         msg = f"{func.__name__}: {(time.time() - start_time) * 1000} ms" + display_args + display_kwargs
-        print(msg)
-        #warnings.warn(format_message(func, reason), category=DeprecationWarning, stacklevel=2)
+        # print(msg)
+        info(msg)
         return result
     return wrapped

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -107,6 +107,9 @@ def duration(func):
 
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
+
+        display_color = color_terminal['displays_colors']
+
         start_time = time.time()
         result = func(*args, **kwargs)
         duration = (time.time() - start_time) * 1000
@@ -115,10 +118,10 @@ def duration(func):
         display_kwargs = (f"\n    {kwargs=}" if kwargs else "")
         func_name = func.__name__
 
-        if color_terminal:
+        if display_color:
             func_name = f"\033[1;31m{func_name}\033[0m"
 
-        if color_terminal:
+        if display_color:
             duration = f"\033[1;32m{duration:.5g} ms\033[0m"
         else:
             duration = f"{duration:.5g} ms" 

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -105,7 +105,7 @@ def deprecated(argument):
         
 def duration(func):
 
-    from sverchok.core import color_terminal
+    from sverchok.utils.ascii_print import color_terminal
 
     @functools.wraps(func)
     def wrapped(*args, **kwargs):

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -112,7 +112,9 @@ def duration(func):
 
         display_args = (f"\n    {args=}" if args else "")
         display_kwargs = (f"\n    {kwargs=}" if kwargs else "")
-        msg = f"{func.__name__}: {(time.time() - start_time) * 1000} ms" + display_args + display_kwargs
+        func_name = func.__name__
+        duration = (time.time() - start_time) * 1000
+        msg = f"\n{func_name}: {duration} ms" + display_args + display_kwargs
         # print(msg)
         info(msg)
         return result

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -21,7 +21,7 @@ import functools
 import inspect
 import warnings
 from sverchok.utils.logging import info
-
+from sverchok.core import color_terminal
 
 string_types = (type(b''), type(u''))
 
@@ -104,6 +104,9 @@ def deprecated(argument):
 
         
 def duration(func):
+
+    from sverchok.core import color_terminal
+
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
         start_time = time.time()
@@ -113,6 +116,8 @@ def duration(func):
         display_args = (f"\n    {args=}" if args else "")
         display_kwargs = (f"\n    {kwargs=}" if kwargs else "")
         func_name = func.__name__
+        func_name = f"\033[1;31m{func_name}\033[0m" if color_terminal else f"{func_name}"
+
         duration = (time.time() - start_time) * 1000
         msg = f"\n{func_name}: {duration} ms" + display_args + display_kwargs
         # print(msg)

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -119,7 +119,7 @@ def duration(func):
         func_name = f"\033[1;31m{func_name}\033[0m" if color_terminal else f"{func_name}"
 
         duration = (time.time() - start_time) * 1000
-        msg = f"\n{func_name}: {duration} ms" + display_args + display_kwargs
+        msg = f"\n{func_name}: {duration:.5g} ms" + display_args + display_kwargs
         # print(msg)
         info(msg)
         return result

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -105,9 +105,13 @@ def duration(func):
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
         start_time = time.time()
+        
         result = func(*args, **kwargs)
-        msg = f"{func.__name__}: {(time.time() - start_time) * 1000} ms \n    {args=}\n    {kwargs=}" 
+
+        display_args = (f"\n    {args=}" if args else "")
+        display_kwargs = (f"\n    {kwargs=}" if kwargs else "")
+        msg = f"{func.__name__}: {(time.time() - start_time) * 1000} ms" + display_args + display_kwargs
         print(msg)
         #warnings.warn(format_message(func, reason), category=DeprecationWarning, stacklevel=2)
-        return result  
+        return result
     return wrapped

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -21,7 +21,7 @@ import functools
 import inspect
 import warnings
 from sverchok.utils.logging import info
-from sverchok.core import color_terminal
+from sverchok.utils.ascii_print import color_terminal
 
 string_types = (type(b''), type(u''))
 
@@ -104,8 +104,6 @@ def deprecated(argument):
 
         
 def duration(func):
-
-    from sverchok.utils.ascii_print import color_terminal
 
     @functools.wraps(func)
     def wrapped(*args, **kwargs):

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -21,7 +21,7 @@ import functools
 import inspect
 import warnings
 from sverchok.utils.logging import info
-from sverchok.utils.ascii_print import color_terminal
+from sverchok.utils.ascii_print import str_color
 
 string_types = (type(b''), type(u''))
 
@@ -108,26 +108,18 @@ def duration(func):
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
 
-        display_color = color_terminal['displays_colors']
-
         start_time = time.time()
         result = func(*args, **kwargs)
         duration = (time.time() - start_time) * 1000
 
-        display_args = (f"\n    {args=}" if args else "")
-        display_kwargs = (f"\n    {kwargs=}" if kwargs else "")
+        # display_args = (f"\n    {args=}" if args else "")
+        # display_kwargs = (f"\n    {kwargs=}" if kwargs else "")
         func_name = func.__name__
 
-        if display_color:
-            func_name = f"\033[1;31m{func_name}\033[0m"
-
-        if display_color:
-            duration = f"\033[1;32m{duration:.5g} ms\033[0m"
-        else:
-            duration = f"{duration:.5g} ms" 
+        func_name = str_color(func_name, 31)
+        duration = str_color(f"{duration:.5g} ms", 32)
         
-        msg = f"\n{func_name}: {duration}" + display_args + display_kwargs
-        # print(msg)
+        msg = f"\n{func_name}: {duration}" # + display_args + display_kwargs
         info(msg)
         return result
     return wrapped

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -114,9 +114,7 @@ def duration(func):
 
         # display_args = (f"\n    {args=}" if args else "")
         # display_kwargs = (f"\n    {kwargs=}" if kwargs else "")
-        func_name = func.__name__
-
-        func_name = str_color(func_name, 31)
+        func_name = str_color(func.__name__, 31)
         duration = str_color(f"{duration:.5g} ms", 32)
         
         msg = f"\n{func_name}: {duration}" # + display_args + display_kwargs

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -121,9 +121,11 @@ def duration(func):
             func_name = f"\033[1;31m{func_name}\033[0m"
 
         if color_terminal:
-            duration = f"\033[1;32m{duration}\033[0m"
+            duration = f"\033[1;32m{duration:.5g} ms\033[0m"
+        else:
+            duration = f"{duration:.5g} ms" 
         
-        msg = f"\n{func_name}: {duration:.5g} ms" + display_args + display_kwargs
+        msg = f"\n{func_name}: {duration}" + display_args + display_kwargs
         # print(msg)
         info(msg)
         return result


### PR DESCRIPTION
- upon sverchok load, it can check if the termnial supports colors, this is stored in a variable inside utils/ascii_print
- `ascii_print.str_color(text, color_id)` will return the string with color markup if terminal can display them.
- adds colors to output of `@duration` 

![image](https://user-images.githubusercontent.com/619340/172923786-822b2714-a1fb-4121-ae11-24d9d3579b7a.png)

just experimenting..  args and kwargs will need to be introspected to avoid printing out large lists of incoming data.