### PR TITLE
"NURBS Curve Nodes" node.

### DIFF
--- a/docs/data_structure/nurbs.rst
+++ b/docs/data_structure/nurbs.rst
@@ -96,6 +96,16 @@ for reference.
   in which distance between neighbour knots is different in different places.
   For example, ``0 0 0.5 0.6 1.5 1.7 1.9 2 2 2`` is a non-uniform (and clamped)
   knot vector.
+* **Node values**, **Node points**. Also known as Greville abscissaes and
+  Greville points, average knot values, or simply edit points. The values of
+  NURBS curve's T parameter, defined as: ``t[i] = sum(u[i+j] for j from 1 to p)
+  / p``, where ``u`` is curve's knotvector, and ``p`` is curve's degree.  NURBS
+  curve *node points* (or Greville points) are points at the curve at parameter
+  values equal to node values.  The number of curve's nodes is equal to the
+  number of curve's control points.  Node points of the curve are positioned on
+  the curve near corresponding control points. So in many NURBS algorithms,
+  node points are used to define the shape of NURBS curve, instead of control
+  points.
 
 .. _Book: https://www.springer.com/gp/book/9783642973857
 

--- a/docs/nodes/curve/curve_index.rst
+++ b/docs/nodes/curve/curve_index.rst
@@ -33,6 +33,7 @@ Curves
    length_rebuild
    curvature
    torsion
+   nurbs_curve_nodes
    deconstruct_curve
    curve_frame
    curve_frame_on_surface

--- a/docs/nodes/curve/nurbs_curve_nodes.rst
+++ b/docs/nodes/curve/nurbs_curve_nodes.rst
@@ -5,7 +5,7 @@ Functionality
 -------------
 
 This node calculates so-called *node* points (also known as Greville points or
-average knot points) of the NURBS curve.
+average knot points, or simply edit points) of the NURBS curve.
 NURBS curve *nodes* (or Greville abscissaes) are defined as:
 ``t[i] = sum(u[i+j] for j from 1 to p) / p``, where ``u`` is curve's knotvector, and
 ``p`` is curve's degree.
@@ -33,4 +33,8 @@ This node has the following outputs:
 
 Example of Usage
 ----------------
+
+Orange is curve's control polygon; dark blue are curve's node points (Greville points):
+
+.. image:: https://user-images.githubusercontent.com/284644/186223165-72a48126-b290-4eb9-a3cc-262fd23bf426.png
 

--- a/docs/nodes/curve/nurbs_curve_nodes.rst
+++ b/docs/nodes/curve/nurbs_curve_nodes.rst
@@ -1,0 +1,36 @@
+NURBS Curve Nodes
+=================
+
+Functionality
+-------------
+
+This node calculates so-called *node* points (also known as Greville points or
+average knot points) of the NURBS curve.
+NURBS curve *nodes* (or Greville abscissaes) are defined as:
+``t[i] = sum(u[i+j] for j from 1 to p) / p``, where ``u`` is curve's knotvector, and
+``p`` is curve's degree.
+NURBS curve *node points* (or Greville points) are points at the curve at
+parameter values equal to node values.
+The number of curve's nodes is equal to the number of curve's control points.
+Node points of the curve are positioned on the curve near corresponding control
+points. So in many NURBS algorithms, node points are used to define the shape
+of NURBS curve, instead of control points.
+
+Inputs
+------
+
+This node has the following input:
+
+* **Curve**. The NURBS Curve object to calculate nodes for. This input is mandatory.
+
+Outputs
+-------
+
+This node has the following outputs:
+
+* **Points**. The calculated node points on the curve.
+* **T**. The calculated node values (values of curve's T parameter corresponding to node points).
+
+Example of Usage
+----------------
+

--- a/index.md
+++ b/index.md
@@ -68,6 +68,7 @@
     SvApproxNurbsCurveMk2Node
     SvExInterpolateNurbsCurveNode
     SvDeconstructCurveNode
+    SvNurbsCurveNodesNode
     ---
     SvCurveInsertKnotNode
     SvCurveRemoveKnotNode

--- a/nodes/curve/nurbs_curve_nodes.py
+++ b/nodes/curve/nurbs_curve_nodes.py
@@ -1,0 +1,69 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import numpy as np
+
+import bpy
+from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import (updateNode, zip_long_repeat, ensure_nesting_level,
+                                     get_data_nesting_level)
+from sverchok.utils.curve import SvCurve
+from sverchok.utils.curve.nurbs import SvNurbsCurve
+
+class SvNurbsCurveNodesNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: NURBS curve nodes (Greville points)
+    Tooltip: Display nodes (a.k.a edit points or Greville points) of a NURBS curve
+    """
+    bl_idname = 'SvNurbsCurveNodesNode'
+    bl_label = 'NURBS Curve Nodes'
+    bl_icon = 'OUTLINER_OB_EMPTY'
+    sv_icon = 'SV_DECONSTRUCT_CURVE'
+
+    def sv_init(self, context):
+        self.inputs.new('SvCurveSocket', "Curve")
+        self.outputs.new('SvVerticesSocket', "Points")
+        self.outputs.new('SvStringsSocket', "T")
+
+    def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+
+        curve_s = self.inputs['Curve'].sv_get()
+
+        curves_level = get_data_nesting_level(curve_s, data_types=(SvCurve,))
+        curve_s = ensure_nesting_level(curve_s, 2, data_types=(SvCurve,))
+
+        points_out = []
+        t_out = []
+        for curves in curve_s:
+            point_list = []
+            t_list = []
+            for curve in curves:
+                ts = curve.calc_greville_ts()
+                pts = curve.evaluate_array(ts)
+                t_list.append(ts.tolist())
+                point_list.append(pts.tolist())
+
+            if curves_level == 2:
+                points_out.append(point_list)
+                t_out.append(t_list)
+            else:
+                points_out.extend(point_list)
+                t_out.extend(t_list)
+
+        self.outputs['Points'].sv_set(points_out)
+        self.outputs['T'].sv_set(t_out)
+                
+def register():
+    bpy.utils.register_class(SvNurbsCurveNodesNode)
+
+def unregister():
+    bpy.utils.unregister_class(SvNurbsCurveNodesNode)
+


### PR DESCRIPTION
This node calculates so-called *node* points (also known as Greville points or
average knot points) of the NURBS curve.
NURBS curve *nodes* (or Greville abscissaes) are defined as:
``t[i] = sum(u[i+j] for j from 1 to p) / p``, where ``u`` is curve's knotvector, and
``p`` is curve's degree.
NURBS curve *node points* (or Greville points) are points at the curve at
parameter values equal to node values.
The number of curve's nodes is equal to the number of curve's control points.
Node points of the curve are positioned on the curve near corresponding control
points. So in many NURBS algorithms, node points are used to define the shape
of NURBS curve, instead of control points.

![Screenshot_20220823_221621](https://user-images.githubusercontent.com/284644/186223165-72a48126-b290-4eb9-a3cc-262fd23bf426.png)



## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

