### PR TITLE
"Curve mapper": respect "use clipping" option.

### DIFF
--- a/docs/nodes/number/curve_mapper.rst
+++ b/docs/nodes/number/curve_mapper.rst
@@ -75,3 +75,14 @@ Example of the Curve output usage:
 * Surface-> :doc:`Revolution Surface </nodes/surface/revolution_surface>`
 * Surface-> :doc:`Evaluate Surface </nodes/surface/evaluate_surface>`
 * Viz-> :doc:`Viewer Draw </nodes/viz/viewer_draw_mk4>`
+
+An example of what the node can do if you disable the "use clipping" option:
+
+.. image:: https://user-images.githubusercontent.com/284644/211205670-277fcbd4-c0fb-4645-a058-c78716156bd5.png
+  :target: https://user-images.githubusercontent.com/284644/211205670-277fcbd4-c0fb-4645-a058-c78716156bd5.png
+
+The same curve with enabled clipping:
+
+.. image:: https://user-images.githubusercontent.com/284644/211205669-998e582e-18f9-4141-bed8-4182f5356d94.png
+  :target: https://user-images.githubusercontent.com/284644/211205669-998e582e-18f9-4141-bed8-4182f5356d94.png
+

--- a/docs/nodes/number/curve_mapper.rst
+++ b/docs/nodes/number/curve_mapper.rst
@@ -9,6 +9,14 @@ Functionality
 
 This node map all the incoming values using the curve you define manually through the interface.
 
+Note: the curve defined by the widget may give results in any range, from minus
+infinity to plus infinity. However, by default, the "use clipping" checkbox in
+curve widget's settings is enabled; the node respects that checkbox. It means,
+that if, for example, **Min Y** and **Max Y** parameters in the curve editor
+widget are set to 0.0 and 1.0, then, even if the curve goes beyond that range,
+the node results will be always within 0.0 - 1.0 range. If you do not need such
+clipping, you can disable it in curve widget settings.
+
 Disclaimer
 ----------
 

--- a/docs/old/nodes/dimensions_svg.rst
+++ b/docs/old/nodes/dimensions_svg.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Dimensions SVG
 ==============
 

--- a/utils/sv_manual_curves_utils.py
+++ b/utils/sv_manual_curves_utils.py
@@ -88,7 +88,14 @@ def get_valid_evaluate_function(group_name, node_name):
     try:  node.mapping.evaluate(curve, 0.0)
     except: node.mapping.initialize()
 
-    evaluate = lambda val: node.mapping.evaluate(curve, val)
+    def evaluate(val):
+        res = node.mapping.evaluate(curve, val)
+        if node.mapping.use_clip:
+            if res < node.mapping.clip_min_y:
+                res = node.mapping.clip_min_y
+            if res > node.mapping.clip_max_y:
+                res = node.mapping.clip_max_y
+        return res
     return evaluate
 
 def get_rgb_curve(group_name, node_name):


### PR DESCRIPTION
Earlier we used
https://docs.blender.org/api/current/bpy.types.CurveMapping.html#bpy.types.CurveMapping.evaluate method to calculate the resulting value of mapper, in hope that it respects clipping settings automatically. However, it appears to do not. As a result, if the curve goes, for example, beyond [0;1] by Y, the result of the curve mapper could go negative even though "use clipping" option in the curve widget is enabled.

This change adds explicit clipping to evaluate function. If someone happened to adapt previous behaviour, they can just untick the "use clipping" checkbox in the curve widget settings.

Clipping enabled:
![Screenshot_20230108_204211](https://user-images.githubusercontent.com/284644/211205669-998e582e-18f9-4141-bed8-4182f5356d94.png)

the same curve with disabled clipping:
![Screenshot_20230108_204144](https://user-images.githubusercontent.com/284644/211205670-277fcbd4-c0fb-4645-a058-c78716156bd5.png)



## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

