### PR TITLE
Curve Viewer Draw & Surface Viewer Draw nodes.

### DIFF
--- a/docs/nodes/viz/viewer_draw_curve.rst
+++ b/docs/nodes/viz/viewer_draw_curve.rst
@@ -53,6 +53,14 @@ The parameters of the node are (in this order):
   display of curve's node points, for NURBS and NURBS-like curves. Nodes are
   not shown by default.
 
+Operators
+---------
+
+This node has the following buttons:
+
+* **BAKE**. Create mesh objects in Blender scene according to curves being displayed.
+* **Align**. Zoom and position 3D view so that generated object is in the center.
+
 Outputs
 -------
 

--- a/docs/nodes/viz/viewer_draw_curve.rst
+++ b/docs/nodes/viz/viewer_draw_curve.rst
@@ -1,0 +1,65 @@
+Viewer Draw Curve
+=================
+
+Functionality
+-------------
+
+This node displays Curve objects in the 3D View, using opengl. The node is
+intended to be a fast way to show you the result of your node tree. 
+
+For NURBS and NURBS-like curves, the node can also additionally display:
+control points, control polygon edges, curve node points. For non-NURBS curves,
+the node just does not try to display these attributes.
+
+This node is automatically created when you select "Connect Viewer Draw" from
+right-click menu for nodes which have Curve output. Also this node pops up as a
+"temporal viewer". when you perform control-click on such a node.
+
+Inputs
+------
+
+This node has the following inputs:
+
+* **Curve**. The curve object(s) to be displayed. This input is mandatory.
+* **Resolution**. Resolution for displaying the curve. The default value is 50.
+
+Parameters
+----------
+
+This node has one main parameter:
+
+* **Show**. The node displays something only when this parameter is enabled.
+
+Most of arameters of this node are groupped in rows; for each type of
+information this node can display, there are three parameters: whether to
+display it, the color to be used, and point size / line width to be used.
+
+The parameters of the node are (in this order):
+
+* **Display Vertices**, **Vertices Color**, **Vertices Size**. Control display
+  of points on the curve (number of points is conrtolled by **Resolution**
+  parameter). Display of points is disabled by default.
+* **Display Curve Line**, **Curve Line Color**, **Curve Line Width**. Control
+  display of the curve itself (more precisely, the edges between curve points).
+  Curve line is shown by default.
+* **Display Control Points**, **Control Points Color**, **Control Points
+  Size**. Control display of curve's control points, for NURBS and NURBS-like
+  curves. Control points are not shown by default.
+* **Display Control Polygon**, **Control Polygon Color**, **Control Polygon
+  Line Width**. Control display of curve's control polygon (edges between
+  control points), for NURBS and NURBS-like curves. Control polygon is not
+  shown by default.
+* **Display Node Points**, **Node Points Color**, **Node Points Size**. Control
+  display of curve's node points, for NURBS and NURBS-like curves. Nodes are
+  not shown by default.
+
+Outputs
+-------
+
+This node has no outputs.
+
+Example of Usage
+----------------
+
+.. image:: https://user-images.githubusercontent.com/284644/189537925-b8d72553-5650-4d18-9fcc-507f70801dff.png
+

--- a/docs/nodes/viz/viewer_draw_surface.rst
+++ b/docs/nodes/viz/viewer_draw_surface.rst
@@ -53,6 +53,14 @@ The parameters of the node are (in this order):
   Control display of surface's control net (edges between control points), for
   NURBS and NURBS-like surfaces. Control net is not displayed by default.
 
+Operators
+---------
+
+This node has the following buttons:
+
+* **BAKE**. Create mesh objects in Blender scene according to curves being displayed.
+* **Align**. Zoom and position 3D view so that generated object is in the center.
+
 Outputs
 -------
 

--- a/docs/nodes/viz/viewer_draw_surface.rst
+++ b/docs/nodes/viz/viewer_draw_surface.rst
@@ -1,0 +1,65 @@
+Viewer Draw Surface
+===================
+
+Functionality
+-------------
+
+This node displays Surface objects in the 3D View, using opengl. The node is
+intended to be a fast way to show you the result of your node tree. 
+
+For NURBS and NURBS-like surfaces, the node can also additionally display
+control points and control net edges. For non-NURBS curves, the node just does
+not try to display these attributes.
+
+This node is automatically created when you select "Connect Viewer Draw" from
+right-click menu for nodes which have Surface output. Also this node pops up as a
+"temporal viewer". when you perform control-click on such a node.
+
+Inputs
+------
+
+This node has the following inputs:
+
+* **Surface**. The surface object(s) to be displayed. This input is mandatory.
+* **Resolution U**, **Resolution V**. Resolution to display the surface, along
+  U and V parameters. The default value is 50.
+
+Parameters
+----------
+
+This node has one main parameter:
+
+* **Show**. The node displays something only when this parameter is enabled.
+
+Most of arameters of this node are groupped in rows; for each type of
+information this node can display, there are three parameters: whether to
+display it, the color to be used, and point size / line width to be used.
+
+The parameters of the node are (in this order):
+
+* **Display Vertices**, **Vertices Color**, **Vertices Size**. Control display
+  of points on the surface (number of points along U and V parameters are
+  controlled by **Resolution U**, **Resolution V** inputs). Display of points
+  is disabled by default.
+* **Display Edges**, **Edges Color**, **Edges Line Width**. Control display of
+  edges on the curve (edges between points). Display of edges is disabled by
+  default.
+* **Display Surface**, **Surface Color**. Control display of the surface
+  itself. The surface is shown by default.
+* **Display Control Points**, **Control Points Color**, **Control Points
+  Size**. Control display of surface's control points, for NURBS and NURBS-like
+  surfaces. Control points are not shown by default.
+* **Display Control Net**, **Control Net Color**, **Control Net Line Width**.
+  Control display of surface's control net (edges between control points), for
+  NURBS and NURBS-like surfaces. Control net is not displayed by default.
+
+Outputs
+-------
+
+This node has no outputs.
+
+Example of Usage
+----------------
+
+.. image:: https://user-images.githubusercontent.com/284644/189537929-2be26995-0cb3-4063-9531-8ca0f955e155.png
+

--- a/docs/nodes/viz/viz_index.rst
+++ b/docs/nodes/viz/viz_index.rst
@@ -8,6 +8,8 @@ Viz
    mesh_viewer
    viewer_2d
    viewer_draw_mk4
