### PR TITLE
"Curve Segment" node: add "NURBS if possible" flag

### DIFF
--- a/docs/nodes/curve/curve_segment.rst
+++ b/docs/nodes/curve/curve_segment.rst
@@ -24,8 +24,13 @@ This node has the following inputs:
 Parameters
 ----------
 
-This node has the following parameter:
+This node has the following parameters:
 
+* **Join**. If checked, the node will always output single flat list of curves.
+* **NURBS if possible**. If checked, for NURBS and NURBS-like curves, the node
+  will calculate a new NURBS curve representing the segment of initial curve.
+  If not checked, the node will always return a generic Curve object. Checked
+  by default. This parameter is available in the N panel only.
 * **Rescale to 0..1**. If checked, then the generated curve will have the
   domain (allowed range of T parameter values)  of `[0.0 .. 1.0]`. Otherwise,
   the domain of generated curve will be defined by node's inputs, i.e. `[TMin

--- a/nodes/curve/curve_segment.py
+++ b/nodes/curve/curve_segment.py
@@ -34,6 +34,12 @@ class SvCurveSegmentNode(SverchCustomTreeNode, bpy.types.Node):
         default = False,
         update = updateNode)
 
+    use_nurbs : BoolProperty(
+        name = "NURBS if possible",
+        description = "If checked, for NURBS curves, calculate a new NURBS curve representing the segment of the old curve. Otherwise, always return a generic Curve object.",
+        default = True,
+        update = updateNode)
+
     join : BoolProperty(
             name = "Join",
             description = "Output single flat list of curves",
@@ -48,6 +54,7 @@ class SvCurveSegmentNode(SverchCustomTreeNode, bpy.types.Node):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "join")
+        layout.prop(self, "use_nurbs")
         layout.prop(self, "rescale")
 
     def process(self):
@@ -67,7 +74,8 @@ class SvCurveSegmentNode(SverchCustomTreeNode, bpy.types.Node):
         for curves, tmins, tmaxs in zip_long_repeat(curve_s, tmin_s, tmax_s):
             new_curves = []
             for curve, t_min, t_max in zip_long_repeat(curves, tmins, tmaxs):
-                new_curve = curve_segment(curve, t_min, t_max, self.rescale)
+                new_curve = curve_segment(curve, t_min, t_max,
+                                use_native = self.use_nurbs, rescale = self.rescale)
                 new_curves.append(new_curve)
             if self.join:
                 curve_out.extend(new_curves)

--- a/nodes/curve/curve_segment.py
+++ b/nodes/curve/curve_segment.py
@@ -54,8 +54,11 @@ class SvCurveSegmentNode(SverchCustomTreeNode, bpy.types.Node):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "join")
-        layout.prop(self, "use_nurbs")
         layout.prop(self, "rescale")
+
+    def draw_buttons_ext(self, context, layout):
+        self.draw_buttons(context, layout)
+        layout.prop(self, "use_nurbs")
 
     def process(self):
         if not any(socket.is_linked for socket in self.outputs):

--- a/utils/curve/algorithms.py
+++ b/utils/curve/algorithms.py
@@ -1026,14 +1026,14 @@ def split_curve(curve, splits, rescale=False):
             result.append(segment)
         return result
 
-def curve_segment(curve, new_t_min, new_t_max, rescale=False):
+def curve_segment(curve, new_t_min, new_t_max, use_native=True, rescale=False):
     """
     Cut a segment out of the curve.
     """
     t_min, t_max = curve.get_u_bounds()
-    if hasattr(curve, 'cut_segment'):
+    if use_native and hasattr(curve, 'cut_segment'):
         return curve.cut_segment(new_t_min, new_t_max, rescale=rescale)
-    elif hasattr(curve, 'split_at') and (new_t_min > t_min or new_t_max < t_max):
+    elif use_native and hasattr(curve, 'split_at') and (new_t_min > t_min or new_t_max < t_max):
         if new_t_min > t_min:
             start, curve = curve.split_at(new_t_min)
         if new_t_max < t_max:


### PR DESCRIPTION
Refs #4722.

Depending on NURBS implementation being used, calculation of new NURBS curve representing the segment of initial NURBS curve can give unexpected results in some special cases. So, let's add a flag to disable such calculation and fall back to trivial algorithm of just taking a subdomain of initial curve - that will return a generic Curve object instead of Nurbs, but will not depend on nurbs implementation.
Since this is useful only in rare cases, I put this flag to the N panel.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

