### PR TITLE
Num Expression Node

### DIFF
--- a/docs/nodes/script/numexpr_node.rst
+++ b/docs/nodes/script/numexpr_node.rst
@@ -1,0 +1,91 @@
+Num Expression
+==============
+
+Functionality
+-------------
+
+This node is currently fastest way to evaluate an expression. For best
+performance the node should get NumPy arrays. But vectorization is slow as
+it is for any other node in Sverchok, so make sure that you have all numbers in
+a single object if performance is important.
+
+The node is based on `NumExpr library`_. It supports next operators:
+
+    * Bitwise operators (and, or, not, xor): :code:`&, |, ~, ^`
+    * Comparison operators: :code:`<, <=, ==, !=, >=, >`
+    * Unary arithmetic operators: :code:`-`
+    * Binary arithmetic operators: :code:`+, -, *, /, **, %, <<, >>`
+
+Supported functions:
+
+    * :code:`where(bool, number1, number2): number` -- number1 if the bool condition
+      is true, number2 otherwise.
+    * :code:`{sin,cos,tan}(float|complex): float|complex` -- trigonometric sine,
+      cosine or tangent.
+    * :code:`{arcsin,arccos,arctan}(float|complex): float|complex` -- trigonometric
+      inverse sine, cosine or tangent.
+    * :code:`arctan2(float1, float2): float` -- trigonometric inverse tangent of
+      float1/float2.
+    * :code:`{sinh,cosh,tanh}(float|complex): float|complex` -- hyperbolic sine,
+      cosine or tangent.
+    * :code:`{arcsinh,arccosh,arctanh}(float|complex): float|complex` -- hyperbolic
+      inverse sine, cosine or tangent.
+    * :code:`{log,log10,log1p}(float|complex): float|complex` -- natural, base-10 and
+      log(1+x) logarithms.
+    * :code:`{exp,expm1}(float|complex): float|complex` -- exponential and exponential
+      minus one.
+    * :code:`sqrt(float|complex): float|complex` -- square root.
+    * :code:`abs(float|complex): float|complex`  -- absolute value.
+    * :code:`conj(complex): complex` -- conjugate value.
+    * :code:`{real,imag}(complex): float` -- real or imaginary part of complex.
+    * :code:`complex(float, float): complex` -- complex from real and imaginary
+      parts.
+    * :code:`contains(np.str, np.str): bool` -- returns True for every string in :code:`op1` that
+      contains :code:`op2`.
+    * :code:`{floor}(float): float` -- returns the greatest integer less than or
+      equal to x.
+    * :code:`{ceil}(float): float` -- returns the least integer greater than or
+      equal to x
+
+Reduction functions:
+
+  * :code:`sum(number, axis=None)`: Sum of array elements over a given axis.
+    Negative axis are not supported.
+  * :code:`prod(number, axis=None)`: Product of array elements over a given axis.
+    Negative axis are not supported.
+  * :code:`{min,max}(number, axis=None)`: Find minimum/maximum value over a given axis.
+    Negative axis are not supported.
+
+*Note:* because of internal limitations, reduction operations must appear the
+last in the stack.  If not, it will be issued an error like::
+
+    >>> ne.evaluate('sum(1)*(-1)')
+    RuntimeError: invalid program: reduction operations must occur last
+
+The node automatically generates sockets for each variable in an input formula.
+The type of sockets can be either float/int or vector. The type of generated
+socket is dependent on the name of the variable. To generate vector type the
+variable should statr with upper ``V`` letter. Any other variable names will
+generate float/int type. The order of sockets is dependent on variable names.
+They are sorted in alphabetical order. The output type is vector if there is
+at least one input vector type. Variable names should be Pythonic.
+
+.. _NumExpr library: https://numexpr.readthedocs.io/projects/NumExpr3/en/latest/user_guide.html
+
+Inputs
+------
+
+Variable number of inputs depending on the input formula.
+
+Outputs
+-------
+
+- Result
+
+Examples
+--------
+
+.. figure:: https://user-images.githubusercontent.com/28003269/210037965-560e2d6b-3563-4efc-9be3-da35bdf3b049.png
+   :target: https://user-images.githubusercontent.com/28003269/210037965-560e2d6b-3563-4efc-9be3-da35bdf3b049.png
+
+   Round a value according to given step.

