### PR TITLE
CAD->bisect node. Some glitches appear on skewed quads. Fixed.

### DIFF
--- a/nodes/modifier_make/bisect.py
+++ b/nodes/modifier_make/bisect.py
@@ -34,7 +34,7 @@ from sverchok.utils.nodes_mixins.sockets_config import ModifierNode
 
 def bisect_bmesh(bm, pp, pno, outer, inner, fill):
 
-
+    bm.normal_update()
     geom_in = bm.verts[:] + bm.edges[:] + bm.faces[:]
     res = bmesh.ops.bisect_plane(
         bm, geom=geom_in, dist=0.00001,
@@ -177,7 +177,6 @@ class SvBisectNode(
         if self.slice_mode:
             bms, cut_mats = params
             for cut_mat, bm in zip(cut_mats, bms):
-                bm.normal_update()
                 pp = cut_mat.to_translation()
                 pno = Vector((0.0, 0.0, 1.0)) @ cut_mat.to_3x3().transposed()
 
@@ -193,7 +192,6 @@ class SvBisectNode(
         else:
             bms, cut_mats_s = params
             for cut_mats, bm in zip(cut_mats_s, bms):
-                bm.normal_update()
                 vs, es, ps = [], [], []
                 for cut_mat in cut_mats:
                     pp = cut_mat.to_translation()

--- a/nodes/modifier_make/bisect.py
+++ b/nodes/modifier_make/bisect.py
@@ -177,6 +177,7 @@ class SvBisectNode(
         if self.slice_mode:
             bms, cut_mats = params
             for cut_mat, bm in zip(cut_mats, bms):
+                bm.normal_update()
                 pp = cut_mat.to_translation()
                 pno = Vector((0.0, 0.0, 1.0)) @ cut_mat.to_3x3().transposed()
 
@@ -192,6 +193,7 @@ class SvBisectNode(
         else:
             bms, cut_mats_s = params
             for cut_mats, bm in zip(cut_mats_s, bms):
+                bm.normal_update()
                 vs, es, ps = [], [], []
                 for cut_mat in cut_mats:
                     pp = cut_mat.to_translation()


### PR DESCRIPTION
Windows 11, Blender 3.3.1, Sverchok-master

Glitches on skewed quads:
![image](https://user-images.githubusercontent.com/14288520/207459009-88a473d4-4d3c-4f9b-9640-b28844ba86a7.png)

![Bisect_without_normal_update v002](https://user-images.githubusercontent.com/14288520/207458668-7ef2a381-7325-4c96-80d5-7e09b63e9e4a.gif)

Expected:

![Bisect_with_normal_update v001 no_errors edited](https://user-images.githubusercontent.com/14288520/207458825-01bde122-848a-43e9-b21b-bda30f4d356a.gif)

and now it works. https://docs.blender.org/api/current/bmesh.types.html#bmesh.types.BMesh.normal_update

I think this patch has to be tested in other functions where **bmesh.ops.bisect_plane** used.

Test:

[Bisect_2022_12_13_23_11.zip](https://github.com/nortikin/sverchok/files/10222818/Bisect_2022_12_13_23_11.zip)

https://user-images.githubusercontent.com/14288520/207464158-75ce0e12-f4a9-4489-9e15-bc0a35d17dfd.mp4