### PR TITLE
fix #4837 (crash Blender if only first vertex in vertices list is empty)

### DIFF
--- a/nodes/viz/viewer_draw_mk4.py
+++ b/nodes/viz/viewer_draw_mk4.py
@@ -185,7 +185,7 @@ def view_3d_geom(context, args):
         bgl.glLineWidth(1)
 
     if config.draw_verts:
-        if len(geom.v_vertices)>0 and len(geom.v_vertices[0])==3 == False:
+        if len(geom.v_vertices)>0 and (len(geom.v_vertices[0])==3) == True:
             bgl.glPointSize(config.point_size)
             if config.uniform_verts:
                 v_batch = batch_for_shader(config.v_shader, 'POINTS', {"pos": geom.v_vertices})

--- a/nodes/viz/viewer_draw_mk4.py
+++ b/nodes/viz/viewer_draw_mk4.py
@@ -198,7 +198,7 @@ def view_3d_geom(context, args):
             v_batch.draw(config.v_shader)
             bgl.glPointSize(1)
 
-    bgl.glEnable(bgl.GL_BLEND)
+    bgl.glDisable( bgl.GL_BLEND )
 
 
 def splitted_polygons_geom(polygon_indices, original_idx, v_path, cols, idx_offset):

--- a/nodes/viz/viewer_draw_mk4.py
+++ b/nodes/viz/viewer_draw_mk4.py
@@ -185,7 +185,7 @@ def view_3d_geom(context, args):
         bgl.glLineWidth(1)
 
     if config.draw_verts:
-        if len(geom.v_vertices)>0 and (len(geom.v_vertices[0])==3) == True:
+        if len(geom.v_vertices)>0 and (len(geom.v_vertices[0])==3):
             bgl.glPointSize(config.point_size)
             if config.uniform_verts:
                 v_batch = batch_for_shader(config.v_shader, 'POINTS', {"pos": geom.v_vertices})

--- a/nodes/viz/viewer_draw_mk4.py
+++ b/nodes/viz/viewer_draw_mk4.py
@@ -197,8 +197,6 @@ def view_3d_geom(context, args):
 
             v_batch.draw(config.v_shader)
             bgl.glPointSize(1)
-        else:
-            pass
 
     bgl.glEnable(bgl.GL_BLEND)
 

--- a/nodes/viz/viewer_draw_mk4.py
+++ b/nodes/viz/viewer_draw_mk4.py
@@ -185,7 +185,7 @@ def view_3d_geom(context, args):
         bgl.glLineWidth(1)
 
     if config.draw_verts:
-        if len(geom.v_vertices)>0 and (len(geom.v_vertices[0])==3):
+        if geom.v_vertices and (len(geom.v_vertices[0])==3):
             bgl.glPointSize(config.point_size)
             if config.uniform_verts:
                 v_batch = batch_for_shader(config.v_shader, 'POINTS', {"pos": geom.v_vertices})
@@ -198,7 +198,7 @@ def view_3d_geom(context, args):
             v_batch.draw(config.v_shader)
             bgl.glPointSize(1)
 
-    bgl.glDisable( bgl.GL_BLEND )
+    bgl.glDisable(bgl.GL_BLEND)
 
 
 def splitted_polygons_geom(polygon_indices, original_idx, v_path, cols, idx_offset):

--- a/nodes/viz/viewer_draw_mk4.py
+++ b/nodes/viz/viewer_draw_mk4.py
@@ -185,17 +185,20 @@ def view_3d_geom(context, args):
         bgl.glLineWidth(1)
 
     if config.draw_verts:
-        bgl.glPointSize(config.point_size)
-        if config.uniform_verts:
-            v_batch = batch_for_shader(config.v_shader, 'POINTS', {"pos": geom.v_vertices})
-            config.v_shader.bind()
-            config.v_shader.uniform_float("color", config.vector_color[0][0])
-        else:
-            v_batch = batch_for_shader(config.v_shader, 'POINTS', {"pos": geom.v_vertices, "color": geom.points_color})
-            config.v_shader.bind()
+        if len(geom.v_vertices)>0 and len(geom.v_vertices[0])==3 == False:
+            bgl.glPointSize(config.point_size)
+            if config.uniform_verts:
+                v_batch = batch_for_shader(config.v_shader, 'POINTS', {"pos": geom.v_vertices})
+                config.v_shader.bind()
+                config.v_shader.uniform_float("color", config.vector_color[0][0])
+            else:
+                v_batch = batch_for_shader(config.v_shader, 'POINTS', {"pos": geom.v_vertices, "color": geom.points_color})
+                config.v_shader.bind()
 
-        v_batch.draw(config.v_shader)
-        bgl.glPointSize(1)
+            v_batch.draw(config.v_shader)
+            bgl.glPointSize(1)
+        else:
+            pass
 
     bgl.glEnable(bgl.GL_BLEND)
 


### PR DESCRIPTION
Windows 11, Blender 3.4.1, Sverchok-master.

#4837 fix