+   viewer_draw_curve
+   viewer_draw_surface
    vd_matrix
    viewer_idx28
    polyline_viewer

--- a/index.md
+++ b/index.md
@@ -603,6 +603,8 @@
     SvMatrixViewer28
     SvIDXViewer28
     SvViewer2D
+    SvCurveViewerDrawNode
+    SvSurfaceViewerDrawNode
     ---
     SvMeshViewer
     SvCurveViewerNodeV28

--- a/nodes/viz/viewer_draw_curve.py
+++ b/nodes/viz/viewer_draw_curve.py
@@ -186,7 +186,7 @@ class SvCurveViewerDrawNode(bpy.types.Node, SverchCustomTreeNode):
             update = updateNode)
 
     def draw_buttons(self, context, layout):
-        layout.prop(self, "activate", text="", icon="HIDE_" + ("OFF" if self.activate else "ON"))
+        layout.prop(self, "activate", icon="HIDE_" + ("OFF" if self.activate else "ON"))
 
         grid = layout.column(align=True)
 

--- a/nodes/viz/viewer_draw_curve.py
+++ b/nodes/viz/viewer_draw_curve.py
@@ -1,0 +1,264 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import numpy as np
+
+import bpy
+from mathutils import Matrix, Vector
+from bpy.props import StringProperty, BoolProperty, IntProperty, EnumProperty, FloatVectorProperty
+import bgl
+import gpu
+from gpu_extras.batch import batch_for_shader
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode, get_data_nesting_level, ensure_nesting_level, zip_long_repeat, node_id
+from sverchok.utils.curve.core import SvCurve
+from sverchok.utils.curve.nurbs import SvNurbsCurve
+from sverchok.ui.bgl_callback_3dview import callback_disable, callback_enable
+
+def draw_edges(shader, points, edges, line_width, color):
+    bgl.glLineWidth(line_width)
+    batch = batch_for_shader(shader, 'LINES', {"pos": points}, indices=edges)
+    shader.bind()
+    shader.uniform_float('color', color)
+    batch.draw(shader)
+    bgl.glLineWidth(1)
+
+def draw_points(shader, points, size, color):
+    bgl.glPointSize(size)
+    batch = batch_for_shader(shader, 'POINTS', {"pos": points})
+    shader.bind()
+    shader.uniform_float('color', color)
+    batch.draw(shader)
+    bgl.glPointSize(1)
+
+def draw_curves(context, args):
+    node, draw_inputs, v_shader, e_shader = args
+
+    bgl.glEnable(bgl.GL_BLEND)
+
+    for curve, resolution in draw_inputs:
+        t_min, t_max = curve.get_u_bounds()
+        ts = np.linspace(t_min, t_max, num=resolution)
+        points = curve.evaluate_array(ts).tolist()
+        if (node.draw_control_polygon or node.draw_control_points) and hasattr(curve, 'get_control_points'):
+            cpts = curve.get_control_points().tolist()
+        else:
+            cpts = None
+
+        if node.draw_line:
+            n = len(ts)
+            edges = [(i,i+1) for i in range(n-1)]
+            draw_edges(e_shader, points, edges, node.line_width, node.line_color)
+
+        if node.draw_control_polygon and cpts is not None:
+            n = len(cpts)
+            edges = [(i,i+1) for i in range(n-1)]
+            draw_edges(e_shader, cpts, edges, node.control_polygon_line_width, node.control_polygon_color)
+
+        if node.draw_control_points and cpts is not None:
+            draw_points(v_shader, cpts, node.control_points_size, node.control_points_color)
+
+        if node.draw_nodes and hasattr(curve, 'calc_greville_points'):
+            gpoints = curve.calc_greville_points().tolist()
+            draw_points(v_shader, gpoints, node.nodes_size, node.nodes_color)
+
+        if node.draw_verts:
+            draw_points(v_shader, points, node.verts_size, node.verts_color)
+
+    bgl.glEnable(bgl.GL_BLEND)
+
+class SvCurveViewerDrawNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: preview curve
+    Tooltip: drawing curves on 3d view
+    """
+
+    bl_idname = 'SvCurveViewerDrawNode'
+    bl_label = 'Viewer Draw Curves'
+    bl_icon = 'GREASEPENCIL'
+    sv_icon = 'SV_DRAW_VIEWER'
+
+    resolution : IntProperty(
+            name = "Resolution",
+            min = 1,
+            default = 50,
+            update = updateNode)
+
+    activate: BoolProperty(
+        name='Show', description='Activate drawing',
+        default=True, update=updateNode)
+
+    draw_verts: BoolProperty(
+        update=updateNode, name='Display Vertices', default=False)
+
+    verts_color: FloatVectorProperty(
+            name = "Vertices Color",
+            default = (0.9, 0.9, 0.95, 1.0),
+            size = 4, min = 0.0, max = 1.0,
+            subtype = 'COLOR',
+            update = updateNode)
+
+    verts_size : IntProperty(
+            name = "Vertices Size",
+            min = 1, default = 3,
+            update = updateNode)
+
+    draw_line: BoolProperty(
+        update=updateNode, name='Display curve line', default=True)
+
+    line_color: FloatVectorProperty(
+            name = "Line Color",
+            default = (0.5, 0.8, 1.0, 1.0),
+            size = 4, min = 0.0, max = 1.0,
+            subtype = 'COLOR',
+            update = updateNode)
+
+    line_width : IntProperty(
+            name = "Line Width",
+            min = 1, default = 2,
+            update = updateNode)
+
+    draw_control_points: BoolProperty(
+        update=updateNode, name='Display control points', default=False)
+
+    control_points_color: FloatVectorProperty(
+            name = "Control Points Color",
+            default = (1.0, 0.5, 0.1, 1.0),
+            size = 4, min = 0.0, max = 1.0,
+            subtype = 'COLOR',
+            update = updateNode)
+
+    control_points_size : IntProperty(
+            name = "Control Points Size",
+            min = 1, default = 3,
+            update = updateNode)
+
+    draw_control_polygon: BoolProperty(
+        update=updateNode, name='Display control polygon', default=False)
+
+    control_polygon_color: FloatVectorProperty(
+            name = "Control Polygon Color",
+            default = (0.9, 0.8, 0.3, 1.0),
+            size = 4, min = 0.0, max = 1.0,
+            subtype = 'COLOR',
+            update = updateNode)
+
+    control_polygon_line_width : IntProperty(
+            name = "Control Polygon Lines Width",
+            min = 1, default = 1,
+            update = updateNode)
+
+    draw_nodes: BoolProperty(
+        update=updateNode, name='Display curve nodes', default=False)
+
+    nodes_color: FloatVectorProperty(
+            name = "Nodes Color",
+            default = (0.1, 0.1, 0.3, 1.0),
+            size = 4, min = 0.0, max = 1.0,
+            subtype = 'COLOR',
+            update = updateNode)
+
+    nodes_size : IntProperty(
+            name = "Node Points Size",
+            min = 1, default = 3,
+            update = updateNode)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "activate", text="", icon="HIDE_" + ("OFF" if self.activate else "ON"))
+
+        grid = layout.column(align=True)
+
+        row = grid.row(align=True)
+        row.prop(self, 'draw_verts', icon='SNAP_MIDPOINT', text='')
+        row.prop(self, 'verts_color', text="")
+        row.prop(self, 'verts_size', text="px")
+
+        row = grid.row(align=True)
+        row.prop(self, 'draw_line', icon='MOD_CURVE', text='')
+        row.prop(self, 'line_color', text="")
+        row.prop(self, 'line_width', text="px")
+
+        row = grid.row(align=True)
+        row.prop(self, 'draw_control_points', icon='DECORATE_KEYFRAME', text='')
+        row.prop(self, 'control_points_color', text="")
+        row.prop(self, 'control_points_size', text="px")
+
+        row = grid.row(align=True)
+        row.prop(self, 'draw_control_polygon', icon='SNAP_EDGE', text='')
+        row.prop(self, 'control_polygon_color', text="")
+        row.prop(self, 'control_polygon_line_width', text="px")
+
+        row = grid.row(align=True)
+        row.prop(self, 'draw_nodes', text="", icon='EVENT_N')
+        row.prop(self, 'nodes_color', text="")
+        row.prop(self, 'nodes_size', text="px")
+
+    def sv_init(self, context):
+        self.inputs.new('SvCurveSocket', 'Curve')
+        self.inputs.new('SvStringsSocket', 'Resolution').prop_name = 'resolution'
+
+    def draw_all(self, draw_inputs):
+
+        v_shader = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+        e_shader = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+
+        draw_data = {
+                'tree_name': self.id_data.name[:],
+                'custom_function': draw_curves,
+                'args': (self, draw_inputs, v_shader, e_shader)
+            }
+        
+        callback_enable(node_id(self), draw_data)
+
+    def process(self):
+        if bpy.app.background:
+            return
+        if not (self.id_data.sv_show and self.activate):
+            callback_disable(node_id(self))
+            return
+        n_id = node_id(self)
+        callback_disable(n_id)
+
+        # end early
+        if not self.activate:
+            return
+
+        if not self.inputs['Curve'].is_linked:
+            return
+
+        curves_s = self.inputs['Curve'].sv_get()
+        resolution_s = self.inputs['Resolution'].sv_get()
+        curves_s = ensure_nesting_level(curves_s, 2, data_types=(SvCurve,))
+        resolution_s = ensure_nesting_level(resolution_s, 2)
+
+        draw_inputs = []
+        for params in zip_long_repeat(curves_s, resolution_s):
+            for curve, resolution in zip_long_repeat(*params):
+                t_curve = SvNurbsCurve.to_nurbs(curve)
+                if t_curve is None:
+                    t_curve = curve
+                draw_inputs.append((t_curve, resolution))
+        self.draw_all(draw_inputs)
+
+    def show_viewport(self, is_show: bool):
+        """It should be called by node tree to show/hide objects"""
+        if not self.activate:
+            # just ignore request
+            pass
+        else:
+            if is_show:
+                self.process()
+            else:
+                callback_disable(node_id(self))
+
+    def sv_free(self):
+        callback_disable(node_id(self))
+
+classes = [SvCurveViewerDrawNode]
+register, unregister = bpy.utils.register_classes_factory(classes)
+

--- a/nodes/viz/viewer_draw_curve.py
+++ b/nodes/viz/viewer_draw_curve.py
@@ -96,7 +96,7 @@ class SvCurveViewerDrawNode(bpy.types.Node, SverchCustomTreeNode):
     """
 
     bl_idname = 'SvCurveViewerDrawNode'
