### PR TITLE
"Approximate NURBS Curve" node FreeCAD implementation

### DIFF
--- a/docs/nodes/curve/approximate_nurbs_curve.rst
+++ b/docs/nodes/curve/approximate_nurbs_curve.rst
@@ -39,25 +39,25 @@ Every single implementation offers different ways of control:
   One can specify the interval of desired degree of the built curve. The final degree 
   cannot be specified but is a result of all the constraints applyed. 
   
-  A global precision of the approximation can be specified as a Tolerance value.
-  Lower values means that the approximation curve will pass closely to the input Vertices.
+  A global precision of the approximation can be specified as a Tolerance value. 
+  Lower values means that the approximation curve will pass closely to the input Vertices. 
   
   The "Parameterization" approximation method allows lots of inner continuity options 
-  and offers three metrics ('Uniform','Centripetal' or 'ChordLength') for the parametrization.
+  and offers three metrics ('Uniform','Centripetal' or 'ChordLength') for the parametrization. 
   
   The "Variational Smoothing" method uses three additional parameters - "Length Weight", 
   "Curvature Weight" and "Torsion Weight". If one of these arguments is not null, 
   the functions approximates the points using variational smoothing algorithm, 
-  which tries to minimize additional criterium:
+  which tries to minimize additional criterium: 
   
-  LengthWeight*CurveLength + CurvatureWeight*Curvature + TorsionWeight*Torsion
+  LengthWeight*CurveLength + CurvatureWeight*Curvature + TorsionWeight*Torsion 
   
   where Continuity must be C0, C1(with "Maximal Degree" >= 3) or 
-  C2(with "Maximal Degree" >= 5).
+  C2(with "Maximal Degree" >= 5). 
   
   The Continuity parameter defines how smooth will be the curve internally. 
-  The values it can take depend on the approximation method used. It defaults to C2.
-  However, it may not be applied if it conflicts with other parameters ( especially Maximal Degree ).
+  The values it can take depend on the approximation method used. It defaults to C2. 
+  However, it may not be applied if it conflicts with other parameters ( especially Maximal Degree ). 
 
 .. _NURBS: https://en.wikipedia.org/wiki/Non-uniform_rational_B-spline
 

--- a/docs/nodes/curve/approximate_nurbs_curve.rst
+++ b/docs/nodes/curve/approximate_nurbs_curve.rst
@@ -35,29 +35,33 @@ Every single implementation offers different ways of control:
   Additionally, when smoothing factor is not zero, you can provide different
   weights for different points.
 * FreeCAD_ implementation supports two main methods and a wide variety of options.
-  
-  One can specify the interval of desired degree of the built curve. The final degree 
-  cannot be specified but is a result of all the constraints applyed. 
-  
-  A global precision of the approximation can be specified as a Tolerance value. 
-  Lower values means that the approximation curve will pass closely to the input Vertices. 
-  
-  The "Parameterization" approximation method allows lots of inner continuity options 
-  and offers three metrics ('Uniform','Centripetal' or 'ChordLength') for the parametrization. 
-  
-  The "Variational Smoothing" method uses three additional parameters - "Length Weight", 
-  "Curvature Weight" and "Torsion Weight". If one of these arguments is not null, 
-  the functions approximates the points using variational smoothing algorithm, 
-  which tries to minimize additional criterium: 
-  
-  LengthWeight*CurveLength + CurvatureWeight*Curvature + TorsionWeight*Torsion 
-  
-  where Continuity must be C0, C1(with "Maximal Degree" >= 3) or 
-  C2(with "Maximal Degree" >= 5). 
-  
-  The Continuity parameter defines how smooth will be the curve internally. 
-  The values it can take depend on the approximation method used. It defaults to C2. 
-  However, it may not be applied if it conflicts with other parameters ( especially Maximal Degree ). 
+
+
+  One can specify the interval of desired degree of the built curve. The final degree
+  cannot be specified but is a result of all the constraints applyed.
+
+
+  A global precision of the approximation can be specified as a Tolerance value.
+  Lower values means that the approximation curve will pass closely to the input Vertices.
+
+
+  The "Parameterization" approximation method allows lots of inner continuity options
+  and offers three metrics ('Uniform','Centripetal' or 'ChordLength') for the parametrization.
+
+
+  The "Variational Smoothing" method uses three additional parameters - "Length Weight",
+  "Curvature Weight" and "Torsion Weight". If one of these arguments is not null,
+  the functions approximates the points using variational smoothing algorithm,
+  which tries to minimize additional criterium:
+  **LengthWeight*CurveLength + CurvatureWeight*Curvature + TorsionWeight*Torsion**
+  where Continuity must be C0, C1(with "Maximal Degree" >= 3) or
+  C2(with "Maximal Degree" >= 5).
+
+
+  The Continuity parameter defines how smooth will be the curve internally.
+  The values it can take depend on the approximation method used. It defaults to C2.
+  However, it may not be applied if it conflicts with other parameters ( especially Maximal Degree ).
+
 
 .. _NURBS: https://en.wikipedia.org/wiki/Non-uniform_rational_B-spline
 

--- a/docs/nodes/curve/approximate_nurbs_curve.rst
+++ b/docs/nodes/curve/approximate_nurbs_curve.rst
@@ -169,6 +169,7 @@ This node has the following parameters:
 
   * **Parametrization**.
   * **Variational smoothing**.
+  * **Explicit Knots**.
 
 * **Continuity**. Available only for the FreeCAD_ implementation. Desired internal smoothness of the result curve. The available values are:
 

--- a/docs/nodes/curve/approximate_nurbs_curve.rst
+++ b/docs/nodes/curve/approximate_nurbs_curve.rst
@@ -35,29 +35,31 @@ Every single implementation offers different ways of control:
   Additionally, when smoothing factor is not zero, you can provide different
   weights for different points.
 * FreeCAD_ implementation supports three approximation methods and a wide variety of options:
-   
-   An exact curve degree cannot be specified. An interval ( Minimal Degree, Maximal Degree ) is used instead.
-   The final curve degree is a result of all the constraints applyed and will be in the specified inverval.
-   
-   A global precision of the approximation can be specified as a **Tolerance** value.
-   Lower values mean that the approximation curve will pass closely to the input Vertices.
-   
-   The **"Parameterization"** approximation method allows lots of inner continuity options   
-   and offers three metrics ( **'Uniform' , 'Centripetal' or 'ChordLength'** ) for the parametrization.
-   
-   The **"Variational Smoothing"** method uses three additional parameters - "Length Weight",
-   "Curvature Weight" and "Torsion Weight". The functions approximates the points using variational
-   smoothing algorithm, which tries to minimize additional criterium:
-   **LengthWeight*CurveLength + CurvatureWeight*Curvature + TorsionWeight*Torsion**
-   where Continuity must be **C0, C1** ( with "Maximal Degree" >= 3 ) or
-   **C2** ( with "Maximal Degree" >= 5 ).
-   
-   With the **"Explicit Knots"** method a custom knot sequence can be specified. The knot sequence can be
-   also provided with the use of the `Generate Knotvector <https://nortikin.github.io/sverchok/docs/nodes/curve/generate_knotvector.html>`_ node based on the metrics from it.
-   
-   The **"Continuity"** parameter defines how smooth will be the curve internally.
-   The values it can take depend on the approximation method used. It defaults to C2.
-   However, it may not be applied if it conflicts with other parameters ( especially "Maximal Degree" ).
+
+  An exact curve degree cannot be specified. An interval ( Minimal Degree, Maximal Degree ) is used instead.
+  The final curve degree is a result of all the constraints applyed and will be in the specified inverval.
+  
+  A global precision of the approximation can be specified as a **Tolerance** value.
+  Lower values mean that the approximation curve will pass closely to the input Vertices.
+  
+  The **"Parameterization"** approximation method allows lots of inner continuity options   
+  and offers three metrics ( **'Uniform' , 'Centripetal' or 'ChordLength'** ) for the parametrization.
+  
+  The **"Variational Smoothing"** method uses three additional parameters - "Length Weight",
+  "Curvature Weight" and "Torsion Weight". The functions approximates the points using variational
+  smoothing algorithm, which tries to minimize additional criterium:
+  
+  **LengthWeight*CurveLength + CurvatureWeight*Curvature + TorsionWeight*Torsion**
+  
+  where Continuity must be **C0, C1** ( with "Maximal Degree" >= 3 ) or
+  **C2** ( with "Maximal Degree" >= 5 ).
+  
+  With the **"Explicit Knots"** method a custom knot sequence can be specified. The knot sequence can be
+  also provided with the use of the `Generate Knotvector <https://nortikin.github.io/sverchok/docs/nodes/curve/generate_knotvector.html>`_ node based on the metrics from it.
+  
+  The **"Continuity"** parameter defines how smooth will be the curve internally.
+  The values it can take depend on the approximation method used. It defaults to C2.
+  However, it may not be applied if it conflicts with other parameters ( especially "Maximal Degree" ).
 
 
 .. _NURBS: https://en.wikipedia.org/wiki/Non-uniform_rational_B-spline
