### PR TITLE
fix 4959. Dot product can be used to realize side of mesh.

### DIFF
--- a/docs/nodes/spatial/random_points_on_mesh.rst
+++ b/docs/nodes/spatial/random_points_on_mesh.rst
@@ -39,7 +39,8 @@ This node has the following parameters:
 
   * **Surface**. Generate points on the surface of the mesh.
   * **Volume**. Generate points inside the volume of the mesh. The mesh is
-    expected to represent a closed volume in this case.
+    expected to represent a closed volume in this case. Recomend use 
+    [Modifiers->Modifier Change-> :doc:`Recalculate Normals </nodes/modifier_change/recalc_normals>`] before node.
   * **Edges**.  Generate points on the edges of the mesh.
 
   The default option is **Surface**.

--- a/nodes/spatial/random_points_on_mesh.py
+++ b/nodes/spatial/random_points_on_mesh.py
@@ -351,7 +351,7 @@ class SvRandomPointsOnMesh(SverchCustomTreeNode, bpy.types.Node):
         updateNode(self, context)
 
     modes = [('SURFACE', "Surface", "Surface", 0),
-             ('VOLUME', "Volume", "Volume", 1),
+             ('VOLUME', "Volume", "Volume. Recomend use 'Recalculate Normals'", 1),
              ('EDGES', "Edges", "Edges", 2),
             ]
 

--- a/utils/sv_mesh_utils.py
+++ b/utils/sv_mesh_utils.py
@@ -376,16 +376,21 @@ def non_redundant_faces_indices_np(faces):
 def point_inside_mesh(bvh, point):
     point = Vector(point)
     axis = Vector((1, 0, 0))
-    outside = False
-    count = 0
-    while True:
-        location, normal, index, distance = bvh.ray_cast(point, axis)
-        if index is None:
-            break
-        count += 1
-        point = location + axis * 0.00001
-    if count % 2 == 0:
-        outside = True
+    outside = True
+    #count = 0
+    location, normal, index, distance = bvh.ray_cast(point, axis)
+    if index is not None:
+        if normal.dot(point-location)<0:
+            outside = False
+
+    # while True:
+    #     location, normal, index, distance = bvh.ray_cast(point, axis)
+    #     if index is None:
+    #         break
+    #     count += 1
+    #     point.x = location.x + axis.x * 0.00001
+    # if count % 2 == 0:
+    #     outside = True
     return not outside
 
 ################


### PR DESCRIPTION
Sverchok 1.3-alpha, Blender 3.6.1,  windows 11.

#4959 

Description of problem:
https://github.com/nortikin/sverchok/blob/44e611da468d60c3134fa8d31634d8b1c1907b00/utils/sv_mesh_utils.py#L376-L389

Core of problem is line 386:
https://github.com/nortikin/sverchok/blob/44e611da468d60c3134fa8d31634d8b1c1907b00/utils/sv_mesh_utils.py#L386-L386

In some cases "point == location + axis * 0.00001"

Solution for box with size=600:

![image](https://github.com/nortikin/sverchok/assets/14288520/270f1296-b26f-4b08-9200-6ae1086de469)
