### PR TITLE
Profile node: Interpolation command

### DIFF
--- a/docs/nodes/script/profile_mk3.rst
+++ b/docs/nodes/script/profile_mk3.rst
@@ -327,6 +327,45 @@ An example with use of "default" and "let" statements:
         n = 10
       l {- straight_len * cos(phi)}, {straight_len * sin(phi)}
 
+A simple example of `@I` command used to define a quadratic interpolation curve through three points:
+
+.. image:: https://user-images.githubusercontent.com/284644/204350806-cba83beb-0eae-4ef5-ba42-15442029c6f2.png
+
+::
+
+      M R0,0
+      @I 2
+         {R0 + dR}, {0.5*H}
+         R0, H ;
+
+An example of closed interpolation curve:
+
+.. image:: https://user-images.githubusercontent.com/284644/204350799-6ee7e89f-0e27-45de-b523-7fae9c17eac8.png
+
+::
+
+      M 0,0
+      @I 3
+         1.5,2
+         2,0
+         0,-3
+         -2,0
+         -1.5,2
+         z ;
+
+An example of `@smooth` keyword usage, to smoothly continue the previous segment defined by C command:
+
+.. image:: https://user-images.githubusercontent.com/284644/204351808-26133e22-7b04-44ad-9c0a-40f97339a672.png
+
+::
+
+      M 0,0
+      C 1,0 1,3 0,3
+      @I @smooth 3
+         -0.8, 2
+         -1, 1
+         -2, 0 ;
+
 Gotchas
 -------
 

--- a/docs/nodes/script/profile_mk3.rst
+++ b/docs/nodes/script/profile_mk3.rst
@@ -10,7 +10,7 @@ by adding some extensions and not supporting some features.
 Profile definition consists of a series of statements (also called commands).
 
 Statements may optionally be separated by semicolons (`;`).
-For some commands (namely: `H`/`h`, `V`/`v`) the trailing semicolon is **required**!
+For some commands (namely: `H`/`h`, `V`/`v`, `@i`) the trailing semicolon is **required**!
 
 There are the following statements supported:
 
@@ -26,33 +26,35 @@ There are the following statements supported:
 
 The following segment types are available:
 