@@ -150,14 +152,14 @@ This node has the following parameters:
   parameter is set to **SciPy**.Metric to be used for interpolation. The
   available values are:
 
-   * Manhattan
-   * Euclidean
-   * Points (just number of points from the beginning)
-   * Chebyshev
-   * Centripetal (square root of Euclidean distance)
-   * X, Y, Z axis - use distance along one of coordinate axis, ignore others.
+  * **Manhattan**
+  * **Euclidean**
+  * **Points** (just number of points from the beginning)
+  * **Chebyshev**
+  * **Centripetal** (square root of Euclidean distance)
+  * **X, Y, Z axis** - use distance along one of coordinate axis, ignore others.
 
-   The default value is Euclidean.
+  The default value is Euclidean.
 
 * **Specify smoothing**. This parameter is available only when
   **Implementation** parameter is set to **SciPy**. If checked, the node will

--- a/docs/nodes/curve/approximate_nurbs_curve.rst
+++ b/docs/nodes/curve/approximate_nurbs_curve.rst
@@ -34,31 +34,34 @@ Every single implementation offers different ways of control:
   selection of metrics. This implementation can make cyclic (closed) curves.
   Additionally, when smoothing factor is not zero, you can provide different
   weights for different points.
-* FreeCAD_ implementation supports two main methods and a wide variety of options:
+* FreeCAD_ implementation supports three approximation methods and a wide variety of options:
    
-   One can specify the interval of desired degree of the built curve. The final degree
-   cannot be specified but is a result of all the constraints applyed.
+   An exact curve degree cannot be specified. An interval ( Minimal Degree, Maximal Degree ) is used instead.
+   The final curve degree is a result of all the constraints applyed and will be in the specified inverval.
    
-   A global precision of the approximation can be specified as a Tolerance value.
-   Lower values means that the approximation curve will pass closely to the input Vertices.
+   A global precision of the approximation can be specified as a **Tolerance** value.
+   Lower values mean that the approximation curve will pass closely to the input Vertices.
    
-   The "Parameterization" approximation method allows lots of inner continuity options   
-   and offers three metrics ('Uniform','Centripetal' or 'ChordLength') for the parametrization.
+   The **"Parameterization"** approximation method allows lots of inner continuity options   
+   and offers three metrics ( **'Uniform' , 'Centripetal' or 'ChordLength'** ) for the parametrization.
    
-   The "Variational Smoothing" method uses three additional parameters - "Length Weight",
-   "Curvature Weight" and "Torsion Weight". If one of these arguments is not null,
-   the functions approximates the points using variational smoothing algorithm,
-   which tries to minimize additional criterium:
+   The **"Variational Smoothing"** method uses three additional parameters - "Length Weight",
+   "Curvature Weight" and "Torsion Weight". The functions approximates the points using variational
+   smoothing algorithm, which tries to minimize additional criterium:
    **LengthWeight*CurveLength + CurvatureWeight*Curvature + TorsionWeight*Torsion**
-   where Continuity must be C0, C1(with "Maximal Degree" >= 3) or
-   C2(with "Maximal Degree" >= 5).
+   where Continuity must be **C0, C1** ( with "Maximal Degree" >= 3 ) or
+   **C2** ( with "Maximal Degree" >= 5 ).
    
-   The Continuity parameter defines how smooth will be the curve internally.
+   With the **"Explicit Knots"** method a custom knot sequence can be specified. The knot sequence can be
+   also provided with the use of the `Generate Knotvector <https://nortikin.github.io/sverchok/docs/nodes/curve/generate_knotvector.html>`_ node based on the metrics from it.
+   
+   The **"Continuity"** parameter defines how smooth will be the curve internally.
    The values it can take depend on the approximation method used. It defaults to C2.
-   However, it may not be applied if it conflicts with other parameters ( especially Maximal Degree ).
+   However, it may not be applied if it conflicts with other parameters ( especially "Maximal Degree" ).
 
 
 .. _NURBS: https://en.wikipedia.org/wiki/Non-uniform_rational_B-spline
+.. _"Generate Knotvector": https://nortikin.github.io/sverchok/docs/nodes/curve/generate_knotvector.html
 
 Inputs
 ------
@@ -87,6 +90,9 @@ This node has the following inputs:
 
 FreeCAD implementation specific inputs:
 
+* **Knots**. The knot sequence. Available only if the "Explicit Knots" method is used.
+  Must contain unique floats in an ascending order. When not connected, the curve will be
+  calculated using Euclidean metric.
 * **Minimal Degree**. Minimal possible degree of the curve to be built. 
   Default value is 3.
 * **Maximal Degree**. Maximal possible degree of the curve to be built. 
@@ -166,13 +172,13 @@ This node has the following parameters:
 
 * **Continuity**. Available only for the FreeCAD_ implementation. Desired internal smoothness of the result curve. The available values are:
 
-  * **C0**. Only positional continuity.
-  * **G1**. Geometric tangent continuity. Available only for the "Parametrization" method.
-  * **C1**. Continuity of the first derivative all along the Curve.
-  * **G2**. Geometric curvature continuity. Available only for the "Parametrization" method.
-  * **C2**. Continuity of the second derivative all along the Curve
-  * **C3**. Continuity of the third derivative all along the Curve. Available only for the "Parametrization" method.
-  * **CN**. Infinite order of continuity. Available only for Parametrization method.
+  * **C0** : Only positional continuity.
+  * **G1** : Geometric tangent continuity. Available only for the "Parametrization" method.
+  * **C1** : Continuity of the first derivative all along the Curve.
+  * **G2** : Geometric curvature continuity. Available only for the "Parametrization" method.
+  * **C2** : Continuity of the second derivative all along the Curve
+  * **C3** : Continuity of the third derivative all along the Curve. Available only for the "Parametrization" method.
+  * **CN** : Infinite order of continuity. Available only for Parametrization method.
   
 * **Type**. The way how the parametrization is calculated. Available only for the FreeCAD_ implementation and when the "Parametrization" method is used. The available values are:
 
@@ -206,4 +212,8 @@ Use SciPy implementation to make a closed curve:
 Example of the FreeCAD implementation usage. Chord Length Parametrization:
 
 .. image:: https://user-images.githubusercontent.com/66558924/214577636-6d91c682-1225-45cd-85ba-350fa110755f.jpg
+
+Example of the FreeCAD implementation using the Explicit Knots method and utilizing the "Generate Knotvector" node:
+
+.. image:: https://user-images.githubusercontent.com/66558924/214834736-5aecc4e0-902b-4c76-9135-9d9dbbac6d1c.jpg
 