-    bl_label = 'Viewer Draw Curves'
+    bl_label = 'Viewer Draw Curve'
     bl_icon = 'GREASEPENCIL'
     sv_icon = 'SV_DRAW_VIEWER'
 

--- a/nodes/viz/viewer_draw_surface.py
+++ b/nodes/viz/viewer_draw_surface.py
@@ -56,10 +56,10 @@ def draw_surfaces(context, args):
         if node.draw_edges:
             draw_edges(e_shader, item.points_list, item.edges, node.edges_line_width, node.edges_color)
 
-        if node.draw_control_net:
+        if node.draw_control_net and item.cpts_list is not None:
             draw_edges(e_shader, item.cpts_list, item.control_net, node.control_net_line_width, node.control_net_color)
 
-        if node.draw_control_points:
+        if node.draw_control_points and item.cpts_list is not None:
             draw_points(v_shader, item.cpts_list, node.control_points_size, node.control_points_color)
 
         if node.draw_verts:

--- a/nodes/viz/viewer_draw_surface.py
+++ b/nodes/viz/viewer_draw_surface.py
@@ -250,7 +250,7 @@ class SvSurfaceViewerDrawNode(bpy.types.Node, SverchCustomTreeNode):
         self.inputs.new('SvStringsSocket', 'ResolutionV').prop_name = 'resolution_v'
 
     def draw_buttons(self, context, layout):
-        layout.prop(self, "activate", text="", icon="HIDE_" + ("OFF" if self.activate else "ON"))
+        layout.prop(self, "activate", icon="HIDE_" + ("OFF" if self.activate else "ON"))
 
         grid = layout.column(align=True)
 