-+---------------+-------+--------------------------------------------------------------------------------+
-| name          | cmd   | parameters                                                                     |
-+===============+=======+================================================================================+
-| MoveTo        | M,  m | <2v coordinate>                                                                |
-+---------------+-------+--------------------------------------------------------------------------------+
-| LineTo        | L,  l | (<2v coordinate>)+ ["n = " num_segments] [z]                                   |
-+---------------+-------+--------------------------------------------------------------------------------+
-| HorLineTo     | H,  h | (<x>)+ ["n = " num_segments] ";"                                               |
-+---------------+-------+--------------------------------------------------------------------------------+
-| VertLineTo    | V,  v | (<y>)+ ["n = " num_segments] ";"                                               |
-+---------------+-------+--------------------------------------------------------------------------------+
-| CurveTo       | C,  c | (<2v control1> <2v control2> <2v knot2>)+ ["n = " num_verts] [z]               |
-+---------------+-------+--------------------------------------------------------------------------------+
-| SmoothCurveTo | S,  s | (<2v control2> <2v knot2>)+ ["n = " num_verts] [z]                             |
-+---------------+-------+--------------------------------------------------------------------------------+
-| QuadCurveTo   | Q,  q | (<2v control> <2v knot2>)+ ["n = " num_segments] [z]                           |
-+---------------+-------+--------------------------------------------------------------------------------+
-| SmthQuadCurve | T,  t | (<2v knot2>)+ ["n = " num_segments] [z]                                        |
-+---------------+-------+--------------------------------------------------------------------------------+
-| ArcTo         | A,  a | <2v rx,ry> <float rot> <int flag1> <int flag2> <2v x,y> ["n = " num_verts] [z] |
-+---------------+-------+--------------------------------------------------------------------------------+
-| ClosePath     | x     |                                                                                |
-+---------------+-------+--------------------------------------------------------------------------------+
-| CloseAll      | X     |                                                                                |
-+---------------+-------+--------------------------------------------------------------------------------+
-| comment       | #     | anything after # is a comment.                                                 |
-+---------------+-------+--------------------------------------------------------------------------------+
++---------------+--------+--------------------------------------------------------------------------------+
+| name          | cmd    | parameters                                                                     |
++===============+========+================================================================================+
+| MoveTo        | M,  m  | <2v coordinate>                                                                |
++---------------+--------+--------------------------------------------------------------------------------+
+| LineTo        | L,  l  | (<2v coordinate>)+ ["n = " num_segments] [z]                                   |
++---------------+--------+--------------------------------------------------------------------------------+
+| HorLineTo     | H,  h  | (<x>)+ ["n = " num_segments] ";"                                               |
++---------------+--------+--------------------------------------------------------------------------------+
+| VertLineTo    | V,  v  | (<y>)+ ["n = " num_segments] ";"                                               |
++---------------+--------+--------------------------------------------------------------------------------+
+| CurveTo       | C,  c  | (<2v control1> <2v control2> <2v knot2>)+ ["n = " num_verts] [z]               |
++---------------+--------+--------------------------------------------------------------------------------+
+| SmoothCurveTo | S,  s  | (<2v control2> <2v knot2>)+ ["n = " num_verts] [z]                             |
++---------------+--------+--------------------------------------------------------------------------------+
+| QuadCurveTo   | Q,  q  | (<2v control> <2v knot2>)+ ["n = " num_segments] [z]                           |
++---------------+--------+--------------------------------------------------------------------------------+
+| SmthQuadCurve | T,  t  | (<2v knot2>)+ ["n = " num_segments] [z]                                        |
++---------------+--------+--------------------------------------------------------------------------------+
+| ArcTo         | A,  a  | <2v rx,ry> <float rot> <int flag1> <int flag2> <2v x,y> ["n = " num_verts] [z] |
++---------------+--------+--------------------------------------------------------------------------------+
+| Interpolate   | @I, @i | ["@smooth"] <degree> (<2v point>)+ ["n = " num_segments] [z] ";"               |
++---------------+--------+--------------------------------------------------------------------------------+
+| ClosePath     | x      |                                                                                |
++---------------+--------+--------------------------------------------------------------------------------+
+| CloseAll      | X      |                                                                                |
++---------------+--------+--------------------------------------------------------------------------------+
+| comment       | #      | anything after # is a comment.                                                 |
++---------------+--------+--------------------------------------------------------------------------------+
 
 ::
 
@@ -94,6 +96,19 @@ to keep it at one segment type per line is mainly to preserve readability.
 Other curve segments (C/c, S/s, Q/q, T/t) allow to draw several segments with
 one command, as well as in SVG; but still, in many cases it is a good idea to
 use one segment per command, for readability reasons.
+
+`@I` / `@i` command is an extension of SVG syntax. It defines a curve as
+interpolating NURBS curve through the provided list of points. Current point,
+at which the pen is located at the start of command, will be considered as
+first point to be interpolated. If `z` is specified in the end, the curve will
+be closed (cyclic); otherwise, this command will define an open curve. If
+special keyword, `@smooth`, is specified, then, while computing interpolation
+curve, this command will consider previous curve segment, defined by previous
+command (C/c, S/s, Q/q, T/t), if it is of the same degree, and draw the curve
+in such a way that in the starting point it will have the same tangent vector,
+as previous curve had in the end point; in other words, at the meeting point of
+segments, the curve will be smooth.  Providing `z` and `@smooth` for the same
+`@i` command is not supported.
 
 All curve segment types allow you to specify how many vertices are
 used to generate the segment. SVG doesn't let you specify such things, but it

--- a/utils/curve/knotvector.py
+++ b/utils/curve/knotvector.py
@@ -81,11 +81,27 @@ def linear_resample(tknots, new_count):
     resampled_tknots = LinearSpline.resample(old_idxs, tknots, new_idxs)
     return resampled_tknots
 
-def from_tknots(degree, tknots, n_cpts=None):
+def add_one_by_resampling(knot_vector, index = None, degree = None):
+    n = len(knot_vector)
+    if index is None:
+        return linear_resample(knot_vector, n+1)
+    else:
+        if degree is None:
+            raise Exception("If index is provided, degree must be provided too")
+        kv_before = knot_vector[:index]
+        kv_after = knot_vector[index + degree + 1 :]
+        kv = linear_resample(knot_vector[index : index + degree + 1], degree+2)
+        return np.concatenate([kv_before, kv, kv_after])
+
+def from_tknots(degree, tknots, include_endpoints=False, n_cpts=None):
     n = len(tknots)
     if n_cpts is None:
         result = [tknots[0]] * (degree+1)