--- a/docs/nodes/curve/approximate_nurbs_curve.rst
+++ b/docs/nodes/curve/approximate_nurbs_curve.rst
@@ -34,23 +34,28 @@ Every single implementation offers different ways of control:
   selection of metrics. This implementation can make cyclic (closed) curves.
   Additionally, when smoothing factor is not zero, you can provide different
   weights for different points.
-* FreeCAD_ implementation supports two main methods and a wide variety of options.
-  One can specify the interval of desired degree of the built curve. The final degree
-  cannot be specified but is a result of all the constraints applyed.
-  A global precision of the approximation can be specified as a Tolerance value.
-  Lower values means that the approximation curve will pass closely to the input Vertices.
-  The "Parameterization" approximation method allows lots of inner continuity options
-  and offers three metrics ('Uniform','Centripetal' or 'ChordLength') for the parametrization.
-  The "Variational Smoothing" method uses three additional parameters - "Length Weight",
-  "Curvature Weight" and "Torsion Weight". If one of these arguments is not null,
-  the functions approximates the points using variational smoothing algorithm,
-  which tries to minimize additional criterium:
-  **LengthWeight*CurveLength + CurvatureWeight*Curvature + TorsionWeight*Torsion**
-  where Continuity must be C0, C1(with "Maximal Degree" >= 3) or
-  C2(with "Maximal Degree" >= 5).
-  The Continuity parameter defines how smooth will be the curve internally.
-  The values it can take depend on the approximation method used. It defaults to C2.
-  However, it may not be applied if it conflicts with other parameters ( especially Maximal Degree ).
+* FreeCAD_ implementation supports two main methods and a wide variety of options:
+   
+   One can specify the interval of desired degree of the built curve. The final degree
+   cannot be specified but is a result of all the constraints applyed.
+   
+   A global precision of the approximation can be specified as a Tolerance value.
+   Lower values means that the approximation curve will pass closely to the input Vertices.
+   
+   The "Parameterization" approximation method allows lots of inner continuity options   
+   and offers three metrics ('Uniform','Centripetal' or 'ChordLength') for the parametrization.
+   
+   The "Variational Smoothing" method uses three additional parameters - "Length Weight",
+   "Curvature Weight" and "Torsion Weight". If one of these arguments is not null,
+   the functions approximates the points using variational smoothing algorithm,
+   which tries to minimize additional criterium:
+   **LengthWeight*CurveLength + CurvatureWeight*Curvature + TorsionWeight*Torsion**
+   where Continuity must be C0, C1(with "Maximal Degree" >= 3) or
+   C2(with "Maximal Degree" >= 5).
+   
+   The Continuity parameter defines how smooth will be the curve internally.
+   The values it can take depend on the approximation method used. It defaults to C2.
+   However, it may not be applied if it conflicts with other parameters ( especially Maximal Degree ).
 
 
 .. _NURBS: https://en.wikipedia.org/wiki/Non-uniform_rational_B-spline

--- a/docs/nodes/curve/approximate_nurbs_curve.rst
+++ b/docs/nodes/curve/approximate_nurbs_curve.rst
@@ -41,7 +41,7 @@ Every single implementation offers different ways of control:
   
   A global precision of the approximation can be specified as a Tolerance value.
   Lower values means that the approximation curve will pass closely to the input Vertices.
-
+  
   The "Parameterization" approximation method allows lots of inner continuity options 
   and offers three metrics ('Uniform','Centripetal' or 'ChordLength') for the parametrization.
   

--- a/docs/nodes/curve/approximate_nurbs_curve.rst
+++ b/docs/nodes/curve/approximate_nurbs_curve.rst
@@ -4,10 +4,11 @@ Approximate NURBS Curve
 Dependencies
 ------------
 
-This node requires either Geomdl_ or SciPy_ library to work.
+This node requires either Geomdl_, SciPy_ and FreeCAD_ library to work.
 
 .. _Geomdl: https://onurraufbingol.com/NURBS-Python/
 .. _SciPy: https://scipy.org/
+.. _FreeCAD: https://www.freecad.org/
 
 Functionality
 -------------
@@ -18,8 +19,8 @@ points, i.e. goes as close to them as possible while remaining a smooth curve.
 In fact, the generated curve always will be a non-rational curve, which means
 that all weights will be equal to 1.
 
-This node supports two implementations of curve approximation algorithm.
-Different implementation give you different ways of controlling them:
+This node supports three different implementations for curve approximation.
+Every single implementation offers different ways of control:
 
 * Geomdl_ implementation can either define the number of control points of
   generated curve automatically, or you can provide it with desired number of
@@ -33,6 +34,30 @@ Different implementation give you different ways of controlling them:
   selection of metrics. This implementation can make cyclic (closed) curves.
   Additionally, when smoothing factor is not zero, you can provide different
   weights for different points.
+* FreeCAD_ implementation supports two main methods and a wide variety of options.
+
+  One can specify the interval of desired degree of the built curve. The final degree 
+  cannot be specified but is a result of all the constraints applyed. 
+  
+  A global precision of the approximation can be specified as a Tolerance value.
+  Lower values means that the approximation curve will pass closely to the input Vertices.
+
+  The "Parameterization" approximation method allows lots of inner continuity options 
+  and offers three metrics ('Uniform','Centripetal' or 'ChordLength') for the parametrization.
+  
+  The "Variational Smoothing" method uses three additional parameters - "Length Weight", 
+  "Curvature Weight" and "Torsion Weight". If one of these arguments is not null, 
+  the functions approximates the points using variational smoothing algorithm, 
+  which tries to minimize additional criterium:
+  
+  LengthWeight*CurveLength + CurvatureWeight*Curvature + TorsionWeight*Torsion
+  
+  where Continuity must be C0, C1(with "Maximal Degree" >= 3) or 
+  C2(with "Maximal Degree" >= 5).
+  
+  The Continuity parameter defines how smooth will be the curve internally. 
+  The values it can take depend on the approximation method used. It defaults to C2.
+  However, it may not be applied if it conflicts with other parameters ( especially Maximal Degree ).
 
 .. _NURBS: https://en.wikipedia.org/wiki/Non-uniform_rational_B-spline
 
@@ -48,10 +73,10 @@ This node has the following inputs:
   smaller distance. This does not have sense if **Smoothing** input is set to
   zero. Optional input. If not connected, the node will consider weights of all
   points as equal.
-* **Degree**. Degree of the curve to be built. Default value is 3. Most useful
-  values are 3, 5 and 7. If Scipy implementation is used, then maximum
-  supported degree is 5. For Geomdl, there is no hard limit, but curves of very
-  high degree can be hard to manipulate with.
+* **Degree**. Available for **Geomdl** and **SciPy** only. Degree of the curve to be built. 
+  Default value is 3. Most useful values are 3, 5 and 7. 
+  If Scipy implementation is used, then maximum supported degree is 5. 
+  For Geomdl, there is no hard limit, but curves of very high degree can be hard to manipulate with.
 * **PointsCnt**. Number of curve's control points. This input is available only
   when **Implementation** parameter is set to **Geomdl**, and **Specify points
   count** parameter is checked. Default value is 5.
@@ -60,6 +85,23 @@ This node has the following inputs:
   Smoothing factor. Bigger values will make more smooth curves. Value of 0
   (zero) mean that the curve will exactly pass through all points. The default
   value is 0.1.
+
+FreeCAD implementation specific inputs:
+
+* **Minimal Degree**. Minimal possible degree of the curve to be built. 
+  Default value is 3.
+* **Maximal Degree**. Maximal possible degree of the curve to be built. 
+  Default value is 5.
+* **Tolerance**. Maximal distance of the built curve from the init Vertices.
+  Default value is 0.0001.
+  
+* **Length Weight**. Available only for the "Variational Smoothing" method. 
+  Default value is 1.0.
+* **Curvature Weight**. Available only for the "Variational Smoothing" method. 
+  Default value is 1.0.
+* **Torsion Weight**. Available only for the "Variational Smoothing" method. 
+  Default value is 1.0.
+
 
 Parameters
 ----------