--- a/nodes/viz/viewer_draw_surface.py
+++ b/nodes/viz/viewer_draw_surface.py
@@ -1,0 +1,349 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import numpy as np
+
+import bpy
+from mathutils import Matrix, Vector
+from bpy.props import StringProperty, BoolProperty, IntProperty, EnumProperty, FloatVectorProperty
+import bgl
+import gpu
+from gpu_extras.batch import batch_for_shader
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode, get_data_nesting_level, ensure_nesting_level, zip_long_repeat, node_id
+from sverchok.utils.surface.core import SvSurface
+from sverchok.utils.surface.nurbs import SvNurbsSurface
+from sverchok.utils.modules.polygon_utils import pols_normals
+from sverchok.utils.modules.vertex_utils import np_vertex_normals
+from sverchok.utils.math import np_dot
+from sverchok.ui.bgl_callback_3dview import callback_disable, callback_enable
+
+def draw_edges(shader, points, edges, line_width, color):
+    bgl.glLineWidth(line_width)
+    batch = batch_for_shader(shader, 'LINES', {"pos": points}, indices=edges)
+    shader.bind()
+    shader.uniform_float('color', color)
+    batch.draw(shader)
+    bgl.glLineWidth(1)
+
+def draw_points(shader, points, size, color):
+    bgl.glPointSize(size)
+    batch = batch_for_shader(shader, 'POINTS', {"pos": points})
+    shader.bind()
+    shader.uniform_float('color', color)
+    batch.draw(shader)
+    bgl.glPointSize(1)
+
+def draw_polygons(shader, points, tris, vertex_colors):
+    batch = batch_for_shader(shader, 'TRIS', {"pos": points, 'color': vertex_colors}, indices=tris)
+    shader.bind()
+    batch.draw(shader)
+
+def make_quad_edges(n_u, n_v):
+    edges = []
+    for row in range(n_v):
+        e_row = [(i + n_u * row, (i+1) + n_u * row) for i in range(n_u-1)]
+        edges.extend(e_row)
+        if row < n_v - 1:
+            e_col = [(i + n_u * row, i + n_u * (row+1)) for i in range(n_u)]
+            edges.extend(e_col)
+    return edges
+
+def make_tris(n_u, n_v):
+    def calc_idx(row_idx, column_idx):
+        return n_u * row_idx + column_idx
+
+    tris = []
+    for row_idx in range(n_v-1):
+        for column_idx in range(n_u-1):
+            pt1 = calc_idx(row_idx, column_idx)
+            pt2 = calc_idx(row_idx, column_idx+1)
+            pt3 = calc_idx(row_idx+1, column_idx+1)
+            pt4 = calc_idx(row_idx+1, column_idx)
+            #tri1 = [pt1, pt2, pt3]
+            #tri2 = [pt1, pt3, pt4]
+            tri1 = [pt1, pt3, pt2]
+            tri2 = [pt1, pt4, pt3]
+            tris.append(tri1)
+            tris.append(tri2)
+    return tris
+
+def vert_light_factor(vecs, polygons, light):
+    return (np_dot(np_vertex_normals(vecs, polygons, output_numpy=True), light)*0.5+0.5).tolist()
+
+def calc_surface_data(light_vector, surface_color, n_u, n_v, points):
+    #points = points.reshape((n_u*n_v, 3))
+    tris = make_tris(n_u, n_v)
+    n_tris = len(tris)
+    light_factor = vert_light_factor(points, tris, light_vector)
+    colors = []
+    col = surface_color
+    for l_factor in light_factor:
+        colors.append([col[0]*l_factor, col[1]*l_factor, col[2]*l_factor, col[3]])
+    return tris, colors
+
+class SurfaceData(object):
+    def __init__(self, node, surface, resolution_u, resolution_v):
+        self.node = node
+        self.surface = surface
+        self.resolution_u = resolution_u
+        self.resolution_v = resolution_v
+
+        u_min, u_max = surface.get_u_bounds()
+        v_min, v_max = surface.get_v_bounds()
+        us = np.linspace(u_min, u_max, num=resolution_u)
+        vs = np.linspace(v_min, v_max, num=resolution_v)
+        us, vs = np.meshgrid(us, vs)
+        us = us.flatten()
+        vs = vs.flatten()
+        self.points = surface.evaluate_array(us, vs)#.tolist()
+        self.points_list = self.points.reshape((resolution_u*resolution_v, 3)).tolist()
+
+        if hasattr(surface, 'get_control_points'):
+            self.cpts = surface.get_control_points()
+            n_v, n_u, _ = self.cpts.shape
+            self.cpts_list = self.cpts.reshape((n_u*n_v, 3)).tolist()
+            self.control_net = make_quad_edges(n_u, n_v)
+
+        self.edges = make_quad_edges(resolution_u, resolution_v)
+        self.tris, self.tri_colors = calc_surface_data(node.light_vector, node.surface_color, resolution_u, resolution_v, self.points)
+
+def draw_surfaces(context, args):
+    node, draw_inputs, v_shader, e_shader, p_shader = args
+
+    bgl.glEnable(bgl.GL_BLEND)
+
+    for item in draw_inputs:
+
+        if node.draw_surface:
+            draw_polygons(p_shader, item.points_list, item.tris, item.tri_colors)
+
+        if node.draw_edges:
+            draw_edges(e_shader, item.points_list, item.edges, node.edges_line_width, node.edges_color)
+
+        if node.draw_control_net:
+            draw_edges(e_shader, item.cpts_list, item.control_net, node.control_net_line_width, node.control_net_color)
+
+        if node.draw_control_points:
+            draw_points(v_shader, item.cpts_list, node.control_points_size, node.control_points_color)
+
+        if node.draw_verts:
+            draw_points(v_shader, item.points_list, node.verts_size, node.verts_color)
+
+    bgl.glEnable(bgl.GL_BLEND)
+
+class SvSurfaceViewerDrawNode(bpy.types.Node, SverchCustomTreeNode):
+    """
+    Triggers: preview surface
+    Tooltip: drawing surfaces on 3d view
+    """
+
+    bl_idname = 'SvSurfaceViewerDrawNode'
+    bl_label = 'Viewer Draw Surface'
+    bl_icon = 'GREASEPENCIL'
+    sv_icon = 'SV_DRAW_VIEWER'
+
+    resolution_u : IntProperty(
+            name = "Resolution U",
+            min = 1,
+            default = 50,
+            update = updateNode)
+
+    resolution_v : IntProperty(
+            name = "Resolution V",
+            min = 1,
+            default = 50,
+            update = updateNode)
+
+    activate: BoolProperty(
+        name='Show', description='Activate drawing',
+        default=True, update=updateNode)
+
+    draw_verts: BoolProperty(
+        update=updateNode, name='Display Vertices', default=False)
+
+    verts_color: FloatVectorProperty(
+            name = "Vertices Color",
+            default = (0.9, 0.9, 0.95, 1.0),
+            size = 4, min = 0.0, max = 1.0,
+            subtype = 'COLOR',
+            update = updateNode)
+
+    verts_size : IntProperty(
+            name = "Vertices Size",
+            min = 1, default = 3,
+            update = updateNode)
+
+    draw_surface : BoolProperty(
+            name = "Display Surface",
+            default = True,
+            update = updateNode)
+
+    surface_color: FloatVectorProperty(
+            name = "Surface Color",
+            default = (0.8, 0.8, 0.95, 1.0),
+            size = 4, min = 0.0, max = 1.0,
+            subtype = 'COLOR',
+            update = updateNode)
+
+    draw_edges : BoolProperty(
+            name = "Display Edges",
+            default = False,
+            update = updateNode)
+
+    edges_line_width : IntProperty(
+            name = "Edges Line Width",
+            min = 1, default = 1,
+            update = updateNode)
+
+    edges_color: FloatVectorProperty(
+            name = "Edges Color",
+            default = (0.22, 0.22, 0.27, 1.0),
+            size = 4, min = 0.0, max = 1.0,
+            subtype = 'COLOR',
+            update = updateNode)
+
+    draw_control_net : BoolProperty(
+            name = "Display Control Net",
+            default = False,
+            update = updateNode)
+
+    control_net_line_width : IntProperty(
+            name = "Control Net Line Width",
+            min = 1, default = 1,
+            update = updateNode)
+
+    control_net_color: FloatVectorProperty(
+            name = "Control Net Color",
+            default = (0.9, 0.8, 0.3, 1.0),
+            size = 4, min = 0.0, max = 1.0,
+            subtype = 'COLOR',
+            update = updateNode)
+
+    draw_control_points: BoolProperty(
+        update=updateNode, name='Display control points', default=False)
+
+    control_points_color: FloatVectorProperty(
+            name = "Control Points Color",
+            default = (1.0, 0.5, 0.1, 1.0),
+            size = 4, min = 0.0, max = 1.0,
+            subtype = 'COLOR',
+            update = updateNode)
+
+    control_points_size : IntProperty(
+            name = "Control Points Size",
+            min = 1, default = 3,
+            update = updateNode)
+
+    light_vector: FloatVectorProperty(
+        name='Light Direction', subtype='DIRECTION', min=0, max=1, size=3,
+        default=(0.2, 0.6, 0.4), update=updateNode)
+
+    def sv_init(self, context):
+        self.inputs.new('SvSurfaceSocket', 'Surface')
+        self.inputs.new('SvStringsSocket', 'ResolutionU').prop_name = 'resolution_u'
+        self.inputs.new('SvStringsSocket', 'ResolutionV').prop_name = 'resolution_v'
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "activate", text="", icon="HIDE_" + ("OFF" if self.activate else "ON"))
+
+        grid = layout.column(align=True)
+
+        row = grid.row(align=True)
+        row.prop(self, 'draw_verts', icon='UV_VERTEXSEL', text='')
+        row.prop(self, 'verts_color', text="")
+        row.prop(self, 'verts_size', text="px")
+
+        row = grid.row(align=True)
+        row.prop(self, 'draw_edges', icon='UV_EDGESEL', text='')
+        row.prop(self, 'edges_color', text="")
+        row.prop(self, 'edges_line_width', text="px")
+
+        row = grid.row(align=True)
+        row.prop(self, 'draw_surface', icon='OUTLINER_OB_SURFACE', text='')
+        row.prop(self, 'surface_color', text="")
+
+        row = grid.row(align=True)
+        row.prop(self, 'draw_control_points', icon='DECORATE_KEYFRAME', text='')
+        row.prop(self, 'control_points_color', text="")
+        row.prop(self, 'control_points_size', text="px")
+
+        row = grid.row(align=True)
+        row.prop(self, 'draw_control_net', icon='GRID', text='')
+        row.prop(self, 'control_net_color', text="")
+        row.prop(self, 'control_net_line_width', text="px")
+
+    def draw_buttons_ext(self, context, layout):
+        layout.prop(self, 'light_vector')
+        self.draw_buttons(context, layout)
+
+    def draw_all(self, draw_inputs):
+
+        v_shader = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+        e_shader = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+        p_shader = gpu.shader.from_builtin('3D_SMOOTH_COLOR')
+
+        draw_data = {
+                'tree_name': self.id_data.name[:],
+                'custom_function': draw_surfaces,
+                'args': (self, draw_inputs, v_shader, e_shader, p_shader)
+            }
+        
+        callback_enable(node_id(self), draw_data)
+
+    def process(self):
+        if bpy.app.background:
+            return
+        if not (self.id_data.sv_show and self.activate):
+            callback_disable(node_id(self))
+            return
+        n_id = node_id(self)
+        callback_disable(n_id)
+
+        # end early
+        if not self.activate:
+            return
+
+        if not self.inputs['Surface'].is_linked:
+            return
+
+        surfaces_s = self.inputs['Surface'].sv_get()
+        resolution_u_s = self.inputs['ResolutionU'].sv_get()
+        resolution_v_s = self.inputs['ResolutionV'].sv_get()
+
+        surfaces_s = ensure_nesting_level(surfaces_s, 2, data_types=(SvSurface,))
+        resolution_u_s = ensure_nesting_level(resolution_u_s, 2)
+        resolution_v_s = ensure_nesting_level(resolution_v_s, 2)
+
+        draw_inputs = []
+        for params in zip_long_repeat(surfaces_s, resolution_u_s, resolution_v_s):
+            for surface, resolution_u, resolution_v in zip_long_repeat(*params):
+                t_surface = SvNurbsSurface.get(surface)
+                if t_surface is None:
+                    t_surface = surface
+                draw_inputs.append(SurfaceData(self, t_surface, resolution_u, resolution_v))
+        self.draw_all(draw_inputs)
+
+    def show_viewport(self, is_show: bool):
+        """It should be called by node tree to show/hide objects"""
+        if not self.activate:
+            # just ignore request
+            pass
+        else:
+            if is_show:
+                self.process()
+            else:
+                callback_disable(node_id(self))
+
+    def sv_free(self):
+        callback_disable(node_id(self))
+
+
+classes = [SvSurfaceViewerDrawNode]
+register, unregister = bpy.utils.register_classes_factory(classes)
+

