### PR TITLE
Component analyzer Faces->Center->(Median Weighted Center) not equal Component analyzer Faces->Matrix->(Median Weighted Center)

### DIFF
--- a/utils/modules/polygon_utils.py
+++ b/utils/modules/polygon_utils.py
@@ -262,7 +262,7 @@ def np_center_weighted(v_pols):
     return np.sum(v_pols * v_factor[:, :, np.newaxis], axis=1)
 
 def edges_lengths(v_pols):
-    return np.linalg.norm(v_pols-np.roll(v_pols, 1, axis=1), axis=2)
+    return np.linalg.norm(v_pols-np.roll(v_pols, -1, axis=1), axis=2)
 
 def np_tangent_longest_edge(v_pols):
     edges_dir = v_pols-np.roll(v_pols, 1, axis=1)


### PR DESCRIPTION
Windows 11, Blender 3.3.1, Sverchok-master

fix for #4704

https://gist.github.com/045b9444303a6b8f1bf159865b55b793

![image](https://user-images.githubusercontent.com/14288520/207944628-02e7367e-09c0-492e-97c7-f9f848ae2f4d.png)

test in dynamic:

![fix 4704](https://user-images.githubusercontent.com/14288520/207945342-652fbb82-0a73-44d9-b910-1b4857199d08.gif)
