### PR TITLE
Snlite newnode operator

### DIFF
--- a/utils/text_editor_plugins.py
+++ b/utils/text_editor_plugins.py
@@ -25,6 +25,69 @@ def fuzzy_compare(named_seeker, named_current):
     except Exception as err:
         print(f"Refresh Current Script called but encountered error {err}")
 
+def get_first_sverchok_nodetree():
+
+    AREA = 'NODE_EDITOR'
+    for window in bpy.context.window_manager.windows:
+        screen = window.screen
+        for area in screen.areas:
+            if not area.type == AREA: continue
+
+            for space in area.spaces:
+                if hasattr(space, "edit_tree"):
+                    if space.tree_type in {'SverchCustomTreeType', 'SvGroupTree'}:
+                        ng = space.edit_tree
+                        for region in area.regions:
+                            if region.type == 'WINDOW': 
+                                override = {
+                                    'window': window,
+                                    'screen': screen,
+                                    'area': area,
+                                    'region': region
+                                }
+                                return ng, override
+
+
+
+class SvSNLiteAddFromTextEditor(bpy.types.Operator):
+    """
+    you want to create an snlite from the current edit_text in TextEditor
+    this will create the node, load it with the text, and center the nodeview on that node.
+    """
+    bl_label = "Make SNlite from Current Script"
+    bl_idname = "text.nodenew_from_texteditor"
+
+    def execute(self, context):
+        self.report({'INFO'}, f"Triggered: {self.bl_idname}")
+
+        ngs = bpy.data.node_groups
+        if not ngs:
+            self.report({'INFO'}, "No NodeGroups")
+            return {'FINISHED'}
+
+        edit_text = bpy.context.edit_text
+        text_file_name = edit_text.name
+        is_sv_tree = lambda ng: ng.bl_idname in {'SverchCustomTreeType', }
+        ngs = list(filter(is_sv_tree, ngs))
+
+        if not ngs:
+            self.report({'INFO'}, "No Sverchok NodeGroups")
+            return {'CANCELLED'}
+
+        if (result := get_first_sverchok_nodetree()):
+            ng, override = result
+            snlite = ng.nodes.new('SvScriptNodeLite')
+            # --- position to center of the view would be nice.
+
+            snlite.script_name = text_file_name
+            snlite.load()
+
+            ng.nodes.active = snlite
+            snlite.select = True
+            bpy.ops.node.view_selected(override)
+
+        return {'FINISHED'}
+
 
 class SvNodeRefreshFromTextEditor(bpy.types.Operator):
 
@@ -33,7 +96,7 @@ class SvNodeRefreshFromTextEditor(bpy.types.Operator):
 
     def execute(self, context):
 
-        self.report({'INFO'}, "Triggered: text.noderefresh_from_texteditor")
+        self.report({'INFO'}, f"Triggered: {self.bl_idname}")
 
         ngs = bpy.data.node_groups
         if not ngs:
@@ -119,9 +182,14 @@ def add_keymap():
 
     if 'noderefresh_from_texteditor' in dir(bpy.ops.text):
         ''' SHORTCUT 1 Node Refresh: Ctrl + Return '''
-        ident_str = 'text.noderefresh_from_texteditor'
+        ident_str = SvNodeRefreshFromTextEditor.bl_idname
         if not (ident_str in keymaps):
             new_shortcut = keymaps.new(ident_str, 'RET', 'PRESS', ctrl=1, head=0)
+            addon_keymaps.append((km, new_shortcut))
+
+        ident_str = SvSNLiteAddFromTextEditor.bl_idname 
+        if not (ident_str in keymaps):
+            new_shortcut = keymaps.new(ident_str, 'RET', 'PRESS', ctrl=1, shift=1, head=0)
             addon_keymaps.append((km, new_shortcut))
 
         logger.debug('Sverchok added keyboard items to Text Editor.')
