### PR TITLE
normally call unregister SV_PT_ToolsMenu on exit blender

### DIFF
--- a/ui/sv_panels.py
+++ b/ui/sv_panels.py
@@ -360,3 +360,6 @@ def unregister():
     del bpy.types.Scene.ui_list_selected_tree
 
     bpy.types.NODE_HT_header.remove(node_show_tree_mode)
+
+    for class_name in sv_tools_classes:
+        bpy.utils.unregister_class(class_name)


### PR DESCRIPTION
Sverchok 1.2.0-alpha master, windows 11, Blender any version (3+).

In dev mode I get next exception and Sverchok do not start:

![image](https://github.com/nortikin/sverchok/assets/14288520/87abf0b0-dcff-49db-ae7c-d7f73800a4f1)
![image](https://github.com/nortikin/sverchok/assets/14288520/30097c70-de0d-4b95-9a4b-335bf9c43962)

This appear over 1 time after good start blender - one time Blender/sverchok start good and next time start failure. Then start is good again. So I restart Blender dev mode every second time.

After fix no error on start blender and sverchok:
![image](https://github.com/nortikin/sverchok/assets/14288520/c1978193-cab4-4790-af93-c1b32c8c60e4)