--- a/ui/development.py
+++ b/ui/development.py
@@ -281,7 +281,7 @@ class SV_MT_LoadPresetMenu(bpy.types.Menu):
             save = layout.operator(SvSaveSelected.bl_idname, text="Save current settings as node preset", icon='SOLO_ON')
             save.id_tree = ntree.name
             save.category = node.bl_idname
-
+            save.is_node_preset = True
 
 def idname_draw(self, context):
     if not displaying_sverchok_nodes(context):

--- a/ui/nodeview_rclick_menu.py
+++ b/ui/nodeview_rclick_menu.py
@@ -136,7 +136,7 @@ def view_node(tree):
     for node in output_map[0]:
         bl_idname_new_node, offset = node
         new_node = nodes.new(bl_idname_new_node)
-        apply_default_preset(new_node)
+        new_node = apply_default_preset(new_node)
         offset_node_location(node_list[-1], new_node, offset)
         frame_adjust(node_list[-1], new_node)
         node_list.append(new_node)
@@ -171,9 +171,9 @@ def add_connection(tree, bl_idname_new_node, offset):
         # single new node..
 
         new_node = nodes.new(bl_idname_new_node)
-        apply_default_preset(new_node)
         offset_node_location(existing_node, new_node, offset)
         frame_adjust(existing_node, new_node)
