### PR TITLE
Pip utils explicit inclusion

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -126,7 +126,7 @@ utils_modules = [
     "sv_curve_utils", "voronoi", "sv_script", "sv_itertools", "script_importhelper", "sv_oldnodes_parser",
     "csg_core", "csg_geom", "geom", "sv_easing_functions", "sv_text_io_common", "sv_obj_baker",
     "snlite_utils", "snlite_importhelper", "snlite_script_searcher",
-    "context_managers", "sv_node_utils", "sv_noise_utils",
+    "context_managers", "sv_node_utils", "sv_noise_utils", "pip_utils",
     "profile", "logging", "testing", "sv_requests", "sv_shader_sources", "tree_structure",
     "avl_tree", "sv_nodeview_draw_helper", "sv_font_xml_parser", "modules.edge_utils", "modules.polygon_utils",
     "wfc_algorithm", "handle_blender_data", "nodes_mixins.generating_objects", "decorators_compilation",

--- a/utils/pip_utils.py
+++ b/utils/pip_utils.py
@@ -20,6 +20,8 @@ def install_whl(package_path):
 
 usage = """\
 
+from sverchok.utils.pip_utils import install_package, install_whl
+
 install_package(['--upgrade', 'pip']) # <-- may not be needed
 install_package('pandas')
 install_package('gdal') # <-- may fail

--- a/utils/pip_utils.py
+++ b/utils/pip_utils.py
@@ -18,7 +18,7 @@ def install_package(package):
 def install_whl(package_path):
     subprocess.call([os.path.join(sys.prefix, 'bin', 'python.exe'), "-m", "pip", "install", f"{package_path}"])
 
-usage = """\
+usage = r"""\
 
 from sverchok.utils.pip_utils import install_package, install_whl
 


### PR DESCRIPTION
resolves an import issue,  files in `sverchok.utils.*` don't become available as an attribute of sverchok.utils unless they are explicitly added to the `__init__.py` module list. 

Without this these pip function would need to be accessed this way
```python
from sverchok.utils import pip_utils
pip_utils.install_package('numba')
```
now it can be run this way
```python
from sverchok.utils.pip_utils import install_package
install_package('numba')
```