@@ -136,6 +204,7 @@ def remove_keymap():
 
 def register():
     global logger
+    bpy.utils.register_class(SvSNLiteAddFromTextEditor)
     bpy.utils.register_class(SvNodeRefreshFromTextEditor)
     logger = getLogger("text_editor_plugins")
     add_keymap()
@@ -143,4 +212,4 @@ def register():
 def unregister():
     remove_keymap()
     bpy.utils.unregister_class(SvNodeRefreshFromTextEditor)
-
+    bpy.utils.unregister_class(SvSNLiteAddFromTextEditor)

--- a/utils/text_editor_plugins.py
+++ b/utils/text_editor_plugins.py
@@ -45,7 +45,7 @@ def get_first_sverchok_nodetree():
                                     'area': area,
                                     'region': region
                                 }
-                                return ng, override
+                                return ng, override, space
 
 
 
@@ -75,10 +75,16 @@ class SvSNLiteAddFromTextEditor(bpy.types.Operator):
             return {'CANCELLED'}
 
         if (result := get_first_sverchok_nodetree()):
-            ng, override = result
-            snlite = ng.nodes.new('SvScriptNodeLite')
-            # --- position to center of the view would be nice.
+            ng, override, space = result
 
+            for n in ng.nodes:
+                if n.bl_idname == "SvScriptNodeLite":
+                    if fuzzy_compare(n.script_name, text_file_name):
+                        n.load()
+                        return {'CANCELLED'}
+
+            snlite = ng.nodes.new('SvScriptNodeLite')
+            snlite.location = ng.view_center
             snlite.script_name = text_file_name
             snlite.load()
 

--- a/utils/text_editor_plugins.py
+++ b/utils/text_editor_plugins.py
@@ -84,7 +84,15 @@ class SvSNLiteAddFromTextEditor(bpy.types.Operator):
                         return {'CANCELLED'}
 
             snlite = ng.nodes.new('SvScriptNodeLite')
-            snlite.location = ng.view_center
+            
+            # middle of view, translated to nodetree location
+            dpi_fac = get_params({'render_location_xy_multiplier': 1.0}, direct=True)[0]
+            region = override['region']
+            mid_x = region.width / 2
+            mid_y = region.height / 2 
+            x, y  = region.view2d.region_to_view(mid_x, mid_y)
+            snlite.location = x * 1 / dpi_fac, y *1 / dpi_fac
+
             snlite.script_name = text_file_name
             snlite.load()
 

--- a/utils/text_editor_plugins.py
+++ b/utils/text_editor_plugins.py
@@ -7,7 +7,7 @@
 
 import bpy
 from sverchok.utils.logging import getLogger
-
+from sverchok.settings import get_params
 
 def has_selection(self, text):
     return not (text.select_end_line == text.current_line and
@@ -89,16 +89,17 @@ class SvSNLiteAddFromTextEditor(bpy.types.Operator):
             dpi_fac = get_params({'render_location_xy_multiplier': 1.0}, direct=True)[0]
             region = override['region']
             mid_x = region.width / 2
-            mid_y = region.height / 2 
+            mid_y = region.height / 2
+            print("mid==", mid_x, mid_y)
             x, y  = region.view2d.region_to_view(mid_x, mid_y)
             snlite.location = x * 1 / dpi_fac, y *1 / dpi_fac
 
             snlite.script_name = text_file_name
             snlite.load()
 
-            ng.nodes.active = snlite
-            snlite.select = True
-            bpy.ops.node.view_selected(override)
+            #ng.nodes.active = snlite
+            #snlite.select = True
+            #bpy.ops.node.view_selected(override)
 
         return {'FINISHED'}
 


### PR DESCRIPTION
this allows  the user to spawn a new scriptnode directly from the open TextEditor, 
- it will fill the scriptnode with `edit_text.name`
- it will call node.load()
- it will position the node at the center of the currently open nodeview.
- keymap  ctrl+shift+return