### PR TITLE
fix #4665

### DIFF
--- a/nodes/scene/3dview_props.py
+++ b/nodes/scene/3dview_props.py
@@ -81,6 +81,10 @@ class Sv3DviewPropsNode(bpy.types.Node, SverchCustomTreeNode):
         row = layout.row(align=True)
         row.prop(prefs.inputs, 'view_rotate_method', text='orbit', expand=True)
 
+    def process(self):
+        pass
+        return
+
 
 def register():
     bpy.utils.register_class(Sv3DviewPropsNode)


### PR DESCRIPTION
3D views node show error

Windows 11, Blender 3.2.2, Sverchok 1.1-beta