### PR TITLE
Install PIP with Blender as snap package

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -122,7 +122,13 @@ class SvExEnsurePip(bpy.types.Operator):
         cmd = [PYPATH, '-m', 'ensurepip']
         ok = subprocess.call(cmd) == 0
         if ok:
-            self.report({'INFO'}, "PIP installed successfully. Please restart Blender to see effect.")
+            if 'snap' in sys.executable:
+                msg = 'It seems that your Blender is a snap package. Such' \
+                      'packages does not support writing any files. Reinstall' \
+                      'Blender to be able to use external Python packages'
+                self.report({'WARNING'}, msg)
+            else:
+                self.report({'INFO'}, "PIP installed successfully. Please restart Blender to see effect.")
             return {'FINISHED'}
         else:
             self.report({'ERROR'}, "Cannot install PIP, see console output for details")

--- a/settings.py
+++ b/settings.py
@@ -119,8 +119,10 @@ class SvExEnsurePip(bpy.types.Operator):
     bl_options = {'REGISTER', 'INTERNAL'}
 
     def execute(self, context):
+        environ_copy = dict(os.environ)
+        environ_copy["PYTHONNOUSERSITE"] = "1"  # is set to disallow pip from checking the user site-packages
         cmd = [PYPATH, '-m', 'ensurepip']
-        ok = subprocess.call(cmd) == 0
+        ok = subprocess.call(cmd, env=environ_copy) == 0
         if ok:
             if 'snap' in sys.executable:
                 msg = 'It seems that your Blender is a snap package. Such' \


### PR DESCRIPTION
Add warning that it's impossible to install pip for Blender as snap package.
