### PR TITLE
Fixing some indentations that cause build_docs to fail

### DIFF
--- a/docs/nodes/list_main/match.rst
+++ b/docs/nodes/list_main/match.rst
@@ -3,8 +3,10 @@ List Match
 
 Great node to cut and extend lists to maximal or minimal length for one of them.
 
+
 Functionality
 -------------
+
 
 Getting multiple inputs node get length for all lists and define maximal/minimal of them.
 
@@ -12,24 +14,29 @@ Getting multiple inputs node get length for all lists and define maximal/minimal
 Inputs
 ------
 
+
 * **data** multisocket
+
 
 Parameters
 ----------
 
-* **Level** level of data
 
-        Next you choose case of matching, two lines are:        
-        
-        **recursive** - recursive case of matching (not working now)    
-        
-        **final** - usual job on defined level  
+* **Level**: level of data
 
-* **Short**: cut all to minimal length of lists         
-* **Cycle**: extend all to maximal length of lists by cyclingly repeating               
-* **Repeat** extend all to maximal length of lists by last item repeating               
-* **X-Ref** extend all to maximal length of lists by multiply lengthes,         
-        i.e. [0,1] and [4,5,6] will give [0,1,0,1,0,1] and [4,4,5,5,6,6] in output             
+  Next you choose case of matching, two lines are:
+
+  **recursive** - recursive case of matching (not working now)
+  
+  **final** - usual job on defined level  
+
+
+* **Short**: cut all to minimal length of lists
+* **Cycle**: extend all to maximal length of lists by cyclingly repeating
+* **Repeat**: extend all to maximal length of lists by last item repeating
+* **X-Ref**: extend all to maximal length of lists by multiply lengthes,
+
+  i.e. [0,1] and [4,5,6] will give [0,1,0,1,0,1] and [4,4,5,5,6,6] in output
 
 
 Outputs
@@ -41,18 +48,24 @@ Outputs
 Examples
 --------
 
-* initial:                
-[0, 1] & [0, 1, 2, 3, 4]                
+* **Initial:**
 
-* short:          
-[0, 1] & [0, 1]         
+  [0, 1] & [0, 1, 2, 3, 4]
 
-* Cycle:          
-[0, 1, 0, 1, 0] & [0, 1, 2, 3, 4]               
+* **Short:**
 
-* Repeat:         
-[0, 1, 1, 1, 1] & [0, 1, 2, 3, 4]               
+  [0, 1] & [0, 1]
 
-* X-Ref:          
-[0, 1, 0, 1, 0, 1, 0, 1, 0, 1] & [0, 0, 1, 1, 2, 2, 3, 3, 4, 4]         
+* **Cycle:**
+
+  [0, 1, 0, 1, 0] & [0, 1, 2, 3, 4]
+
+* **Repeat:**
+
+  [0, 1, 1, 1, 1] & [0, 1, 2, 3, 4]
+
+* **X-Ref:**
+
+  [0, 1, 0, 1, 0, 1, 0, 1, 0, 1] & [0, 0, 1, 1, 2, 2, 3, 3, 4, 4]
+
 


### PR DESCRIPTION
This PR should (hopefully) fix those build_docs warnings.

![list_match_warnings](https://user-images.githubusercontent.com/66558924/215507178-88fa2834-3bba-4206-a0dd-18d98642594b.jpg)
