### PR TITLE
Number->Oscillator mode "Triangle" issue. Some corner values reset to minimum

### DIFF
--- a/nodes/number/oscillator.py
+++ b/nodes/number/oscillator.py
@@ -58,7 +58,7 @@ def oscillator(params, constant, matching_f):
             res = amplitude - amplitude * (((val / period + phase) * 2) % 2) + offset
 
         elif mode == 'Triangular':
-            mask = ((val / period + phase) * 2) % 2 > 1
+            mask = ((val / period + phase) * 2) % 2 >= 1
             res = 2 * amplitude * (((val / period + phase)*2) % 1) - amplitude
             res[mask] *= -1
             res += offset


### PR DESCRIPTION
Windows 11, Blender 3.3.1, Sverchok Master.

Some values near to maximum go down to minimum (with "Num Verts"=177, 181, 185, 189 and so on):

![image](https://user-images.githubusercontent.com/14288520/202894929-9db2d728-1477-4e60-898e-b303d0b704f1.png)

gist: https://gist.github.com/6fcfc463c17befcc51f15924b769830e

if "Num Verts"=188 then all look good:

![image](https://user-images.githubusercontent.com/14288520/202894873-5ad8d0c9-163e-4792-b65a-e9e1ddd19473.png)

This pull request fix this issue (177, 181, 185, 189 ...):

![image](https://user-images.githubusercontent.com/14288520/202896451-ab552910-6cfa-404f-8286-ed97ba6c9b4b.png)
