### PR TITLE
Implement G2 continuity for some nodes

### DIFF
--- a/docs/nodes/curve/blend_curves.rst
+++ b/docs/nodes/curve/blend_curves.rst
@@ -66,7 +66,7 @@ This node has the following parameters:
 * **Continuity**. This defines how smooth the connection between initial curves
   and generated blending curves should be. The available options are:
 
-  * **0 - Position**. Blending curve starts at the end of first curve and ends
+  * **C0 - Position**. Blending curve starts at the end of first curve and ends
     at the beginning of the second curve, but no attempts are made to make
     these connections smooth. As a result, the blending curve is always a
     segment of a straight line.
@@ -74,21 +74,21 @@ This node has the following parameters:
     .. image:: https://user-images.githubusercontent.com/14288520/211332041-419c7002-28bb-45ca-b507-238ff4f13dcd.png
       :target: https://user-images.githubusercontent.com/14288520/211332041-419c7002-28bb-45ca-b507-238ff4f13dcd.png
 
-  * **1 - Tangency**. The blending curves are generated so that the tangent
+  * **G1 - Tangency**. The blending curves are generated so that the tangent
     vectors of the curves are equal at their meeting points. The generated
     curves are cubic Bezier curves.
 
     .. image:: https://user-images.githubusercontent.com/14288520/211333493-3dfe0a3f-1143-429f-bd1c-7a9c04ce45bf.png
       :target: https://user-images.githubusercontent.com/14288520/211333493-3dfe0a3f-1143-429f-bd1c-7a9c04ce45bf.png
 
-  * **1b - Bi Arc**. The blending curves are generated as biarc_ curves, i.e.
+  * **G1 - Bi Arc**. The blending curves are generated as biarc_ curves, i.e.
     pairs of circular arcs; they are generated so that the tanent vectors of
     the curves are equal at their meeting points.
 
     .. image:: https://user-images.githubusercontent.com/14288520/211338021-ae8c68d9-bc02-4323-8cc5-8888c0c8ad33.png
       :target: https://user-images.githubusercontent.com/14288520/211338021-ae8c68d9-bc02-4323-8cc5-8888c0c8ad33.png
 
-  * **2 - Normals**. The blending curves are generated so that 1) tangent
+  * **C2 - Smooth Normals**. The blending curves are generated so that 1) tangent
     vectors of the curves are equal at the meeting points; 2) second
     derivatives of the curves are also equal at the meeting points. Thus,
     normal and binormal vectors of the curves are equal at their meeting
@@ -97,7 +97,7 @@ This node has the following parameters:
     .. image:: https://user-images.githubusercontent.com/14288520/211343223-f0c9bc79-bf16-4833-a3cd-6b651d52d099.png
       :target: https://user-images.githubusercontent.com/14288520/211343223-f0c9bc79-bf16-4833-a3cd-6b651d52d099.png
 
-  * **3 - Curvature**. The blending curves are generated so that 1) tangent
+  * **C3 - Smooth Curvature**. The blending curves are generated so that 1) tangent
     vectors of the curves are equal at the meeting points; 2) second and third
     derivatives of the curves are also equal at the meeting points. Thus,
     normal and binormal vectors of the curves, as well as curvatures of the
@@ -106,6 +106,14 @@ This node has the following parameters:
 
     .. image:: https://user-images.githubusercontent.com/14288520/211344080-1146e033-7296-4f92-9bd5-f36348d7ebd7.png
       :target: https://user-images.githubusercontent.com/14288520/211344080-1146e033-7296-4f92-9bd5-f36348d7ebd7.png
+
+  * **G2 - Curvature**. This means continuous curvature. Curvature comb rim
+    line is continuous, but not smooth. In this sense, this mode is similar to
+    "C2 - Smooth Normals" mode. But with G2 mode, the blending curve does not
+    go so far from touching points as in C2 or C3 mode.
+
+    .. image:: https://user-images.githubusercontent.com/284644/210864882-de4a8a95-f73a-42d3-b30f-1f01ad7a6c33.png
+      :target: https://user-images.githubusercontent.com/284644/210864882-de4a8a95-f73a-42d3-b30f-1f01ad7a6c33.png
 
   The default value is **1 - Tangency**.
 

--- a/docs/nodes/surface/blend_surface.rst
+++ b/docs/nodes/surface/blend_surface.rst
@@ -55,6 +55,21 @@ Parameters
 
 This node has the following parameters:
 
+* **Smoothness**. This defines how smooth the connection between initial
+  surfaces and generated blending surface should be. The available options are:
+
+  * **G1 - Tangency**. Exact matching of tangents is guaranteed.
+    
+    .. image:: https://user-images.githubusercontent.com/284644/210866314-f05d511e-8ae9-46aa-88b1-feb030c67ce1.png
+      :target: https://user-images.githubusercontent.com/284644/210866314-f05d511e-8ae9-46aa-88b1-feb030c67ce1.png
+
+  * **G2 - Curvature**. Matching of geometric curvature is guaranteed.
+
+    .. image:: https://user-images.githubusercontent.com/284644/210866466-2a0d5628-0d00-48ad-a28b-5c037d84b7fd.png
+      :target: https://user-images.githubusercontent.com/284644/210866466-2a0d5628-0d00-48ad-a28b-5c037d84b7fd.png
+
+   The default option is **G1 - Tangency**.
+
 * **Curve1**. This defines where the blending surface should touch the first surface. The available options are:
 
   * **Min U**. Use the edge of the surface with the minimum value of U parameter.

--- a/nodes/curve/blend_curves.py
+++ b/nodes/curve/blend_curves.py
@@ -186,83 +186,6 @@ class SvBlendCurvesMk2Node(SverchCustomTreeNode, bpy.types.Node):
                 if len(params)==1 and curve1==curve2 and self.cyclic==False:
                     if self.output_src:
                         new_curves.append(curve1)
