### PR TITLE
fix Euclidean typos

### DIFF
--- a/docs/nodes/curve/generate_knotvector.rst
+++ b/docs/nodes/curve/generate_knotvector.rst
@@ -45,7 +45,7 @@ This node has the following parameters:
 
 * **Metric**. The metric to be used to calculate distances between points. This
   parameter is only available when **Mode** parameter is set to **From
-  Points**. The default option is **Euclidian**.
+  Points**. The default option is **Euclidean**.
 * **Set control points number**. This parameter is only available when **Mode**
   parameter is set to **From Points** or **From T Values**. If checked, the
   node will allow to specify arbitrary number of curve's (or surface's) control

--- a/docs/nodes/number/oscillator.rst
+++ b/docs/nodes/number/oscillator.rst
@@ -50,7 +50,7 @@ Advanced Parameters
 In the N-Panel (and on the right-click menu) you can find:
 
 * **Wave Interpolation**: (On Custom mode) Define how the wave should be interpolated (Linear or Cubic)
-* **Wave Knots Mode**: (On Custom mode) Define how the wave knots should be interpolated (Manhattan - Manhattan distance metric, Euclidan - Eudlcian distance metric, Points - Points based, Chebyshev - Chebyshev distance)
+* **Wave Knots Mode**: (On Custom mode) Define how the wave knots should be interpolated (Manhattan - Manhattan distance metric, Euclidean - Euclidean distance metric, Points - Points based, Chebyshev - Chebyshev distance)
 * **Output NumPy**: Get NumPy arrays in stead of regular lists (makes the node faster)
 * **List Match**: Define how list with different lengths should be matched
 

--- a/docs/nodes/vector/interpolation_mk3.rst
+++ b/docs/nodes/vector/interpolation_mk3.rst
@@ -38,7 +38,7 @@ Parameters
 Extra Parameters
 ----------------
 
-  - *Knot Mode*: Used for different cubic interpolations. Can be 'Manhattan', 'Euclidan', 'Points' and 'Chebyshev'
+  - *Knot Mode*: Used for different cubic interpolations. Can be 'Manhattan', 'Euclidean', 'Points' and 'Chebyshev'
   - *List Match*: How List should be matched
   - *Output Numpy*: Outputs numpy arrays in stead of regular python lists (makes node faster)
 

--- a/nodes/curve/bezier_fit.py
+++ b/nodes/curve/bezier_fit.py
@@ -51,7 +51,7 @@ class SvExBezierCurveFitNode(SverchCustomTreeNode, bpy.types.Node):
 
     metrics = [
         ('MANHATTAN', 'Manhattan', "Manhattan distance metric", 0),
-        ('DISTANCE', 'Euclidan', "Eudlcian distance metric", 1),
+        ('DISTANCE', 'Euclidean', "Euclidean distance metric", 1),
         ('POINTS', 'Points', "Points based", 2),
         ('CHEBYSHEV', 'Chebyshev', "Chebyshev distance", 3)]
 

--- a/nodes/curve/kinky_curve.py
+++ b/nodes/curve/kinky_curve.py
@@ -27,7 +27,7 @@ class SvKinkyCurveNode(SverchCustomTreeNode, bpy.types.Node):
 
     metrics = [
         ('MANHATTAN', 'Manhattan', "Manhattan distance metric", 0),
-        ('DISTANCE', 'Euclidan', "Eudlcian distance metric", 1),
+        ('DISTANCE', 'Euclidean', "Euclidean distance metric", 1),
         ('POINTS', 'Points', "Points based", 2),
         ('CHEBYSHEV', 'Chebyshev', "Chebyshev distance", 3)]
 

--- a/nodes/curve/polyline.py
+++ b/nodes/curve/polyline.py
@@ -25,7 +25,7 @@ class SvPolylineNode(SverchCustomTreeNode, bpy.types.Node):
 
     metrics = [
         ('MANHATTAN', 'Manhattan', "Manhattan distance metric", 0),
-        ('DISTANCE', 'Euclidan', "Eudlcian distance metric", 1),
+        ('DISTANCE', 'Euclidean', "Euclidean distance metric", 1),
         ('POINTS', 'Points', "Points based", 2),
         ('CHEBYSHEV', 'Chebyshev', "Chebyshev distance", 3)]
 

