### PR TITLE
fix curves->curve lerp. Node does not interpolate with two-dots bezier curves.

### DIFF
--- a/utils/curve/bezier.py
+++ b/utils/curve/bezier.py
@@ -633,11 +633,11 @@ class SvCubicBezierCurve(SvCurve, SvBezierSplitMixin):
 
     def lerp_to(self, curve2, coefficient):
         if isinstance(curve2, SvCubicBezierCurve):
+            p0 = (1.0 - coefficient) * self.p0 + coefficient * curve2.p0
             p1 = (1.0 - coefficient) * self.p1 + coefficient * curve2.p1
             p2 = (1.0 - coefficient) * self.p2 + coefficient * curve2.p2
             p3 = (1.0 - coefficient) * self.p3 + coefficient * curve2.p3
-            p4 = (1.0 - coefficient) * self.p4 + coefficient * curve2.p4
-            return SvCubicBezierCurve(p1, p2, p3, p4)
+            return SvCubicBezierCurve(p0, p1, p2, p3)
         return self.to_nurbs().lerp_to(curve2, coefficient)
 
     def is_line(self, tolerance=0.001):


### PR DESCRIPTION
Windows 11, Blender 3.4.1, Sverchok-master.

![image](https://user-images.githubusercontent.com/14288520/211165062-c4456ced-23cf-42f1-b247-0f62c4b0e40d.png)

After fix:

![image](https://user-images.githubusercontent.com/14288520/211164957-4e9e5467-5794-4999-bcf5-d1aee136c4fc.png)

![image](https://user-images.githubusercontent.com/14288520/211165003-63d9aabb-9dba-4b60-85c6-a395c8bece10.png)