-                _, t_max_1 = curve1.get_u_bounds()
-                t_min_2, _ = curve2.get_u_bounds()
-
-                curve1_end = curve1.evaluate(t_max_1)
-                curve2_begin = curve2.evaluate(t_min_2)
-
-                smooth = self.smooth_mode
-
-                if smooth == '0':
-                    new_curve = SvLine.from_two_points(curve1_end, curve2_begin)
-                    controls = [curve1_end, curve2_begin]
-                elif smooth == '1':
-                    tangent_1_end = curve1.tangent(t_max_1)
-                    tangent_2_begin = curve2.tangent(t_min_2)
-
-                    tangent1 = factor1 * tangent_1_end
-                    tangent2 = factor2 * tangent_2_begin
-
-                    new_curve = SvCubicBezierCurve(
-                            curve1_end,
-                            curve1_end + tangent1 / 3.0,
-                            curve2_begin - tangent2 / 3.0,
-                            curve2_begin
-                        )
-                    controls = [new_curve.p0.tolist(), new_curve.p1.tolist(),
-                                    new_curve.p2.tolist(), new_curve.p3.tolist()]
-                elif smooth == '1b':
-                    tangent_1_end = curve1.tangent(t_max_1)
-                    tangent_2_begin = curve2.tangent(t_min_2)
-
-                    new_curve = SvBiArc.calc(
-                            curve1_end, curve2_begin,
-                            tangent_1_end, tangent_2_begin,
-                            parameter,
-                            planar_tolerance = self.planar_tolerance)
-                    
-                    controls = [new_curve.junction.tolist()]
-                elif smooth == '2':
-                    tangent_1_end = curve1.tangent(t_max_1)
-                    tangent_2_begin = curve2.tangent(t_min_2)
-                    second_1_end = curve1.second_derivative(t_max_1)
-                    second_2_begin = curve2.second_derivative(t_min_2)
-
-                    new_curve = SvBezierCurve.blend_second_derivatives(
-                                    curve1_end, tangent_1_end, second_1_end,
-                                    curve2_begin, tangent_2_begin, second_2_begin)
-                    controls = [p.tolist() for p in new_curve.points]
-                elif smooth == '3':
-                    tangent_1_end = curve1.tangent(t_max_1)
-                    tangent_2_begin = curve2.tangent(t_min_2)
-                    second_1_end = curve1.second_derivative(t_max_1)
-                    second_2_begin = curve2.second_derivative(t_min_2)
-                    third_1_end = curve1.third_derivative_array(np.array([t_max_1]))[0]
-                    third_2_begin = curve2.third_derivative_array(np.array([t_min_2]))[0]
-
-                    new_curve = SvBezierCurve.blend_third_derivatives(
-                                    curve1_end, tangent_1_end, second_1_end, third_1_end,
-                                    curve2_begin, tangent_2_begin, second_2_begin, third_2_begin)
-                    controls = [p.tolist() for p in new_curve.points]
-                elif smooth == 'G2':
-                    tangent_1_end = curve1.tangent(t_max_1)
-                    tangent_2_begin = curve2.tangent(t_min_2)
-                    tangent1 = factor1 * tangent_1_end
-                    tangent2 = factor2 * tangent_2_begin
-                    normal_1_end = curve1.main_normal(t_max_1)
-                    normal_2_begin = curve2.main_normal(t_min_2)
-                    curvature_1_end = curve1.curvature(t_max_1)
-                    curvature_2_begin = curve2.curvature(t_min_2)
-                    
-                    #print(f"Bz: P1 {curve1_end}, P2 {curve2_begin}, T1 {tangent1}, T2 {tangent2}, n1 {normal_1_end}, n2 {normal_2_begin}, c1 {curvature_1_end}, c2 {curvature_2_begin}")
-                    new_curve = SvBezierCurve.from_tangents_normals_curvatures(
-                                    curve1_end, curve2_begin,
-                                    tangent1, tangent2,
-                                    normal_1_end, normal_2_begin,
-                                    curvature_1_end, curvature_2_begin)
-                    controls = new_curve.get_control_points().tolist()
-
                 else:
                     _, t_max_1 = curve1.get_u_bounds()
                     t_min_2, _ = curve2.get_u_bounds()
@@ -323,8 +246,23 @@ class SvBlendCurvesMk2Node(SverchCustomTreeNode, bpy.types.Node):
                                         curve1_end, tangent_1_end, second_1_end, third_1_end,
                                         curve2_begin, tangent_2_begin, second_2_begin, third_2_begin)
                         controls = [p.tolist() for p in new_curve.points]
-                    else:
-                        raise Exception("Unsupported smooth level")
+                    elif smooth == 'G2':
+                        tangent_1_end = curve1.tangent(t_max_1)
+                        tangent_2_begin = curve2.tangent(t_min_2)
+                        tangent1 = factor1 * tangent_1_end
+                        tangent2 = factor2 * tangent_2_begin
+                        normal_1_end = curve1.main_normal(t_max_1)
+                        normal_2_begin = curve2.main_normal(t_min_2)
+                        curvature_1_end = curve1.curvature(t_max_1)
+                        curvature_2_begin = curve2.curvature(t_min_2)
+                        
+                        #print(f"Bz: P1 {curve1_end}, P2 {curve2_begin}, T1 {tangent1}, T2 {tangent2}, n1 {normal_1_end}, n2 {normal_2_begin}, c1 {curvature_1_end}, c2 {curvature_2_begin}")
+                        new_curve = SvBezierCurve.from_tangents_normals_curvatures(
+                                        curve1_end, curve2_begin,
+                                        tangent1, tangent2,
+                                        normal_1_end, normal_2_begin,
+                                        curvature_1_end, curvature_2_begin)
+                        controls = new_curve.get_control_points().tolist()
 
                     # There is two templates of result:
                     # 1. curve1 new_curve1 curve2 new_curve2 curve3 [new_curve3 curve4]/cyclic->curve1

--- a/nodes/curve/blend_curves.py
+++ b/nodes/curve/blend_curves.py
@@ -60,11 +60,6 @@ class SvBlendCurvesMk2Node(SverchCustomTreeNode, bpy.types.Node):
         update = update_sockets)
 
     smooth_modes = [
-            ('0',  "0 - Position", "Connect ends of curves with straight line segment", 0),
-            ('1',  "1 - Tangency", "Connect curves such that their tangents are smoothly joined", 1),
-            ('1b', "1b - Bi Arc", "Connect curves with Bi Arc, such that tangents are smoothly joined", 2),
-            ('2',  "2 - Normals", "Connect curves such that their normals (second derivatives) are smoothly joined", 3),
-            ('3',  "3 - Curvature", "Connect curves such that their curvatures (third derivatives) are smoothly joined", 4)
             ('0', "C0 - Position", "Connect ends of curves with straight line segment", 0),
             ('1', "G1 - Tangency", "Connect curves such that their tangents are continuosly joined", 1),
             ('1b', "G1 - Bi Arc", "Connect curves with Bi Arc, such that tangents are continuosly joined", 2),
@@ -188,11 +183,9 @@ class SvBlendCurvesMk2Node(SverchCustomTreeNode, bpy.types.Node):
             new_curves = []
             new_controls = []
             for curve1, curve2, factor1, factor2, parameter in params:
-<<<<<<< HEAD
                 if len(params)==1 and curve1==curve2 and self.cyclic==False:
                     if self.output_src:
                         new_curves.append(curve1)
-=======
                 _, t_max_1 = curve1.get_u_bounds()
                 t_min_2, _ = curve2.get_u_bounds()
 
@@ -269,7 +262,7 @@ class SvBlendCurvesMk2Node(SverchCustomTreeNode, bpy.types.Node):
                                     normal_1_end, normal_2_begin,
                                     curvature_1_end, curvature_2_begin)
                     controls = new_curve.get_control_points().tolist()
