### PR TITLE
stethoscope offset scale fix

### DIFF
--- a/nodes/text/stethoscope_v28.py
+++ b/nodes/text/stethoscope_v28.py
@@ -248,7 +248,7 @@ class SvStethoscopeNodeMK2(SverchCustomTreeNode, bpy.types.Node, LexMixin, SvNod
                 'content': processed_data,
                 'location': get_xy_for_bgl_drawing,
                 'color': self.text_color[:],
-                'scale' : float(scale),
+                'scale' : float(scale*bpy.context.preferences.system.ui_scale),
                 'mode': self.selected_mode[:],
                 'font_id': int(self.font_id)
             }

--- a/utils/sv_nodeview_draw_helper.py
+++ b/utils/sv_nodeview_draw_helper.py
@@ -19,7 +19,8 @@ def get_xy_for_bgl_drawing(node):
     # adjust proposed text location in case node is framed.
     # take into consideration the hidden state
     _x, _y = node.absolute_location
-    _x, _y = (_x + node.width + 20), _y
+    ui_scale = bpy.context.preferences.system.ui_scale
+    _x, _y = (_x + node.width + 20)*ui_scale, _y*ui_scale
 
     # this alters location based on DPI/Scale settings.
     return _x * node.location_theta, _y * node.location_theta


### PR DESCRIPTION
Windows 11, Blender 3.4.1, Sverchok-master

Proposal to fix #4709 

If Blender ui scale in preferences set to non 1.0 then offset of stethoscope show text in unexpected location:

![image](https://user-images.githubusercontent.com/14288520/209127214-8f344010-367a-41c8-ad37-1894272c0ff1.png)

**Position of text look good after fix**:

![image](https://user-images.githubusercontent.com/14288520/209127501-32c44fbf-3ee1-47b8-ba07-c6eb6bac65ec.png)

![UI_SCALE ISSUE fix 001](https://user-images.githubusercontent.com/14288520/209129227-a92e66c3-fc55-4925-9aa6-61efb1d62ccd.gif)

