### PR TITLE
Generalize Coons Patch node.

### DIFF
--- a/docs/nodes/surface/coons_patch.rst
+++ b/docs/nodes/surface/coons_patch.rst
@@ -55,7 +55,7 @@ This node has the following parameters:
 * **Input**. This defines how the curves are provided. The following options are available:
 
   * **List of curves**. All curves are provided in a single input **Curves**.
-  * **4 Curves**. Each curve is provided in separate input **Curve1** - **Curve4**.
+  * **Separate inputs**. Each curve is provided in separate input **Curve1** - **Curve4**.
 
   The default value is **List of Curves**.
 

--- a/docs/nodes/surface/coons_patch.rst
+++ b/docs/nodes/surface/coons_patch.rst
@@ -1,5 +1,5 @@
-Surface from Four Curves
-========================
+Surface from Boundary Curves
+============================
 
 Functionality
 -------------
@@ -18,6 +18,11 @@ That is, the second curve must begin at the point where the first curve ends;
 and the third curve must begin at the point where the second curve ends; and so
 on.
 
+It is also possible to omit the fourth curve, thus to build a surface from
+three boundary curves. If the third curve does not end in the same point where
+the first curve started, the node will use a straight line segment as fourth
+curve.
+
 The surface is calculated as a Coons patch, see https://en.wikipedia.org/wiki/Coons_patch.
 
 When all provided curves are NURBS or NURBS-like, then the node will try to
@@ -34,12 +39,13 @@ This node has the following inputs:
 
 * **Curves**. The list of curves to build a surface form. This input can accept
   data with nesting level of 1 or 2 (list of curves or list of lists of
-  curves). Each list of curves must have length of 4. This input is available
+  curves). Each list of curves must have length of 3 or 4. This input is available
   and mandatory only if **Input** parameter is set to **List of Curves**.
 * **Curve1**, **Curve2**, **Curve3**, **Curve4**. Curves to build surface from.
   These inputs can accept data with nesting level 1 only (list of curves).
-  These inputs are available and mandatory only if **Input** parameter is set
-  to **4 Curves**.
+  These inputs are available only if **Input** parameter is set
+  to **4 Curves**. Inputs **Curve1**, **Curve2** and **Curve3** are mandatory.
+  **Curve4** input is optional.
 
 Parameters
 ----------
@@ -102,4 +108,13 @@ One may use such surface to generate another topology:
 It is possible to use the node together with "Split Curve" node to generate a surface from one closed curve:
 
 .. image:: https://user-images.githubusercontent.com/284644/82479760-3deb1f80-9aec-11ea-8411-22ffd273259f.png
+
+It is possible to use only three boundary curves:
+
+.. image:: https://user-images.githubusercontent.com/284644/210209607-113759b7-9992-4e5d-870d-6aa6dafe0c32.png
+
+If the third curve end does not coincide with the beginning of the first curve,
+the node will close the cycle with a straight line segment:
+
+.. image:: https://user-images.githubusercontent.com/284644/210209611-052c63b6-ef39-4c12-a047-d7d369f3469c.png
 