--- a/nodes/field/attractor_field_mk2.py
+++ b/nodes/field/attractor_field_mk2.py
@@ -94,7 +94,7 @@ class SvAttractorFieldNodeMk2(SverchCustomTreeNode, bpy.types.Node):
             update = updateNode)
 
     metrics = [
-            ('DISTANCE', 'Euclidan', "Eudlcian distance metric", 0),
+            ('DISTANCE', 'Euclidean', "Euclidean distance metric", 0),
             ('MANHATTAN', 'Manhattan', "Manhattan distance metric", 1),
             ('CHEBYSHEV', 'Chebyshev', "Chebyshev distance", 2),
             ('CUSTOM', "Custom", "Custom Minkowski metric defined by exponent factor", 3)

--- a/nodes/field/voronoi_field.py
+++ b/nodes/field/voronoi_field.py
@@ -21,7 +21,7 @@ class SvVoronoiFieldNode(SverchCustomTreeNode, bpy.types.Node):
     sv_icon = 'SV_VORONOI'
 
     metrics = [
-            ('DISTANCE', 'Euclidan', "Eudlcian distance metric", 0),
+            ('DISTANCE', 'Euclidean', "Euclidean distance metric", 0),
             ('MANHATTAN', 'Manhattan', "Manhattan distance metric", 1),
             ('CHEBYSHEV', 'Chebyshev', "Chebyshev distance", 2),
             ('CUSTOM', "Custom", "Custom Minkowski metric defined by exponent factor", 3)

--- a/nodes/modifier_make/bevel_curve.py
+++ b/nodes/modifier_make/bevel_curve.py
@@ -76,7 +76,7 @@ class SvBevelCurveNode(ModifierNode, SverchCustomTreeNode, bpy.types.Node):
 
     metrics = [
         ('MANHATTAN', 'Manhattan', "Manhattan distance metric", 0),
-        ('DISTANCE', 'Euclidan', "Eudlcian distance metric", 1),
+        ('DISTANCE', 'Euclidean', "Euclidean distance metric", 1),
         ('POINTS', 'Points', "Points based", 2),
         ('CHEBYSHEV', 'Chebyshev', "Chebyshev distance", 3)]
 

--- a/nodes/number/oscillator.py
+++ b/nodes/number/oscillator.py
@@ -104,7 +104,7 @@ class SvOscillatorNode(SverchCustomTreeNode, bpy.types.Node):
         items=wave_interp_modes, update=updateNode)
 
     knot_modes = [('MANHATTAN', 'Manhattan', "Manhattan distance metric", 0),
-                  ('DISTANCE', 'Euclidan', "Eudlcian distance metric", 1),
+                  ('DISTANCE', 'Euclidean', "Euclidean distance metric", 1),
                   ('POINTS', 'Points', "Points based", 2),
                   ('CHEBYSHEV', 'Chebyshev', "Chebyshev distance", 3)]
 

--- a/nodes/transforms/bend_along_path.py
+++ b/nodes/transforms/bend_along_path.py
@@ -52,7 +52,7 @@ class SvBendAlongPathNode(SverchCustomTreeNode, bpy.types.Node):
     mode: EnumProperty(name='Mode', default="SPL", items=modes, update=updateNode)
 
     metrics =    [('MANHATTAN', 'Manhattan', "Manhattan distance metric", 0),
-                  ('DISTANCE', 'Euclidan', "Eudlcian distance metric", 1),
+                  ('DISTANCE', 'Euclidean', "Euclidean distance metric", 1),
                   ('POINTS', 'Points', "Points based", 2),
                   ('CHEBYSHEV', 'Chebyshev', "Chebyshev distance", 3)]
 

--- a/nodes/transforms/bend_along_surface.py
+++ b/nodes/transforms/bend_along_surface.py
@@ -43,7 +43,7 @@ class SvBendAlongSurfaceNode(SverchCustomTreeNode, bpy.types.Node):
     mode: EnumProperty(name='Mode', default="SPL", items=modes, update=updateNode)
 
     metrics =    [('MANHATTAN', 'Manhattan', "Manhattan distance metric", 0),
-                  ('DISTANCE', 'Euclidan', "Eudlcian distance metric", 1),
+                  ('DISTANCE', 'Euclidean', "Euclidean distance metric", 1),
                   ('POINTS', 'Points', "Points based", 2),
                   ('CHEBYSHEV', 'Chebyshev', "Chebyshev distance", 3)]
 

--- a/nodes/vector/interpolation_mk3.py
+++ b/nodes/vector/interpolation_mk3.py
@@ -70,7 +70,7 @@ class SvInterpolationNodeMK3(SverchCustomTreeNode, bpy.types.Node, SvRecursiveNo
     mode: EnumProperty(name='Mode', default="LIN", items=modes, update=updateNode)
 
     knot_modes = [('MANHATTAN', 'Manhattan', "Manhattan distance metric", 0),
-                  ('DISTANCE', 'Euclidan', "Eudlcian distance metric", 1),
+                  ('DISTANCE', 'Euclidean', "Euclidean distance metric", 1),
                   ('POINTS', 'Points', "Points based", 2),
                   ('CHEBYSHEV', 'Chebyshev', "Chebyshev distance", 3)]
 

--- a/utils/math.py
+++ b/utils/math.py
@@ -75,7 +75,7 @@ rbf_functions = [
 
 supported_metrics = [
         ('MANHATTAN', 'Manhattan', "Manhattan distance metric", 0),
-        ('DISTANCE', 'Euclidan', "Eudlcian distance metric", 1),
+        ('DISTANCE', 'Euclidean', "Euclidean distance metric", 1),
         ('POINTS', 'Points', "Points based", 2),
         ('CHEBYSHEV', 'Chebyshev', "Chebyshev distance", 3),
         ('CENTRIPETAL', "Centripetal", "Centripetal distance - square root of Euclidean distance", 4)


### PR DESCRIPTION
Windows 11, Blender 3.3.1, Sverchok-master

I found several lines where 'Euclidean' was written with typos. May be this is not critical to fix them in drop down menus? Indexes unchanged.