### PR TITLE
Snlite templates add timed execution

### DIFF
--- a/node_scripts/SNLite_templates/templates/numba_VF_timed.py
+++ b/node_scripts/SNLite_templates/templates/numba_VF_timed.py
@@ -6,7 +6,7 @@ out _faces s
 """
 
 from sverchok.utils.decorators_compilation import njit, numba_uncache
-
+from sverchok.utils.context_managers import timed
 # if other numba features are needed
 # from sverchok.dependencies import numba
 
@@ -23,6 +23,7 @@ def your_function(vlist, flist):
 
 
 for vlist, flist in zip(verts, faces):
-    v, f = your_function(vlist, flist)
+    with timed(your_function) as your_function:
+        v, f = your_function(vlist, flist)
     _verts.append(v)
     _faces.append(f)

--- a/utils/context_managers.py
+++ b/utils/context_managers.py
@@ -49,6 +49,8 @@ def timed(func):
             result = func(....)    
         ...
 
+        >>> func_name: 29.987335205078125
+
     """
 
     from sverchok.utils.ascii_print import str_color
@@ -62,5 +64,34 @@ def timed(func):
     func_name = str_color(func.__name__, 31)
     duration = str_color(f"{duration:.5g} ms", 32)
     func_name = func.__name__
-    msg = f"\n{func_name}: {duration}"
+    msg = f"{func_name}: {duration}"
+    print(msg)
+
+@contextmanager
+def timepart(section_name=">"):
+    """
+    usage:
+    
+    from sverchok.utils.context_managers import timepart
+
+    ...
+
+        with timepart("section 1"):
+            f = []
+            for i in range(100_000):
+                f.append(i*random())
+
+        >>> section 1: 29.987335205078125
+
+    """
+    from sverchok.utils.ascii_print import str_color
+    start_time = time.time()
+    
+    yield None
+
+    duration = (time.time() - start_time) * 1000
+
+    section_name = str_color(section_name, 31)
+    duration = str_color(f"{duration:.5g} ms", 32)
+    msg = f"{section_name}: {duration}"
     print(msg)

--- a/utils/context_managers.py
+++ b/utils/context_managers.py
@@ -58,12 +58,9 @@ def timed(func):
     yield func
 
     duration = (time.time() - start_time) * 1000
-
-    # display_args = (f"\n    {args=}" if args else "")
-    # display_kwargs = (f"\n    {kwargs=}" if kwargs else "")
     
     func_name = str_color(func.__name__, 31)
     duration = str_color(f"{duration:.5g} ms", 32)
     func_name = func.__name__
-    msg = f"\n{func_name}: {duration}" # + display_args + display_kwargs
+    msg = f"\n{func_name}: {duration}"
     print(msg)

--- a/utils/context_managers.py
+++ b/utils/context_managers.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+import time
 
 import bpy
 import sverchok
@@ -34,3 +35,35 @@ def addon_preferences(addon_name):
     addon = bpy.context.preferences.addons.get(addon_name)
     if addon and hasattr(addon, "preferences"):
         yield addon.preferences
+
+@contextmanager
+def timed(func):
+    """
+    usage:
+    
+    from sverchok.utils.context_managers import timed
+
+    ...
+
+        with timed(your_func) as func:
+            result = func(....)    
+        ...
+
+    """
+
+    from sverchok.utils.ascii_print import str_color
+
+    start_time = time.time()
+    
+    yield func
+
+    duration = (time.time() - start_time) * 1000
+
+    # display_args = (f"\n    {args=}" if args else "")
+    # display_kwargs = (f"\n    {kwargs=}" if kwargs else "")
+    
+    func_name = str_color(func.__name__, 31)
+    duration = str_color(f"{duration:.5g} ms", 32)
+    func_name = func.__name__
+    msg = f"\n{func_name}: {duration}" # + display_args + display_kwargs
+    print(msg)

--- a/utils/context_managers.py
+++ b/utils/context_managers.py
@@ -85,6 +85,7 @@ def timepart(section_name=">"):
 
     """
     from sverchok.utils.ascii_print import str_color
+
     start_time = time.time()
     
     yield None


### PR DESCRIPTION
adds timed context_manager, which returns a function. and prints the duration of the context manager.
usage
```python
    from sverchok.utils.context_managers import timed

    ...

    with timed(your_func) as func:
        result = func(....)    
    ...
```
useful for general timing functions, it is extended to behave with no functions and just time how long it takes to exit.
```python

    from sverchok.utils.context_managers import timepart

    ...

    with timepart("named section x"):
        # some code here
    ...
```

the easier it is to time functions and section of code, the better.