+        new_node = apply_default_preset(new_node)
 
         outputs = existing_node.outputs
         inputs = new_node.inputs

--- a/ui/presets.py
+++ b/ui/presets.py
@@ -385,7 +385,8 @@ def get_preset(category, name):
 def apply_default_preset(node):
     preset = get_preset(node.bl_idname, "Default")
     if preset is not None:
-        JSONImporter(preset.data).import_node_settings(node)
+        node = JSONImporter(preset.data).import_node_settings(node)
+    return node
 
 class SvUserPresetsPanelProps(bpy.types.PropertyGroup):
     manage_mode: BoolProperty(

--- a/ui/sv_temporal_viewers.py
+++ b/ui/sv_temporal_viewers.py
@@ -67,6 +67,23 @@ def add_temporal_viewer_draw(nodes, links, existing_node, cut_links):
                 links.new(socket, inputs[3])
                 break
 
+def add_temporal_viewer_node(nodes, links, existing_node, output_kind, new_node_bl_idname, new_node_name, new_node_input_name, new_node_color, cut_links=True):
+    try:
+        new_node = nodes[new_node_name]
+    except KeyError:
+        new_node = nodes.new(new_node_bl_idname)
+        new_node.name = new_node_name
+        new_node.label = new_node_name
+        new_node.color = new_node_color
+
+    new_node.parent = None
+    new_node.location = (0, 0)
+
+    offset_node_location(existing_node, new_node, [100, 250])
+    frame_adjust(existing_node, new_node)
+
+    output_map = get_output_sockets_map(existing_node)
+    links.new(existing_node.outputs[output_map[output_kind]], new_node.inputs[new_node_input_name])
 
 def add_temporal_stethoscope(nodes, links, existing_node):
     """Add Temporal Stethoscope and connects it to existing node"""
@@ -122,15 +139,42 @@ def add_temporal_viewer(context, force_stetoscope: bool, cut_links: bool):
     if not hasattr(existing_node, 'outputs') or len(existing_node.outputs) == 0:
         return
 
-    is_drawable = any([socket.bl_idname in ['SvMatrixSocket', 'SvVerticesSocket'] for socket in existing_node.outputs])
+    is_geometry = any([socket.bl_idname in ['SvMatrixSocket', 'SvVerticesSocket'] for socket in existing_node.outputs])
+    is_curve = any(socket.bl_idname == 'SvCurveSocket' for socket in existing_node.outputs)
+    is_surface = any(socket.bl_idname == 'SvSurfaceSocket' for socket in existing_node.outputs)
+    is_solid = any(socket.bl_idname == 'SvSolidSocket' for socket in existing_node.outputs)
     nodes = tree.nodes
     links = tree.links
 
-    if not force_stetoscope and is_drawable:
-        add_temporal_viewer_draw(nodes, links, existing_node, cut_links)
-    else:
+    if force_stetoscope:
         add_temporal_stethoscope(nodes, links, existing_node)
-
+    else:
+        if is_solid:
+            add_temporal_viewer_node(nodes, links, existing_node,
+                    output_kind = 'solid',
+                    new_node_bl_idname = 'SvSolidViewerNode',
+                    new_node_name = "Temporal Solid Viewer",
+                    new_node_input_name = 'Solid',
+                    new_node_color = (0.63, 0.374, 0.138),
+                    cut_links = cut_links)
+        elif is_surface:
+            add_temporal_viewer_node(nodes, links, existing_node,
+                    output_kind = 'surface',
+                    new_node_bl_idname = 'SvSurfaceViewerDrawNode',
+                    new_node_name = "Temporal Surface Viewer",
+                    new_node_input_name = 'Surface',
+                    new_node_color = (0.63, 0.374, 0.138),
+                    cut_links = cut_links)
+        elif is_curve:
+            add_temporal_viewer_node(nodes, links, existing_node,
+                    output_kind = 'curve',
+                    new_node_bl_idname = 'SvCurveViewerDrawNode',
+                    new_node_name = "Temporal Curve Viewer",
+                    new_node_input_name = 'Curve',
+                    new_node_color = (0.63, 0.374, 0.138),
+                    cut_links = cut_links)
+        elif is_geometry:
+            add_temporal_viewer_draw(nodes, links, existing_node, cut_links)
 
 class SvTemporalViewerOperator(Operator):
     """Connect to temporal Viewer"""

--- a/ui/sv_temporal_viewers.py
+++ b/ui/sv_temporal_viewers.py
@@ -21,6 +21,7 @@ import bpy
 from bpy.types import Operator
 from sverchok.ui.nodeview_rclick_menu import get_output_sockets_map
 from sverchok.utils.sv_node_utils import frame_adjust
+from sverchok.ui.presets import apply_default_preset
 
 
 def offset_node_location(existing_node, new_node, offset):
@@ -39,6 +40,7 @@ def add_temporal_viewer_draw(nodes, links, existing_node, cut_links):
 
     except KeyError:
         new_node = nodes.new(bl_idname_new_node)
+        new_node = apply_default_preset(new_node)
         new_node.name = 'Temporal Viewer'
         new_node.label = 'Temporal Viewer'
         new_node.color = (0.666141, 0.203022, 0)
@@ -72,6 +74,7 @@ def add_temporal_viewer_node(nodes, links, existing_node, output_kind, new_node_
         new_node = nodes[new_node_name]
     except KeyError:
         new_node = nodes.new(new_node_bl_idname)
+        new_node = apply_default_preset(new_node)
         new_node.name = new_node_name
         new_node.label = new_node_name
         new_node.color = new_node_color
@@ -93,6 +96,7 @@ def add_temporal_stethoscope(nodes, links, existing_node):
 
     except KeyError:
         new_node = nodes.new(bl_idname_new_node)
+        new_node = apply_default_preset(new_node)
         new_node.name = 'Temporal Stethoscope'
         new_node.label = 'Temporal Stethoscope'
         new_node.color = (0.336045, 0.336045, 0.666654)

--- a/utils/curve/bakery.py
+++ b/utils/curve/bakery.py
@@ -1,0 +1,62 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import numpy as np
+
+import bpy
+
+def curve_to_meshdata(curve, resolution):
+    t_min, t_max = curve.get_u_bounds()
+    ts = np.linspace(t_min, t_max, num=resolution)
+    points = curve.evaluate_array(ts).tolist()
+    edges = [(i,i+1) for i in range(resolution-1)]
+    return points, edges
+
+def bake_curve(curve, resolution, object_name):
+    points, edges = curve_to_meshdata(curve, resolution)
+    me = bpy.data.meshes.new(object_name)
+    me.from_pydata(points, edges, [])
+    ob = bpy.data.objects.new(object_name, me)
+    bpy.context.scene.collection.objects.link(ob)
+    return ob
+
+class CurveData(object):
+    def __init__(self, node, curve, resolution):
+        self.node = node
+        self.curve = curve
+        self.resolution = resolution
+
+        if node.draw_line or node.draw_verts:
+            t_min, t_max = curve.get_u_bounds()
+            ts = np.linspace(t_min, t_max, num=resolution)
+            self.points = curve.evaluate_array(ts).tolist()
+
+        if node.draw_line:
+            n = len(ts)
+            self.edges = [(i,i+1) for i in range(n-1)]
+
+        if (node.draw_control_polygon or node.draw_control_points) and hasattr(curve, 'get_control_points'):
+            self.control_points = curve.get_control_points().tolist()
+        else:
+            self.control_points = None
+
+        if node.draw_control_polygon:
+            n = len(self.control_points)
+            self.control_polygon_edges = [(i,i+1) for i in range(n-1)]
+
+        if node.draw_nodes and hasattr(curve, 'calc_greville_points'):
+            self.node_points = curve.calc_greville_points().tolist()
+        else:
+            self.node_points = None
+
+    def bake(self, object_name):
+        me = bpy.data.meshes.new(object_name)
+        me.from_pydata(self.points, self.edges, [])
+        ob = bpy.data.objects.new(object_name, me)
+        bpy.context.scene.collection.objects.link(ob)
+        return ob
+

--- a/utils/surface/bakery.py
+++ b/utils/surface/bakery.py
@@ -1,0 +1,124 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import numpy as np
+
+import bpy
+
+from sverchok.utils.modules.polygon_utils import pols_normals
+from sverchok.utils.modules.vertex_utils import np_vertex_normals
+from sverchok.utils.math import np_dot
+
+def make_quad_edges(n_u, n_v):
+    edges = []
+    for row in range(n_v):
+        e_row = [(i + n_u * row, (i+1) + n_u * row) for i in range(n_u-1)]
+        edges.extend(e_row)
+        if row < n_v - 1:
+            e_col = [(i + n_u * row, i + n_u * (row+1)) for i in range(n_u)]
+            edges.extend(e_col)
+    return edges
+
+def make_quad_faces(samples_u, samples_v):
+    faces = []
+    for row in range(samples_v - 1):
+        for col in range(samples_u - 1):
+            i = row * samples_u + col
+            face = (i, i+samples_u, i+samples_u+1, i+1)
+            faces.append(face)
+    return faces
+
+def surface_to_meshdata(surface, resolution_u, resolution_v):
+    u_min, u_max = surface.get_u_bounds()
+    v_min, v_max = surface.get_v_bounds()
+    us = np.linspace(u_min, u_max, num=resolution_u)
+    vs = np.linspace(v_min, v_max, num=resolution_v)
+    us, vs = np.meshgrid(us, vs)
+    us = us.flatten()
+    vs = vs.flatten()
+    points = surface.evaluate_array(us, vs).tolist()
+    edges = make_quad_edges(resolution_u, resolution_v)
+    faces = make_quad_faces(resolution_u, resolution_v)
+    return points, edges, faces
+
+def bake_surface(surface, resolution_u, resolution_v, object_name):
+    verts, edges, faces = surface_to_meshdata(surface, resolution_u, resolution_v)
+    me = bpy.data.meshes.new(object_name)
+    me.from_pydata(points, edges, faces)
+    ob = bpy.data.objects.new(object_name, me)
+    bpy.context.scene.collection.objects.link(ob)
+    return ob
+
+def make_tris(n_u, n_v):
+    def calc_idx(row_idx, column_idx):
+        return n_u * row_idx + column_idx
+
+    tris = []
+    for row_idx in range(n_v-1):
+        for column_idx in range(n_u-1):
+            pt1 = calc_idx(row_idx, column_idx)
+            pt2 = calc_idx(row_idx, column_idx+1)
+            pt3 = calc_idx(row_idx+1, column_idx+1)
+            pt4 = calc_idx(row_idx+1, column_idx)
+            #tri1 = [pt1, pt2, pt3]
+            #tri2 = [pt1, pt3, pt4]
+            tri1 = [pt1, pt3, pt2]
+            tri2 = [pt1, pt4, pt3]
+            tris.append(tri1)
+            tris.append(tri2)
+    return tris
+
+def vert_light_factor(vecs, polygons, light):
+    return (np_dot(np_vertex_normals(vecs, polygons, output_numpy=True), light)*0.5+0.5).tolist()
+
+def calc_surface_data(light_vector, surface_color, n_u, n_v, points):
+    #points = points.reshape((n_u*n_v, 3))
+    tris = make_tris(n_u, n_v)
+    n_tris = len(tris)
+    light_factor = vert_light_factor(points, tris, light_vector)
+    colors = []
+    col = surface_color
+    for l_factor in light_factor:
+        colors.append([col[0]*l_factor, col[1]*l_factor, col[2]*l_factor, col[3]])
+    return tris, colors
+
+class SurfaceData(object):
+    def __init__(self, node, surface, resolution_u, resolution_v):
+        self.node = node
+        self.surface = surface
+        self.resolution_u = resolution_u
+        self.resolution_v = resolution_v
+
+        u_min, u_max = surface.get_u_bounds()
+        v_min, v_max = surface.get_v_bounds()
+        us = np.linspace(u_min, u_max, num=resolution_u)
+        vs = np.linspace(v_min, v_max, num=resolution_v)
+        us, vs = np.meshgrid(us, vs)
+        us = us.flatten()
+        vs = vs.flatten()
+        self.points = surface.evaluate_array(us, vs)#.tolist()
+        self.points_list = self.points.reshape((resolution_u*resolution_v, 3)).tolist()
+
+        if hasattr(surface, 'get_control_points'):
+            self.cpts = surface.get_control_points()
+            n_v, n_u, _ = self.cpts.shape
+            self.cpts_list = self.cpts.reshape((n_u*n_v, 3)).tolist()
+            self.control_net = make_quad_edges(n_u, n_v)
+
+        self.edges = make_quad_edges(resolution_u, resolution_v)
+        self.tris, self.tri_colors = calc_surface_data(node.light_vector, node.surface_color, resolution_u, resolution_v, self.points)
+    
+    def bake(self, object_name):
+        me = bpy.data.meshes.new(object_name)
+        faces = make_quad_faces(self.resolution_u, self.resolution_v)
+        me.from_pydata(self.points_list, self.edges, faces)
+        is_smooth = np.ones(len(faces), dtype=bool)
+        me.polygons.foreach_set('use_smooth', is_smooth)
+        ob = bpy.data.objects.new(object_name, me)
+        bpy.context.scene.collection.objects.link(ob)
+        return ob
+

--- a/utils/surface/bakery.py
+++ b/utils/surface/bakery.py
@@ -108,6 +108,8 @@ class SurfaceData(object):
             n_v, n_u, _ = self.cpts.shape
             self.cpts_list = self.cpts.reshape((n_u*n_v, 3)).tolist()
             self.control_net = make_quad_edges(n_u, n_v)
+        else:
+            self.cpts_list = None
 
         self.edges = make_quad_edges(resolution_u, resolution_v)
         self.tris, self.tri_colors = calc_surface_data(node.light_vector, node.surface_color, resolution_u, resolution_v, self.points)

--- a/utils/surface/core.py
+++ b/utils/surface/core.py
@@ -149,6 +149,12 @@ class SvSurface(object):
     def get_domain(self):
         return (self.get_u_min(), self.get_u_max(), self.get_v_min(), self.get_v_max())
 
+    def get_u_bounds(self):
+        return (self.get_u_min(), self.get_u_max())
+
+    def get_v_bounds(self):
+        return (self.get_v_min(), self.get_v_max())
+
     @property
     def u_size(self):
         m,M = self.get_u_min(), self.get_u_max()

--- a/utils/sv_json_import.py
+++ b/utils/sv_json_import.py
@@ -61,7 +61,7 @@ class JSONImporter:
 
     def import_node_settings(self, node: SverchCustomTreeNode):
         if self.structure_version < 1.0:
-            self._old_import_node_settings(node)
+            return self._old_import_node_settings(node)
         else:
             return NodePresetFileStruct(logger=self._fails_log, structure=self._structure).build(node)
 
@@ -78,8 +78,7 @@ class JSONImporter:
         tree_importer = TreeImporter01(node.data.id_data, self._structure, self._fails_log)
         for node_name, node_type, node_structure in tree_importer.nodes():
             node_importer = NodeImporter01(node.data, node_structure, self._fails_log, tree_importer.file_version)
-            node_importer.import_node(apply_attributes=False)
-            break
+            return node_importer.import_node(apply_attributes=False)
 
     @property
     def has_fails(self) -> bool:
@@ -212,6 +211,7 @@ class NodeImporter01:
                 prop = BPYProperty(socket, prop_name)
                 if prop.is_valid:
                     prop.value = prop_value
+        return self._node
 
     def _node_attributes(self) -> Generator[tuple]:
         """Reads node attributes from node structure, returns (attr_name, value)"""

--- a/utils/sv_json_import.py
+++ b/utils/sv_json_import.py
@@ -63,7 +63,7 @@ class JSONImporter:
         if self.structure_version < 1.0:
             self._old_import_node_settings(node)
         else:
-            NodePresetFileStruct(logger=self._fails_log, structure=self._structure).build(node)
+            return NodePresetFileStruct(logger=self._fails_log, structure=self._structure).build(node)
 
     def _old_import_node_settings(self, node: SverchCustomTreeNode):
         """

--- a/utils/sv_json_struct.py
+++ b/utils/sv_json_struct.py
@@ -448,6 +448,7 @@ class NodePresetFileStruct(Struct):
             # for now breaking links will be considered as desired behaviour
 
         node.process_node(bpy.context)
+        return node
 
     def _data_blocks_reader(self):
         struct_type: StrTypes


### PR DESCRIPTION
Shorthand nodes for viewing curves and surfaces in 3D View.

In my experience, I tend to use 4 nodes to inspect the curve I generated: Evaluate Curve + Viewer Draw, and Deconstruct Curve + Viewer Draw. Similarly with surfaces.

These nodes allow to replace four nodes with one.

For NURBS, the nodes can show control polygon / control net; "Viewer Draw Curve" node can also show "node points" (Greville points) of the curve.
For non-NURBS, the nodes just do not try to show these NURBS-specific things.

The nodes also have "bake" capability.

![Screenshot_20220911_211123](https://user-images.githubusercontent.com/284644/189537925-b8d72553-5650-4d18-9fcc-507f70801dff.png)
![Screenshot_20220911_210840](https://user-images.githubusercontent.com/284644/189537929-2be26995-0cb3-4063-9531-8ca0f955e155.png)


## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

