### PR TITLE
CAD->bisect node. Fix fill holes on complex objects (ex. torus).

### DIFF
--- a/nodes/modifier_make/bisect.py
+++ b/nodes/modifier_make/bisect.py
@@ -46,7 +46,7 @@ def bisect_bmesh(bm, pp, pno, outer, inner, fill):
         fres = bmesh.ops.edgenet_prepare(
             bm, edges=[e for e in res['geom_cut'] if isinstance(e, bmesh.types.BMEdge)]
         )
-        bmesh.ops.edgeloop_fill(bm, edges=fres['edges'])
+        bmesh.ops.triangle_fill(bm, edges=fres['edges'], use_beauty=True, use_dissolve=True, normal=pno)
 
     edges = []
     faces = []


### PR DESCRIPTION
Windows 11, Blender 3.3.1, Sverchok-master

ex. #4799 if replay with Bisect then result is unexpected too:

![image](https://user-images.githubusercontent.com/14288520/206429307-09b8792d-9943-471d-906f-1754a8c43d6c.png)

But Blender do bisect well:

![image](https://user-images.githubusercontent.com/14288520/206436514-68860dcb-512b-4cdf-8c86-2b3d3f268b77.png)

What the problem? The part of problem is in operator **bmesh.ops.bisect_plane**. The Bisect Operator does not fill holes! (Unexpected!).
See:

https://github.com/blender/blender/blob/3780a402651aeac0caa86767f823a8517a6f8bae/source/blender/editors/mesh/editmesh_bisect.c#L322-L333

![image](https://user-images.githubusercontent.com/14288520/206430480-56d51c8f-19c9-452a-bd87-3c1dcc4528b6.png)

But how Blender do fill? It do fill later with **triangle_fill** operator (https://docs.blender.org/api/current/bmesh.ops.html#bmesh.ops.triangle_fill)! 

https://github.com/blender/blender/blob/3780a402651aeac0caa86767f823a8517a6f8bae/source/blender/editors/mesh/editmesh_bisect.c#L346-L355

![image](https://user-images.githubusercontent.com/14288520/206430826-399efcb7-4148-4b4b-b46b-9f7b47bbb4ba.png)

But how Sverchok do fill on bisect [see line 49]?

https://github.com/nortikin/sverchok/blob/9ff8f36eab43ccb926840123dff58469c50bff6b/nodes/modifier_make/bisect.py#L44-L49

I think this is a problem. So I try replace **bmesh.ops.edgeloop_fill** to **bmesh.ops.triangle_fill**. And I got next result that look good:

![image](https://user-images.githubusercontent.com/14288520/206432126-1e11efd2-35f9-4d2a-a22f-181d4de4a95e.png)

![Bisect 001](https://user-images.githubusercontent.com/14288520/206432877-99214bdf-8ffd-447e-8d17-5dc5f97a68f1.gif)

With joined mesh:

![Bisect 002](https://user-images.githubusercontent.com/14288520/206433761-3adc442b-d6dc-44ac-8b41-42df5f6c86db.gif)

Suzanne tomography:

![Bisect 003](https://user-images.githubusercontent.com/14288520/206435026-726d99a4-c8f0-4a58-b211-bbac503ac70f.gif)

Suzanna has non-manifold geometry so glitches are expected.

for test this pull request: https://gist.github.com/78671a6264b9255acbb3883779fefc73



