### PR TITLE
Clean Blender text logs before file saving

### DIFF
--- a/core/handlers.py
+++ b/core/handlers.py
@@ -4,6 +4,7 @@ from bpy.app.handlers import persistent
 from sverchok import old_nodes
 from sverchok import data_structure
 import sverchok.core.events as ev
+import sverchok.utils.logging as log
 from sverchok.core.event_system import handle_event
 from sverchok.core.socket_data import clear_all_socket_cache
 from sverchok.ui import bgl_callback_nodeview, bgl_callback_3dview
@@ -218,12 +219,18 @@ def update_frame_change_mode():
     set_frame_change(mode)
 
 
+@persistent
+def save_pre_handler(scene):
+    log.clear_internal_buffer()
+
+
 handler_dict = {
     'undo_pre': sv_handler_undo_pre,
     'undo_post': sv_handler_undo_post,
     'load_pre': sv_pre_load,
     'load_post': sv_post_load,
     'depsgraph_update_pre': sv_main_handler,
+    'save_pre': save_pre_handler,
 }
 
 

--- a/settings.py
+++ b/settings.py
@@ -396,9 +396,10 @@ class SverchokPreferences(AddonPreferences):
     log_to_buffer: BoolProperty(name = "Log to text buffer",
             description = "Enable log output to internal Blender's text buffer (requires restart)",
             default = True)
-    log_to_buffer_clean: BoolProperty(name = "Clear buffer at startup",
-            description = "Clear text buffer at each Blender startup (requires restart)",
-            default = False)
+    log_to_buffer_clean: BoolProperty(
+        name="Clear buffer at saving file",
+        description="Clear text buffer each time when file is saved",
+        default=True)
     log_to_file: BoolProperty(name = "Log to file",
             description = "Enable log output to external file (requires restart)",
             default = False)

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -146,9 +146,6 @@ def try_initialize():
             if prefs.log_to_buffer:
                 buffer = get_log_buffer(prefs.log_buffer_name)
                 if buffer is not None:
-                    if prefs.log_to_buffer_clean:
-                        buffer.clear()
-                        logging.debug("Internal text buffer cleared")
                     handler = TextBufferHandler(prefs.log_buffer_name)
                     handler.setFormatter(logging.Formatter(log_format))
                     logging.getLogger().addHandler(handler)
@@ -190,6 +187,15 @@ def try_initialize():
                     ("no" if not prefs.log_to_file else prefs.log_file_name),
                     ("yes" if prefs.log_to_console else "no"))
             initialized = True
+
+
+def clear_internal_buffer():
+    """It clears only BLender text editor"""
+    with sv_preferences() as prefs:
+        if prefs.log_to_buffer_clean:
+            get_log_buffer(prefs.log_buffer_name).clear()
+            logging.debug("Internal text buffer cleared")
+
 
 # Convenience functions
 


### PR DESCRIPTION
## Addressed problem description

Closes #4391

I found that cleaning on blender exit does not have sense because these changes wont get into saved file. So the solution is to clean logs at file saving.

## Preflight checklist

- [x] Code changes complete.


