### PR TITLE
Snlite templates

### DIFF
--- a/node_scripts/SNLite_templates/templates/numba_VF.py
+++ b/node_scripts/SNLite_templates/templates/numba_VF.py
@@ -1,6 +1,6 @@
 """
->in verts v       # ..
->in faces s       # only start execution if both of these are connected
+>in verts v    #
+>in faces s    # no computation until both input sockets are connected
 out _verts v
 out _faces s
 """

--- a/node_scripts/SNLite_templates/templates/numba_VF.py
+++ b/node_scripts/SNLite_templates/templates/numba_VF.py
@@ -1,0 +1,28 @@
+"""
+>in verts v       # ..
+>in faces s       # only start execution if both of these are connected
+out _verts v
+out _faces s
+"""
+
+from sverchok.utils.decorators_compilation import njit, numba_uncache
+
+# if other numba features are needed
+# from sverchok.dependencies import numba
+
+# there are two ways to clear sverchok's njit cache
+#   1. numba_uncache(your_function_name)
+#   2. rename the function, into something that does not yet exist in the cache
+
+# this will compile, the first time it's run, then subsequent
+# calls to your_function are from the cached compilation.
+
+#@njit(cache=True)
+def your_function(vlist, flist):
+	return nvlist, nflist
+
+
+for vlist, flist in zip(verts, faces):
+	v, f = your_function(vlist, flist)
+	_verts.append(v)
+	_faces.append(f)

--- a/nodes/script/script1_lite.py
+++ b/nodes/script/script1_lite.py
@@ -45,7 +45,7 @@ snlite_template_path = os.path.join(sv_path, 'node_scripts', 'SNLite_templates')
 
 defaults = [0] * 32
 
-template_categories = ['demo', 'bpy_stuff', 'bmesh', 'utils']
+template_categories = ['demo', 'bpy_stuff', 'bmesh', 'utils', 'templates']
 
 
 

--- a/utils/decorators_compilation.py
+++ b/utils/decorators_compilation.py
@@ -21,6 +21,12 @@ def njit(**kwargs):
             if function_name not in local_numba_storage:
                 jitted_func = numba.njit(**kwargs)(function_to_compile)
                 local_numba_storage[function_name] = jitted_func
+            
+            #elif function_name in local_numba_storage and function_str_hash doesn't match:
+            #    # recache
+            # the dowside to this would be that it becomes whitespace/comment changes sensitive
+            # unless whitespace and comments are removed from functionstring before compilation..
+
             return local_numba_storage[function_name]
 
     else:
@@ -47,3 +53,6 @@ def jit(**kwargs):
             return function_to_compile
 
     return wrapper
+
+def numba_uncache(function_name):
+    del local_numba_storage[function_name]

--- a/utils/snlite_importhelper.py
+++ b/utils/snlite_importhelper.py
@@ -85,6 +85,9 @@ def parse_required_socket_line(node, line):
     line = trim_comment(line)
 
     lsp = line.strip().split()
+    if len(lsp) > 3:
+        lsp = lsp[:3]
+
     if len(lsp) == 3:
         socket_type = sock_dict.get(lsp[2])
         socket_name = lsp[1]
@@ -92,7 +95,7 @@ def parse_required_socket_line(node, line):
             return UNPARSABLE
         return socket_type, socket_name, None, None
 
-    node.error(f'directive: (socket line) "{line}" -> is malformed, missing socket type?')
+    node.error(f'directive: (socket line) "{line}" -> is malformed, missing socket type? {lsp}')
     return UNPARSABLE
 
 

--- a/utils/snlite_importhelper.py
+++ b/utils/snlite_importhelper.py
@@ -71,10 +71,19 @@ def parse_socket_line(node, line):
             nested = processed(lsp[4])
             return socket_type, socket_name, default, nested
 
+def trim_comment(line):
+    idx = line.find("#")
+    if idx < 0:
+        return line
+    return line[:idx]
+
 def parse_required_socket_line(node, line):
     # receives a line like
     # required input sockets do not accept defaults or nested info, what would be the point?
     # >in socketname sockettype
+
+    line = trim_comment(line)
+
     lsp = line.strip().split()
     if len(lsp) == 3:
         socket_type = sock_dict.get(lsp[2])

--- a/utils/snlite_importhelper.py
+++ b/utils/snlite_importhelper.py
@@ -78,8 +78,8 @@ def trim_comment(line):
     return line[:idx]
 
 def parse_required_socket_line(node, line):
-    # receives a line like
     # required input sockets do not accept defaults or nested info, what would be the point?
+    # receives a line like
     # >in socketname sockettype
 
     line = trim_comment(line)

--- a/utils/snlite_utils.py
+++ b/utils/snlite_utils.py
@@ -47,6 +47,7 @@ def ddir(content, filter_str=None):
         vals = [n for n in dir(content) if not n.startswith('__') and filter_str in n]
     return vals
 
+# deprecated, use decorators_compilation.njit instead
 
 def sv_njit(function_to_njit, parameters):
     fn_name = function_to_njit.__name__


### PR DESCRIPTION
- adds templates to snlite folders
- fixes parsing error in required-socket mode, when a comment was present, but it should raise an exception perhaps..as there are many other scenarios possible to make this crash.
- add numba_uncache