--- a/index.yaml
+++ b/index.yaml
@@ -786,6 +786,7 @@
     - icon_name: WORDWRAP_ON
     - extra_menu: AdvancedObjectsPartialMenu
     - SvFormulaNodeMk5
+    - SvNumExprNode
     - SvFormulaInterpolateNode
     - SvExecNodeMod
     - SvProfileNodeMK3

--- a/menus/full_by_data_type.yaml
+++ b/menus/full_by_data_type.yaml
@@ -815,6 +815,7 @@
     - icon_name: WORDWRAP_ON
     - extra_menu: AdvancedObjectsPartialMenu
     - SvFormulaNodeMk5
+    - SvNumExprNode
     - SvFormulaInterpolateNode
     - SvExecNodeMod
     - SvProfileNodeMK3

--- a/menus/full_nortikin.yaml
+++ b/menus/full_nortikin.yaml
@@ -649,6 +649,7 @@
     - icon_name: WORDWRAP_ON
     - extra_menu: BasicDataPartialMenu
     - SvFormulaNodeMk5
+    - SvNumExprNode
     - SvFormulaInterpolateNode
     - SvExecNodeMod
     - SvProfileNodeMK3

--- a/node_tree.py
+++ b/node_tree.py
@@ -626,13 +626,8 @@ class NodeDependencies:
     def missing_dependency(cls) -> bool:
         """Returns True if any of dependent libraries are not installed"""
         if cls._missing_dependency is None:
-            # node_module = sys.modules[cls.__module__]
-            extension_name, *_ = cls.__module__.partition('.')
-            deps_module = sys.modules.get(f"{extension_name}.dependencies")
-            if deps_module is None:
-                debug(f'Extension "{extension_name}" does node define the dependencies module')
             for dep in cls.sv_dependencies:
-                if getattr(deps_module, dep) is None:
+                if dep not in sys.modules:
                     cls._missing_dependency = True
                     break
             else:

