### PR TITLE
Curvature comb is missing the end spike

### DIFF
--- a/utils/curve/bakery.py
+++ b/utils/curve/bakery.py
@@ -71,7 +71,7 @@ class CurveData(object):
             comb_normals = node.comb_scale * curvatures * normals
             comb_points = self.points - comb_normals
             self.comb_points = np.concatenate((self.points, comb_points)).tolist()
-            comb_normal_edges = [(i, i+n) for i in range(n-1)]
+            comb_normal_edges = [(i, i+n) for i in range(n)]
             comb_tangent_edges = [(i, i+1) for i in range(n, 2*n-1)]
             self.comb_edges = comb_normal_edges + comb_tangent_edges
         else:


### PR DESCRIPTION
I noticed that Curvature Comb is missing the end spike. 
![CurveComb_MissingEndSpike](https://user-images.githubusercontent.com/66558924/208463160-c67c9a7e-bfc9-47e1-9047-9c03b7ce179e.jpg)

So this change is for fixing this.
![CurveComb_MissingEndSpike_Fixed](https://user-images.githubusercontent.com/66558924/208463276-653a10ed-c010-459e-834b-05e580aa6c39.jpg)
