### PR TITLE
Repeater vectorization

### DIFF
--- a/nodes/list_struct/repeater.py
+++ b/nodes/list_struct/repeater.py
@@ -55,12 +55,12 @@ class ListRepeaterNode(bpy.types.Node, SverchCustomTreeNode):
 
         if self.level == 1:  # only for 1 otherwise it changes behaviour dramatically
             obj_num = max(len(data), len(number))
-            data = fixed_iter(data, obj_num)
+            data = fixed_iter(data, obj_num) if data else []
 
         out_ = self.count(data, self.level, number)
         if self.unwrap:
+            out = []
             if len(out_) > 0:
-                out = []
                 for o in out_:
                     out.extend(o)
         else:

--- a/nodes/list_struct/repeater.py
+++ b/nodes/list_struct/repeater.py
@@ -53,8 +53,9 @@ class ListRepeaterNode(bpy.types.Node, SverchCustomTreeNode):
         data = self.inputs['Data'].sv_get(deepcopy=False, default=[])
         number = self.inputs['Number'].sv_get(deepcopy=False)[0]
 
-        obj_num = max(len(data), len(number))
-        data = fixed_iter(data, obj_num)
+        if self.level == 1:  # only for 1 otherwise it changes behaviour dramatically
+            obj_num = max(len(data), len(number))
+            data = fixed_iter(data, obj_num)
 
         out_ = self.count(data, self.level, number)
         if self.unwrap:


### PR DESCRIPTION
## Addressed problem description

Closes #3870

It changes the node behavior slightly to more consistency. I don't think it requires new version because previous behavior looked like a bug

Now it work like this (But probably it should return empty list but not zeros. 🤔)

![new](https://user-images.githubusercontent.com/28003269/181430143-5ff8d35f-7b5d-462d-b701-3ee7cbbc7f1e.gif)

Previous behavior

![old](https://user-images.githubusercontent.com/28003269/181430170-6eaf0cdb-577a-4a8a-93b9-1e719a553e19.gif)

## Preflight checklist

- [x] Code changes complete.


