### PR TITLE
allow output only mode

### DIFF
--- a/json_examples/Architecture/Power_transmission_tower.json
+++ b/json_examples/Architecture/Power_transmission_tower.json
@@ -66,7 +66,7 @@
       ],
       "params": {
         "divisions": 2,
-        "rad_": 3.5799999237060547,
+        "rad_": 3.94,
         "sides_": 4
       },
       "use_custom_color": true,

--- a/nodes/script/script1_lite.py
+++ b/nodes/script/script1_lite.py
@@ -292,8 +292,8 @@ class SvScriptNodeLite(bpy.types.Node, SverchCustomTreeNode):
 
     def update_sockets(self):
         socket_info = parse_sockets(self)
-        if not socket_info['inputs']:
-            return
+        #if not socket_info['inputs']:
+        #    return
 
         for k, v in socket_info.items():
             if not (k in {'inputs', 'outputs'}):


### PR DESCRIPTION
allows scripts to have no input, but at least one output is still enforced.. maybe later i'll add a mode that permits no IO, just storage.