--- a/utils/curve/bezier.py
+++ b/utils/curve/bezier.py
@@ -75,7 +75,7 @@ class SvBezierCurve(SvCurve, SvBezierSplitMixin):
     Bezier curve of arbitrary degree.
     """
     def __init__(self, points):
-        self.points = points
+        self.points = np.asarray(points)
         self.tangent_delta = 0.001
         n = self.degree = len(points) - 1
         self.__description__ = "Bezier[{}]".format(n)

--- a/utils/curve/primitives.py
+++ b/utils/curve/primitives.py
@@ -145,6 +145,63 @@ class SvLine(SvCurve):
     def is_closed(self, *args):
         return False
 
+    def extrude_along_vector(self, vector):
+        return self.to_nurbs().extrude_along_vector(vector)
+
+    def make_revolution_surface(self, point, direction, v_min, v_max, global_origin):
+        return self.to_nurbs().make_revolution_surface(point, direction, v_min, v_max, global_origin)
+    
+    def make_ruled_surface(self, curve2, vmin, vmax):
+        return self.to_nurbs().make_ruled_surface(curve2, vmin, vmax)
+
+    def extrude_to_point(self, point):
+        return self.to_nurbs().extrude_to_point(point)
+
+    def lerp_to(self, curve2, coefficient):
+        return self.to_nurbs().lerp_to(curve2, coefficient)
+
+class SvPointCurve(SvCurve):
+    __description__ = "Single-Point"
+
+    def __init__(self, point):
+        self.point = np.asarray(point)
+
+    def evaluate(self, t):
+        return self.point
+
+    def evaluate_array(self, ts):
+        points = np.empty((len(ts),3))
+        points[:] = self.point
+        return points
+    
+    def get_u_bounds(self):
+        return (0.0, 1.0)
+
+    def get_degree(self):
+        return 1
+
+    def to_bezier(self):
+        u_min, u_max = self.get_u_bounds()
+        p1 = self.evaluate(u_min)
+        p2 = self.evaluate(u_max)
+        return SvBezierCurve([p1, p2])
+
+    def to_bezier_segments(self):
+        return [self.to_bezier()]
+
+    def is_closed(self, *args):
+        return False
+
+    def concatenate(self, curve2, *args):
+        return curve2
+
+    def to_nurbs(self, implementation = SvNurbsMaths.NATIVE):
+        return self.to_bezier().to_nurbs()
+
+    def reverse(self):
+        return SvPointCurve(self.point)
+
+
 def rotate_radius(radius, normal, thetas):
     """Internal method"""
     ct = np.cos(thetas)[np.newaxis].T

--- a/utils/surface/coons.py
+++ b/utils/surface/coons.py
@@ -12,7 +12,7 @@ from sverchok.utils.nurbs_common import from_homogenous
 from sverchok.utils.curve import knotvector as sv_knotvector
 from sverchok.utils.curve.core import UnsupportedCurveTypeException
 from sverchok.utils.curve.nurbs import SvNurbsCurve
-from sverchok.utils.curve.algorithms import reverse_curve, reparametrize_curve
+from sverchok.utils.curve.algorithms import reverse_curve, reparametrize_curve, unify_curves_degree
 from sverchok.utils.curve.nurbs_algorithms import unify_curves, unify_two_curves
 from sverchok.utils.surface.core import SvSurface
 from sverchok.utils.surface.nurbs import SvNurbsSurface
@@ -83,10 +83,11 @@ def coons_surface(curve1, curve2, curve3, curve4, use_nurbs=NURBS_IF_POSSIBLE):
             return SvCoonsSurface(*curves)
     try:
         nurbs_curves = [c.reparametrize(0,1) for c in nurbs_curves]
-        degrees = [c.get_degree() for c in nurbs_curves]
         implementation = nurbs_curves[0].get_nurbs_implementation()
 
+        nurbs_curves[0], nurbs_curves[2] = unify_curves_degree([nurbs_curves[0], nurbs_curves[2]])
         nurbs_curves[0], nurbs_curves[2] = unify_curves([nurbs_curves[0], nurbs_curves[2]])
+        nurbs_curves[1], nurbs_curves[3] = unify_curves_degree([nurbs_curves[1], nurbs_curves[3]])
         nurbs_curves[1], nurbs_curves[3] = unify_curves([nurbs_curves[1], nurbs_curves[3]])
 
         degree_u = nurbs_curves[0].get_degree()


### PR DESCRIPTION
Now it is possible to build the patch from three curves.

If the third curve does not end in the same point where the first curve started, the node will use a straight line segment as a fourth curve.

Thus, the node is renamed to **Surface from Boundary Curves**.

![Screenshot_20230102_133819](https://user-images.githubusercontent.com/284644/210209607-113759b7-9992-4e5d-870d-6aa6dafe0c32.png)
![Screenshot_20230102_133623](https://user-images.githubusercontent.com/284644/210209611-052c63b6-ef39-4c12-a047-d7d369f3469c.png)


## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

