### PR TITLE
- fix minimize_scalar for "brent" and "Golden section" for "Nearest Point on Curve"

### DIFF
--- a/docs/nodes/curve/nearest_point.rst
+++ b/docs/nodes/curve/nearest_point.rst
@@ -53,11 +53,19 @@ This node has the following parameters:
   initial guess, so the precise algorithm will be faster; but that can require
   more evaluations at the first stage. The default value is 50. In many cases,
   you do not have to change this value.
+
+  .. image:: https://user-images.githubusercontent.com/14288520/212115819-a1b732f4-b294-45e6-a360-24718dce1518.png
+    :target: https://user-images.githubusercontent.com/14288520/212115819-a1b732f4-b294-45e6-a360-24718dce1518.png
+
 * **Precise**. If not checked, then the precise calculation step will not be
   executed, and the node will just output the nearest point out of points
   generated at the first step - so it will be "roughly nearest point". So, if
   this parameter is not checked, higher values of **Init resolution** parameter
   will lead to more precise output. Checked by default.
+
+  .. image:: https://user-images.githubusercontent.com/14288520/212117620-5ab3eb5f-bfb2-4cbb-95e3-a77d29a60c72.gif
+    :target: https://user-images.githubusercontent.com/14288520/212117620-5ab3eb5f-bfb2-4cbb-95e3-a77d29a60c72.gif
+
 * **Method**. This parameter is available in the N panel only. This defines the
   algorithm to be used. In simple cases, all algorithms will give the same
   result; in more complex cases, you will have to try all and select the one
@@ -70,6 +78,9 @@ This node has the following parameters:
    * Golden. Uses the golden section search technique. It uses analog of the
      bisection method to decrease the bracketed interval. It is usually
      preferable to use the Brent method.
+
+.. image:: https://user-images.githubusercontent.com/14288520/212128791-d00c63bd-be86-4dc0-979e-0eb51361862b.png
+  :target: https://user-images.githubusercontent.com/14288520/212128791-d00c63bd-be86-4dc0-979e-0eb51361862b.png
 
 Outputs
 -------

--- a/utils/manifolds.py
+++ b/utils/manifolds.py
@@ -166,11 +166,19 @@ def nearest_point_on_curve(src_points, curve, samples=10, precise=True, method='
                 
                 logger.debug("T_min %s, T_max %s, init_t %s", t_min, t_max, raw_t)
 
-                result = minimize_scalar(goal,
-                            bounds = bounds,
-                            bracket = bracket,
-                            method = method
-                        )
+                if method == 'Brent' or method == 'Golden':
+                    bracket = (interval[0], interval[1])
+                    result = minimize_scalar(goal,
+                                #bounds = bounds, - Use of `bounds` is incompatible with 'method=Brent'.
+                                bracket = bracket,
+                                method = method
+                            )
+                else:
+                    result = minimize_scalar(goal,
+                                bounds = bounds,
+                                bracket = bracket,
+                                method = method
+                            )
 
                 if not result.success:
                     if hasattr(result, 'message'):


### PR DESCRIPTION
Windows 11, Blender 3.4.1, Sverchok-master.

if select Bent or "Golder section" got message "Use of `bounds` is incompatible with 'method=Brent/Golden section'."

Fixed