### PR TITLE
"Blend surface" node: NURBS mode.

### DIFF
--- a/docs/nodes/surface/blend_surface.rst
+++ b/docs/nodes/surface/blend_surface.rst
@@ -32,6 +32,10 @@ This node has the following inputs:
   second surface. Bigger values lead to more smooth touch. Negative values will
   mean that the blending surface will touch the surface from another side of
   curve / edge. The default value is 1.0.
+* **Samples**. This input is available only when the **NURBS** parameter is
+  checked. This defines the number of points used to approximate initial
+  (touching) curves with NURBS curves. The default value is 10. Greater values
+  mean better approximation, but worse performance.
 
 Parameters
 ----------
@@ -58,6 +62,11 @@ This node has the following parameters:
 * **Flip Curve 2**. If checked, the direction of curve (or edge), where the
   blending surface touches the second surface, will be reversed. Unchecked by
   default.
+* **NURBS**. If checked, the node will generate a NURBS surface instead of
+  generic surface object. The NURBS surface only approximates the ideal
+  blending surface. It is constructed as a Gordon surface, by approximating the
+  two initial curves with NURBS curves. The number of points used for
+  approximation is controlled by **Samples** input. Unchecked by default.
 
 Outputs
 -------

--- a/docs/nodes/surface/blend_surface.rst
+++ b/docs/nodes/surface/blend_surface.rst
@@ -88,3 +88,7 @@ circular arc:
 
 .. image:: https://user-images.githubusercontent.com/284644/89387738-5a2a5000-d71c-11ea-9018-4d62f6eb464f.png
 
+An example of NURBS mode:
+
+.. image:: https://user-images.githubusercontent.com/284644/209392203-c9da3a3f-5a5b-469c-8a8b-0afda3f5f176.png
+

--- a/index.yaml
+++ b/index.yaml
@@ -184,7 +184,7 @@
     - SvExCurveLerpNode
     - SvExSurfaceLerpNode
     - SvCoonsPatchNode
-    - SvBlendSurfaceNode
+    - SvBlendSurfaceNodeMk2
     - SvExApplyFieldToSurfaceNode
     - ---
     - SvExSurfaceDomainNode

--- a/tests/nurbs_tests.py
+++ b/tests/nurbs_tests.py
@@ -6,10 +6,11 @@ from mathutils import Matrix
 
 from sverchok.utils.testing import SverchokTestCase, requires
 from sverchok.utils.geom import circle_by_three_points
+from sverchok.utils.nurbs_common import SvNurbsMaths, elevate_bezier_degree, from_homogenous
 from sverchok.utils.curve import knotvector as sv_knotvector
 from sverchok.utils.curve.primitives import SvCircle
 from sverchok.utils.curve.nurbs import SvGeomdlCurve, SvNativeNurbsCurve, SvNurbsBasisFunctions, SvNurbsCurve
-from sverchok.utils.nurbs_common import SvNurbsMaths, elevate_bezier_degree, from_homogenous
+from sverchok.utils.curve.nurbs_solver_applications import knotvector_with_tangents_from_tknots
 from sverchok.utils.surface.nurbs import SvGeomdlSurface, SvNativeNurbsSurface
 from sverchok.utils.surface.algorithms import SvCurveLerpSurface
 from sverchok.dependencies import geomdl
@@ -908,6 +909,12 @@ class InterpolateTests(SverchokTestCase):
         weights = curve.get_weights()
         expected_weights = np.array([1, 3, 1])
         self.assert_numpy_arrays_equal(weights, expected_weights, precision=6)
+
+    def test_knotvector_with_tangents_1(self):
+        u = np.array([0.0, 1.0])
+        kv = knotvector_with_tangents_from_tknots(3, u)
+        expected = np.array([0,0,0,0, 1,1,1,1])
+        self.assert_numpy_arrays_equal(kv, expected, precision=4)
 
 class TaylorTests(SverchokTestCase):
     def test_bezier_to_taylor_1(self):

--- a/utils/curve/algorithms.py
+++ b/utils/curve/algorithms.py
@@ -742,7 +742,7 @@ class SvLengthRebuiltCurve(SvCurve):
         c_ts = self.solver.solve(ts)
         return self.curve.evaluate_array(c_ts)
 
