### PR TITLE
[Curves->Marching Squares on Surface] gap fix.

### DIFF
--- a/nodes/curve/marching_squares_on_surface.py
+++ b/nodes/curve/marching_squares_on_surface.py
@@ -116,11 +116,20 @@ class SvExMSquaresOnSurfaceNode(SverchCustomTreeNode, bpy.types.Node):
                 u_size = (u_max - u_min)/(samples_u-1)
                 v_size = (v_max - v_min)/(samples_v-1)
 
-                # some times [(u_max - u_min)/(samples_u-1)]*(samples_u-1) > (u_max-umin) !!! need compensation:
-                if( (u_max - u_min) < u_size*(samples_u-1)):
-                    u_size -= ((u_max - u_min)/(samples_u-1)*(samples_u-1)-(u_max-u_min))/(samples_u-1)
-                if( (v_max - v_min) < v_size*(samples_v-1)):
-                    v_size -= ((v_max - v_min)/(samples_v-1)*(samples_v-1)-(v_max-v_min))/(samples_v-1)
+                # some times u_max < u_min + u_size*(samples_u-1) !!! need compensation:
+                if( u_max < u_min + u_size*(samples_u-1)):
+                    for i in range(10):
+                        _u_size = u_size - i*((u_max - u_min)/(samples_u-1)*(samples_u-1) - u_max+u_min)/(samples_u-1)
+                        if( u_max > u_min + _u_size*(samples_u-1)):
+                            u_size = _u_size
+                            break
+
+                if( v_max < v_min + v_size*(samples_v-1)):
+                    for i in range(10):
+                        _v_size = v_size - i*((v_max - v_min)/(samples_v-1)*(samples_v-1) - v_max+v_min)/(samples_v-1)
+                        if( v_max > v_min + v_size*(samples_v-1)):
+                            v_size = _v_size
+                            break
 
                 uv_contours, new_edges, _ = make_contours(samples_u, samples_v, u_min, u_size, v_min, v_size, 0, contours, make_faces=True, connect_bounds = self.connect_bounds)
 

--- a/nodes/curve/marching_squares_on_surface.py
+++ b/nodes/curve/marching_squares_on_surface.py
@@ -117,10 +117,10 @@ class SvExMSquaresOnSurfaceNode(SverchCustomTreeNode, bpy.types.Node):
                 v_size = (v_max - v_min)/(samples_v-1)
 
                 # some times [(u_max - u_min)/(samples_u-1)]*(samples_u-1) > (u_max-umin) !!! need compensation:
-                if(u_max < u_size*(samples_u-1)):
-                    u_size -= ((u_max - u_min)/(samples_u-1)*(samples_u-1)-u_max)/(samples_u-1)
-                if(v_max < v_size*(samples_v-1)):
-                    v_size -= ((v_max - v_min)/(samples_v-1)*(samples_v-1)-v_max)/(samples_v-1)
+                if( (u_max - u_min) < u_size*(samples_u-1)):
+                    u_size -= ((u_max - u_min)/(samples_u-1)*(samples_u-1)-(u_max-u_min))/(samples_u-1)
+                if( (v_max - v_min) < v_size*(samples_v-1)):
+                    v_size -= ((v_max - v_min)/(samples_v-1)*(samples_v-1)-(v_max-v_min))/(samples_v-1)
 
                 uv_contours, new_edges, _ = make_contours(samples_u, samples_v, u_min, u_size, v_min, v_size, 0, contours, make_faces=True, connect_bounds = self.connect_bounds)
 

--- a/nodes/curve/marching_squares_on_surface.py
+++ b/nodes/curve/marching_squares_on_surface.py
@@ -113,8 +113,8 @@ class SvExMSquaresOnSurfaceNode(SverchCustomTreeNode, bpy.types.Node):
 
                 contours = measure.find_contours(field_values, level=value)
 
-                u_size = (u_max - u_min)/samples_u
-                v_size = (v_max - v_min)/samples_v
+                u_size = (u_max - u_min)/(samples_u-1)-0.0000001
+                v_size = (v_max - v_min)/(samples_v-1)-0.0000001
 
                 uv_contours, new_edges, _ = make_contours(samples_u, samples_v, u_min, u_size, v_min, v_size, 0, contours, make_faces=True, connect_bounds = self.connect_bounds)
 

--- a/nodes/curve/marching_squares_on_surface.py
+++ b/nodes/curve/marching_squares_on_surface.py
@@ -113,8 +113,14 @@ class SvExMSquaresOnSurfaceNode(SverchCustomTreeNode, bpy.types.Node):
 
                 contours = measure.find_contours(field_values, level=value)
 
-                u_size = (u_max - u_min)/(samples_u-1)-0.0000001
-                v_size = (v_max - v_min)/(samples_v-1)-0.0000001
+                u_size = (u_max - u_min)/(samples_u-1)
+                v_size = (v_max - v_min)/(samples_v-1)
+
+                # some times [(u_max - u_min)/(samples_u-1)]*(samples_u-1) > (u_max-umin) !!! need compensation:
+                if(u_max < u_size*(samples_u-1)):
+                    u_size -= ((u_max - u_min)/(samples_u-1)*(samples_u-1)-u_max)/(samples_u-1)
+                if(v_max < v_size*(samples_v-1)):
+                    v_size -= ((v_max - v_min)/(samples_v-1)*(samples_v-1)-v_max)/(samples_v-1)
 
                 uv_contours, new_edges, _ = make_contours(samples_u, samples_v, u_min, u_size, v_min, v_size, 0, contours, make_faces=True, connect_bounds = self.connect_bounds)
 

