### PR TITLE
Add support of profiling Sverchok startup

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,8 +2,6 @@ import importlib
 import sverchok
 from sverchok.core.socket_data import clear_all_socket_cache
 
-reload_event = False
-
 root_modules = [
     "node_tree", "data_structure", "core",
     "utils", "ui", "nodes", "old_nodes"

--- a/utils/profile.py
+++ b/utils/profile.py
@@ -55,14 +55,6 @@ def is_profiling_enabled(section):
     with sv_preferences() as prefs:
         return prefs.profile_mode == section
 
-def is_profiling_enabled_in_settings():
-    """
-    Check if profiling is not set to NONE in addon preferences.
-    """
-    with sv_preferences() as prefs:
-        if prefs is None:
-            return True
-        return prefs.profile_mode != "NONE"
 
 def profile(function = None, section = "MANUAL"):
     """
@@ -168,43 +160,6 @@ def reset_stats():
     global _global_profile
     _global_profile = None
 
-@contextmanager
-def profiling_enabled():
-    if is_profiling_enabled_in_settings():
-        global _profile_nesting
-        profile = None
-        try:
-            profile = get_global_profile()
-            _profile_nesting += 1
-            if _profile_nesting == 1:
-                profile.enable()
-            yield profile
-        finally:
-            _profile_nesting -= 1
-            if _profile_nesting == 0 and profile is not None:
-                profile.disable()
-    else:
-        yield None
-
-@contextmanager
-def profiling_startup():
-    if "--profile-sverchok-startup" in sys.argv:
-        global _profile_nesting
-        profile = None
-        try:
-            profile = get_global_profile()
-            _profile_nesting += 1
-            if _profile_nesting == 1:
-                profile.enable()
-            yield profile
-        finally:
-            _profile_nesting -= 1
-            if _profile_nesting == 0 and profile is not None:
-                profile.disable()
-            dump_stats(file_path="sverchok_profile.txt")
-            save_stats("sverchok_profile.prof")
-    else:
-        yield None
 
 ########################
 #


### PR DESCRIPTION
## Addressed problem description

Should hep to solve this #4752

Start blender with `blender -- --sv-profile` to create two files with profiling of Sverchok startup. "imp_stats" file keeps stats of importing modules and "reg_stats" keeps stats of add-on registration.