@@ -70,6 +112,7 @@ This node has the following parameters:
 
   * **Geomdl**. Use the implementation from Geomdl_ library. This is available only when Geomdl library is installed.
   * **SciPy**. Use the implementation from SciPy_ library. This is available only when SciPy library is installed.
+  * **FreeCAD**. Use the implementation from FreeCAD_ library. This is available only when FreeCAD library is installed.
 
   By default, the first available implementation is used.
 
@@ -116,6 +159,30 @@ This node has the following parameters:
   allow you to specify smoothing factor via **Smoothing** input. If not
   checked, the node will select the smoothing factor automatically. Unchecked
   by default.
+  
+* **Method**. Available only for the FreeCAD_ implementation. Approximation algorithm implementation to be used. The available values are:
+
+  * **Parametrization**.
+  * **Variational smoothing**.
+
+* **Continuity**. Available only for the FreeCAD_ implementation. Desired internal smoothness of the result curve. The available values are:
+
+  * **C0**. Only positional continuity.
+  * **G1**. Geometric tangent continuity. Available only for the "Parametrization" method.
+  * **C1**. Continuity of the first derivative all along the Curve.
+  * **G2**. Geometric curvature continuity. Available only for the "Parametrization" method.
+  * **C2**. Continuity of the second derivative all along the Curve
+  * **C3**. Continuity of the third derivative all along the Curve. Available only for the "Parametrization" method.
+  * **CN**. Infinite order of continuity. Available only for Parametrization method.
+  
+* **Type**. The way how the parametrization is calculated. Available only for the FreeCAD_ implementation and when the "Parametrization" method is used. The available values are:
+
+  * **Chord Length**. Parameters of points are proportionate to distances between them
+  * **Centripetal**. Parameters of points are proportionate to square roots of distances between them.
+  * **Uniform**. Parameters of points are distributed uniformly
+    
+
+
 
 Outputs
 -------
@@ -136,4 +203,8 @@ Take points from Greasepencil drawing and approximate them with a smooth curve:
 Use SciPy implementation to make a closed curve:
 
 .. image:: https://user-images.githubusercontent.com/284644/101246890-d61ebe00-3737-11eb-942d-c31e02bf3c3d.png
+
+Example of the FreeCAD implementation usage. Chord Length Parametrization:
+
+.. image:: https://user-images.githubusercontent.com/66558924/214577636-6d91c682-1225-45cd-85ba-350fa110755f.jpg
 

--- a/docs/nodes/curve/approximate_nurbs_curve.rst
+++ b/docs/nodes/curve/approximate_nurbs_curve.rst
@@ -35,23 +35,22 @@ Every single implementation offers different ways of control:
   Additionally, when smoothing factor is not zero, you can provide different
   weights for different points.
 * FreeCAD_ implementation supports two main methods and a wide variety of options.
-
-  * One can specify the interval of desired degree of the built curve. The final degree
-    cannot be specified but is a result of all the constraints applyed.
-  * A global precision of the approximation can be specified as a Tolerance value.
-    Lower values means that the approximation curve will pass closely to the input Vertices.
-  * The "Parameterization" approximation method allows lots of inner continuity options
-    and offers three metrics ('Uniform','Centripetal' or 'ChordLength') for the parametrization.
-  * The "Variational Smoothing" method uses three additional parameters - "Length Weight",
-    "Curvature Weight" and "Torsion Weight". If one of these arguments is not null,
-    the functions approximates the points using variational smoothing algorithm,
-    which tries to minimize additional criterium:
-    **LengthWeight*CurveLength + CurvatureWeight*Curvature + TorsionWeight*Torsion**
-    where Continuity must be C0, C1(with "Maximal Degree" >= 3) or
-    C2(with "Maximal Degree" >= 5).
-  * The Continuity parameter defines how smooth will be the curve internally.
-    The values it can take depend on the approximation method used. It defaults to C2.
-    However, it may not be applied if it conflicts with other parameters ( especially Maximal Degree ).
+  One can specify the interval of desired degree of the built curve. The final degree
+  cannot be specified but is a result of all the constraints applyed.
+  A global precision of the approximation can be specified as a Tolerance value.
+  Lower values means that the approximation curve will pass closely to the input Vertices.
+  The "Parameterization" approximation method allows lots of inner continuity options
+  and offers three metrics ('Uniform','Centripetal' or 'ChordLength') for the parametrization.
+  The "Variational Smoothing" method uses three additional parameters - "Length Weight",
+  "Curvature Weight" and "Torsion Weight". If one of these arguments is not null,
+  the functions approximates the points using variational smoothing algorithm,
+  which tries to minimize additional criterium:
+  **LengthWeight*CurveLength + CurvatureWeight*Curvature + TorsionWeight*Torsion**
+  where Continuity must be C0, C1(with "Maximal Degree" >= 3) or
+  C2(with "Maximal Degree" >= 5).
+  The Continuity parameter defines how smooth will be the curve internally.
+  The values it can take depend on the approximation method used. It defaults to C2.
+  However, it may not be applied if it conflicts with other parameters ( especially Maximal Degree ).
 
 
 .. _NURBS: https://en.wikipedia.org/wiki/Non-uniform_rational_B-spline

--- a/docs/nodes/curve/approximate_nurbs_curve.rst
+++ b/docs/nodes/curve/approximate_nurbs_curve.rst
@@ -35,7 +35,7 @@ Every single implementation offers different ways of control:
   Additionally, when smoothing factor is not zero, you can provide different
   weights for different points.
 * FreeCAD_ implementation supports two main methods and a wide variety of options.
-
+  
   One can specify the interval of desired degree of the built curve. The final degree 
   cannot be specified but is a result of all the constraints applyed. 
   

--- a/docs/nodes/curve/approximate_nurbs_curve.rst
+++ b/docs/nodes/curve/approximate_nurbs_curve.rst
@@ -4,7 +4,7 @@ Approximate NURBS Curve
 Dependencies
 ------------
 
-This node requires either Geomdl_, SciPy_ and FreeCAD_ library to work.
+This node requires either Geomdl_, SciPy_ or FreeCAD_ library to work.
 
 .. _Geomdl: https://onurraufbingol.com/NURBS-Python/
 .. _SciPy: https://scipy.org/
@@ -177,17 +177,15 @@ This node has the following parameters:
   * **G1** : Geometric tangent continuity. Available only for the "Parametrization" method.
   * **C1** : Continuity of the first derivative all along the Curve.
   * **G2** : Geometric curvature continuity. Available only for the "Parametrization" method.
-  * **C2** : Continuity of the second derivative all along the Curve
+  * **C2** : Continuity of the second derivative all along the Curve.
   * **C3** : Continuity of the third derivative all along the Curve. Available only for the "Parametrization" method.
   * **CN** : Infinite order of continuity. Available only for Parametrization method.
   
 * **Type**. The way how the parametrization is calculated. Available only for the FreeCAD_ implementation and when the "Parametrization" method is used. The available values are:
 
-  * **Chord Length**. Parameters of points are proportionate to distances between them
+  * **Chord Length**. Parameters of points are proportionate to distances between them.
   * **Centripetal**. Parameters of points are proportionate to square roots of distances between them.
-  * **Uniform**. Parameters of points are distributed uniformly
-    
-
+  * **Uniform**. Parameters of points are distributed uniformly.
 
 
 Outputs

--- a/docs/nodes/curve/approximate_nurbs_curve.rst
+++ b/docs/nodes/curve/approximate_nurbs_curve.rst
@@ -43,7 +43,7 @@ Every single implementation offers different ways of control:
   Lower values mean that the approximation curve will pass closely to the input Vertices.
   
   The **"Parameterization"** approximation method allows lots of inner continuity options   
-  and offers three metrics ( **'Uniform' , 'Centripetal' or 'ChordLength'** ) for the parametrization.
+  and offers a list of metrics for the parametrization.
   
   The **"Variational Smoothing"** method uses three additional parameters - "Length Weight",
   "Curvature Weight" and "Torsion Weight". The functions approximates the points using variational
