### PR TITLE
Fix various typos

### DIFF
--- a/core/update_system.py
+++ b/core/update_system.py
@@ -138,7 +138,7 @@ class SearchTree:
 
     def nodes_from_socket(self, socket: NodeSocket) -> list['SvNode']:
         """Returns linked to the given socket nodes.
-        The list will be empy if the socket is not connected.
+        The list will be empty if the socket is not connected.
         Connected input socket will always return list with one node"""
         if socket.is_output:
             next_socks = self._to_socks.get(socket, [])

--- a/docs/contributing/api_documentation.rst
+++ b/docs/contributing/api_documentation.rst
@@ -2,7 +2,7 @@
 Sverchok API Documentation
 ==========================
 
-Nowadays Sverchok has a large set of modules, classes and funtions, allowing to
+Nowadays Sverchok has a large set of modules, classes and functions, allowing to
 manipulate data structures, meshes, basic geometry objects, curves and surfaces
 (including NURBS), fields and solids (with help of FreeCAD library). These
 methods are used by Sverchok nodes internally. But also this API can be used by

--- a/docs/contributing/node_api.rst
+++ b/docs/contributing/node_api.rst
@@ -6,7 +6,7 @@ This page claims to define all aspects of node creation. A brief introduction
 to node creation is represented :doc:`on this page <add_new_node>`. Api
 documentation of base class of all nodes can be found
 `here <http://nortikin.github.io/sverchok/apidocs/sverchok/node_tree.html>`_.
-Also read the `Alpha/Beta Node State`_ section before creating new ndoe.
+Also read the `Alpha/Beta Node State`_ section before creating new node.
 
 The Code of a new node should be created in a separate file. The file should be placed in
 one of the available categories in the ``nodes`` folder.
@@ -576,7 +576,7 @@ There are helping functions / generators to perform data matching in
    and so they can't be recommended for use for now.
 
 .. note::
-   In future vectorization should leve the nodes area and arrive to execution
+   In future vectorization should leave the nodes area and arrive to execution
    system. In this case nodes only have to add information to sockets to give to
    execution system to know how to match data.
 
@@ -987,4 +987,4 @@ assigned to ``sv_icon`` attribute of the node class.
 
 It's recommended to mark new nodes and new version of existing node with
 *in development* state if there are doubts in robustness of the nodes. A node
-should loos the state when new Sverchok's release is introduced.
+should lose the state when new Sverchok's release is introduced.

--- a/docs/nodes/curve/flip_curve.rst
+++ b/docs/nodes/curve/flip_curve.rst
@@ -4,7 +4,7 @@ Flip Curve
 Functionality
 -------------
 
-This node generates a curve by inverting the direciton of parametrization of another curve; in other words, it generates the curve identical to provided one, but with the opposite direction.
+This node generates a curve by inverting the direction of parametrization of another curve; in other words, it generates the curve identical to provided one, but with the opposite direction.
 
 Inputs
 ------

--- a/node_tree.py
+++ b/node_tree.py
@@ -674,7 +674,7 @@ class NodeDocumentation:
     def get_doc_link(self, link_type='ONLINE') -> Optional[str]:
         """Returns URL to online documentation of the node, or to GitHub
         documentation, or path to a documentation file of the node, or None.
-        This method can be overriden by Sverchok's extensions to implement
+        This method can be overridden by Sverchok's extensions to implement
         their own way to generate the links."""
         *_, node_file_name = self.__module__.rpartition('.')
         node_docs = Path(sverchok.__file__).parent / 'docs' / 'nodes'

--- a/nodes/generators_extended/hilbert_image.py
+++ b/nodes/generators_extended/hilbert_image.py
@@ -25,7 +25,7 @@ from sverchok.data_structure import updateNode
 
 class HilbertImageNode(SverchCustomTreeNode, bpy.types.Node):
     '''Hilbert image recreator by interpolating image on pixels.
-    In: level, size, sensivity
+    In: level, size, sensitivity
     Params: RGB map, image selector
     Out: Vertices, Edges
     '''

--- a/ui/nodeview_space_menu.py
+++ b/ui/nodeview_space_menu.py
@@ -49,7 +49,7 @@ registered. And un-registration is not needed because they will be reloaded
 during reloading Sverchok add-on (extensions can't be reloaded without reloading
 Sverchok)
 
-The module parses `index.yaml` file and creates tre like data structure `Category`
+The module parses `index.yaml` file and creates a tree-like data structure `Category`
 which is used for adding nodes in different areas of user interface. Also it
 contains `CallPartialMenu` which shows alternative menus by pressing 1, 2, 3, 4, 5.
 It's possible to add categories to the menus by adding `- extra_menu: menu_name`
@@ -322,7 +322,7 @@ class Category(MenuItem):
         - `'SomeNode'` - String of node `bl_idname` to define Add Node operator.
         - `{'Sub category name': [option, menu_item, ...]}` - Dictionary of
           a subcategory.
-        - `{'Operator name': [option, ...]}` - Dictionary of a custom opeartor
+        - `{'Operator name': [option, ...]}` - Dictionary of a custom operator
           to call. Options for operator call are not supported currently.
         - `{'Menu name': [option, ...]}` - Custom menu to show.
 
@@ -354,7 +354,7 @@ class Category(MenuItem):
 
         The example of format can be found in the `sverchok/index.yaml` file.
 
-        Extra_props should have keys oly from the __init__ method of `MenuItem`
+        Extra_props should have keys only from the __init__ method of `MenuItem`
         subclasses.
         """
         parsed_items = []

--- a/utils/modules/geom_utils.py
+++ b/utils/modules/geom_utils.py
@@ -54,7 +54,7 @@ def normalize(v):
 
 def sub_v3_v3v3(a, b):
     """
-    subtract b fom a.
+    subtract b from a.
 
     inputs: two 3-element-vector-like-iterables, a and b
     output: one 3-element-vector-like tuple

--- a/utils/surface/gordon.py
+++ b/utils/surface/gordon.py
@@ -59,8 +59,8 @@ def gordon_surface(u_curves, v_curves, intersections, metric='POINTS', u_knots=N
     """
     Generate a NURBS surface from a net of NURBS curves, by use of Gordon's algorithm.
 
-    :param u_curves - list of NURBS curves along U direciton (length N)
-    :param v_curves - list of NURBS curves along V direcion (length M)
+    :param u_curves - list of NURBS curves along U direction (length N)
+    :param v_curves - list of NURBS curves along V direction (length M)
     :param intersections - np.array of shape (N, M, 3): points of curves intersection
     :param metric - metric function that can be used to calculate T values of curves
                     intersections from their positions.


### PR DESCRIPTION
Found via `codespell -q 3 -S ./.git,./docs/old,./old_nodes -L bu,indicies,nd,nin,pullrequest,ro,splitted,vertexes`