-        for j in range(1, n - degree):
+        if include_endpoints:
+            j_min, j_max = 0, n - degree + 1
+        else:
+            j_min, j_max = 1, n - degree
+        for j in range(j_min, j_max):
             u = tknots[j:j+degree].sum() / degree
             result.append(u)
         result.extend([tknots[-1]] * (degree+1))

--- a/utils/curve/nurbs_solver.py
+++ b/utils/curve/nurbs_solver.py
@@ -559,6 +559,9 @@ class SvNurbsCurveSolver(SvCurve):
 
     def get_control_points(self):
         return self.to_nurbs().get_control_points()
+    
+    def get_knotvector(self):
+        return self.knotvector
 
     def set_curve_weights(self, weights):
         if len(weights) != self.n_cpts:
@@ -645,6 +648,11 @@ class SvNurbsCurveSolver(SvCurve):
 
     def solve(self, implementation = SvNurbsMaths.NATIVE, logger = None):
         problem_type, residue, curve = self.solve_ex(implementation = implementation, logger = logger)
+        return curve
+
+    def solve_welldetermined(self, implementation = SvNurbsMaths.NATIVE, logger = None):
+        problem_type, residue, curve = self.solve_ex(problem_types = {SvNurbsCurveSolver.PROBLEM_WELLDETERMINED},
+                                        implementation = implementation, logger = logger)
         return curve
 
     def solve_ex(self, problem_types = PROBLEM_ANY, implementation = SvNurbsMaths.NATIVE, logger = None):

--- a/utils/modules/profile_mk3/parser.py
+++ b/utils/modules/profile_mk3/parser.py
@@ -194,6 +194,18 @@ def parse_VertLineTo(src):
     for (is_abs, ys, num_segments, _), rest in parser(src):
         yield VerticalLineTo(is_abs, ys, num_segments), rest
 
+def parse_Interpolate(src):
+    parser = sequence(
+                parse_letter("@I", "@i"),
+                optional(parse_word("@smooth")),
+                parse_value,
+                many(parse_pair, backtracking=True),
+                optional(parse_parameter("n")),
+                optional(parse_word("z")),
+                parse_semicolon)
+    for (is_abs, smooth, degree, points, num_segments, z, _), rest in parser(src):
+        yield InterpolatedCurveTo(is_abs, degree, points, num_segments, 'DISTANCE', smooth is not None, z is not None), rest
+
 parse_CloseAll = parse_word("X", CloseAll())
 parse_ClosePath = parse_word("x", ClosePath())
 
@@ -231,6 +243,7 @@ parse_statement = one_of(
                     parse_QuadCurveTo,
                     parse_SmoothQuadCurveTo,
                     parse_ArcTo,
+                    parse_Interpolate,
                     parse_ClosePath,
                     parse_CloseAll
                 )


### PR DESCRIPTION
This adds a new command, `@I` / `@i`, to the syntax of Profile Mk3 node definitions.

`@I` / `@i` command is an extension of SVG syntax. It defines a curve as
interpolating NURBS curve through the provided list of points. Current point,
at which the pen is located at the start of command, will be considered as
first point to be interpolated. If `z` is specified in the end, the curve will
be closed (cyclic); otherwise, this command will define an open curve. If
special keyword, `@smooth`, is specified, then, while computing interpolation
curve, this command will consider previous curve segment, defined by previous
command (C/c, S/s, Q/q, T/t), if it is of the same degree, and draw the curve
in such a way that in the starting point it will have the same tangent vector,
as previous curve had in the end point; in other words, at the meeting point of
segments, the curve will be smooth.  Providing `z` and `@smooth` for the same
`@i` command is not supported.

![Screenshot_20221128_231313](https://user-images.githubusercontent.com/284644/204350799-6ee7e89f-0e27-45de-b523-7fae9c17eac8.png)
![Screenshot_20221128_230736](https://user-images.githubusercontent.com/284644/204350806-cba83beb-0eae-4ef5-ba42-15442029c6f2.png)
![Screenshot_20221128_232046](https://user-images.githubusercontent.com/284644/204351808-26133e22-7b04-44ad-9c0a-40f97339a672.png)


## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