@@ -148,16 +148,16 @@ This node has the following parameters:
   distance between the first and the last points being approximated, for which
   the node will make the curve cyclic. Default value is 0.0, i.e. the points
   must exactly coincide in order for curve to be closed.
-* **Metric**. This parameter is available only when **Implementation**
-  parameter is set to **SciPy**.Metric to be used for interpolation. The
-  available values are:
+* **Metric**. This parameter is available when **Implementation**
+  parameter is set to **SciPy** and **FreeCAD/Parametrization**. It's the metric (the specific knot values) to be used for interpolation. The
+  available options are:
 
-  * **Manhattan**
-  * **Euclidean**
-  * **Points** (just number of points from the beginning)
-  * **Chebyshev**
-  * **Centripetal** (square root of Euclidean distance)
-  * **X, Y, Z axis** - use distance along one of coordinate axis, ignore others.
+  * **Manhattan** metric is also known as Taxicab metric or rectilinear distance.
+  * **Euclidean** also known as Chord-Length or Distance metric. The parameters of the points are proportionate to the distances between them.
+  * **Points** also known as Uniform metric. The parameters of the points are distributed uniformly. Just the number of the points from the beginning.
+  * **Chebyshev** metric is also known as Chessboard distance.
+  * **Centripetal** The parameters of the points are proportionate to square roots of distances between them.
+  * **X, Y, Z axis** Use distance along one of coordinate axis, ignore others.
 
   The default value is Euclidean.
 
@@ -182,12 +182,6 @@ This node has the following parameters:
   * **C2** : Continuity of the second derivative all along the Curve.
   * **C3** : Continuity of the third derivative all along the Curve. Available only for the "Parametrization" method.
   * **CN** : Infinite order of continuity. Available only for Parametrization method.
-  
-* **Type**. The way how the parametrization is calculated. Available only for the FreeCAD_ implementation and when the "Parametrization" method is used. The available values are:
-
-  * **Chord Length**. Parameters of points are proportionate to distances between them.
-  * **Centripetal**. Parameters of points are proportionate to square roots of distances between them.
-  * **Uniform**. Parameters of points are distributed uniformly.
 
 
 Outputs

--- a/docs/nodes/curve/approximate_nurbs_curve.rst
+++ b/docs/nodes/curve/approximate_nurbs_curve.rst
@@ -36,31 +36,22 @@ Every single implementation offers different ways of control:
   weights for different points.
 * FreeCAD_ implementation supports two main methods and a wide variety of options.
 
-
-  One can specify the interval of desired degree of the built curve. The final degree
-  cannot be specified but is a result of all the constraints applyed.
-
-
-  A global precision of the approximation can be specified as a Tolerance value.
-  Lower values means that the approximation curve will pass closely to the input Vertices.
-
-
-  The "Parameterization" approximation method allows lots of inner continuity options
-  and offers three metrics ('Uniform','Centripetal' or 'ChordLength') for the parametrization.
-
-
-  The "Variational Smoothing" method uses three additional parameters - "Length Weight",
-  "Curvature Weight" and "Torsion Weight". If one of these arguments is not null,
-  the functions approximates the points using variational smoothing algorithm,
-  which tries to minimize additional criterium:
-  **LengthWeight*CurveLength + CurvatureWeight*Curvature + TorsionWeight*Torsion**
-  where Continuity must be C0, C1(with "Maximal Degree" >= 3) or
-  C2(with "Maximal Degree" >= 5).
-
-
-  The Continuity parameter defines how smooth will be the curve internally.
-  The values it can take depend on the approximation method used. It defaults to C2.
-  However, it may not be applied if it conflicts with other parameters ( especially Maximal Degree ).
+  * One can specify the interval of desired degree of the built curve. The final degree
+    cannot be specified but is a result of all the constraints applyed.
+  * A global precision of the approximation can be specified as a Tolerance value.
+    Lower values means that the approximation curve will pass closely to the input Vertices.
+  * The "Parameterization" approximation method allows lots of inner continuity options
+    and offers three metrics ('Uniform','Centripetal' or 'ChordLength') for the parametrization.
+  * The "Variational Smoothing" method uses three additional parameters - "Length Weight",
+    "Curvature Weight" and "Torsion Weight". If one of these arguments is not null,
+    the functions approximates the points using variational smoothing algorithm,
+    which tries to minimize additional criterium:
+    **LengthWeight*CurveLength + CurvatureWeight*Curvature + TorsionWeight*Torsion**
+    where Continuity must be C0, C1(with "Maximal Degree" >= 3) or
+    C2(with "Maximal Degree" >= 5).
+  * The Continuity parameter defines how smooth will be the curve internally.
+    The values it can take depend on the approximation method used. It defaults to C2.
+    However, it may not be applied if it conflicts with other parameters ( especially Maximal Degree ).
 
 
 .. _NURBS: https://en.wikipedia.org/wiki/Non-uniform_rational_B-spline

--- a/index.yaml
+++ b/index.yaml
@@ -87,7 +87,7 @@
         - SvExBezierCurveFitNode
     - Curve NURBS:
         - SvExNurbsCurveNode
-        - SvApproxNurbsCurveMk2Node
+        - SvApproxNurbsCurveMk3Node
         - SvExInterpolateNurbsCurveNode
         - SvFilletCurveNode
         - SvDeconstructCurveNode

--- a/menus/full_by_data_type.yaml
+++ b/menus/full_by_data_type.yaml
@@ -264,7 +264,7 @@
     - Generate NURBS Curve:
         - icon_name: EVENT_N
         - SvExNurbsCurveNode
-        - SvApproxNurbsCurveMk2Node
+        - SvApproxNurbsCurveMk3Node
         - SvExInterpolateNurbsCurveNode
         - ---
         - SvGenerateKnotvectorNode

--- a/menus/full_nortikin.yaml
+++ b/menus/full_nortikin.yaml
@@ -89,7 +89,7 @@
         - GC NURBS:
             - icon_name: MESH_CUBE
             - SvExNurbsCurveNode
-            - SvApproxNurbsCurveMk2Node
+            - SvApproxNurbsCurveMk3Node
             - SvExInterpolateNurbsCurveNode
         - GC SCRIPTED:
             - icon_name: PLUGIN

--- a/nodes/curve/approximate_nurbs_curve.py
+++ b/nodes/curve/approximate_nurbs_curve.py
@@ -16,22 +16,27 @@ from sverchok.data_structure import updateNode, zip_long_repeat, get_data_nestin
 from sverchok.utils.math import supported_metrics, xyz_metrics
 from sverchok.utils.curve.nurbs import SvGeomdlCurve
 from sverchok.utils.curve.splprep import scipy_nurbs_approximate
-from sverchok.dependencies import geomdl, scipy
+from sverchok.utils.curve.freecad import SvSolidEdgeCurve
+from sverchok.dependencies import geomdl, scipy, FreeCAD
 
 if geomdl is not None:
     from geomdl import fitting
 
+if FreeCAD is not None:
+    import Part
+    from Part import BSplineCurve
 