->>>>>>> 7b578d5a3 ("Blend Curves": G2 mode.)
+
                 else:
                     _, t_max_1 = curve1.get_u_bounds()
                     t_min_2, _ = curve2.get_u_bounds()

--- a/nodes/curve/blend_curves.py
+++ b/nodes/curve/blend_curves.py
@@ -262,6 +262,7 @@ class SvBlendCurvesMk2Node(SverchCustomTreeNode, bpy.types.Node):
                     curvature_1_end = curve1.curvature(t_max_1)
                     curvature_2_begin = curve2.curvature(t_min_2)
                     
+                    #print(f"Bz: P1 {curve1_end}, P2 {curve2_begin}, T1 {tangent1}, T2 {tangent2}, n1 {normal_1_end}, n2 {normal_2_begin}, c1 {curvature_1_end}, c2 {curvature_2_begin}")
                     new_curve = SvBezierCurve.from_tangents_normals_curvatures(
                                     curve1_end, curve2_begin,
                                     tangent1, tangent2,

--- a/nodes/curve/fillet_curve.py
+++ b/nodes/curve/fillet_curve.py
@@ -17,6 +17,7 @@ from sverchok.utils.curve.core import SvCurve
 from sverchok.utils.curve.nurbs import SvNurbsCurve
 from sverchok.utils.curve.fillet import (
         SMOOTH_POSITION, SMOOTH_TANGENT, SMOOTH_ARC, SMOOTH_BIARC, SMOOTH_QUAD, SMOOTH_NORMAL, SMOOTH_CURVATURE,
+        SMOOTH_G2,
         fillet_polyline_from_curve, fillet_nurbs_curve
     )
 from sverchok.utils.handle_blender_data import keep_enum_reference
@@ -69,6 +70,7 @@ class SvFilletCurveNode(SverchCustomTreeNode, bpy.types.Node):
             items.append((SMOOTH_BIARC, "1 - Bi Arc", "Connect segments with Bi Arc, such that tangents are smoothly joined", 2))
             #items.append((SMOOTH_NORMAL, "2 - Normals", "Connect segments such that their normals (second derivatives) are smoothly joined", 3))
             #items.append((SMOOTH_CURVATURE, "3 - Curvature", "Connect segments such that their curvatures (third derivatives) are smoothly joined", 4))
+            #items.append((SMOOTH_G2, "G2 - Curvature", "Connect curves such that their tangents, normals and curvatures are continuosly joined", 6))
         else:
             items.append((SMOOTH_ARC, "1 - Circular Arc", "Connect segments with circular arcs", 5))
         return items

--- a/nodes/surface/blend_surface.py
+++ b/nodes/surface/blend_surface.py
@@ -109,7 +109,6 @@ class SvBlendSurfaceNodeMk2(SverchCustomTreeNode, bpy.types.Node):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'tangency_mode')
-        layout.prop(self, 'absolute_bulge')
         box = layout.row(align=True)
         box.prop(self, 'curve1_mode', text='')
         box.prop(self, 'flip1', toggle=True, text='Flip')
@@ -117,6 +116,10 @@ class SvBlendSurfaceNodeMk2(SverchCustomTreeNode, bpy.types.Node):
         box.prop(self, 'curve2_mode', text='')
         box.prop(self, 'flip2', toggle=True, text='Flip')
         layout.prop(self, 'use_nurbs')
+
+    def draw_buttons_ext(self, context, layout):
+        self.draw_buttons(context, layout)
+        layout.prop(self, 'absolute_bulge')
 
     def sv_init(self, context):
         self.inputs.new('SvSurfaceSocket', 'Surface1')

--- a/nodes/surface/blend_surface.py
+++ b/nodes/surface/blend_surface.py
@@ -68,7 +68,7 @@ class SvBlendSurfaceNodeMk2(SverchCustomTreeNode, bpy.types.Node):
     absolute_bulge : BoolProperty(
             name = "Absolute bulge",
             description = "If checked, then bulge values specified are actual required tangent vector lengths; otherwise, bulge values are specified as multipliers of surface's tangent vectors",
-            default = False,
+            default = True,
             update = updateNode)
 
     bulge1 : FloatProperty(

--- a/nodes/surface/blend_surface.py
+++ b/nodes/surface/blend_surface.py
@@ -107,6 +107,17 @@ class SvBlendSurfaceNodeMk2(SverchCustomTreeNode, bpy.types.Node):
             min = 3,
             update = updateNode)
 
+    ortho_modes = [
+            ('3D', "3D space", "Make V isolines of the surface orthogonal to touching curves in 3D space", 0),
+            ('UV', "UV space", "Make V isolines of the surface continue isolines in original surfaces UV space", 1)
+        ]
+
+    ortho_mode : EnumProperty(
+            name = "Ortho mode",
+            items = ortho_modes,
+            default = '3D',
+            update = updateNode)
+
     def draw_buttons(self, context, layout):
         layout.prop(self, 'tangency_mode')
         box = layout.row(align=True)
@@ -115,6 +126,7 @@ class SvBlendSurfaceNodeMk2(SverchCustomTreeNode, bpy.types.Node):
         box = layout.row(align=True)
         box.prop(self, 'curve2_mode', text='')
         box.prop(self, 'flip2', toggle=True, text='Flip')
+        layout.prop(self, 'ortho_mode')
         layout.prop(self, 'use_nurbs')
 
     def draw_buttons_ext(self, context, layout):
@@ -198,11 +210,13 @@ class SvBlendSurfaceNodeMk2(SverchCustomTreeNode, bpy.types.Node):
                     surface = nurbs_blend_surfaces(surface1, surface2, curve1, curve2, bulge1, bulge2, 3, samples,
                                 absolute_bulge = self.absolute_bulge,
                                 tangency = self.tangency_mode,
+                                ortho_mode = self.ortho_mode,
                                 logger = self.get_logger())
                 else:
                     surface = SvBlendSurface(surface1, surface2, curve1, curve2, bulge1, bulge2,
                                 absolute_bulge = self.absolute_bulge,
-                                tangency = self.tangency_mode)
+                                tangency = self.tangency_mode,
+                                ortho_mode = self.ortho_mode)
                 new_surfaces.append(surface)
             surfaces_out.append(new_surfaces)
 

--- a/nodes/surface/blend_surface.py
+++ b/nodes/surface/blend_surface.py
@@ -214,7 +214,7 @@ class SvBlendSurfaceNodeMk2(SverchCustomTreeNode, bpy.types.Node):
                                 absolute_bulge = absolute_bulge,
                                 tangency = self.tangency_mode,
                                 ortho_mode = self.ortho_mode,
