### PR TITLE
testing.py: add some command-line options.

### DIFF
--- a/utils/testing.py
+++ b/utils/testing.py
@@ -822,7 +822,7 @@ if __name__ == "__main__":
 
         parser = argparse.ArgumentParser(prog = "testing.py", description = "Run Sverchok tests")
         parser.add_argument('pattern', metavar='*.PY', nargs='?', default = '*_tests.py', help="Test case files pattern")
-        parser.add_argument('-t', '--test', nargs='+', default = argparse.SUPPRESS)
+        #parser.add_argument('-t', '--test', nargs='+', default = argparse.SUPPRESS)
         parser.add_argument('-o', '--output', metavar='FILE.log', default='sverchok_tests.log', help="Path to output log file")
         parser.add_argument('-f', '--fail-fast', action='store_true', help="Stop after first failing test")
         parser.add_argument('-v', '--verbose', action='count', default=2, help="Set the verbosity level")


### PR DESCRIPTION
```
usage: testing.py [-h] [-t TEST [TEST ...]] [-o FILE.log] [-f] [-v] [-q] [--debug] [--info] [*.PY]

Run Sverchok tests

positional arguments:
  *.PY                  Test case files pattern

options:
  -h, --help            show this help message and exit
  -o FILE.log, --output FILE.log
                        Path to output log file
  -f, --fail-fast       Stop after first failing test
  -v, --verbose         Set the verbosity level
  -q, --quiet           Be quiet
  --debug               Enable debug logging
  --info                Log only information messages
```

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