-class SvApproxNurbsCurveMk2Node(SverchCustomTreeNode, bpy.types.Node):
+
+class SvApproxNurbsCurveMk3Node(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: NURBS Curve
     Tooltip: Approximate NURBS Curve
     """
-    bl_idname = 'SvApproxNurbsCurveMk2Node'
+    bl_idname = 'SvApproxNurbsCurveMk3Node'
     bl_label = 'Approximate NURBS Curve'
     bl_icon = 'CURVE_NCURVE'
     sv_icon = 'SV_APPROXIMATE_CURVE'
-    sv_dependencies = {'geomdl', 'scipy'}
+    sv_dependencies = {'geomdl', 'scipy', 'FreeCAD'}
 
     degree : IntProperty(
             name = "Degree",
@@ -44,15 +49,26 @@ class SvApproxNurbsCurveMk2Node(SverchCustomTreeNode, bpy.types.Node):
             default = False,
             update = updateNode)
 
-    metric: EnumProperty(name='Metric',
-        description = "Knot mode",
-        default="DISTANCE", items=supported_metrics + xyz_metrics,
-        update=updateNode)
+    metric: EnumProperty(
+            name = 'Metric',
+            description = "Knot mode",
+            default = "DISTANCE", items=supported_metrics + xyz_metrics,
+            update = updateNode)
 
     def update_sockets(self, context):
         self.inputs['PointsCnt'].hide_safe = not (self.implementation == 'GEOMDL' and self.has_points_cnt)
+        self.inputs['Degree'].hide_safe = not (self.implementation == 'GEOMDL' or self.implementation == 'SCIPY')
+
         self.inputs['Smoothing'].hide_safe = not (self.implementation == 'SCIPY' and self.has_smoothing)
         self.inputs['Weights'].hide_safe = not (self.implementation == 'SCIPY')
+
+        self.inputs['DegreeMin'].hide_safe = not (self.implementation == 'FREECAD')
+        self.inputs['DegreeMax'].hide_safe = not (self.implementation == 'FREECAD')
+        self.inputs['Tolerance'].hide_safe = not (self.implementation == 'FREECAD')
+        self.inputs['LengthWeight'].hide_safe = not (self.implementation == 'FREECAD' and self.method == 'vari_smoothing')
+        self.inputs['CurvatureWeight'].hide_safe = not (self.implementation == 'FREECAD' and self.method == 'vari_smoothing')
+        self.inputs['TorsionWeight'].hide_safe = not (self.implementation == 'FREECAD' and self.method == 'vari_smoothing')
+
         updateNode(self, context)
 
     has_points_cnt : BoolProperty(
@@ -70,10 +86,13 @@ class SvApproxNurbsCurveMk2Node(SverchCustomTreeNode, bpy.types.Node):
         implementations.append(('GEOMDL', "Geomdl", "Geomdl (NURBS-Python) package implementation", 0))
     if scipy is not None:
         implementations.append(('SCIPY', "SciPy", "SciPy package implementation", 1))
-    
-    implementation : EnumProperty(name = "Implementation",
+    if FreeCAD is not None:
+        implementations.append(('FREECAD', "FreeCAD", "FreeCAD package implementation", 2))
+
+    implementation : EnumProperty(
+            name = "Implementation",
             description = "Approximation algorithm implementation",
-            items=implementations,
+            items = implementations,
             update = update_sockets)
 
     smoothing : FloatProperty(
@@ -82,7 +101,7 @@ class SvApproxNurbsCurveMk2Node(SverchCustomTreeNode, bpy.types.Node):
             min = 0.0,
             default = 0.1,
             update = updateNode)
-    
+
     has_smoothing : BoolProperty(
             name = "Specify smoothing",
             default = False,
@@ -122,13 +141,99 @@ class SvApproxNurbsCurveMk2Node(SverchCustomTreeNode, bpy.types.Node):
             min = 0.0,
             update = updateNode)
 
+    method: EnumProperty(
+            name = 'Method',
+            description = "Approximation Method",
+            default = "parametrization",
+            items = [("parametrization", "Parametrization", "Parametrize the init points using certain metric"),
+                     ("vari_smoothing", "Variational Smoothing", "Smoothing algorithm, which tries to minimize an additional criterium")
+                    ],
+        update = update_sockets)
+
+    degree_min : IntProperty(
+            name = "Minimal Degree",
+            min = 1,
+            default = 3,
+            update = updateNode)
+
+    degree_max : IntProperty(
+            name = "Maximal Degree",
+            min = 1,
+            default = 5,
+            update = updateNode)
+
+    tolerance : FloatProperty(
+            name = "Tolerance",
+            description = "Maximal distance from the init points",
+            default = 0.0001,
+            precision = 6,
+            min = 0.0,
+            update = updateNode)
+
+    continuity_p: EnumProperty( # method : Parametrization
+        name = 'Continuity',
+        description = "Internal Curve Continuity",
+        default = "C2",
+        items = [("C0", "C0", "Only positional continuity"),
+                 ("G1", "G1", "Geometric tangent continuity"),
+                 ("C1", "C1", "Continuity of the first derivative all along the Curve"),
+                 ("G2", "G2", "Geometric curvature continuity"),
+                 ("C2", "C2", "Continuity of the second derivative all along the Curve"),
+                 ("C3", "C3", "Continuity of the third derivative all along the Curve"),
+                 ("CN", "CN", "Infinite order of continuity")
+                ],
+        update = updateNode)
+
+    continuity_s: EnumProperty( # method : Variational Smoothing
+        name = 'Continuity',
+        description = "Internal Curve Continuity",
+        default = "C2",
+        items = [("C0", "C0", "Only positional continuity"),
+                 ("C1", "C1", "Continuity of the first derivative all along the Curve"),
+                 ("C2", "C2", "Continuity of the second derivative all along the Curve")
+                ],
+        update = updateNode)
+
+    length_weight : FloatProperty(
+            name = "Length Weight",
+            description = "Variational smoothing parameter",
+            default = 1.0,
+            precision = 6,
+            min = 0.0,
+            update = updateNode)
+
+    curvature_weight : FloatProperty(
+            name = "Curvature Weight",
+            description = "Variational smoothing parameter",
+            default = 1.0,
+            precision = 6,
+            min = 0.0,
+            update = updateNode)
+
+    torsion_weight : FloatProperty(
+            name = "Torsion Weight",
+            description = "Variational smoothing parameter",
+            default = 1.0,
+            precision = 6,
+            min = 0.0,
+            update = updateNode)
+
+    param_type: EnumProperty(name='Type',
+        description = "Parametrization Type",
+        default = "ChordLength",
+        items = [("ChordLength", "Chord Length", "Parameters of points are proportionate to distances between them"),
+                 ("Centripetal", "Centripetal", "Parameters of points are proportionate to square roots of distances between them"),
+                 ("Uniform", "Uniform", "Parameters of points are distributed uniformly")
+                ],
+        update = updateNode)
+
     def draw_buttons(self, context, layout):
-        layout.prop(self, 'implementation', text='')
+        layout.prop(self, 'implementation', text = '')
         if self.implementation == 'GEOMDL':
             layout.prop(self, 'centripetal')
             layout.prop(self, 'has_points_cnt')
-        else:
-            row = layout.row(align=True)
+        elif self.implementation == 'SCIPY':
+            row = layout.row(align = True)
             row.prop(self, 'is_cyclic')
             if self.is_cyclic:
                 row.prop(self, 'auto_cyclic')
@@ -136,6 +241,13 @@ class SvApproxNurbsCurveMk2Node(SverchCustomTreeNode, bpy.types.Node):
                     layout.prop(self, 'cyclic_threshold')
             layout.prop(self, 'metric')
             layout.prop(self, 'has_smoothing')
+        else:
+            layout.prop(self, 'method')
+            if self.method == 'parametrization':
+                layout.prop(self, 'continuity_p')
+                layout.prop(self, 'param_type')
+            else:
+                layout.prop(self, 'continuity_s')
 
     def draw_buttons_ext(self, context, layout):
         self.draw_buttons(context, layout)
@@ -145,11 +257,20 @@ class SvApproxNurbsCurveMk2Node(SverchCustomTreeNode, bpy.types.Node):
                 layout.prop(self, 'threshold')
 
     def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', "LengthWeight").prop_name = 'length_weight'
+        self.inputs.new('SvStringsSocket', "CurvatureWeight").prop_name = 'curvature_weight'
+        self.inputs.new('SvStringsSocket', "TorsionWeight").prop_name = 'torsion_weight'
+        
         self.inputs.new('SvVerticesSocket', "Vertices")
         self.inputs.new('SvStringsSocket', "Weights")
         self.inputs.new('SvStringsSocket', "Degree").prop_name = 'degree'
         self.inputs.new('SvStringsSocket', "PointsCnt").prop_name = 'points_cnt'
         self.inputs.new('SvStringsSocket', "Smoothing").prop_name = 'smoothing'
+
+        self.inputs.new('SvStringsSocket', "DegreeMin").prop_name = 'degree_min'
+        self.inputs.new('SvStringsSocket', "DegreeMax").prop_name = 'degree_max'
+        self.inputs.new('SvStringsSocket', "Tolerance").prop_name = 'tolerance'
+
         self.outputs.new('SvCurveSocket', "Curve")
         self.outputs.new('SvVerticesSocket', "ControlPoints")
         self.outputs.new('SvStringsSocket', "Knots")
@@ -165,11 +286,26 @@ class SvApproxNurbsCurveMk2Node(SverchCustomTreeNode, bpy.types.Node):
         points_cnt_s = self.inputs['PointsCnt'].sv_get()
         smoothing_s = self.inputs['Smoothing'].sv_get()
 
+        degree_min_s = self.inputs['DegreeMin'].sv_get()
+        degree_max_s = self.inputs['DegreeMax'].sv_get()
+        tolerance_s = self.inputs['Tolerance'].sv_get()
+        length_weight_s = self.inputs['LengthWeight'].sv_get()
+        curvature_weight_s = self.inputs['CurvatureWeight'].sv_get()
+        torsion_weight_s = self.inputs['TorsionWeight'].sv_get()
+
         input_level = get_data_nesting_level(vertices_s)
         vertices_s = ensure_nesting_level(vertices_s, 4)
         degree_s = ensure_nesting_level(degree_s, 2)
         points_cnt_s = ensure_nesting_level(points_cnt_s, 2)
         smoothing_s = ensure_nesting_level(smoothing_s, 2)
+
+        degree_min_s = ensure_nesting_level(degree_min_s, 2)
+        degree_max_s = ensure_nesting_level(degree_max_s, 2)
+        tolerance_s = ensure_nesting_level(tolerance_s, 2)
+        length_weight_s = ensure_nesting_level(length_weight_s, 2)
+        curvature_weight_s = ensure_nesting_level(curvature_weight_s, 2)
+        torsion_weight_s = ensure_nesting_level(torsion_weight_s, 2)
+
         has_weights = self.inputs['Weights'].is_linked
         if has_weights:
             weights_s = ensure_nesting_level(weights_s, 3)
@@ -179,11 +315,11 @@ class SvApproxNurbsCurveMk2Node(SverchCustomTreeNode, bpy.types.Node):
         curves_out = []
         points_out = []
         knots_out = []
-        for params in zip_long_repeat(vertices_s, weights_s, degree_s, points_cnt_s, smoothing_s):
+        for params in zip_long_repeat(vertices_s, weights_s, degree_s, points_cnt_s, smoothing_s, degree_min_s, degree_max_s, tolerance_s, length_weight_s, curvature_weight_s, torsion_weight_s):
             new_curves = []
             new_points = []
             new_knots = []
-            for vertices, weights, degree, points_cnt, smoothing in zip_long_repeat(*params):
+            for vertices, weights, degree, points_cnt, smoothing, degree_min, degree_max, tolerance, length_weight, curvature_weight, torsion_weight in zip_long_repeat(*params):
 
                 if self.implementation == 'GEOMDL':
                     kwargs = dict(centripetal = self.centripetal)
@@ -194,7 +330,8 @@ class SvApproxNurbsCurveMk2Node(SverchCustomTreeNode, bpy.types.Node):
                     control_points = curve.ctrlpts
                     knotvector = curve.knotvector
                     curve = SvGeomdlCurve(curve)
-                else: # SCIPY:
+
+                elif self.implementation == 'SCIPY':
                     points = np.array(vertices)
                     if has_weights:
                         weights = repeat_last_for_length(weights, len(vertices))
@@ -224,6 +361,32 @@ class SvApproxNurbsCurveMk2Node(SverchCustomTreeNode, bpy.types.Node):
                     control_points = curve.get_control_points().tolist()
                     knotvector = curve.get_knotvector().tolist()
 
+                else: # FREECAD:
+                    bspline = Part.BSplineCurve()
+                    if self.method == 'parametrization':
+                        bspline.approximate(Points = vertices,
+                                            DegMin = degree_min,
+                                            DegMax = degree_max,
+                                            Tolerance = tolerance,
+                                            Continuity = self.continuity_p,
+                                            ParamType = self.param_type
+                                            )
+                    else: # Variable Smoothing:
+                        bspline.approximate(Points = vertices,
+                                            DegMin = degree_min,
+                                            DegMax = degree_max,
+                                            Tolerance = tolerance,
+                                            Continuity = self.continuity_s,
+                                            LengthWeight = length_weight,
+                                            CurvatureWeight = curvature_weight,
+                                            TorsionWeight = torsion_weight
+                                            )
+                    curve = bspline.toShape()
+                    curve = SvSolidEdgeCurve(curve)
+                    curve = curve.to_nurbs()
+                    control_points = curve.get_control_points().tolist()
+                    knotvector = curve.get_knotvector().tolist()
+
                 new_curves.append(curve)
                 new_points.append(control_points)
                 new_knots.append(knotvector)
@@ -243,8 +406,10 @@ class SvApproxNurbsCurveMk2Node(SverchCustomTreeNode, bpy.types.Node):
 
 
 def register():
-    bpy.utils.register_class(SvApproxNurbsCurveMk2Node)
+    bpy.utils.register_class(SvApproxNurbsCurveMk3Node)
 
 
 def unregister():
-    bpy.utils.unregister_class(SvApproxNurbsCurveMk2Node)
+    bpy.utils.unregister_class(SvApproxNurbsCurveMk3Node)
+
+

--- a/old_nodes/approximate_nurbs_curve_mk2.py
+++ b/old_nodes/approximate_nurbs_curve_mk2.py
@@ -1,0 +1,252 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import numpy as np
+
+import bpy
+from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import updateNode, zip_long_repeat, get_data_nesting_level, ensure_nesting_level,\
+    repeat_last_for_length
+from sverchok.utils.math import supported_metrics, xyz_metrics
+from sverchok.utils.curve.nurbs import SvGeomdlCurve
+from sverchok.utils.curve.splprep import scipy_nurbs_approximate
+from sverchok.dependencies import geomdl, scipy
+
+if geomdl is not None:
+    from geomdl import fitting
+
+
+class SvApproxNurbsCurveMk2Node(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: NURBS Curve
+    Tooltip: Approximate NURBS Curve
+    """
+    bl_idname = 'SvApproxNurbsCurveMk2Node'
+    bl_label = 'Approximate NURBS Curve'
+    bl_icon = 'CURVE_NCURVE'
+    sv_icon = 'SV_APPROXIMATE_CURVE'
+    sv_dependencies = {'geomdl', 'scipy'}
+    
+    replacement_nodes = [('SvApproxNurbsCurveMk3Node', None, None)]
+
+    degree : IntProperty(
+            name = "Degree",
+            min = 1,
+            default = 3,
+            update = updateNode)
+
+    centripetal : BoolProperty(
+            name = "Centripetal",
+            default = False,
+            update = updateNode)
+
+    metric: EnumProperty(name='Metric',
+        description = "Knot mode",
+        default="DISTANCE", items=supported_metrics + xyz_metrics,
+        update=updateNode)
+
+    def update_sockets(self, context):
+        self.inputs['PointsCnt'].hide_safe = not (self.implementation == 'GEOMDL' and self.has_points_cnt)
+        self.inputs['Smoothing'].hide_safe = not (self.implementation == 'SCIPY' and self.has_smoothing)
+        self.inputs['Weights'].hide_safe = not (self.implementation == 'SCIPY')
+        updateNode(self, context)
+
+    has_points_cnt : BoolProperty(
+            name = "Specify points count",
+            default = False,
+            update = update_sockets)
+
+    points_cnt : IntProperty(
+            name = "Points count",
+            min = 3, default = 5,
+            update = updateNode)
+
+    implementations = []
+    if geomdl is not None:
+        implementations.append(('GEOMDL', "Geomdl", "Geomdl (NURBS-Python) package implementation", 0))
+    if scipy is not None:
+        implementations.append(('SCIPY', "SciPy", "SciPy package implementation", 1))
+    
+    implementation : EnumProperty(name = "Implementation",
+            description = "Approximation algorithm implementation",
+            items=implementations,
+            update = update_sockets)
+
+    smoothing : FloatProperty(
+            name = "Smoothing",
+            description = "Smoothing factor. Set to 0 to do interpolation",
+            min = 0.0,
+            default = 0.1,
+            update = updateNode)
+    
+    has_smoothing : BoolProperty(
+            name = "Specify smoothing",
+            default = False,
+            update = update_sockets)
+
+    is_cyclic : BoolProperty(
+            name = "Cyclic",
+            description = "Make the curve cyclic (closed)",
+            default = False,
+            update = updateNode)
+
+    auto_cyclic : BoolProperty(
+            name = "Auto",
+            description = "Make the curve cyclic only if it's start and end points are close enough",
+            default = False,
+            update = updateNode)
+
+    cyclic_threshold : FloatProperty(
+            name = "Cyclic threshold",
+            description = "Maximum distance between start and end points to make the curve closed",
+            default = 0.0,
+            min = 0.0,
+            precision = 4,
+            update = updateNode)
+
+    remove_doubles : BoolProperty(
+            name = "Remove doubles",
+            description = "Remove consecutive points that go too close",
+            default = False,
+            update = updateNode)
+
+    threshold : FloatProperty(
+            name = "Threshold",
+            description = "Threshold for remove doubles function",
+            default = 0.0001,
+            precision = 5,
+            min = 0.0,
+            update = updateNode)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'implementation', text='')
+        if self.implementation == 'GEOMDL':
+            layout.prop(self, 'centripetal')
+            layout.prop(self, 'has_points_cnt')
+        else:
+            row = layout.row(align=True)
+            row.prop(self, 'is_cyclic')
+            if self.is_cyclic:
+                row.prop(self, 'auto_cyclic')
+                if self.auto_cyclic:
+                    layout.prop(self, 'cyclic_threshold')
+            layout.prop(self, 'metric')
+            layout.prop(self, 'has_smoothing')
+
+    def draw_buttons_ext(self, context, layout):
+        self.draw_buttons(context, layout)
+        if self.implementation == 'SCIPY':
+            layout.prop(self, 'remove_doubles')
+            if self.remove_doubles:
+                layout.prop(self, 'threshold')
+
+    def sv_init(self, context):
+        self.inputs.new('SvVerticesSocket', "Vertices")
+        self.inputs.new('SvStringsSocket', "Weights")
+        self.inputs.new('SvStringsSocket', "Degree").prop_name = 'degree'
+        self.inputs.new('SvStringsSocket', "PointsCnt").prop_name = 'points_cnt'
+        self.inputs.new('SvStringsSocket', "Smoothing").prop_name = 'smoothing'
+        self.outputs.new('SvCurveSocket', "Curve")
+        self.outputs.new('SvVerticesSocket', "ControlPoints")
+        self.outputs.new('SvStringsSocket', "Knots")
+        self.update_sockets(context)
+
+    def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+
+        vertices_s = self.inputs['Vertices'].sv_get()
+        weights_s = self.inputs['Weights'].sv_get(default=[[[None]]])
+        degree_s = self.inputs['Degree'].sv_get()
+        points_cnt_s = self.inputs['PointsCnt'].sv_get()
+        smoothing_s = self.inputs['Smoothing'].sv_get()
+
+        input_level = get_data_nesting_level(vertices_s)
+        vertices_s = ensure_nesting_level(vertices_s, 4)
+        degree_s = ensure_nesting_level(degree_s, 2)
+        points_cnt_s = ensure_nesting_level(points_cnt_s, 2)
+        smoothing_s = ensure_nesting_level(smoothing_s, 2)
+        has_weights = self.inputs['Weights'].is_linked
+        if has_weights:
+            weights_s = ensure_nesting_level(weights_s, 3)
+
+        nested_output = input_level > 3
+
+        curves_out = []
+        points_out = []
+        knots_out = []
+        for params in zip_long_repeat(vertices_s, weights_s, degree_s, points_cnt_s, smoothing_s):
+            new_curves = []
+            new_points = []
+            new_knots = []
+            for vertices, weights, degree, points_cnt, smoothing in zip_long_repeat(*params):
+
+                if self.implementation == 'GEOMDL':
+                    kwargs = dict(centripetal = self.centripetal)
+                    if self.has_points_cnt:
+                        kwargs['ctrlpts_size'] = points_cnt
+
+                    curve = fitting.approximate_curve(vertices, degree, **kwargs)
+                    control_points = curve.ctrlpts
+                    knotvector = curve.knotvector
+                    curve = SvGeomdlCurve(curve)
+                else: # SCIPY:
+                    points = np.array(vertices)
+                    if has_weights:
+                        weights = repeat_last_for_length(weights, len(vertices))
+                    else:
+                        weights = None
+                    if not self.has_smoothing:
+                        smoothing = None
+
+                    if self.is_cyclic:
+                        if self.auto_cyclic: 
+                            dv = np.linalg.norm(points[0] - points[-1])
+                            is_cyclic = dv <= self.cyclic_threshold
+                            self.info("Dv %s, threshold %s => is_cyclic %s", dv, self.cyclic_threshold, is_cyclic)
+                        else:
+                            is_cyclic = True
+                    else:
+                        is_cyclic = False
+
+                    curve = scipy_nurbs_approximate(points,
+                                weights = weights,
+                                metric = self.metric,
+                                degree = degree,
+                                filter_doubles = None if not self.remove_doubles else self.threshold,
+                                smoothing = smoothing,
+                                is_cyclic = is_cyclic)
+
+                    control_points = curve.get_control_points().tolist()
+                    knotvector = curve.get_knotvector().tolist()
+
+                new_curves.append(curve)
+                new_points.append(control_points)
+                new_knots.append(knotvector)
+
+            if nested_output:
+                curves_out.append(new_curves)
+                points_out.append(new_points)
+                knots_out.append(new_knots)
+            else:
+                curves_out.extend(new_curves)
+                points_out.extend(new_points)
+                knots_out.extend(new_knots)
+
+        self.outputs['Curve'].sv_set(curves_out)
+        self.outputs['ControlPoints'].sv_set(points_out)
+        self.outputs['Knots'].sv_set(knots_out)
+
+
+def register():
+    bpy.utils.register_class(SvApproxNurbsCurveMk2Node)
+
+
+def unregister():
+    bpy.utils.unregister_class(SvApproxNurbsCurveMk2Node)


### PR DESCRIPTION
This PR adds the PointsToBSpline OCCT method from FreeCAD for approximating points to a NURBS curve.

Example of Chord Length Parametrization:
![FreeCAD_Approx_Parametrization](https://user-images.githubusercontent.com/66558924/214577636-6d91c682-1225-45cd-85ba-350fa110755f.jpg)

Example of using Variational Smoothing:
![FreeCAD_Approx_Smoothing](https://user-images.githubusercontent.com/66558924/214579352-ff121851-ce46-4128-93da-01a796df4472.jpg)

EDIT:
I added an option where we can specify the knots explicitly:
![FreeCAD_Approx_ExplicitKnots](https://user-images.githubusercontent.com/66558924/214834736-5aecc4e0-902b-4c76-9135-9d9dbbac6d1c.jpg)

The cool thing here is that we can utilize the "Generate Knotvector" node and use the metrics from it.