-                                logger = self.get_logger())
+                                logger = self.sv_logger)
                 else:
                     surface = SvBlendSurface(surface1, surface2, curve1, curve2, bulge1, bulge2,
                                 absolute_bulge = absolute_bulge,

--- a/utils/curve/algorithms.py
+++ b/utils/curve/algorithms.py
@@ -797,9 +797,14 @@ class SvCurveOnSurfaceCurvaturesCalculator(object):
 
     def calc_curvatures_across_curve(self):
         v1, v2 = self.calc_tangent_cosines()
-        mean = self.surface_calculator.mean()
-        curvatures = self.surface_calculator.curvature_along_direction(v1, v2)
-        curvatures = 2*mean - curvatures
+
+        #mean = self.surface_calculator.mean()
+        #curvatures = self.surface_calculator.curvature_along_direction(v1, v2)
+        #curvatures = 2*mean - curvatures
+
+        n1 = -np.sqrt(1 - v1*v1)
+        n2 = np.sqrt(1 - v2*v2)
+        curvatures = self.surface_calculator.curvature_along_direction(n1, n2)
         return curvatures
 
     def curve_frame_on_surface_array(self, normalize=True, on_zero_curvature=SvCurve.ASIS):
@@ -824,9 +829,9 @@ class SvCurveOnSurfaceCurvaturesCalculator(object):
         """
         surf_points = self.surface_calculator.points
         if normalize:
-            tangents = self.tangents
-        else:
             tangents = self.unit_tangents
+        else:
+            tangents = self.tangents
 
         normals = self.surface_calculator.normals
         if normalize:

--- a/utils/curve/bezier.py
+++ b/utils/curve/bezier.py
@@ -184,17 +184,19 @@ class SvBezierCurve(SvCurve, SvBezierSplitMixin):
 
         b = (B2 - B1) / np.linalg.norm(B2 - B1)
 
-        cos_alpha1 = np.dot(t1dir, b)
-        cos_beta1 = np.dot(n1dir, b)
-        t12 = (r1 * cos_beta1) / (1 - cos_alpha1**2)
-        t11 = cos_alpha1 * t12
-        C1 = B1 + r1 * n1dir + t11 * t1dir
+#         cos_alpha1 = np.dot(t1dir, b)
+#         cos_beta1 = np.dot(n1dir, b)
+#         t12 = (r1 * cos_beta1) / (1 - cos_alpha1**2)
+#         t11 = cos_alpha1 * t12
+#         C1 = B1 + r1 * n1dir + t11 * t1dir
+        C1 = B1 + r1 * n1dir + (B1 - A1)
 
-        cos_alpha2 = np.dot(t2dir, -b)
-        cos_beta2 = np.dot(n2dir, -b)
-        t22 = (r2 * cos_beta2) / (1 - cos_alpha2**2)
-        t21 = cos_alpha2 * t22
-        C2 = B2 + r2 * n2dir + t21 * t2dir
+#         cos_alpha2 = np.dot(t2dir, -b)
+#         cos_beta2 = np.dot(n2dir, -b)
+#         t22 = (r2 * cos_beta2) / (1 - cos_alpha2**2)
+#         t21 = cos_alpha2 * t22
+#         C2 = B2 + r2 * n2dir + t21 * t2dir
+        C2 = B2 + r2 * n2dir + (B2 - A2)
 
         return SvBezierCurve([A1, B1, C1, C2, B2, A2])
 

--- a/utils/curve/bezier.py
+++ b/utils/curve/bezier.py
@@ -182,8 +182,19 @@ class SvBezierCurve(SvCurve, SvBezierSplitMixin):
         r1 = curvature1 * np.linalg.norm(tangent1)**2 / 20
         r2 = curvature2 * np.linalg.norm(tangent2)**2 / 20
 
-        C1 = B1 + r1 * n1dir
-        C2 = B2 + r2 * n2dir
+        b = (B2 - B1) / np.linalg.norm(B2 - B1)
+
+        cos_alpha1 = np.dot(t1dir, b)
+        cos_beta1 = np.dot(n1dir, b)
+        t12 = (r1 * cos_beta1) / (1 - cos_alpha1**2)
+        t11 = cos_alpha1 * t12
+        C1 = B1 + r1 * n1dir + t11 * t1dir
+
+        cos_alpha2 = np.dot(t2dir, -b)
+        cos_beta2 = np.dot(n2dir, -b)
+        t22 = (r2 * cos_beta2) / (1 - cos_alpha2**2)
+        t21 = cos_alpha2 * t22
+        C2 = B2 + r2 * n2dir + t21 * t2dir
 
         return SvBezierCurve([A1, B1, C1, C2, B2, A2])
 

--- a/utils/curve/core.py
+++ b/utils/curve/core.py
@@ -401,6 +401,10 @@ class SvCurve(object):
 
         return integral, new_matrices
 
+    def curvature(self, t, tangent_delta=None):
+        h = self.get_tangent_delta(tangent_delta)
+        return self.curvature_array(np.array([t]), tangent_delta=h)[0]
+
     def curvature_array(self, ts, tangent_delta=None):
         h = self.get_tangent_delta(tangent_delta)
         tangents, seconds = self.derivatives_array(2, ts, tangent_delta=h)

--- a/utils/surface/algorithms.py
+++ b/utils/surface/algorithms.py
@@ -27,7 +27,8 @@ from sverchok.utils.curve import knotvector as sv_knotvector
 from sverchok.utils.curve.algorithms import (
             SvNormalTrack, curve_frame_on_surface_array,
             MathutilsRotationCalculator, DifferentialRotationCalculator,
-            reparametrize_curve
+            reparametrize_curve,
+            SvCurveOnSurface
         )
 from sverchok.utils.surface.core import SvSurface, UnsupportedSurfaceTypeException
 from sverchok.utils.surface.nurbs import SvNurbsSurface
@@ -1035,14 +1036,35 @@ class SvTaperSweepSurface(SvSurface):
         profile_points = self.profile.evaluate_array(us)
         return profile_points * scale + taper_projections
 
+def calc_curvatures_across_curve(uv_curve, surface, ts):
+    ts = np.asarray(ts)
+    uv_points = uv_curve.evaluate_array(ts)
+    curve = SvCurveOnSurface(uv_curve, surface, axis=2)
+    tangents = curve.tangent_array(ts)
+    tangents /= np.linalg.norm(tangents, axis=1, keepdims=True)
+    calc = surface.curvature_calculator(uv_points[:,0], uv_points[:,1])
+    du = calc.fu / np.linalg.norm(calc.fu, axis=1, keepdims=True)
+    dv = calc.fv / np.linalg.norm(calc.fv, axis=1, keepdims=True)
+    v1 = (tangents * du).sum(axis=1)
+    v2 = (tangents * dv).sum(axis=1)
+    mean = calc.mean()
+    curvatures = calc.curvature_along_direction(v1, v2)
+    curvatures = 2*mean - curvatures
+    return curvatures
+
 class SvBlendSurface(SvSurface):
-    def __init__(self, surface1, surface2, curve1, curve2, bulge1, bulge2):
+    G1 = 'G1'
+    G2 = 'G2'
+
+    def __init__(self, surface1, surface2, curve1, curve2, bulge1, bulge2, absolute_bulge = True, tangency = G1):
         self.surface1 = surface1
         self.surface2 = surface2
         self.curve1 = curve1
         self.curve2 = curve2
         self.bulge1 = bulge1
         self.bulge2 = bulge2
+        self.absolute_bulge = absolute_bulge
+        self.tangency = tangency
         self.u_bounds = (0.0, 1.0)
         self.v_bounds = (0.0, 1.0)
 
@@ -1064,28 +1086,67 @@ class SvBlendSurface(SvSurface):
         c1_us = (c1_max - c1_min) * us + c1_min
         c2_us = (c2_max - c2_min) * us + c2_min
 
-        _, c1_points, _, _, c1_binormals = curve_frame_on_surface_array(self.surface1, self.curve1, c1_us)
-        _, c2_points, _, _, c2_binormals = curve_frame_on_surface_array(self.surface2, self.curve2, c2_us)
-        c1_binormals = self.bulge1 * c1_binormals
-        c2_binormals = self.bulge2 * c2_binormals
+        _, c1_points, c1_tangents, _, c1_binormals = curve_frame_on_surface_array(self.surface1, self.curve1, c1_us, normalize=False)
+        _, c2_points, c2_tangents, _, c2_binormals = curve_frame_on_surface_array(self.surface2, self.curve2, c2_us, normalize=False)
+        t1dir = c1_binormals / np.linalg.norm(c1_binormals, axis=1, keepdims=True)
+        t2dir = c2_binormals / np.linalg.norm(c2_binormals, axis=1, keepdims=True)
 
-        # See also sverchok.utils.curve.bezier.SvCubicBezierCurve.
-        # Here we have re-implementation of the same algorithm
-        # which works with arrays of control points
-        p0s = c1_points                 # (n, 3)
-        p1s = c1_points + c1_binormals
-        p2s = c2_points + c2_binormals
-        p3s = c2_points
+        if self.absolute_bulge:
+            c1_binormals = self.bulge1 * t1dir
+            c2_binormals = self.bulge2 * t2dir
+        else:
+            c1_binormals = self.bulge1 * c1_binormals
+            c2_binormals = self.bulge2 * c2_binormals
 
-        c0 = (1 - vs)**3      # (n,)
-        c1 = 3*vs*(1-vs)**2
-        c2 = 3*vs**2*(1-vs)
-        c3 = vs**3
+        if self.tangency == SvBlendSurface.G2:
+            c1_across = calc_curvatures_across_curve(self.curve1, self.surface1, c1_us)
+            c2_across = calc_curvatures_across_curve(self.curve2, self.surface2, c2_us)
 
-        # (n,1)
-        c0, c1, c2, c3 = c0[:,np.newaxis], c1[:,np.newaxis], c2[:,np.newaxis], c3[:,np.newaxis]
+            A1 = c1_points
+            A2 = c2_points
+            B1 = A1 + c1_binormals / 5
+            B2 = A2 + c2_binormals / 5
 
-        return c0*p0s + c1*p1s + c2*p2s + c3*p3s
+            n1dir = c1_tangents / np.linalg.norm(c1_tangents, axis=1, keepdims=True)
+            n2dir = c2_tangents / np.linalg.norm(c2_tangents, axis=1, keepdims=True)
+
+            r1 = c1_across * np.linalg.norm(c1_binormals, axis=1)**2 / 20
+            r2 = c2_across * np.linalg.norm(c2_binormals, axis=1)**2 / 20
+            r1 = r1[np.newaxis].T
+            r2 = r2[np.newaxis].T
+
+            C1 = B1 + r1 * n1dir
+            C2 = B2 + r2 * n2dir
+
+            # See also sverchok.utils.curve.bezier.SvBezierCurve.
+            c0 = (1 - vs)**5      # (n,)
+            c1 = 5*vs*(1-vs)**4
+            c2 = 10*vs**2*(1-vs)**3
+            c3 = 10*vs**3*(1-vs)**2
+            c4 = 5*vs**4*(1-vs)
+            c5 = vs**5
+
+            # (n,1)
+            c0, c1, c2, c3, c4, c5 = c0[:,np.newaxis], c1[:,np.newaxis], c2[:,np.newaxis], c3[:,np.newaxis], c4[:,np.newaxis], c5[:,np.newaxis]
+
+            return c0*A1 + c1*B1 + c2*C1 + c3*C2 + c4*B2 + c5*A2
+        else: # G1
+            # See also sverchok.utils.curve.bezier.SvCubicBezierCurve.
+            # Here we have re-implementation of the same algorithm
+            # which works with arrays of control points
+            p0s = c1_points                 # (n, 3)
+            p1s = c1_points + c1_binormals
+            p2s = c2_points + c2_binormals
+            p3s = c2_points
+
+            c0 = (1 - vs)**3      # (n,)
+            c1 = 3*vs*(1-vs)**2
+            c2 = 3*vs**2*(1-vs)
+            c3 = vs**3
+
+            c0, c1, c2, c3 = c0[:,np.newaxis], c1[:,np.newaxis], c2[:,np.newaxis], c3[:,np.newaxis]
+            return c0*p0s + c1*p1s + c2*p2s + c3*p3s
+
 
 class SvConcatSurface(SvSurface):
     def __init__(self, direction, surfaces):

--- a/utils/surface/algorithms.py
+++ b/utils/surface/algorithms.py
@@ -1106,17 +1106,19 @@ class SvBlendSurface(SvSurface):
 
             bs = (B2 - B1) / np.linalg.norm(B2 - B1, axis=1, keepdims=True)
 
-            cos_alpha1 = np_dot(t1dir, bs)[np.newaxis].T
-            cos_beta1 = np_dot(n1dir, bs)[np.newaxis].T
-            t12 = (r1 * cos_beta1) / (1 - cos_alpha1**2)
-            t11 = cos_alpha1 * t12
-            C1 = B1 + r1 * n1dir + t11 * t1dir
+#             cos_alpha1 = np_dot(t1dir, bs)[np.newaxis].T
+#             cos_beta1 = np_dot(n1dir, bs)[np.newaxis].T
+#             t12 = (r1 * cos_beta1) / (1 - cos_alpha1**2)
+#             t11 = cos_alpha1 * t12
+#             C1 = B1 + r1 * n1dir + t11 * t1dir
+            C1 = B1 + r1 * n1dir + (B1 - A1)
 
-            cos_alpha2 = np_dot(t2dir, -bs)[np.newaxis].T
-            cos_beta2 = np_dot(n2dir, -bs)[np.newaxis].T
-            t22 = (r2 * cos_beta2) / (1 - cos_alpha2**2)
-            t21 = cos_alpha2 * t22
-            C2 = B2 + r2 * n2dir + t21 * t2dir
+#             cos_alpha2 = np_dot(t2dir, -bs)[np.newaxis].T
+#             cos_beta2 = np_dot(n2dir, -bs)[np.newaxis].T
+#             t22 = (r2 * cos_beta2) / (1 - cos_alpha2**2)
+#             t21 = cos_alpha2 * t22
+#             C2 = B2 + r2 * n2dir + t21 * t2dir
+            C2 = B2 + r2 * n2dir + (B2 - A2)
 
             # See also sverchok.utils.curve.bezier.SvBezierCurve.
             c0 = (1 - vs)**5      # (n,)

--- a/utils/surface/algorithms.py
+++ b/utils/surface/algorithms.py
@@ -1040,7 +1040,10 @@ class SvBlendSurface(SvSurface):
     G1 = 'G1'
     G2 = 'G2'
 
-    def __init__(self, surface1, surface2, curve1, curve2, bulge1, bulge2, absolute_bulge = True, tangency = G1):
+    ORTHO_3D = '3D'
+    ORTHO_UV = 'UV'
+
+    def __init__(self, surface1, surface2, curve1, curve2, bulge1, bulge2, absolute_bulge = True, tangency = G1, ortho_mode = ORTHO_3D):
         self.surface1 = surface1
         self.surface2 = surface2
         self.curve1 = curve1
@@ -1049,6 +1052,7 @@ class SvBlendSurface(SvSurface):
         self.bulge2 = bulge2
         self.absolute_bulge = absolute_bulge
         self.tangency = tangency
+        self.ortho_mode = ortho_mode
         self.u_bounds = (0.0, 1.0)
         self.v_bounds = (0.0, 1.0)
 
@@ -1079,6 +1083,10 @@ class SvBlendSurface(SvSurface):
         _, c2_points, c2_tangents, c2_normals, c2_binormals = calc2.curve_frame_on_surface_array(normalize=False)
         t1dir = c1_binormals / np.linalg.norm(c1_binormals, axis=1, keepdims=True)
         t2dir = c2_binormals / np.linalg.norm(c2_binormals, axis=1, keepdims=True)
+
+        if self.ortho_mode == SvBlendSurface.ORTHO_UV:
+            c1_binormals = calc1.uv_normals_in_3d
+            c2_binormals = calc2.uv_normals_in_3d
 
         if self.absolute_bulge:
             c1_binormals = self.bulge1 * t1dir

--- a/utils/surface/algorithms.py
+++ b/utils/surface/algorithms.py
@@ -1080,6 +1080,9 @@ class SvBlendSurface(SvSurface):
     def get_v_max(self):
         return self.v_bounds[1]
 
+    def evaluate(self, u, v):
+        return self.evaluate_array(np.array([u]), np.array([v]))[0]
+
     def evaluate_array(self, us, vs):
         c1_min, c1_max = self.curve1.get_u_bounds()
         c2_min, c2_max = self.curve2.get_u_bounds()

--- a/utils/surface/data.py
+++ b/utils/surface/data.py
@@ -73,6 +73,17 @@ class SurfaceDerivativesData(object):
         else:
             return matrices_np
 
+    def tangents_in_direction(self, uv_directions, w_axis=2):
+        if w_axis == 2:
+            U, V = 0, 1
+        elif w_axis == 1:
+            U, V = 0, 2
+        else:
+            U, V = 1, 2
+        d_u = uv_directions[:,U][np.newaxis].T
+        d_v = uv_directions[:,V][np.newaxis].T
+        return self.du * d_u + self.dv * d_v
+
 class SurfaceCurvatureCalculator(object):
     """
     This class contains pre-calculated first and second surface derivatives,
@@ -87,6 +98,7 @@ class SurfaceCurvatureCalculator(object):
         self.nuu = self.nvv = self.nuv = None
         self.points = None
         self.normals = None
+        self._derivatives_data = None
 
     def set(self, points, normals, fu, fv, duu, dvv, duv, nuu, nvv, nuv):
         """Set derivatives information"""
@@ -100,6 +112,14 @@ class SurfaceCurvatureCalculator(object):
         self.nuu = nuu # (fuu, normal), a.k.a l
         self.nvv = nvv # (fvv, normal), a.k.a n
         self.nuv = nuv # (fuv, normal), a.k.a m
+
+    @property
+    def derivatives_data(self):
+        if self._derivatives_data is None:
+            if self.points is None or self.fu is None or self.fv is None:
+                raise Exception("SurfaceCurvatureCalculator.set() was not called before call to SurfaceCurvatureCalculator.derivatives_data")
+            self._derivatives_data = SurfaceDerivativesData(self.points, self.fu, self.fv)
+        return self._derivatives_data
 
     def mean(self):
         """

--- a/utils/surface/gordon.py
+++ b/utils/surface/gordon.py
@@ -155,8 +155,8 @@ def nurbs_blend_surfaces(surface1, surface2, curve1, curve2, bulge1, bulge2, u_d
 
     c1_across = calc1.calc_curvatures_across_curve()
     c2_across = calc2.calc_curvatures_across_curve()
-    #c1_along = calc1.calc_curvatures_along_curve()
-    #c2_along = calc2.calc_curvatures_along_curve()
+    c1_along = calc1.calc_curvatures_along_curve()
+    c2_along = calc2.calc_curvatures_along_curve()
     #print(f"C1: {list(zip(ts1, c1_across, c1_along))}")
     #print(f"C2: {list(zip(ts2, c2_across, c1_along))}")
 

--- a/utils/surface/gordon.py
+++ b/utils/surface/gordon.py
@@ -135,7 +135,10 @@ def gordon_surface(u_curves, v_curves, intersections, metric='POINTS', u_knots=N
 TANGENCY_G1 = 'G1'
 TANGENCY_G2 = 'G2'
 
-def nurbs_blend_surfaces(surface1, surface2, curve1, curve2, bulge1, bulge2, u_degree, u_samples, absolute_bulge = True, tangency = TANGENCY_G1, logger=None):
+ORTHO_3D = '3D'
+ORTHO_UV = 'UV'
+
+def nurbs_blend_surfaces(surface1, surface2, curve1, curve2, bulge1, bulge2, u_degree, u_samples, absolute_bulge = True, tangency = TANGENCY_G1, ortho_mode = ORTHO_UV, logger=None):
     t_min, t_max = curve1.get_u_bounds()
     ts1 = np.linspace(t_min, t_max, num=u_samples)
 
@@ -146,6 +149,11 @@ def nurbs_blend_surfaces(surface1, surface2, curve1, curve2, bulge1, bulge2, u_d
     calc2 = SvCurveOnSurfaceCurvaturesCalculator(curve2, surface2, ts2)
     _, c1_points, c1_tangents, c1_normals, c1_binormals = calc1.curve_frame_on_surface_array(normalize=False)
     _, c2_points, c2_tangents, c2_normals, c2_binormals = calc2.curve_frame_on_surface_array(normalize=False)
+
+    if ortho_mode == ORTHO_UV:
+        c1_binormals = calc1.uv_normals_in_3d
+        c2_binormals = calc2.uv_normals_in_3d
+
     if absolute_bulge:
         c1_binormals = bulge1 * c1_binormals / np.linalg.norm(c1_binormals, axis=1, keepdims=True)
         c2_binormals = bulge2 * c2_binormals / np.linalg.norm(c2_binormals, axis=1, keepdims=True)
@@ -155,15 +163,17 @@ def nurbs_blend_surfaces(surface1, surface2, curve1, curve2, bulge1, bulge2, u_d
 
     c1_across = calc1.calc_curvatures_across_curve()
     c2_across = calc2.calc_curvatures_across_curve()
-    c1_along = calc1.calc_curvatures_along_curve()
-    c2_along = calc2.calc_curvatures_along_curve()
+    #c1_along = calc1.calc_curvatures_along_curve()
+    #c2_along = calc2.calc_curvatures_along_curve()
     #print(f"C1: {list(zip(ts1, c1_across, c1_along))}")
     #print(f"C2: {list(zip(ts2, c2_across, c1_along))}")
 
-    bad1 = (c1_across * c1_along) > 0
-    bad2 = (c2_across * c2_along) > 0
-    c1_normals[bad1] = - c1_normals[bad1]
-    c2_normals[bad2] = - c2_normals[bad2]
+    #bad1 = (c1_across * c1_along) < 0
+    #bad2 = (c2_across * c2_along) < 0
+    #print(f"Bad1: {bad1}")
+    #print(f"Bad2: {bad2}")
+    #c1_normals[bad1] = - c1_normals[bad1]
+    #c2_normals[bad2] = - c2_normals[bad2]
 
     #curve1 = interpolate_nurbs_curve_with_tangents(u_degree, c1_points, c1_tangents, tknots=ts1, logger=logger)
     #curve2 = interpolate_nurbs_curve_with_tangents(u_degree, c2_points, c2_tangents, tknots=ts2, logger=logger)

--- a/utils/surface/gordon.py
+++ b/utils/surface/gordon.py
@@ -155,6 +155,15 @@ def nurbs_blend_surfaces(surface1, surface2, curve1, curve2, bulge1, bulge2, u_d
 
     c1_across = calc1.calc_curvatures_across_curve()
     c2_across = calc2.calc_curvatures_across_curve()
+    #c1_along = calc1.calc_curvatures_along_curve()
+    #c2_along = calc2.calc_curvatures_along_curve()
+    #print(f"C1: {list(zip(ts1, c1_across, c1_along))}")
+    #print(f"C2: {list(zip(ts2, c2_across, c1_along))}")
+
+    bad1 = (c1_across * c1_along) > 0
+    bad2 = (c2_across * c2_along) > 0
+    c1_normals[bad1] = - c1_normals[bad1]
+    c2_normals[bad2] = - c2_normals[bad2]
 
     #curve1 = interpolate_nurbs_curve_with_tangents(u_degree, c1_points, c1_tangents, tknots=ts1, logger=logger)
     #curve2 = interpolate_nurbs_curve_with_tangents(u_degree, c2_points, c2_tangents, tknots=ts2, logger=logger)
@@ -166,7 +175,8 @@ def nurbs_blend_surfaces(surface1, surface2, curve1, curve2, bulge1, bulge2, u_d
         v_curves = [SvBezierCurve.from_control_points([p1, p1+t1, p2+t2, p2]) for p1, t1, p2, t2 in zip(c1_points, c1_binormals, c2_points, c2_binormals)]
     else: # G2
         v_curves = []
-        for p1, p2, t1, t2, n1, n2, c1, c2 in zip(c1_points, c2_points, c1_binormals, c2_binormals, c1_normals, c2_normals, c1_across, c2_across):
+        for u1, u2, p1, p2, t1, t2, n1, n2, c1, c2 in zip(ts1, ts2, c1_points, c2_points, c1_binormals, c2_binormals, c1_normals, c2_normals, c1_across, c2_across):
+            #print(f"T1 {u1}, T2 {u2}: P1 {p1}, P2 {p2}, T1 {t1}, -T2 {-t2}, n1 {n1}, n2 {n2}, c1 {c1}, c2 {c2}")
             v_curve = SvBezierCurve.from_tangents_normals_curvatures(p1, p2, t1, -t2, n1, n2, c1, c2)
             v_curves.append(v_curve)
 

--- a/utils/surface/gordon.py
+++ b/utils/surface/gordon.py
@@ -2,16 +2,10 @@ import numpy as np
 
 from sverchok.utils.curve.bezier import SvBezierCurve
 from sverchok.utils.curve.nurbs_algorithms import unify_curves
-from sverchok.utils.curve.algorithms import unify_curves_degree, curve_frame_on_surface_array
-from sverchok.utils.curve.nurbs_algorithms import unify_curves, nurbs_curve_to_xoy, nurbs_curve_matrix
-from sverchok.utils.curve.algorithms import unify_curves_degree, SvCurveFrameCalculator, curve_frame_on_surface_array, SvCurveOnSurface
-from sverchok.utils.curve.nurbs_solver_applications import interpolate_nurbs_curve_with_tangents
+from sverchok.utils.curve.algorithms import unify_curves_degree, SvCurveOnSurfaceCurvaturesCalculator
+from sverchok.utils.curve.nurbs_solver_applications import interpolate_nurbs_curve_with_tangents, interpolate_nurbs_curve
 from sverchok.utils.surface.nurbs import SvNurbsSurface, simple_loft, interpolate_nurbs_surface
 from sverchok.utils.surface.algorithms import unify_nurbs_surfaces
-from sverchok.utils.sv_logging import get_logger
-from sverchok.utils.surface.algorithms import unify_nurbs_surfaces, calc_curvatures_across_curve
-from sverchok.utils.logging import getLogger
-from sverchok.data_structure import repeat_last_for_length
 
 def reparametrize_by_segments(curve, t_values, tolerance=1e-2):
     # Reparametrize given curve so that parameter values from t_values parameter
@@ -148,8 +142,10 @@ def nurbs_blend_surfaces(surface1, surface2, curve1, curve2, bulge1, bulge2, u_d
     t_min, t_max = curve2.get_u_bounds()
     ts2 = np.linspace(t_min, t_max, num=u_samples)
 
-    _, c1_points, c1_tangents, _, c1_binormals = curve_frame_on_surface_array(surface1, curve1, ts1, normalize=False)
-    _, c2_points, c2_tangents, _, c2_binormals = curve_frame_on_surface_array(surface2, curve2, ts2, normalize=False)
+    calc1 = SvCurveOnSurfaceCurvaturesCalculator(curve1, surface1, ts1)
+    calc2 = SvCurveOnSurfaceCurvaturesCalculator(curve2, surface2, ts2)
+    _, c1_points, c1_tangents, c1_normals, c1_binormals = calc1.curve_frame_on_surface_array(normalize=False)
+    _, c2_points, c2_tangents, c2_normals, c2_binormals = calc2.curve_frame_on_surface_array(normalize=False)
     if absolute_bulge:
         c1_binormals = bulge1 * c1_binormals / np.linalg.norm(c1_binormals, axis=1, keepdims=True)
         c2_binormals = bulge2 * c2_binormals / np.linalg.norm(c2_binormals, axis=1, keepdims=True)
@@ -157,18 +153,20 @@ def nurbs_blend_surfaces(surface1, surface2, curve1, curve2, bulge1, bulge2, u_d
         c1_binormals = bulge1 * c1_binormals
         c2_binormals = bulge2 * c2_binormals
 
-    c1_across = calc_curvatures_across_curve(curve1, surface1, ts1)
-    c2_across = calc_curvatures_across_curve(curve2, surface2, ts2)
+    c1_across = calc1.calc_curvatures_across_curve()
+    c2_across = calc2.calc_curvatures_across_curve()
 
-    curve1 = interpolate_nurbs_curve_with_tangents(u_degree, c1_points, c1_tangents, tknots=ts1, logger=logger)
-    curve2 = interpolate_nurbs_curve_with_tangents(u_degree, c2_points, c2_tangents, tknots=ts2, logger=logger)
+    #curve1 = interpolate_nurbs_curve_with_tangents(u_degree, c1_points, c1_tangents, tknots=ts1, logger=logger)
+    #curve2 = interpolate_nurbs_curve_with_tangents(u_degree, c2_points, c2_tangents, tknots=ts2, logger=logger)
+    curve1 = interpolate_nurbs_curve(u_degree, c1_points, tknots=ts1, logger=logger)
+    curve2 = interpolate_nurbs_curve(u_degree, c2_points, tknots=ts2, logger=logger)
     u_curves = [curve1, curve2]
 
     if tangency == TANGENCY_G1:
         v_curves = [SvBezierCurve.from_control_points([p1, p1+t1, p2+t2, p2]) for p1, t1, p2, t2 in zip(c1_points, c1_binormals, c2_points, c2_binormals)]
     else: # G2
         v_curves = []
-        for p1, p2, t1, t2, n1, n2, c1, c2 in zip(c1_points, c2_points, c1_binormals, c2_binormals, c1_tangents, c2_tangents, c1_across, c2_across):
+        for p1, p2, t1, t2, n1, n2, c1, c2 in zip(c1_points, c2_points, c1_binormals, c2_binormals, c1_normals, c2_normals, c1_across, c2_across):
             v_curve = SvBezierCurve.from_tangents_normals_curvatures(p1, p2, t1, -t2, n1, n2, c1, c2)
             v_curves.append(v_curve)
 

--- a/utils/surface/gordon.py
+++ b/utils/surface/gordon.py
@@ -6,6 +6,7 @@ from sverchok.utils.curve.algorithms import unify_curves_degree, SvCurveOnSurfac
 from sverchok.utils.curve.nurbs_solver_applications import interpolate_nurbs_curve_with_tangents, interpolate_nurbs_curve
 from sverchok.utils.surface.nurbs import SvNurbsSurface, simple_loft, interpolate_nurbs_surface
 from sverchok.utils.surface.algorithms import unify_nurbs_surfaces
+from sverchok.utils.sv_logging import get_logger
 
 def reparametrize_by_segments(curve, t_values, tolerance=1e-2):
     # Reparametrize given curve so that parameter values from t_values parameter


### PR DESCRIPTION
In scope:
* [x] Blend Curve
* [ ] Fillet Curve
* [x] Blend Surface

## Blend Curve node

C1 - Tangency mode. The curve itself is smooth, but the normal changes direction radically at the point of curve touching. This is because the curve changes the direction where it turns to, at these points.
![Screenshot_20230103_003759](https://user-images.githubusercontent.com/284644/210272809-34189f02-8cd3-4d7f-82bd-a7a56605f3e9.png)

C1 - BiArc mode. Blending curve is made of two circular arcs, and the curvature comb clearly shows us where these two arcs begin and end - there are two segments of constant curvature. At touching points curve's curvature changes suddenly.
![Screenshot_20230103_003820](https://user-images.githubusercontent.com/284644/210272808-228e4de8-ef5a-47b8-8b7c-09931366ea70.png)

C2 - Smooth Normals mode. C2 means continuous second derivative. Now normal does not change it's direction so suddenly as in "C1 - Tangency" mode. Nor does curvature value change suddenly. The curvature comb rim line is continuous. But you may notice that at touching points the rim line is not smooth, albeit continuous. Also, you can notice that C2 mode creates more "curvy" blending line, which goes farther from touching points, comparing to C1 modes. Informally speaking, C2 mode makes blending line preserve more inertia from the curves being blended.
![Screenshot_20230103_003913](https://user-images.githubusercontent.com/284644/210272805-7f3e381e-c186-4d58-8cdc-2867839d423b.png)

C3 - Smooth Curvature mode. C3 means continuous third derivative. Now not only curvature comb rim line is continuous, it is smooth. But now blending curve goes even farther from touching points compared to C1 and C2 modes, as it preserves even more inertia.
![Screenshot_20230103_003949](https://user-images.githubusercontent.com/284644/210272804-73edfddb-0e57-4266-87d3-0ee825733343.png)

G2 - Curvature mode. This means continuous curvature. Curvature comb rim line is continuous, but not smooth. In this sense, this mode is similar to "C2 - Smooth Normals" mode. But with G2 mode, the blending curve does not go so far from touching points as in C2 or C3 mode.
![Screenshot_20230106_003253](https://user-images.githubusercontent.com/284644/210864882-de4a8a95-f73a-42d3-b30f-1f01ad7a6c33.png)

## Blend Surfaces node

G1 - Tangency mode (this is the mode which is currently used):

![Screenshot_20230106_004018](https://user-images.githubusercontent.com/284644/210866314-f05d511e-8ae9-46aa-88b1-feb030c67ce1.png)

G2 -Curvature mode:

![Screenshot_20230106_004049](https://user-images.githubusercontent.com/284644/210866466-2a0d5628-0d00-48ad-a28b-5c037d84b7fd.png)

Comparison of G1 and G2 modes (this is the same shape which is used on pictures above, just with dotted matcap):
![Screenshot_20230106_010305](https://user-images.githubusercontent.com/284644/210870063-dfae1492-c380-4a6e-851e-2972f9fd3e13.png)


## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

