### PR TITLE
Deal with case when inputs contains empty lists

### DIFF
--- a/nodes/list_masks/mask_join.py
+++ b/nodes/list_masks/mask_join.py
@@ -80,7 +80,23 @@ class SvMaskJoinNodeMK2(bpy.types.Node, SverchCustomTreeNode):
 
     def apply_choice_mask(self, mask, data_t, data_f):
         out = []
-        param = list_match_func[self.list_match_global]([mask, data_t, data_f])
+        if len(mask) == 0:
+            raise ValueError('Mask is empty')
+        if len(data_t) == 0 and len(data_f) == 0:
+            raise ValueError('Data is empty')
+        elif len(data_t) == 0:
+            if any(mask):
+                raise ValueError('Data True is empty')
+            else:
+                param = list_match_func[self.list_match_global]([mask, [0]*len(mask), data_f])
+        elif len(data_f) == 0:
+            if all(mask):
+                param = list_match_func[self.list_match_global]([mask, data_t, [0]*len(mask)])
+            else:
+                raise ValueError('Data False is empty')
+        else:
+            param = list_match_func[self.list_match_global]([mask, data_t, data_f])
+            
         for m, t, f in zip(*param):
             if m:
                 out.append(t)
@@ -91,6 +107,8 @@ class SvMaskJoinNodeMK2(bpy.types.Node, SverchCustomTreeNode):
     def apply_mask(self, mask, data_t, data_f):
         ind_t, ind_f = 0, 0
         out = []
+        if len(mask) == 0:
+            raise ValueError('Mask is empty')
         for m in cycle(mask):
             if m:
                 if ind_t == len(data_t):


### PR DESCRIPTION
## Addressed problem description

Sometimes, the List Mask Join (In) node can be used to switch between empty lists and non empty ones, in order to make sure no empty list get to the rest of the treatment. In this case, the chosen data with the mask is of course that of the non-empty lists, but the node outputed nothing because of the match length option.

## Solution description

So, I changed how matching length was done so that it works fine even in this case, while preserving how the node works in other cases. While I was at it, I added ValueErrors when mask is empty, both true and false data are empty, or data from an empty list is selected with the mask.

## Preflight checklist

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Manual testing done. 
- [ ] Ready for merge.

