### PR TITLE
Fix performance Voronoi on Solid

### DIFF
--- a/nodes/spatial/voronoi_on_solid.py
+++ b/nodes/spatial/voronoi_on_solid.py
@@ -164,7 +164,7 @@ class SvVoronoiOnSolidNode(SverchCustomTreeNode, bpy.types.Node):
                     src = solid
 
                 if need_inner:
-                    inner = [src.common(fragment) for fragment in fragments]
+                    inner = [src.common(fragments)]
                     if self.flat_output:
                         new_inner_fragments.extend(inner)
                     else:


### PR DESCRIPTION
Sverchok 1.3.0-alpha, master, Blender 3.6.1, Windows 11.

Explanation:

![image](https://github.com/nortikin/sverchok/assets/14288520/dbef42b1-52a7-4a73-aa76-f3d5a7c16e9f)

For tests: [Spatial.Voronoi on Solid.001.blend.zip](https://github.com/nortikin/sverchok/files/12325162/Spatial.Voronoi.on.Solid.001.blend.zip)