--- a/nodes/curve/marching_squares_on_surface.py
+++ b/nodes/curve/marching_squares_on_surface.py
@@ -116,22 +116,7 @@ class SvExMSquaresOnSurfaceNode(SverchCustomTreeNode, bpy.types.Node):
                 u_size = (u_max - u_min)/(samples_u-1)
                 v_size = (v_max - v_min)/(samples_v-1)
 
-                # some times u_max < u_min + u_size*(samples_u-1) !!! need compensation:
-                if( u_max < u_min + u_size*(samples_u-1)):
-                    for i in range(10):
-                        _u_size = u_size - i*((u_max - u_min)/(samples_u-1)*(samples_u-1) - u_max+u_min)/(samples_u-1)
-                        if( u_max > u_min + _u_size*(samples_u-1)):
-                            u_size = _u_size
-                            break
-
-                if( v_max < v_min + v_size*(samples_v-1)):
-                    for i in range(10):
-                        _v_size = v_size - i*((v_max - v_min)/(samples_v-1)*(samples_v-1) - v_max+v_min)/(samples_v-1)
-                        if( v_max > v_min + v_size*(samples_v-1)):
-                            v_size = _v_size
-                            break
-
-                uv_contours, new_edges, _ = make_contours(samples_u, samples_v, u_min, u_size, v_min, v_size, 0, contours, make_faces=True, connect_bounds = self.connect_bounds)
+                uv_contours, new_edges, _ = make_contours(samples_u, samples_v, u_min, u_size, v_min, v_size, 0, contours, make_faces=True, connect_bounds = self.connect_bounds, u_max = u_max, v_max=v_max)
 
                 if uv_contours:
                     for uv_points in uv_contours:

--- a/utils/marching_squares.py
+++ b/utils/marching_squares.py
@@ -28,8 +28,8 @@ def make_contour(samples_x, samples_y, min_x, x_size, min_y, y_size, z, contour,
                 elif i == n-1:
                     vert_n_bound = 'B'
 
-        x = min_x + x_size * x0 + x_size/2.0
-        y = min_y + y_size * y0 + y_size/2.0
+        x = min_x + x_size * x0 #+ x_size/2.0
+        y = min_y + y_size * y0 #+ y_size/2.0
         vertex = (x, y, z)
         verts.append(vertex)
 

--- a/utils/marching_squares.py
+++ b/utils/marching_squares.py
@@ -1,5 +1,5 @@
 
-def make_contour(samples_x, samples_y, min_x, x_size, min_y, y_size, z, contour, make_faces=False, connect_bounds=False):
+def make_contour(samples_x, samples_y, min_x, x_size, min_y, y_size, z, contour, make_faces=False, connect_bounds=False, u_max=None, v_max=None):
     n = len(contour)
     verts = []
     vert_0_bound = None
@@ -28,8 +28,21 @@ def make_contour(samples_x, samples_y, min_x, x_size, min_y, y_size, z, contour,
                 elif i == n-1:
                     vert_n_bound = 'B'
 
-        x = min_x + x_size * x0 #+ x_size/2.0
-        y = min_y + y_size * y0 #+ y_size/2.0
+        x = min_x + x_size * x0
+        y = min_y + y_size * y0
+
+        #if(i==0 or i==n-1): ?
+        if( u_max is not None):
+            if(x0==samples_x-1): 
+                if(x!=u_max): # for catching situation in debugging
+                    x = u_max
+        if(v_max is not None):
+            if(y0==samples_y-1):
+                if(y!=v_max):
+                    y = v_max
+
+
+
         vertex = (x, y, z)
         verts.append(vertex)
 
@@ -47,12 +60,12 @@ def make_contour(samples_x, samples_y, min_x, x_size, min_y, y_size, z, contour,
         faces = []
     return verts, edges, faces
 
-def make_contours(samples_x, samples_y, min_x, x_size, min_y, y_size, z, contours, make_faces=False, connect_bounds=False):
+def make_contours(samples_x, samples_y, min_x, x_size, min_y, y_size, z, contours, make_faces=False, connect_bounds=False, u_max=None, v_max=None):
     verts = []
     edges = []
     faces = []
     for contour in contours:
-        new_verts, new_edges, new_faces = make_contour(samples_x, samples_y, min_x, x_size, min_y, y_size, z, contour, make_faces=make_faces, connect_bounds=connect_bounds)
+        new_verts, new_edges, new_faces = make_contour(samples_x, samples_y, min_x, x_size, min_y, y_size, z, contour, make_faces=make_faces, connect_bounds=connect_bounds, u_max=u_max, v_max=v_max)
         verts.append(new_verts)
         edges.append(new_edges)
         faces.append(new_faces)


### PR DESCRIPTION
Windows 11, Blender 3.3.1, Sverchok-master

In node's example of [Marching Squares on Surface] there is a gap:
http://nortikin.github.io/sverchok/docs/nodes/curve/marching_squares_on_surface.html
![image](https://user-images.githubusercontent.com/14288520/208320686-7fe5865c-53de-4b52-b06a-a634b2ef9566.png)

and:
![image](https://user-images.githubusercontent.com/14288520/208321014-3d531806-cc0f-4add-bf7e-54adacb93049.png)

Recreated scheme of nodes:

https://gist.github.com/a7846c7f7a3c1de01b182ae4981d79c2

![image](https://user-images.githubusercontent.com/14288520/208320734-c68270e6-9f7a-449a-9e10-7707f4729155.png)

In this fix I remove a gap:

![image](https://user-images.githubusercontent.com/14288520/208320778-222883d6-dc4b-4b74-b66b-87c03e9504dc.png)

![image](https://user-images.githubusercontent.com/14288520/208321087-0ea1b9a0-872a-4ce8-b4d4-87d3b28aa79d.png)