--- a/nodes/script/numexpr_node.py
+++ b/nodes/script/numexpr_node.py
@@ -1,0 +1,97 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+import re
+
+import numpy as np
+try:
+    import numexpr as ne
+except ImportError:
+    ne = None
+
+import bpy
+from bpy.props import StringProperty
+
+from sverchok.data_structure import numpy_full_list
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvNumExprNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers:
+    Tooltip:
+    """
+    bl_idname = 'SvNumExprNode'
+    bl_label = 'Num Expression node'
+    bl_icon = 'MOD_BOOLEAN'
+
+    function_names = {
+        'where', 'sin', 'cos', 'tan', 'arcsin', 'arccos', 'arctan', 'arctan2',
+        'sinh', 'cosh', 'tanh', 'arcsinh', 'arccosh', 'arctanh', 'log',
+        'log10', 'log1p', 'exp', 'expm1', 'sqrt', 'abs', 'conj', 'real',
+        'imag', 'complex', 'contains', 'sum', 'prod'}
+
+    def expression_update(self, context):
+        variables = []
+        invalid_names = []
+        for word in re.split(r'\W+', self.expression):  # https://regexr.com/
+            if not word or word.isdigit() or word in self.function_names:
+                continue
+            if word.isidentifier():
+                variables.append(word)
+            else:
+                invalid_names.append(word)
+        self['variables'] = variables
+        self['invalid_names'] = invalid_names
+        self.sv_init(context)
+        self.process_node(context)
+
+    expression: StringProperty(update=expression_update)
+
+    def sv_draw_buttons(self, context, layout):
+        row = layout.row()
+        row.alert = bool(self.get('invalid_names'))
+        row.prop(self, 'expression', text='')
+
+    def sv_init(self, context):
+        expr_vars = set(self.get('variables'))
+        if not self.outputs:
+            self.outputs.new('SvStringsSocket', 'Result')
+
+        # remove all sockets
+        if not expr_vars:
+            self.inputs.clear()
+
+        # remove sockets which are not presented in the modifier
+        for sv_s in self.inputs:
+            if sv_s.identifier not in expr_vars:
+                self.inputs.remove(sv_s)
+
+        # add new sockets
+        socks = {s.name: i for i, s in enumerate(self.inputs)}
+        for var in expr_vars:
+            if var in socks:
+                continue
+            s = self.inputs.new('SvStringsSocket', var)
+            s.use_prop = True
+            s.show_property_type = True
+
+    def process(self):
+        if not self.expression:
+            self.outputs[0].sv_set([])
+            return
+        if invalid_names := self.get('invalid_names'):
+            raise NameError(f"{invalid_names=}")
+        inp_vars = {s.name: np.asarray(s.sv_get(deepcopy=False)[0])
+                    for s in self.inputs}
+        data_len = max(len(d) for d in inp_vars.values())
+        inp_vars = {n: numpy_full_list(d, data_len) if len(d) > 1 else d
+                    for n, d in inp_vars.items()}
+        result = ne.evaluate(self.expression, local_dict=inp_vars)
+        self.outputs[0].sv_set([result])
+
+
+register, unregister = bpy.utils.register_classes_factory(SvNumExprNode)

--- a/nodes/script/numexpr_node.py
+++ b/nodes/script/numexpr_node.py
@@ -7,16 +7,18 @@
 import re
 
 import numpy as np
+
 try:
     import numexpr as ne
 except ImportError:
     ne = None
 
 import bpy
-from bpy.props import StringProperty
+from bpy.props import StringProperty, EnumProperty
 
 from sverchok.data_structure import numpy_full_list, fixed_iter
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.ui.sv_icons import custom_icon
 
 
 class SvNumExprNode(SverchCustomTreeNode, bpy.types.Node):
@@ -27,39 +29,91 @@ class SvNumExprNode(SverchCustomTreeNode, bpy.types.Node):
     bl_idname = 'SvNumExprNode'
     bl_label = 'Num Expression node'
     bl_icon = 'MOD_BOOLEAN'
+    sv_dependencies = ['numexpr']
 
     function_names = {
         'where', 'sin', 'cos', 'tan', 'arcsin', 'arccos', 'arctan', 'arctan2',
         'sinh', 'cosh', 'tanh', 'arcsinh', 'arccosh', 'arctanh', 'log',
         'log10', 'log1p', 'exp', 'expm1', 'sqrt', 'abs', 'conj', 'real',
-        'imag', 'complex', 'contains', 'sum', 'prod'}
+        'imag', 'complex', 'contains', 'sum', 'prod', 'min', 'max', 'floor',
+        'ceil'}
 
     def expression_update(self, context):
-        variables = []
-        invalid_names = []
+        variables = set()
+        invalid_names = set()
         for word in re.split(r'\W+', self.expression):  # https://regexr.com/
             if not word or word.isdigit() or word in self.function_names:
                 continue
             if word.isidentifier():
-                variables.append(word)
+                variables.add(word)
             else:
-                invalid_names.append(word)
-        self['variables'] = variables
-        self['invalid_names'] = invalid_names
+                invalid_names.add(word)
+        self['variables'] = list(variables)
+        self['invalid_names'] = list(invalid_names)
         self.sv_init(context)
         self.process_node(context)
 
     expression: StringProperty(update=expression_update)
 
+    presets = [  # can be edited any way during live time of the node
+        ("", "Scalar", "", custom_icon("SV_NUMBER"), 0),
+        ("VALUE", "Value", "", "DOT", 1),
+        ("MAP_RANGE", 'Map Range', "", "MOD_OFFSET", 2),
+        ("MIX_NUMBERS", 'Mix Numbers', "", custom_icon('SV_MIX_INPUTS'), 3),
+        ("CLAMP", "Clamp", "", "NOCURVE", 4),
+        ("STEPPING", "Stepping", "Round value with step", "IPO_CONSTANT", 5),
+        ("LENGTH", "Length", "Length of the array", custom_icon("SV_LIST_LEN"), 6),
+        ("", "Vector", "", custom_icon("SV_VECTOR"), 7),
+        ("VECTOR_VALUE", "Value", "", "DOT", 8),
+        ("MOVE", "Move", "", custom_icon('SV_MOVE'), 9),
+        ("VECTOR_SCALE", "Scale", "", custom_icon('SV_SCALE'), 10),
+        ("", "Logic", "", custom_icon("SV_LOGIC"), 11),
+        ("AND", "And", "", "", 12),
+        ("OR", "Or", "", "", 13),
+        ("NOT", "Not", "", "", 14),
+        ("SWITCH", "Switch", "", "", 15),
+    ]
+
+    preset_formulas = {
+        # Scalar
+        "VALUE": 'value',
+        "MAP_RANGE": "new_min+(__val-_old_min)*((new_max-new_min)/(_old_max-_old_min))",
+        "MIX_NUMBERS": "(val2-val1)*factor+val1",
+        "CLAMP": "where(__value>max_,max_, where(__value<_min,_min,__value))",
+        "STEPPING": "floor(_value/step)*step",
+        "LENGTH": "sum(floor(a==a))",
+        # VECTOR
+        "VECTOR_VALUE": "Value",
+        "MOVE": "V1+V2*strength",
+        "VECTOR_SCALE": "(V-VCenters)*(VScale*multiplier)+VCenters",
+        # LOGIC
+        "AND": "(a!=0) & (b!=0)",
+        "OR": "(a!=0) | (b!=0)",
+        "NOT": "~(a!=0)",
+        "SWITCH": "where(_switch!=0,true,false)",
+    }
+
+    def apply_preset(self, context):
+        self.expression = self.preset_formulas[self.preset]
+
+    preset: EnumProperty(items=presets, update=apply_preset)
+
     def sv_draw_buttons(self, context, layout):
-        row = layout.row()
-        row.alert = bool(self.get('invalid_names'))
+        row = layout.row(align=True)
         row.prop(self, 'expression', text='')
+        row.prop(self, 'preset', icon='PRESET', icon_only=True)
 
     def sv_init(self, context):
-        expr_vars = set(self.get('variables'))
+        expr_vars = sorted(self.get('variables', []))
         if not self.outputs:
             self.outputs.new('SvStringsSocket', 'Result')
+
+        out_type = 'SvVerticesSocket' if any(v.startswith('V') for v in expr_vars) \
+            else 'SvStringsSocket'
+
+        # fix out type
+        if out_type != self.outputs[0].bl_idname:
+            self.outputs[0].replace_socket(out_type)
 
         # remove all sockets
         if not expr_vars:
@@ -75,9 +129,23 @@ class SvNumExprNode(SverchCustomTreeNode, bpy.types.Node):
         for var in expr_vars:
             if var in socks:
                 continue
-            s = self.inputs.new('SvStringsSocket', var)
-            s.use_prop = True
-            s.show_property_type = True
+            if var.startswith('V'):
+                self.inputs.new('SvVerticesSocket', var).use_prop = True
+            else:
+                s = self.inputs.new('SvStringsSocket', var)
+                s.use_prop = True
+                s.show_property_type = True
+
+        # fix socket positions
+        for _ in range(100):
+            for pos, sock in enumerate(self.inputs):
+                if pos != (to_pos := expr_vars.index(sock.name)):
+                    self.inputs.move(pos, to_pos)
+                    break
+            else:
+                break
+        else:
+            self.debug("It seems there is some problem in ordering sockets")
 
     def process(self):
         if not self.expression:
@@ -87,7 +155,7 @@ class SvNumExprNode(SverchCustomTreeNode, bpy.types.Node):
             raise NameError(f"{invalid_names=}")
         inp_vars = [s.sv_get(deepcopy=False) for s in self.inputs]
         names = [s.name for s in self.inputs]
-        inp_len = max(len(d) for d in inp_vars)
+        inp_len = max(len(d) for d in inp_vars) if names else 0
         inp_vars = [fixed_iter(d, inp_len) for d in inp_vars]
         out = []
         for obj_vars in zip(*inp_vars):
@@ -95,7 +163,7 @@ class SvNumExprNode(SverchCustomTreeNode, bpy.types.Node):
             obj_vars = {n: numpy_full_list(np.asarray(d), obj_len) if len(d) > 1 else d
                         for n, d in zip(names, obj_vars)}
             result = ne.evaluate(self.expression, local_dict=obj_vars)
-            out.append([result])
+            out.append(result)
         self.outputs[0].sv_set(out)
 
 

--- a/nodes/script/numexpr_node.py
+++ b/nodes/script/numexpr_node.py
@@ -20,12 +20,12 @@ from sverchok.utils.vectorize import match_sockets
 
 class SvNumExprNode(SverchCustomTreeNode, bpy.types.Node):
     """
