### PR TITLE
Node "Voronoi on Mesh" cannot process lines and flats sites

### DIFF
--- a/nodes/spatial/voronoi_on_mesh.py
+++ b/nodes/spatial/voronoi_on_mesh.py
@@ -148,9 +148,8 @@ class SvVoronoiOnMeshNode(SverchCustomTreeNode, bpy.types.Node):
                             #clip_inner = self.clip_inner, clip_outer = self.clip_outer,
                             do_clip=True, clipping=None,
                             mode = self.mode,
+                            normal_update = self.normals,
                             precision = precision)
-                if self.mode == 'VOLUME' and self.normals:
-                    verts, edges, faces = recalc_normals(verts, edges, faces, loop=True)
 
                 if self.join_mode == 'FLAT':
                     new_verts.extend(verts)

--- a/utils/voronoi3d.py
+++ b/utils/voronoi3d.py
@@ -381,6 +381,8 @@ def voronoi_on_mesh_bmesh(verts, faces, n_orig_sites, sites, spacing=0.0, mode='
 
         # if src_mesh has vertices then return mesh data
         pydata = pydata_from_bmesh(src_mesh)
+        src_mesh.clear() #remember to clear geometry before return
+        src_mesh.free()
         return pydata
 
     verts_out = []

--- a/utils/voronoi3d.py
+++ b/utils/voronoi3d.py
@@ -236,7 +236,7 @@ def calc_bvh_projections(bvh, sites):
     return np.array(projections)
 
 # see additional info https://github.com/nortikin/sverchok/pull/4948
-def voronoi_on_mesh_bmesh(verts, faces, n_orig_sites, sites, spacing=0.0, mode='VOLUME', precision=1e-8):
+def voronoi_on_mesh_bmesh(verts, faces, n_orig_sites, sites, spacing=0.0, mode='VOLUME', normal_update = False, precision=1e-8):
 
     def get_sites_delaunay_params(delaunay, n_orig_sites):
         result = defaultdict(list)
@@ -380,6 +380,8 @@ def voronoi_on_mesh_bmesh(verts, faces, n_orig_sites, sites, spacing=0.0, mode='
             return None
 
         # if src_mesh has vertices then return mesh data
+        if mode=='VOLUME' and normal_update==True:
+            src_mesh.normal_update()
         pydata = pydata_from_bmesh(src_mesh)
         src_mesh.clear() #remember to clear geometry before return
         src_mesh.free()
@@ -438,7 +440,7 @@ def voronoi_on_mesh_bmesh(verts, faces, n_orig_sites, sites, spacing=0.0, mode='
 def voronoi_on_mesh(verts, faces, sites, thickness,
     spacing = 0.0,
     clip_inner=True, clip_outer=True, do_clip=True,
-    clipping=1.0, mode = 'REGIONS',
+    clipping=1.0, mode = 'REGIONS', normal_update=False,
     precision = 1e-8):
     bvh = BVHTree.FromPolygons(verts, faces)
     npoints = len(sites)
@@ -468,7 +470,7 @@ def voronoi_on_mesh(verts, faces, sites, thickness,
     else: # VOLUME, SURFACE
         all_points = sites[:]
         verts, edges, faces = voronoi_on_mesh_bmesh(verts, faces, len(sites), all_points,
-                spacing = spacing, mode = mode,
+                spacing = spacing, mode = mode, normal_update = normal_update,
                 precision = precision)
         return verts, edges, faces, all_points
 


### PR DESCRIPTION
fix for #4951 
- General Solution for 1D,2D and 3D
- Add rule: check ridges for sites before bisect. If no ridge then no bisect and no mesh in result
- Remove rule [3] in bisect optimization

file for tests: 
[Voronoi on mesh.008.test delaunay 1D,2D,3D.blend.zip](https://github.com/nortikin/sverchok/files/12099214/Voronoi.on.mesh.008.test.delaunay.1D.2D.3D.blend.zip)

Example:

https://github.com/nortikin/sverchok/assets/14288520/8076c340-3190-4eb4-b909-1c6117151df1

Blinking on plane while rotate is a glitch. Solved in this PR later. Scroll down.