-def curve_frame_on_surface_array(surface, uv_curve, us, w_axis=2, on_zero_curvature=SvCurve.ASIS):
+def curve_frame_on_surface_array(surface, uv_curve, us, w_axis=2, normalize=True, on_zero_curvature=SvCurve.ASIS):
     """
     Curve frame which is lying in the surface.
 
@@ -778,11 +778,13 @@ def curve_frame_on_surface_array(surface, uv_curve, us, w_axis=2, on_zero_curvat
     curve = SvCurveOnSurface(uv_curve, surface, axis=w_axis)
     surf_points = curve.evaluate_array(us)
     tangents = curve.tangent_array(us)
-    tangents = tangents / np.linalg.norm(tangents, axis=1, keepdims=True)
+    if normalize:
+        tangents = tangents / np.linalg.norm(tangents, axis=1, keepdims=True)
 
     us, vs = uv_points[:,U], uv_points[:,V]
     normals = surface.normal_array(us, vs)
-    normals = normals / np.linalg.norm(normals, axis=1, keepdims=True)
+    if normalize:
+        normals = normals / np.linalg.norm(normals, axis=1, keepdims=True)
 
     if on_zero_curvature != SvCurve.ASIS:
         zero_normal = np.linalg.norm(normals, axis=1) < 1e-6

--- a/utils/curve/nurbs_solver_applications.py
+++ b/utils/curve/nurbs_solver_applications.py
@@ -214,12 +214,16 @@ def interpolate_nurbs_curve_with_tangents(degree, points, tangents,
                                     logger = logger)
     return curve
 
-def curve_to_nurbs(degree, curve, samples, logger=None):
+def curve_to_nurbs(degree, curve, samples, metric = 'DISTANCE', use_tangents = False, logger=None):
     is_cyclic = curve.is_closed()
     t_min, t_max = curve.get_u_bounds()
     ts = np.linspace(t_min, t_max, num=samples)
     if is_cyclic:
         ts = ts[:-1]
     points = curve.evaluate_array(ts)
-    return interpolate_nurbs_curve(degree, points, cyclic=is_cyclic, logger=logger)
+    if use_tangents:
+        tangents = curve.tangent_array(ts)
+        return interpolate_nurbs_curve_with_tangents(degree, points, tangents, metric=metric, logger=logger)
+    else:
+        return interpolate_nurbs_curve(degree, points, cyclic=is_cyclic, metric=metric, logger=logger)
 

--- a/utils/curve/nurbs_solver_applications.py
+++ b/utils/curve/nurbs_solver_applications.py
@@ -170,6 +170,9 @@ def knotvector_with_tangents_from_tknots(degree, u):
         kv.extend([u[-1], u[-1]])
         return np.array(kv)
     elif degree == 3:
+        if len(u) == 2:
+            return np.array([u[0], u[0], u[0], u[0],
+                             u[1], u[1], u[1], u[1]])
         kv = [u[0], u[0], u[0],u[0]]
         kv.append(u[1]/2.0)
         for i in range(1, n-2):
@@ -193,11 +196,14 @@ def interpolate_nurbs_curve_with_tangents(degree, points, tangents,
     tangents = np.asarray(tangents)
     if len(points) != len(tangents):
         raise Exception(f"Number of points ({len(points)}) must be equal to number of tangent vectors ({len(tangents)})")
+    ndim = points.shape[-1]
+    if ndim not in {3,4}:
+        raise Exception(f"Points must be 3 or 4 dimensional, not {ndim}")
 
     if tknots is None:
         tknots = Spline.create_knots(points, metric=metric)
 
-    solver = SvNurbsCurveSolver(degree=degree, ndim=4)
+    solver = SvNurbsCurveSolver(degree=degree, ndim=ndim)
     solver.add_goal(SvNurbsCurvePoints(tknots, points, relative=False))
     solver.add_goal(SvNurbsCurveTangents(tknots, tangents, relative=False))
     knotvector = knotvector_with_tangents_from_tknots(degree, tknots)


### PR DESCRIPTION
This adds a mode in "Blend Surfaces" node, which generates NURBS surfaces instead of generic surfaces.
Note: generated surface may be not ideal, although good enough. On the other hand, evaluation of such NURBS surface can be much faster, than evaluation of precise, but generic blending surface.

![Screenshot_20221223_233147](https://user-images.githubusercontent.com/284644/209392203-c9da3a3f-5a5b-469c-8a8b-0afda3f5f176.png)


## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

