### PR TITLE
Menu presets: automatic application.

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -447,16 +447,16 @@ class SverchokPreferences(AddonPreferences):
             items = get_menu_presets,
         )
 
-    menu_application_modes = [
-            ('ALWAYS', "Apply at each startup", "Menu preset will be automatically applied upon each Blender startup", 0),
-            ('MANUAL', "Apply manually", "Menu preset will be applied only explicitly, allowing you to maintain your own version of index.yaml in datafiles", 1)
+    menu_usage_options = [
+            ('SVERCHOK', "Use preset file", "Original menu preset file will be used. So the menu will be updated automatically when the preset is updated within Sverchok distribution", 0),
+            ('COPY', "Use local copy of preset file", "Menu preset file will be copied under your datafiles directory. You may edit it manually without touching the preset file in Sverchok directory. But the responsibility of updating the menu when a node is added into Sverchok is yours", 1)
         ]
 
-    menu_preset_application : EnumProperty(
+    menu_preset_usage : EnumProperty(
             name = "Application mode",
             description = "Menu preset application mode",
-            items = menu_application_modes,
-            default = 'ALWAYS'
+            items = menu_usage_options,
+            default = 'SVERCHOK'
         )
 
     def general_tab(self, layout):
@@ -468,12 +468,15 @@ class SverchokPreferences(AddonPreferences):
         box.label(text = "Menu presets:")
         menu_col = box.column()
         menu_col.prop(self, 'menu_preset', text='Preset')
-        menu_split = menu_col.split(factor=0.8)
-        split_prop = menu_split.column()
-        split_prop.prop(self, 'menu_preset_application', text='')
-        op_split = menu_split.column()
-        op = op_split.operator(SvOverwriteMenuFile.bl_idname, text="Apply")
-        op.preset_path = self.menu_preset
+        if self.menu_preset_usage == 'COPY':
+            menu_split = menu_col.split(factor=0.8)
+            split_prop = menu_split.column()
+            split_prop.prop(self, 'menu_preset_usage', text='')
+            op_split = menu_split.column()
+            op = op_split.operator(SvOverwriteMenuFile.bl_idname, text="Copy")
+            op.preset_path = self.menu_preset
+        else:
+            menu_col.prop(self, 'menu_preset_usage', text='')
 
         col1.prop(self, "external_editor", text="Ext Editor")
         col1.prop(self, "real_sverchok_path", text="Src Directory")

--- a/settings.py
+++ b/settings.py
@@ -9,7 +9,13 @@ import bpy
 from bpy.types import AddonPreferences
 from bpy.props import BoolProperty, FloatVectorProperty, EnumProperty, IntProperty, FloatProperty, StringProperty
 
-from sverchok.ui.utils import message_on_layout
+from sverchok.ui.utils import (
+        MENU_TYPE_DEFAULT, MENU_TYPE_SVERCHOK, MENU_TYPE_USER,
+        get_sverchok_menu_presets_directory, get_user_menu_presets_directory,
+        get_menu_preset_path,
+        datafiles,
+        message_on_layout
+    )
 
 """Don't import other Sverchok modules here"""
 
@@ -25,18 +31,6 @@ set_frame_change = None
 info, setLevel = [None] * 2
 draw_extra_addons = None
 apply_theme, rebuild_color_cache, color_callback = [None] * 3
-
-MENU_TYPE_DEFAULT = '__DEFAULT__'
-MENU_TYPE_SVERCHOK = '__SVERCHOK__'
-MENU_TYPE_USER = '__USER__'
-
-datafiles = join(bpy.utils.user_resource('DATAFILES', path='sverchok', create=True))
-
-def get_sverchok_menu_presets_directory():
-    return join(dirname(__file__), 'menus')
-
-def get_user_menu_presets_directory():
-    return join(datafiles, 'menus')
 
 def get_params(prop_names_and_fallbacks, direct=False):
     """
@@ -207,14 +201,7 @@ class SvOverwriteMenuFile(bpy.types.Operator):
 
     def execute(self, context):
         target_menu_file = join(datafiles, 'index.yaml')
-        preset_type, preset_name = self.preset_path.split(os.sep)
-        if preset_type == MENU_TYPE_DEFAULT:
-            directory = dirname(__file__)
-        elif preset_type == MENU_TYPE_SVERCHOK:
-            directory = get_sverchok_menu_presets_directory()
-        else: # MENU_TYPE_USER
-            directory = get_user_menu_presets_directory()
-        preset_path = join(directory, preset_name)
+        preset_path = get_menu_preset_path(self.preset_path)
         shutil.copy(preset_path, target_menu_file)
         self.report({'INFO'}, f"Menu preset {preset_path} saved as {target_menu_file}. Please restart Blender to see effect.")
         return {'FINISHED'}
@@ -460,18 +447,32 @@ class SverchokPreferences(AddonPreferences):
             items = get_menu_presets,
         )
 
+    menu_application_modes = [
+            ('ALWAYS', "Apply at each startup", "Menu preset will be automatically applied upon each Blender startup", 0),
+            ('MANUAL', "Apply manually", "Menu preset will be applied only explicitly, allowing you to maintain your own version of index.yaml in datafiles", 1)
+        ]
+
+    menu_preset_application : EnumProperty(
+            name = "Application mode",
+            description = "Menu preset application mode",
+            items = menu_application_modes,
+            default = 'ALWAYS'
+        )
 
     def general_tab(self, layout):
         col = layout.row().column()
         col_split = col.split(factor=0.5)
         col1 = col_split.column()
 
-        row = col1.row()
-        split = row.split(factor=0.85)
-        split_prop = split.column()
-        split_prop.prop(self, 'menu_preset')
-        split_op = split.column()
-        op = split_op.operator(SvOverwriteMenuFile.bl_idname, text="Set")
+        box = col1.box()
+        box.label(text = "Menu presets:")
+        menu_col = box.column()
+        menu_col.prop(self, 'menu_preset', text='Preset')
+        menu_split = menu_col.split(factor=0.8)
+        split_prop = menu_split.column()
+        split_prop.prop(self, 'menu_preset_application', text='')
+        op_split = menu_split.column()
+        op = op_split.operator(SvOverwriteMenuFile.bl_idname, text="Apply")
         op.preset_path = self.menu_preset
 
         col1.prop(self, "external_editor", text="Ext Editor")

--- a/ui/add_nodes_panel.py
+++ b/ui/add_nodes_panel.py
@@ -41,7 +41,7 @@ class AddNodeToolPanel(bpy.types.Panel):
             return
 
         categories = defaultdict(list)
-        for cat in sm.add_node_menu.walk_categories():
+        for cat in sm.get_add_node_menu().walk_categories():
             for add_node in cat:
                 if not isinstance(add_node, sm.AddNode):
                     continue
@@ -52,7 +52,7 @@ class AddNodeToolPanel(bpy.types.Panel):
 
     def select_category_update(self, context):
         cat_name = context.scene.sv_add_node_panel_settings.selected_category
-        for cat in sm.add_node_menu.walk_categories():
+        for cat in sm.get_add_node_menu().walk_categories():
             if cat.menu_cls.__name__ == cat_name:
                 items = [n for n in cat if isinstance(n, (sm.AddNode, sm.Separator))]
                 AddNodeToolPanel._items = items
@@ -121,7 +121,7 @@ class AddNodePanelSettings(bpy.types.PropertyGroup):
     def categories(self, context):
         # this should be a function because new categories can be added
         # by Sverchok's extensions after the registration
-        for i, category in enumerate(sm.add_node_menu.walk_categories()):
+        for i, category in enumerate(sm.get_add_node_menu().walk_categories()):
             if any(isinstance(add_node, sm.AddNode) for add_node in category):
                 identifier = category.menu_cls.__name__
                 yield identifier, category.name, category.name, i

--- a/ui/color_def.py
+++ b/ui/color_def.py
@@ -24,7 +24,7 @@ import sverchok.settings as settings
 from sverchok.utils.logging import debug
 import sverchok
 from sverchok.utils.handle_blender_data import BlTrees
-from sverchok.ui.nodeview_space_menu import add_node_menu
+from sverchok.ui.nodeview_space_menu import get_add_node_menu
 
 colors_cache = {}
 
@@ -100,7 +100,7 @@ def sv_colors_definition():
         sv_node_colors = default_theme
     sv_cats_node = {}
 
-    for cat in add_node_menu.walk_categories():
+    for cat in get_add_node_menu().walk_categories():
         for elem in cat:
             if not hasattr(elem, 'bl_idname'):
                 continue

--- a/ui/nodeview_space_menu.py
+++ b/ui/nodeview_space_menu.py
@@ -29,8 +29,11 @@ from bpy.props import StringProperty
 from sverchok.ui.sv_icons import node_icon, icon, get_icon_switch
 from sverchok.ui import presets
 from sverchok.ui.presets import apply_default_preset
+from sverchok.ui.utils import get_menu_preset_path
+from sverchok.utils.context_managers import sv_preferences
 from sverchok.utils import yaml_parser
 from sverchok.utils.modules_inspection import iter_classes_from_module
+from sverchok.utils.logging import info, debug
 
 
 """
@@ -466,13 +469,34 @@ class CategoryMenuTemplate(SverchokContext):
         for elem in self.draw_data:
             elem.draw(self.layout)
 
+add_node_menu = None
 
-datafiles = Path(bpy.utils.user_resource('DATAFILES', path='sverchok', create=True))
-menu_file = datafiles / 'index.yaml'
-if not menu_file.exists():
+def setup_add_menu():
+    global add_node_menu
+    datafiles = Path(bpy.utils.user_resource('DATAFILES', path='sverchok', create=True))
+    menu_file = datafiles / 'index.yaml'
+
+    need_apply_preset = False
     default_menu_file = Path(__file__).parents[1] / 'index.yaml'
-    shutil.copy(default_menu_file, menu_file)
-add_node_menu = Category.from_config(yaml_parser.load(menu_file), 'All Categories', icon_name='RNA')
+
+    if not menu_file.exists():
+        need_apply_preset = True
+    else:
+        with sv_preferences() as prefs:
+            if prefs.menu_preset_application == 'ALWAYS':
+                need_apply_preset = True
+                default_menu_file = get_menu_preset_path(prefs.menu_preset)
+
+    if need_apply_preset:
+        info(f"Applying menu preset {default_menu_file} at startup")
+        shutil.copy(default_menu_file, menu_file)
+    add_node_menu = Category.from_config(yaml_parser.load(menu_file), 'All Categories', icon_name='RNA')
+
+def get_add_node_menu():
+    global add_node_menu
+    if add_node_menu is None:
+        setup_add_menu()
+    return add_node_menu
 
 class AddNodeOp(bl_operators.node.NodeAddOperator):
     extra_description: StringProperty()
@@ -658,7 +682,7 @@ def register():
     for class_name in classes:
         bpy.utils.register_class(class_name)
     bpy.types.NODE_MT_add.append(sv_draw_menu)
-    add_node_menu.register()
+    get_add_node_menu().register()
 
 
 def unregister():

--- a/ui/nodeview_space_menu.py
+++ b/ui/nodeview_space_menu.py
@@ -474,22 +474,24 @@ add_node_menu = None
 def setup_add_menu():
     global add_node_menu
     datafiles = Path(bpy.utils.user_resource('DATAFILES', path='sverchok', create=True))
-    menu_file = datafiles / 'index.yaml'
 
-    need_apply_preset = False
     default_menu_file = Path(__file__).parents[1] / 'index.yaml'
 
-    if not menu_file.exists():
-        need_apply_preset = True
-    else:
-        with sv_preferences() as prefs:
-            if prefs.menu_preset_application == 'ALWAYS':
-                need_apply_preset = True
-                default_menu_file = get_menu_preset_path(prefs.menu_preset)
+    with sv_preferences() as prefs:
+        if prefs is None:
+            raise Exception("Internal error: Sverchok preferences are not initialized yet at the moment of loading the menu")
+        if prefs.menu_preset_usage == 'COPY':
+            default_menu_file = get_menu_preset_path(prefs.menu_preset)
+            menu_file = datafiles / 'index.yaml'
+            use_preset_copy = True
+        else:
+            menu_file = get_menu_preset_path(prefs.menu_preset)
+            use_preset_copy = False
 
-    if need_apply_preset:
+    if use_preset_copy and not menu_file.exists():
         info(f"Applying menu preset {default_menu_file} at startup")
         shutil.copy(default_menu_file, menu_file)
+    debug(f"Using menu preset file: {menu_file}")
     add_node_menu = Category.from_config(yaml_parser.load(menu_file), 'All Categories', icon_name='RNA')
 
 def get_add_node_menu():

--- a/ui/sv_extra_search.py
+++ b/ui/sv_extra_search.py
@@ -27,7 +27,7 @@ import sverchok
 from sverchok.utils.logging import error
 from sverchok.utils.docstring import SvDocstring
 from sverchok.utils.sv_default_macros import macros, DefaultMacros
-from sverchok.ui.nodeview_space_menu import add_node_menu
+from sverchok.ui.nodeview_space_menu import get_add_node_menu
 
 
 addon_name = sverchok.__name__
@@ -101,7 +101,7 @@ def gather_items(context):
     fx = []
     idx = 0
 
-    for cat in add_node_menu.walk_categories():
+    for cat in get_add_node_menu().walk_categories():
         for item in cat:
             if not hasattr(item, 'bl_idname'):
                 continue

--- a/ui/sv_panel_display_nodes.py
+++ b/ui/sv_panel_display_nodes.py
@@ -24,7 +24,7 @@ from sverchok.settings import get_dpi_factor
 from sverchok.utils.logging import debug
 from collections import namedtuple
 
-from sverchok.ui.nodeview_space_menu import add_node_menu
+from sverchok.ui.nodeview_space_menu import get_add_node_menu
 
 _node_category_cache = {}  # cache for the node categories
 _spawned_nodes = {}  # cache for the spawned nodes
@@ -115,14 +115,14 @@ def cache_node_categories():
     if _node_category_cache:
         return
 
-    categories = [c.name for c in add_node_menu.walk_categories()]
+    categories = [c.name for c in get_add_node_menu().walk_categories()]
 
     _node_category_cache["categories"] = {}
     _node_category_cache["categories"]["names"] = list(categories)
     _node_category_cache["categories"]["names"].append("All")
     _node_category_cache["categories"]["All"] = {}
     _node_category_cache["categories"]["All"]["nodes"] = []
-    for cat in add_node_menu.walk_categories():
+    for cat in get_add_node_menu().walk_categories():
         nodes = [n.bl_idname for n in cat if hasattr(n, 'bl_idname')]
         nodes = list(filter(lambda node: should_display_node(node), nodes))
         _node_category_cache["categories"][cat.name] = {}
@@ -251,7 +251,10 @@ class SvDisplayNodePanelProperties(bpy.types.PropertyGroup):
     def category_items(self, context):
         ''' Get the items to display in the category enum property '''
         cache_node_categories()
-        return _node_category_cache["categories"]["items"]
+        if _node_category_cache:
+            return _node_category_cache["categories"]["items"]
+        else:
+            return []
 
     def arrange_nodes(self, context):
         ''' Arrange the nodes in current category (using bin-packing) '''

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -16,7 +16,12 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
+import os
+from os.path import dirname, basename, join
+from pathlib import Path
 import textwrap
+
+import bpy
 
 def message_on_layout(layout, text, width=140, **kwargs):
     box = layout.box()
@@ -29,3 +34,27 @@ def enum_split(layout, node, prop_name, label, factor):
     enum_row = layout.split(factor=factor, align=False)
     enum_row.label(text=label)
     enum_row.prop(node, prop_name, text="")
+
+MENU_TYPE_DEFAULT = '__DEFAULT__'
+MENU_TYPE_SVERCHOK = '__SVERCHOK__'
+MENU_TYPE_USER = '__USER__'
+
+datafiles = join(bpy.utils.user_resource('DATAFILES', path='sverchok', create=True))
+
+def get_sverchok_menu_presets_directory():
+    return Path(__file__).parents[1] / 'menus'
+
+def get_user_menu_presets_directory():
+    return join(datafiles, 'menus')
+
+def get_menu_preset_path(preset_path):
+    preset_type, preset_name = preset_path.split(os.sep)
+    if preset_type == MENU_TYPE_DEFAULT:
+        directory = Path(__file__).parents[1]
+    elif preset_type == MENU_TYPE_SVERCHOK:
+        directory = get_sverchok_menu_presets_directory()
+    else: # MENU_TYPE_USER
+        directory = get_user_menu_presets_directory()
+    preset_path = join(directory, preset_name)
+    return preset_path
+


### PR DESCRIPTION
## Addressed problem description

This is a continuation of #4841.

When we add a node, or just rearrange menu presets for some reason, user's index.yaml in datafiles directory still has to be updated. Before current PR, user had to press "Set" in preferences manually after each sverchok update. This is not obvious at all.

## Options which were considered

1. Original solution: copy the preset from sverchok directory to user's datafiles directory only at first sverchok startup, when there is no file in datafiles. - :x: Rejected: the file will not be updated when we add a new node in Sverchok, or rearrange the default menu.
2. Add a possibility to apply the selected menu preset automatically, at each blender startup. If enabled, at startup, copy the selected preset file from sverchok directory to user's datafiles. — :x: Rejected: there is no sense in having `index.yaml` in user's datafiles, if that file is never actually used, as it is overwritten at each blender startup.
3. ...If enabled, overwrite user's `index.yaml` only when the file in sverchok directory is newer than the one in datafiles. :x: Rejected: not obvious for user, when his changes are overwritten, and there is no clear enough way to notify the user of such actions (message in the log will be most probably ignored).
  * Sub-option: preserve previous version of user's `index.yaml` as `index.yaml.bak`. :x: Rejected: there is no clear or obvious way for user to merge his version of menu with the one from sverchok preset. And again, no clear way for user to know when his changes were overwritten.
4. Options 1 - 3 were designed having in mind the problem that we can not refer to preferences at the moment when we are loading the menu. But, if we need an option to enable or disable menu file overwriting, then we will have to solve that problem somehow. But, once it is solved, we can look into preferences and use menu preset file name from there. So: If the option is enabled, then do not copy anything, just use menu preset file from sverchok directory. If it is disabled, then we copy the preset file once at first Sverchok startup, and when the user explicitly presses the button. This means that if the option is disabled, the user takes responsibility of updating his `index.yaml`. :heavy_check_mark: 

## Solution description

Add a possibility to use the menu preset file from sverchok directory directly, ignoring the file in user's datafiles.

If the feature is not enabled, it means the user takes the responsibility on updating his index.yaml manually.

![Screenshot_20230104_115648](https://user-images.githubusercontent.com/284644/210500488-f67da1e8-4a49-45d7-ac39-22abe048a90b.png)


Technically, for this to work, I had to implement "lazy" initialization of "add node" menu, because in previous state, when I tried to call to preferences at the place where we located `index.yaml`, it appeared that preferences were not registered yet.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [ ] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