-    Triggers:
-    Tooltip:
+    Triggers: math formula script
+    Tooltip: Node supplies routines for the fast evaluation of array expressions elementwise
     """
     bl_idname = 'SvNumExprNode'
     bl_label = 'Num Expression node'
-    bl_icon = 'MOD_BOOLEAN'
+    sv_icon = 'SV_ALPHA'  # 'SV_FORMULA'
     sv_dependencies = ['numexpr']
 
     function_names = {

--- a/utils/vectorize.py
+++ b/utils/vectorize.py
@@ -371,7 +371,3 @@ def walk_data(walkers: List[DataWalker], out_list: List[list]) -> Tuple[list, Li
             max_value_len = max(w.next_values_number for w in walkers)
             [w.step_down_matching(max_value_len, match_mode) for w in walkers]
             [t.step_down() for t in result_data]
-
-
-if __name__ == '__main__':
-    print("DONE")

--- a/utils/vectorize.py
+++ b/utils/vectorize.py
@@ -5,12 +5,36 @@ import numpy as np
 
 from mathutils import Matrix
 
-from sverchok.data_structure import levels_of_list_or_np
-
+from sverchok.data_structure import fixed_iter, levels_of_list_or_np, numpy_full_list
 
 SvVerts = List[Tuple[float, float, float]]
 SvEdges = List[Tuple[int, int]]
 SvPolys = List[List[int]]
+
+
+def match_sockets(*sockets_data):
+    """
+    data1 = [[1,2,3]]
+    data2 = [[4,5], [6,7]]
+    data3 = [[8]]
+    for d1, d2, d3 in match_sockets(data1, data2, data3):
+        print(f"{d1=}, {d2=}, {d3=}")
+    # print(1) d1=[1,2,3], d2=[4,5,5], d3=[8]
+    # print(2) d2=[1,2,3], d2=[6,7,7], d3=[8]
+    """
+    obj_len = max(len(data) for data in sockets_data) if sockets_data else 0
+    sockets_data = [fixed_iter(d, obj_len) for d in sockets_data]
+    for objects in zip(*sockets_data):
+        data_len = max(len(d) for d in objects)
+        layer_data = []
+        for data in objects:
+            if len(data) != data_len and len(data) > 1:
+                if isinstance(data, np.ndarray):
+                    data = numpy_full_list(data, data_len)
+                else:  # Python list?
+                    data = list(fixed_iter(data, data_len))
+            layer_data.append(data)
+        yield layer_data
 
 
 def vectorize(func=None, *, match_mode="REPEAT"):
@@ -347,3 +371,7 @@ def walk_data(walkers: List[DataWalker], out_list: List[list]) -> Tuple[list, Li
             max_value_len = max(w.next_values_number for w in walkers)
             [w.step_down_matching(max_value_len, match_mode) for w in walkers]
             [t.step_down() for t in result_data]
+
+
+if __name__ == '__main__':
+    print("DONE")


### PR DESCRIPTION
## Addressed problem description

The node adds support of [NumExpr library](https://numexpr.readthedocs.io/projects/NumExpr3/en/latest/user_guide.html).
The range of speed-ups for NumExpr respect to NumPy can vary from 0.95x and 20x.

![2022-12-29_14-39-30](https://user-images.githubusercontent.com/28003269/209940252-01975f46-5cc9-4290-8963-dd27a6c89050.png)

![image](https://user-images.githubusercontent.com/28003269/209940228-da497c81-6736-49af-8011-d359ce94e0ee.png)


## Preflight checklist

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 

