### PR TITLE
#4947 fixing Overlapping Voronoi 3D sites

### DIFF
--- a/utils/voronoi3d.py
+++ b/utils/voronoi3d.py
@@ -329,7 +329,6 @@ def voronoi_on_mesh_bmesh(verts, faces, n_orig_sites, sites, spacing=0.0, fill=T
             lst_ringes_to_bisect = []
             lst_dist_p = []
             lst_dist_m = []
-            arr_dist_site_middle = np.empty(0)
 
             out_of_bbox = False
             src_mesh = None
@@ -360,18 +359,8 @@ def voronoi_on_mesh_bmesh(verts, faces, n_orig_sites, sites, spacing=0.0, fill=T
                     else:
                         lst_dist_m.append( [dist*sings, site_pair_idx, site_vert, site_pair_vert, middle, plane_no, plane, ] )
                 
-                # [3]. for test if all (site, middle) dist are less 0.5 spacing?
-                #    if spacing to big and eat all area [all (site-middle).lenght <= spacing/2]
-                arr_dist_site_middle = np.append(arr_dist_site_middle, np.linalg.norm(site_vert-middle) )
-
                 # here is the place to extend optimization variants to exclude bisect from process.
                 # To the future: one cannot optimize process of bisection. Only count of bisects can be optimized.
-                pass
-
-            # (3).
-            # out_of_bbox may realized before all site pairs observed so arr_dist_site_middle may contain not all dists
-            if out_of_bbox==False and (arr_dist_site_middle<=0.5 * spacing).all():
-                out_of_bbox = True
                 pass
 
             if out_of_bbox==False:
@@ -385,7 +374,7 @@ def voronoi_on_mesh_bmesh(verts, faces, n_orig_sites, sites, spacing=0.0, fill=T
                 lst_dist_m.sort() #reverse=True)
                 lst_ringes_to_bisect = lst_dist_m + lst_dist_p # bisect planes with negative normals first may cutoff more geometry from beginning of process (but not always)
                 # A main bisection process
-                for i, (_, site_pair_idx, site_vert, site_pair_vert, middle, plane_no, plane) in enumerate(lst_ringes_to_bisect):
+                for i, (dist_center_of_mass_to_plane, site_pair_idx, site_vert, site_pair_vert, middle, plane_no, plane) in enumerate(lst_ringes_to_bisect):
                     plane_co = middle - 0.5 * spacing * plane_no
 
                     ## For many vertices spended time near spended time of bisect_plane.
@@ -461,7 +450,7 @@ def voronoi_on_mesh_bmesh(verts, faces, n_orig_sites, sites, spacing=0.0, fill=T
     edges_out = []
     faces_out = []
 
-    # hhttp://www.qhull.org/html/qdelaun.htm
+    # http://www.qhull.org/html/qdelaun.htm
     # https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.Delaunay.html
     delaunay = Delaunay(np.array(sites, dtype=np.float32))
     sites_delaunay_params = get_sites_delaunay_params(delaunay)

--- a/utils/voronoi3d.py
+++ b/utils/voronoi3d.py
@@ -236,6 +236,7 @@ def calc_bvh_projections(bvh, sites):
             projections.append(loc)
     return np.array(projections)
 
+# see additional info https://github.com/nortikin/sverchok/pull/4948
 def voronoi_on_mesh_bmesh(verts, faces, n_orig_sites, sites, spacing=0.0, fill=True, precision=1e-8):
 
     def bounding_box_aligned(verts):

--- a/utils/voronoi3d.py
+++ b/utils/voronoi3d.py
@@ -329,6 +329,7 @@ def voronoi_on_mesh_bmesh(verts, faces, n_orig_sites, sites, spacing=0.0, fill=T
             lst_ringes_to_bisect = []
             lst_dist_p = []
             lst_dist_m = []
+            arr_dist_site_middle = np.empty(0)
 
             out_of_bbox = False
             src_mesh = None
@@ -359,8 +360,18 @@ def voronoi_on_mesh_bmesh(verts, faces, n_orig_sites, sites, spacing=0.0, fill=T
                     else:
                         lst_dist_m.append( [dist*sings, site_pair_idx, site_vert, site_pair_vert, middle, plane_no, plane, ] )
                 
+                # [3]. for test if all (site, middle) dist are less 0.5 spacing?
+                #    if spacing to big and eat all area [all (site-middle).lenght <= spacing/2]
+                arr_dist_site_middle = np.append(arr_dist_site_middle, np.linalg.norm(site_vert-middle) )
+
                 # here is the place to extend optimization variants to exclude bisect from process.
                 # To the future: one cannot optimize process of bisection. Only count of bisects can be optimized.
+                pass
+
+            # (3).
+            # out_of_bbox may realized before all site pairs observed so arr_dist_site_middle may contain not all dists
+            if out_of_bbox==False and (arr_dist_site_middle<=0.5 * spacing).all():
+                out_of_bbox = True
                 pass
 
             if out_of_bbox==False:


### PR DESCRIPTION
01. Fix some glitches of disappearing parts if spacing is growing.
02. Voronoi algorithm speed up. Has some glitches. qhull do not see some sites near each other.

---------

01.
![image](https://github.com/nortikin/sverchok/assets/14288520/13b62008-4f3f-4148-8d10-6d56e16b496a)

02.
![image](https://github.com/nortikin/sverchok/assets/14288520/a3904fb3-d2f8-4f32-8012-dbb4a54e3fb7)

Sites 1 and 9 overlapped. QHull do not see them as overlapped.

for tests:
[Voronoi on mesh.004.glitches.overlapped sites.blend.zip](https://github.com/nortikin/sverchok/files/12016780/Voronoi.on.mesh.004.glitches.overlapped.sites.blend.zip)

---------

See also:

- https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.Voronoi.html
- http://www.qhull.org/html/qh-quick.htm#options

