### PR TITLE
Bgl replacement (and other 3.5 / 4.0 curiosities)

### DIFF
--- a/nodes/number/easing.py
+++ b/nodes/number/easing.py
@@ -1,20 +1,10 @@
-# ##### BEGIN GPL LICENSE BLOCK #####
-#
-#  This program is free software; you can redistribute it and/or
-#  modify it under the terms of the GNU General Public License
-#  as published by the Free Software Foundation; either version 2
-#  of the License, or (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software Foundation,
-#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ##### END GPL LICENSE BLOCK #####
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
 
 from mathutils import Vector
 import bpy

--- a/nodes/number/easing.py
+++ b/nodes/number/easing.py
@@ -20,8 +20,6 @@ from mathutils import Vector
 import bpy
 from bpy.props import FloatProperty, EnumProperty, StringProperty, BoolProperty
 
-import blf
-import bgl
 import gpu
 from gpu_extras.batch import batch_for_shader
 

--- a/nodes/solid/solid_viewer.py
+++ b/nodes/solid/solid_viewer.py
@@ -7,7 +7,6 @@
 from math import pi
 import numpy as np
 
-import bgl
 import bpy
 import gpu
 from gpu_extras.batch import batch_for_shader
@@ -23,6 +22,7 @@ from sverchok.ui.bgl_callback_3dview import callback_disable, callback_enable
 from sverchok.utils.sv_shader_sources import dashed_vertex_shader, dashed_fragment_shader
 from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata
 from sverchok.utils.modules.geom_utils import obtain_normal3 as normal
+from sverchok.utils.modules.drawing_abstractions import drawing
 
 from sverchok.dependencies import FreeCAD
 if FreeCAD is not None:
@@ -83,9 +83,9 @@ def generate_normals_data(verts, faces):
 
 def draw_uniform(GL_KIND, coords, indices, color, width=1, dashed_data=None):
     if GL_KIND == 'LINES':
-        bgl.glLineWidth(width)
+        drawing.set_line_width(width)
     elif GL_KIND == 'POINTS':
-        bgl.glPointSize(width)
+        drawing.set_point_size(width)
 
     params = dict(indices=indices) if indices else {}
 
@@ -112,9 +112,9 @@ def draw_uniform(GL_KIND, coords, indices, color, width=1, dashed_data=None):
         batch.draw(shader)
 
     if GL_KIND == 'LINES':
-        bgl.glLineWidth(1)
+        drawing.reset_line_width()
     elif GL_KIND == 'POINTS':
-        bgl.glPointSize(1)
+        drawing.reset_point_size()
 
 
 def draw_smooth(coords, vcols, indices=None):
@@ -183,11 +183,11 @@ def draw_faces_uniform(context, args):
     geom, config = args
     # print(geom.f_faces, config.shade)
     if config.draw_gl_wireframe:
-        bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_LINE)
+        drawing.set_wireframe_line()
 
     if config.draw_gl_polygonoffset:
-        bgl.glEnable(bgl.GL_POLYGON_OFFSET_FILL)
-        bgl.glPolygonOffset(1.0, 1.0)
+        drawing.enable_polygon_offset_fill()
+        drawing.set_polygon_offset_amounts()
 
     if config.shade == "flat":
         draw_uniform('TRIS', geom.f_verts, geom.f_faces, config.face4f)
@@ -199,7 +199,7 @@ def draw_faces_uniform(context, args):
         draw_smooth(geom.f_verts, geom.smooth_vnorms, indices=geom.f_faces)
 
     if config.draw_gl_wireframe:
-        bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_FILL)
+        drawing.set_wireframe_fill()
 
 
 def edges_geom(geom, config):
@@ -231,10 +231,10 @@ def edges_geom(geom, config):
 def draw_complex(context, args):
     geom, config = args
     if config.draw_gl_polygonoffset:
-        bgl.glDisable(bgl.GL_POLYGON_OFFSET_FILL)
+        drawing.disable_polygon_offset_fill()
 
     if config.shade != 'normals':
-        bgl.glEnable(bgl.GL_BLEND)
+        drawing.enable_blendmode()
 
     if config.display_edges:
         draw_lines_uniform(context, config, geom.e_vertices, geom.e_edges, config.line4f, config.line_width)
@@ -243,10 +243,10 @@ def draw_complex(context, args):
     if config.display_verts:
         draw_uniform('POINTS', geom.verts, None, config.vcol, config.point_size)
     if config.shade != 'normals':
-        bgl.glDisable(bgl.GL_BLEND)
+        drawing.disable_blendmode()
     if config.draw_gl_polygonoffset:
         # or restore to the state found when entering this function. TODO!
-        bgl.glDisable(bgl.GL_POLYGON_OFFSET_FILL)
+        drawing.disable_polygon_offset_fill()
 
 
 class SvSolidViewerNode(SverchCustomTreeNode, bpy.types.Node):

--- a/nodes/solid/solid_viewer.py
+++ b/nodes/solid/solid_viewer.py
@@ -22,7 +22,7 @@ from sverchok.ui.bgl_callback_3dview import callback_disable, callback_enable
 from sverchok.utils.sv_shader_sources import dashed_vertex_shader, dashed_fragment_shader
 from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata
 from sverchok.utils.modules.geom_utils import obtain_normal3 as normal
-from sverchok.utils.modules.drawing_abstractions import drawing
+from sverchok.utils.modules.drawing_abstractions import drawing, shading_3d
 
 from sverchok.dependencies import FreeCAD
 if FreeCAD is not None:
@@ -102,9 +102,7 @@ def draw_uniform(GL_KIND, coords, indices, color, width=1, dashed_data=None):
         batch.draw(shader)
 
     else:
-        # print(GL_KIND,coords)
-        shader_name = f'{"3D_" if bpy.app.version < (3, 4) else ""}UNIFORM_COLOR'
-        shader = gpu.shader.from_builtin(shader_name)
+        shader = gpu.shader.from_builtin(shading_3d.UNIFORM_COLOR)
         batch = batch_for_shader(shader, GL_KIND, {"pos" : coords}, **params)
         shader.bind()
         shader.uniform_float("color", color)
@@ -118,8 +116,7 @@ def draw_uniform(GL_KIND, coords, indices, color, width=1, dashed_data=None):
 
 
 def draw_smooth(coords, vcols, indices=None):
-    shader_name = f'{"3D_" if bpy.app.version < (3, 4) else ""}SMOOTH_COLOR'
-    shader = gpu.shader.from_builtin(shader_name)
+    shader = gpu.shader.from_builtin(shading_3d.SMOOTH_COLOR)
     params = dict(indices=indices) if indices else {}
     batch = batch_for_shader(shader, 'TRIS', {"pos" : coords, "color": vcols}, **params)
     batch.draw(shader)

--- a/nodes/solid/solid_viewer.py
+++ b/nodes/solid/solid_viewer.py
@@ -198,6 +198,7 @@ def draw_faces_uniform(context, args):
         draw_smooth(geom.f_verts, geom.smooth_vnorms, indices=geom.f_faces)
 
     if config.draw_gl_wireframe:
+        # this is to reset the state of drawing to fill
         drawing.set_polygonmode_fill()
 
 

--- a/nodes/solid/solid_viewer.py
+++ b/nodes/solid/solid_viewer.py
@@ -181,9 +181,8 @@ def face_geom(geom, config):
 
 def draw_faces_uniform(context, args):
     geom, config = args
-    # print(geom.f_faces, config.shade)
     if config.draw_gl_wireframe:
-        drawing.set_wireframe_line()
+        drawing.set_polygonmode_line()
 
     if config.draw_gl_polygonoffset:
         drawing.enable_polygon_offset_fill()
@@ -199,7 +198,7 @@ def draw_faces_uniform(context, args):
         draw_smooth(geom.f_verts, geom.smooth_vnorms, indices=geom.f_faces)
 
     if config.draw_gl_wireframe:
-        drawing.set_wireframe_fill()
+        drawing.set_polygonmode_fill()
 
 
 def edges_geom(geom, config):

--- a/nodes/viz/console_node.py
+++ b/nodes/viz/console_node.py
@@ -12,7 +12,6 @@ import numpy as np
 import itertools
 
 import bpy
-import bgl
 import gpu
 from gpu_extras.batch import batch_for_shader
 
@@ -391,8 +390,8 @@ def terminal_text_to_uv(lines):
 
 def simple_console_xy(context, args, loc):
     texture, config = args
-    act_tex = bgl.Buffer(bgl.GL_INT, 1)
-    bgl.glBindTexture(bgl.GL_TEXTURE_2D, texture.texture_dict['texture'])
+    act_tex = drawing.new_buffer_texture()
+    drawing.bind_texture_2d(texture.texture_dict['texture'])
     config.shader.bind()
     
     # if not config.syntax_mode == "None":
@@ -543,23 +542,12 @@ class SvConsoleNode(SverchCustomTreeNode, bpy.types.Node, SvNodeViewDrawMixin):
         for color_name in lexed_colors:
             row = col.row()
             row.prop(self, color_name)
-
     
     def init_texture(self, width, height):
-        clr = bgl.GL_RGBA
         texname = self.texture_dict['texture']
         data = self.texture_dict['texture_data']
+        initialize_complex_texture(width, height, texname, texture, data, 'RGBA')
 
-        texture = bgl.Buffer(bgl.GL_FLOAT, data.size, data.tolist())
-        bgl.glPixelStorei(bgl.GL_UNPACK_ALIGNMENT, 1)
-        bgl.glEnable(bgl.GL_TEXTURE_2D)
-        bgl.glBindTexture(bgl.GL_TEXTURE_2D, texname)
-        bgl.glActiveTexture(bgl.GL_TEXTURE0)
-        bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_S, bgl.GL_CLAMP_TO_EDGE)
-        bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_T, bgl.GL_CLAMP_TO_EDGE)
-        bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MAG_FILTER, bgl.GL_LINEAR)
-        bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MIN_FILTER, bgl.GL_LINEAR)
-        bgl.glTexImage2D(bgl.GL_TEXTURE_2D, 0, clr, width, height, 0, clr, bgl.GL_FLOAT, texture)
 
     def set_node_props(self, socket_data):
         multiline, (chars_x, chars_y) = text_decompose('\n'.join(socket_data), self.last_n_lines)

--- a/nodes/viz/console_node.py
+++ b/nodes/viz/console_node.py
@@ -513,13 +513,13 @@ class SvConsoleNode(SverchCustomTreeNode, bpy.types.Node, SvNodeViewDrawMixin):
             dsize = data.size
             data = data.repeat(3).reshape(-1, 3)
             data = np.concatenate((data, np.ones(dsize)[:,None]),axis=1).flatten()
-            name = bgl.Buffer(bgl.GL_INT, 1)
-            bgl.glGenTextures(1, name)
-            self.texture_dict['texture'] = name[0]
-            self.texture_dict['texture_data'] = data # bgl.Buffer(bgl.GL_FLOAT, data.size, data.tolist())
-           
-        # return self.texture_dict.get('texture')
+            name = drawing.new_buffer_texture()
+            drawing.generate_textures(name)
 
+            self.texture_dict['texture'] = name[0]
+            self.texture_dict['texture_data'] = data
+           
+  
     def sv_init(self, context):
         self.inputs.new("SvStringsSocket", "text")
         self.id_data.update_gl_scale_info()
@@ -547,7 +547,7 @@ class SvConsoleNode(SverchCustomTreeNode, bpy.types.Node, SvNodeViewDrawMixin):
     def init_texture(self, width, height):
         texname = self.texture_dict['texture']
         data = self.texture_dict['texture_data']
-        initialize_complex_texture(width, height, texname, texture, data, 'RGBA')
+        drawing.init_complex_texture(width, height, texname, texture, data, 'RGBA')
 
 
     def set_node_props(self, socket_data):

--- a/nodes/viz/console_node.py
+++ b/nodes/viz/console_node.py
@@ -547,7 +547,7 @@ class SvConsoleNode(SverchCustomTreeNode, bpy.types.Node, SvNodeViewDrawMixin):
     def init_texture(self, width, height):
         texname = self.texture_dict['texture']
         data = self.texture_dict['texture_data']
-        drawing.init_complex_texture(width, height, texname, texture, data, 'RGBA')
+        drawing.init_complex_texture(width, height, texname, data, 'RGBA')
 
 
     def set_node_props(self, socket_data):

--- a/nodes/viz/console_node.py
+++ b/nodes/viz/console_node.py
@@ -22,6 +22,7 @@ from sverchok.ui import bgl_callback_nodeview as nvBGL2
 from sverchok.utils.sv_update_utils import sv_get_local_path
 from sverchok.utils.sv_font_xml_parser import get_lookup_dict, letters_to_uv
 from sverchok.utils.sv_nodeview_draw_helper import SvNodeViewDrawMixin, get_console_grid
+from sverchok.utils.modules.drawing_abstractions import drawing
 #from sverchok.utils.decorators_compilation import njit
 
 def get_desired_xy(node):

--- a/nodes/viz/vd_matrix.py
+++ b/nodes/viz/vd_matrix.py
@@ -18,11 +18,10 @@ from sverchok.ui.bgl_callback_3dview import callback_disable, callback_enable
 from sverchok.utils.sv_batch_primitives import MatrixDraw28
 from sverchok.data_structure import node_id, updateNode
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.utils.modules.drawing_abstractions import drawing
+from sverchok.utils.modules.drawing_abstractions import drawing, shading_2d
 
 if not bpy.app.background:
-    shader_name = f'{"2D_" if bpy.app.version < (3, 4) else ""}SMOOTH_COLOR'
-    smooth_2d_shader = gpu.shader.from_builtin(shader_name)
+    smooth_2d_shader = gpu.shader.from_builtin(shading_2d.SMOOTH_COLOR)
 else:
     smooth_2d_shader = None
 

--- a/nodes/viz/vd_matrix.py
+++ b/nodes/viz/vd_matrix.py
@@ -1,23 +1,12 @@
-# ##### BEGIN GPL LICENSE BLOCK #####
-#
-#  This program is free software; you can redistribute it and/or
-#  modify it under the terms of the GNU General Public License
-#  as published by the Free Software Foundation; either version 2
-#  of the License, or (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software Foundation,
-#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ##### END GPL LICENSE BLOCK #####
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
 
 
-import bgl
+
 import bpy
 import gpu
 from gpu_extras.batch import batch_for_shader
@@ -29,6 +18,7 @@ from sverchok.ui.bgl_callback_3dview import callback_disable, callback_enable
 from sverchok.utils.sv_batch_primitives import MatrixDraw28
 from sverchok.data_structure import node_id, updateNode
 from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.modules.drawing_abstractions import drawing
 
 if not bpy.app.background:
     shader_name = f'{"2D_" if bpy.app.version < (3, 4) else ""}SMOOTH_COLOR'
@@ -77,9 +67,9 @@ def screen_v3d_batch_matrix_overlay(context, args):
         indices=indices_shifted)
 
     # smooth_2d_shader.bind()
-    bgl.glEnable( bgl.GL_BLEND )
+    drawing.enable_blendmode()
     batch.draw(smooth_2d_shader)
-    bgl.glDisable( bgl.GL_BLEND )
+    drawing.disable_blendmode()
 
 
 def match_color_to_matrix(node):

--- a/nodes/viz/viewer_2d.py
+++ b/nodes/viz/viewer_2d.py
@@ -24,10 +24,10 @@ from numpy import float64 as np_float64, linspace as np_linspace
 import bpy
 from bpy.props import FloatProperty, IntProperty, EnumProperty, BoolProperty, FloatVectorProperty, IntVectorProperty
 
-import bgl
 import gpu
 from gpu_extras.batch import batch_for_shader
 
+from sverchok.utils.modules.drawing_abstractions import drawing 
 from sverchok.data_structure import updateNode, node_id
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.ui import bgl_callback_nodeview as nvBGL
@@ -186,24 +186,24 @@ def view_2d_geom(x, y, args):
         config.p_batch.draw(config.p_shader)
 
     if config.draw_edges:
-        bgl.glLineWidth(config.edge_width)
+        drawing.set_line_width(config.edge_width) # bgl.glLineWidth(config.edge_width)
         config.e_batch = batch_for_shader(config.e_shader, 'LINES', {"pos": geom.e_vertices, "color": geom.e_vertex_colors}, indices=geom.e_indices)
         config.e_shader.bind()
         config.e_shader.uniform_float("x_offset", x)
         config.e_shader.uniform_float("y_offset", y)
         config.e_shader.uniform_float("viewProjectionMatrix", matrix)
         config.e_batch.draw(config.e_shader)
-        bgl.glLineWidth(1)
+        drawing.reset_line_width()
 
     if config.draw_verts:
-        bgl.glPointSize(config.point_size)
+        drawing.set_point_size(config.point_size)
         config.v_batch = batch_for_shader(config.v_shader, 'POINTS', {"pos": geom.v_vertices, "color": geom.points_color})
         config.v_shader.bind()
         config.v_shader.uniform_float("x_offset", x)
         config.v_shader.uniform_float("y_offset", y)
         config.v_shader.uniform_float("viewProjectionMatrix", matrix)
         config.v_batch.draw(config.v_shader)
-        bgl.glPointSize(1)
+        drawing.reset_point_size()
 
 
 def path_from_nums(nums, x, y, num_width, num_height, maxmin, sys_scale):

--- a/nodes/viz/viewer_2d.py
+++ b/nodes/viz/viewer_2d.py
@@ -186,7 +186,7 @@ def view_2d_geom(x, y, args):
         config.p_batch.draw(config.p_shader)
 
     if config.draw_edges:
-        drawing.set_line_width(config.edge_width) # bgl.glLineWidth(config.edge_width)
+        drawing.set_line_width(config.edge_width)
         config.e_batch = batch_for_shader(config.e_shader, 'LINES', {"pos": geom.e_vertices, "color": geom.e_vertex_colors}, indices=geom.e_indices)
         config.e_shader.bind()
         config.e_shader.uniform_float("x_offset", x)

--- a/nodes/viz/viewer_draw_curve.py
+++ b/nodes/viz/viewer_draw_curve.py
@@ -10,7 +10,7 @@ import numpy as np
 import bpy
 from mathutils import Matrix, Vector
 from bpy.props import StringProperty, BoolProperty, IntProperty, EnumProperty, FloatVectorProperty, FloatProperty
-import bgl
+
 import gpu
 from gpu_extras.batch import batch_for_shader
 
@@ -22,46 +22,47 @@ from sverchok.utils.curve.bakery import CurveData
 from sverchok.utils.sv_operator_mixins import SvGenericNodeLocator
 from sverchok.ui.bgl_callback_3dview import callback_disable, callback_enable
 from sverchok.utils.sv_3dview_tools import Sv3DviewAlign
+from sverchok.utils.modules.drawing_abstractions import drawing
 
 
 def draw_edges(shader, points, edges, line_width, color, is_smooth=False):
     if is_smooth:
         draw_edges_colored(shader, points, edges, line_width, [color for i in range(len(points))])
     else:
-        bgl.glLineWidth(line_width)
+        drawing.set_line_width(line_width)
         batch = batch_for_shader(shader, 'LINES', {"pos": points}, indices=edges)
         shader.bind()
         shader.uniform_float('color', color)
         batch.draw(shader)
-        bgl.glLineWidth(1)
+        drawing.reset_line_width()
 
 def draw_edges_colored(shader, points, edges, line_width, colors):
-    bgl.glLineWidth(line_width)
+    drawing.set_line_width(line_width)
     batch = batch_for_shader(shader, 'LINES', {"pos": points, "color": colors}, indices=edges)
     shader.bind()
     batch.draw(shader)
-    bgl.glLineWidth(1)
+    drawing.reset_line_width()
 
 def draw_points(shader, points, size, color):
-    bgl.glPointSize(size)
+    drawing.set_point_size(size)
     batch = batch_for_shader(shader, 'POINTS', {"pos": points})
     shader.bind()
     shader.uniform_float('color', color)
     batch.draw(shader)
-    bgl.glPointSize(1)
+    drawing.reset_point_size()
 
 def draw_points_colored(shader, points, size, colors):
-    bgl.glPointSize(size)
+    drawing.set_point_size(size)
     batch = batch_for_shader(shader, 'POINTS', {"pos": points, "color": colors})
     shader.bind()
     batch.draw(shader)
-    bgl.glPointSize(1)
+    drawing.reset_point_size()
 
 def draw_curves(context, args):
     node, draw_inputs, v_shader, e_shader = args
     is_smooth = node.draw_curvature
 
-    bgl.glEnable(bgl.GL_BLEND)
+    drawing.enable_blendmode()
 
     for item in draw_inputs:
 
@@ -87,7 +88,7 @@ def draw_curves(context, args):
         if node.draw_verts and item.points is not None:
             draw_points(v_shader, item.points, node.verts_size, node.verts_color)
 
-    bgl.glEnable(bgl.GL_BLEND)
+    drawing.enable_blendmode()
 
 class SvBakeCurveOp(bpy.types.Operator, SvGenericNodeLocator):
     """B A K E CURVES"""

--- a/nodes/viz/viewer_draw_curve.py
+++ b/nodes/viz/viewer_draw_curve.py
@@ -22,7 +22,7 @@ from sverchok.utils.curve.bakery import CurveData
 from sverchok.utils.sv_operator_mixins import SvGenericNodeLocator
 from sverchok.ui.bgl_callback_3dview import callback_disable, callback_enable
 from sverchok.utils.sv_3dview_tools import Sv3DviewAlign
-from sverchok.utils.modules.drawing_abstractions import drawing
+from sverchok.utils.modules.drawing_abstractions import drawing, shading_3d
 
 
 def draw_edges(shader, points, edges, line_width, color, is_smooth=False):
@@ -281,14 +281,11 @@ class SvCurveViewerDrawNode(SverchCustomTreeNode, bpy.types.Node):
         self.inputs.new('SvStringsSocket', 'Resolution').prop_name = 'resolution'
 
     def draw_all(self, draw_inputs):
-        shader_name = f'{"3D_" if bpy.app.version < (3, 4) else ""}UNIFORM_COLOR'
-        v_shader = gpu.shader.from_builtin(shader_name)
+        v_shader = gpu.shader.from_builtin(shading_3d.UNIFORM_COLOR)
         if self.draw_curvature:
-            shader_name = f'{"3D_" if bpy.app.version < (3, 4) else ""}SMOOTH_COLOR'
-            e_shader = gpu.shader.from_builtin(shader_name)
+            e_shader = gpu.shader.from_builtin(shading_3d.SMOOTH_COLOR)
         else:
-            shader_name = f'{"3D_" if bpy.app.version < (3, 4) else ""}UNIFORM_COLOR'
-            e_shader = gpu.shader.from_builtin(shader_name)
+            e_shader = gpu.shader.from_builtin(shading_3d.UNIFORM_COLOR)
 
         draw_data = {
                 'tree_name': self.id_data.name[:],

--- a/nodes/viz/viewer_draw_mk4.py
+++ b/nodes/viz/viewer_draw_mk4.py
@@ -197,7 +197,7 @@ def view_3d_geom(context, args):
                 config.v_shader.bind()
 
             v_batch.draw(config.v_shader)
-            drawing.reset_point_size(1)
+            drawing.reset_point_size()
 
     drawing.disable_blendmode()
 

--- a/nodes/viz/viewer_draw_mk4.py
+++ b/nodes/viz/viewer_draw_mk4.py
@@ -155,6 +155,7 @@ def view_3d_geom(context, args):
         if config.draw_gl_polygonoffset:
             drawing.disable_polygon_offset_fill()
         if config.draw_gl_wireframe:
+            # this is to reset the state of drawing to fill
             drawing.set_polygonmode_fill()
 
 

--- a/nodes/viz/viewer_draw_mk4.py
+++ b/nodes/viz/viewer_draw_mk4.py
@@ -130,7 +130,7 @@ def view_3d_geom(context, args):
 
     if config.draw_polys:
         if config.draw_gl_wireframe:
-            drawing.set_wireframe_line()
+            drawing.set_polygonmode_line()
         if config.draw_gl_polygonoffset:
             drawing.enable_polygon_offset_fill()
             drawing.set_polygon_offset_amounts()
@@ -155,7 +155,7 @@ def view_3d_geom(context, args):
         if config.draw_gl_polygonoffset:
             drawing.disable_polygon_offset_fill()
         if config.draw_gl_wireframe:
-            drawing.set_wireframe_fill()
+            drawing.set_polygonmode_fill()
 
 
     if config.draw_edges:

--- a/nodes/viz/viewer_draw_mk4.py
+++ b/nodes/viz/viewer_draw_mk4.py
@@ -55,7 +55,13 @@ default_geometry_shader = '''
     uniform mat4 viewProjectionMatrix;
 
     in vec3 pos[];
-    out vec3 face_normal;
+    //out vec3 face_normal;
+
+    out VS_OUT
+    {
+        vec3 FaceNormal;
+    } vs_out;
+
 
     layout(triangles) in;
     layout(triangle_strip, max_vertices = 3) out;
@@ -66,7 +72,7 @@ default_geometry_shader = '''
         vec3 ac = gl_in[2].gl_Position.xyz - gl_in[0].gl_Position.xyz;
         vec3 normal3 = normalize(cross(ab, ac));
         vec4 normal4 = vec4(normal3, 1.0);
-        face_normal = normal3;
+        vs_out.FaceNormal = normal3;
         vec4 rescale = vec4(0.00003, 0.00003, 0.00003, 0.0);
         vec4 offset = vec4(normal4 * rescale);
 
@@ -84,13 +90,18 @@ default_geometry_shader = '''
 default_fragment_shader = '''
     //uniform float brightness;
 
-    in vec3 pos[];
-    in vec3 face_normal[];
+    in vec4 pos[];
+    // in vec3 face_normal[];
+    in VS_OUT
+    {
+        vec3 FaceNormal;
+    } fs_in;
+
     out vec4 gl_FragColor;
 
     void main()
     {
-        gl_FragColor = vec4(face_normal[0].r, 0.7, 0.7, 0.7);
+        gl_FragColor = vec4(fs_in.FaceNormal.xyz, 0.7);
     }
 '''
 

--- a/nodes/viz/viewer_draw_mk4.py
+++ b/nodes/viz/viewer_draw_mk4.py
@@ -55,29 +55,26 @@ default_geometry_shader = '''
     uniform mat4 viewProjectionMatrix;
 
     in vec3 pos[];
-    //in vec4 FragColor[];
 
     layout(triangles) in;
     layout(triangle_strip, max_vertices = 3) out;
 
     void main()
     {
-        //vec3 ab = gl_in[1].gl_Position.xyz - gl_in[0].gl_Position.xyz;
-        //vec3 ac = gl_in[2].gl_Position.xyz - gl_in[0].gl_Position.xyz;
-        //vec3 normal3 = normalize(cross(ab, ac));
-        //vec4 normal4 = vec4(normal3, 1.0);
-        //vec4 rescale = vec4(0.000003, 0.000003, 0.000003, 1.0);
-        //vec4 offset = vec4(normal4 * rescale);
-        vec4 offset = vec4(0.0, 0.0, 0.00003, 1.0);
+        vec3 ab = gl_in[1].gl_Position.xyz - gl_in[0].gl_Position.xyz;
+        vec3 ac = gl_in[2].gl_Position.xyz - gl_in[0].gl_Position.xyz;
+        vec3 normal3 = normalize(cross(ab, ac));
+        vec4 normal4 = vec4(normal3, 1.0);
+        vec4 rescale = vec4(0.00003, 0.00003, 0.00003, 0.0);
+        vec4 offset = vec4(normal4 * rescale);
 
         for (int i = 0; i < gl_in.length(); i++)
         {
-            gl_Position = gl_in[i].gl_Position + offset;
+            gl_Position = gl_in[i].gl_Position + offset; // + vec4(1.0, 0.0, 0.0, );
             EmitVertex();
         }
 
         EndPrimitive();        
-
     }
 
 '''
@@ -90,9 +87,7 @@ default_fragment_shader = '''
 
     void main()
     {
-        //FragColor = vec4(pos[0] * brightness, 1.0);
-        //FragColor = vec4(1.0, 1.0, 0.5*brightness, 1.0); //pos[0] * brightness, 1.0);
-        FragColor = vec4(pos[0][0] * brightness, pos[0][1] * brightness, pos[0][2] * brightness, 1.0);
+        FragColor = vec4(pos[0].x * brightness, pos[0].y * brightness, pos[0].z * brightness, 1.0);
     }
 '''
 

--- a/nodes/viz/viewer_draw_mk4.py
+++ b/nodes/viz/viewer_draw_mk4.py
@@ -49,9 +49,7 @@ default_vertex_shader = '''
 '''
 
 default_geometry_shader = '''
-
     uniform mat4 viewProjectionMatrix;
-    in vec3 pos[];
 
     out VS_OUT
     {
@@ -85,7 +83,6 @@ default_geometry_shader = '''
 
 default_fragment_shader = '''
 
-    in vec4 pos[];
     in VS_OUT
     {
         vec3 FaceNormal;

--- a/nodes/viz/viewer_draw_mk4.py
+++ b/nodes/viz/viewer_draw_mk4.py
@@ -62,6 +62,34 @@ default_fragment_shader = '''
     }
 '''
 
+default_geometry_shader = '''
+
+    uniform mat4 viewProjectionMatrix;
+
+    layout(triangles) in;
+    layout(triangle_strip, max_vertices = 3) out;
+
+    void main()
+    {
+        vec3 ab = gl_in[1].gl_Position.xyz - gl_in[0].gl_Position.xyz;
+        vec3 ac = gl_in[2].gl_Position.xyz - gl_in[0].gl_Position.xyz;
+        vec3 normal3 = normalize(cross(ab, ac));
+        vec4 rescale = vec4(0.0003, 0.0003, 0.0003, 1.0);
+        vec4 normal4 = vec4(normal3, 1.0);
+
+        int i = 0;
+        for (i = 0; i < gl_in.length(); i++)
+        {
+            gl_Position = gl_in[i].gl_Position + (normal4 * rescale);
+            EmitVertex();
+        }
+
+        EndPrimitive();        
+
+    }
+
+'''
+
 def ensure_triangles(coords, indices, handle_concave_quads):
     """
     this fully tesselates the incoming topology into tris,
@@ -496,7 +524,7 @@ def generate_mesh_geom(config, vecs_in):
             config.draw_fragment_function = ND.get('draw_fragment')
             config.p_shader = gpu.types.GPUShader(config.node.custom_vertex_shader, config.node.custom_fragment_shader)
         else:
-            config.p_shader = gpu.types.GPUShader(default_vertex_shader, default_fragment_shader)
+            config.p_shader = gpu.types.GPUShader(default_vertex_shader, default_fragment_shader, geocode=default_geometry_shader)
         geom.p_vertices, geom.p_vertex_colors, geom.p_indices = p_vertices, p_vertex_colors, p_indices
 
     return geom

--- a/nodes/viz/viewer_draw_mk4.py
+++ b/nodes/viz/viewer_draw_mk4.py
@@ -70,7 +70,7 @@ default_geometry_shader = '''
 
         for (int i = 0; i < gl_in.length(); i++)
         {
-            gl_Position = gl_in[i].gl_Position + offset; // + vec4(1.0, 0.0, 0.0, );
+            gl_Position = gl_in[i].gl_Position + offset;
             EmitVertex();
         }
 
@@ -87,7 +87,7 @@ default_fragment_shader = '''
 
     void main()
     {
-        FragColor = vec4(pos[0].x * brightness, pos[0].y * brightness, pos[0].z * brightness, 1.0);
+        FragColor = vec4(0.1, 0.5*brightness, 0.8, 1.0);
     }
 '''
 

--- a/nodes/viz/viewer_draw_mk4.py
+++ b/nodes/viz/viewer_draw_mk4.py
@@ -90,7 +90,7 @@ default_fragment_shader = '''
 
     void main()
     {
-        gl_FragColor = vec4(face_normal[0].x, 0.7, 0.7, 0.7);
+        gl_FragColor = vec4(face_normal[0].r, 0.7, 0.7, 0.7);
     }
 '''
 

--- a/nodes/viz/viewer_draw_mk4.py
+++ b/nodes/viz/viewer_draw_mk4.py
@@ -55,6 +55,7 @@ default_geometry_shader = '''
     uniform mat4 viewProjectionMatrix;
 
     in vec3 pos[];
+    out vec3 face_normal;
 
     layout(triangles) in;
     layout(triangle_strip, max_vertices = 3) out;
@@ -65,6 +66,7 @@ default_geometry_shader = '''
         vec3 ac = gl_in[2].gl_Position.xyz - gl_in[0].gl_Position.xyz;
         vec3 normal3 = normalize(cross(ab, ac));
         vec4 normal4 = vec4(normal3, 1.0);
+        face_normal = normal3;
         vec4 rescale = vec4(0.00003, 0.00003, 0.00003, 0.0);
         vec4 offset = vec4(normal4 * rescale);
 
@@ -80,14 +82,15 @@ default_geometry_shader = '''
 '''
 
 default_fragment_shader = '''
-    uniform float brightness;
+    //uniform float brightness;
 
     in vec3 pos[];
-    out vec4 FragColor;
+    in vec3 face_normal[];
+    out vec4 gl_FragColor;
 
     void main()
     {
-        FragColor = vec4(0.1, 0.5*brightness, 0.8, 1.0);
+        gl_FragColor = vec4(face_normal[0].x, 0.7, 0.7, 0.7);
     }
 '''
 
@@ -171,10 +174,10 @@ def view_3d_geom(context, args):
             config.p_shader.bind()
             matrix = context.region_data.perspective_matrix
             config.p_shader.uniform_float("viewProjectionMatrix", matrix)
-            if hasattr(config, "brightness"):
-                config.p_shader.uniform_float("brightness", config.brightness)
-            else:
-                config.p_shader.uniform_float("brightness", 0.5)
+            #if hasattr(config, "brightness"):
+            #    config.p_shader.uniform_float("brightness", config.brightness)
+            #else:
+            #    config.p_shader.uniform_float("brightness", 0.5)
         else:
             if config.uniform_pols:
                 p_batch = batch_for_shader(config.p_shader, 'TRIS', {"pos": geom.p_vertices}, indices=geom.p_indices)
@@ -585,7 +588,7 @@ class SvViewerDrawMk4(SverchCustomTreeNode, bpy.types.Node):
         name="Draw gl wireframe",
         default=False, update=updateNode)
 
-    brightness: FloatProperty(min=0.0, max=1.0)
+    brightness: FloatProperty(min=0.0, max=1.0, default=0.8)
 
     vector_light: FloatVectorProperty(
         name='vector light', subtype='DIRECTION', min=0, max=1, size=3,
@@ -849,7 +852,7 @@ class SvViewerDrawMk4(SverchCustomTreeNode, bpy.types.Node):
         config.u_dash_size = self.u_dash_size
         config.u_gap_size = self.u_gap_size
         config.u_resolution = self.u_resolution[:]
-        config.brightness = self.brightness  # this is only to test the passthrough of the geometry shader.
+        # config.brightness = self.brightness  # this is only to test the passthrough of the geometry shader.
 
         config.node = self
         return config

--- a/nodes/viz/viewer_draw_mk4.py
+++ b/nodes/viz/viewer_draw_mk4.py
@@ -126,14 +126,14 @@ def view_3d_geom(context, args):
 
     geom, config = args
 
-    drawing.enable_blendmode() # bgl.glEnable(bgl.GL_BLEND)
+    drawing.enable_blendmode()
 
     if config.draw_polys:
         if config.draw_gl_wireframe:
             drawing.set_wireframe_line()
         if config.draw_gl_polygonoffset:
-            drawing.enable_polygon_offset_fill() # bgl.glEnable(bgl.GL_POLYGON_OFFSET_FILL)
-            drawing.set_polygon_offset_amounts() #bgl.glPolygonOffset(1.0, 1.0)
+            drawing.enable_polygon_offset_fill()
+            drawing.set_polygon_offset_amounts()
 
         if config.shade_mode == 'fragment':
             p_batch = batch_for_shader(config.p_shader, 'TRIS', {"position": geom.p_vertices}, indices=geom.p_indices)
@@ -153,9 +153,9 @@ def view_3d_geom(context, args):
         p_batch.draw(config.p_shader)
 
         if config.draw_gl_polygonoffset:
-            drawing.disable_polygon_offset_fill() # bgl.glDisable(bgl.GL_POLYGON_OFFSET_FILL)
+            drawing.disable_polygon_offset_fill()
         if config.draw_gl_wireframe:
-            drawing.set_wireframe_fill() # bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_FILL)
+            drawing.set_wireframe_fill()
 
 
     if config.draw_edges:
@@ -949,7 +949,6 @@ class SvViewerDrawMk4(SverchCustomTreeNode, bpy.types.Node):
                 self.process()
             else:
                 callback_disable(node_id(self))
-
 
 
 classes = [SvViewerDrawMk4,]

--- a/nodes/viz/viewer_draw_mk4.py
+++ b/nodes/viz/viewer_draw_mk4.py
@@ -41,11 +41,9 @@ default_vertex_shader = '''
     uniform mat4 viewProjectionMatrix;
 
     in vec3 position;
-    out vec3 pos;
 
     void main()
     {
-        pos = position;
         gl_Position = viewProjectionMatrix * vec4(position, 1.0f);
     }
 '''
@@ -53,9 +51,7 @@ default_vertex_shader = '''
 default_geometry_shader = '''
 
     uniform mat4 viewProjectionMatrix;
-
     in vec3 pos[];
-    //out vec3 face_normal;
 
     out VS_OUT
     {
@@ -88,10 +84,8 @@ default_geometry_shader = '''
 '''
 
 default_fragment_shader = '''
-    //uniform float brightness;
 
     in vec4 pos[];
-    // in vec3 face_normal[];
     in VS_OUT
     {
         vec3 FaceNormal;

--- a/nodes/viz/viewer_draw_surface.py
+++ b/nodes/viz/viewer_draw_surface.py
@@ -10,7 +10,6 @@ import numpy as np
 import bpy
 from mathutils import Matrix, Vector
 from bpy.props import StringProperty, BoolProperty, IntProperty, EnumProperty, FloatVectorProperty
-import bgl
 import gpu
 from gpu_extras.batch import batch_for_shader
 
@@ -22,23 +21,24 @@ from sverchok.utils.surface.bakery import SurfaceData
 from sverchok.utils.sv_operator_mixins import SvGenericNodeLocator
 from sverchok.ui.bgl_callback_3dview import callback_disable, callback_enable
 from sverchok.utils.sv_3dview_tools import Sv3DviewAlign
+from sverchok.utils.modules.drawing_abstractions import drawing, shading_3d
 
 
 def draw_edges(shader, points, edges, line_width, color):
-    bgl.glLineWidth(line_width)
+    drawing.set_line_width(line_width)
     batch = batch_for_shader(shader, 'LINES', {"pos": points}, indices=edges)
     shader.bind()
     shader.uniform_float('color', color)
     batch.draw(shader)
-    bgl.glLineWidth(1)
+    drawing.reset_line_width()
 
 def draw_points(shader, points, size, color):
-    bgl.glPointSize(size)
+    drawing.set_point_size(size)
     batch = batch_for_shader(shader, 'POINTS', {"pos": points})
     shader.bind()
     shader.uniform_float('color', color)
     batch.draw(shader)
-    bgl.glPointSize(1)
+    drawing.reset_point_size()
 
 def draw_polygons(shader, points, tris, vertex_colors):
     batch = batch_for_shader(shader, 'TRIS', {"pos": points, 'color': vertex_colors}, indices=tris)
@@ -48,7 +48,7 @@ def draw_polygons(shader, points, tris, vertex_colors):
 def draw_surfaces(context, args):
     node, draw_inputs, v_shader, e_shader, p_shader = args
 
-    bgl.glEnable(bgl.GL_BLEND)
+    drawing.enable_blendmode()
 
     for item in draw_inputs:
 
@@ -73,7 +73,7 @@ def draw_surfaces(context, args):
         if node.draw_verts:
             draw_points(v_shader, item.points_list, node.verts_size, node.verts_color)
 
-    bgl.glEnable(bgl.GL_BLEND)
+    drawing.disable_blendmode()
 
 class SvBakeSurfaceOp(bpy.types.Operator, SvGenericNodeLocator):
     """B A K E SURFACES"""
@@ -304,12 +304,9 @@ class SvSurfaceViewerDrawNode(SverchCustomTreeNode, bpy.types.Node):
         self.draw_buttons(context, layout)
 
     def draw_all(self, draw_inputs):
-        shader_name = f'{"3D_" if bpy.app.version < (3, 4) else ""}UNIFORM_COLOR'
-        v_shader = gpu.shader.from_builtin(shader_name)
-        shader_name = f'{"3D_" if bpy.app.version < (3, 4) else ""}UNIFORM_COLOR'
-        e_shader = gpu.shader.from_builtin(shader_name)
-        shader_name = f'{"3D_" if bpy.app.version < (3, 4) else ""}SMOOTH_COLOR'
-        p_shader = gpu.shader.from_builtin(shader_name)
+        v_shader = gpu.shader.from_builtin(shading_3d.UNIFORM_COLOR)
+        e_shader = gpu.shader.from_builtin(shading_3d.UNIFORM_COLOR)
+        p_shader = gpu.shader.from_builtin(shading_3d.SMOOTH_COLOR)
 
         draw_data = {
                 'tree_name': self.id_data.name[:],

--- a/nodes/viz/viewer_texture.py
+++ b/nodes/viz/viewer_texture.py
@@ -14,7 +14,6 @@ import numpy as np
 
 import bpy
 import gpu
-import bgl
 
 from bpy.props import (
     FloatProperty, EnumProperty, StringProperty, BoolProperty, IntProperty
@@ -25,6 +24,7 @@ from sverchok.data_structure import updateNode, node_id
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.ui import bgl_callback_nodeview as nvBGL2
 from sverchok.ui import sv_image as svIMG
+from sverchok.utils.modules.drawing_abstractions import drawing 
 
 # shared stuff between implementations
 from sverchok.utils.sv_texture_utils import generate_batch_shader
@@ -264,8 +264,8 @@ class SvTextureViewerNode(SverchCustomTreeNode, bpy.types.Node):
     def delete_texture(self):
         n_id = node_id(self)
         if n_id in self.texture:
-            names = bgl.Buffer(bgl.GL_INT, 1, [self.texture[n_id]])
-            bgl.glDeleteTextures(1, names)
+            names = drawing.get_buffer(self.texture[n_id])
+            drawing.delete_texture(names)
 
     def process(self):
         if not self.inputs['Float'].is_linked:
@@ -295,12 +295,10 @@ class SvTextureViewerNode(SverchCustomTreeNode, bpy.types.Node):
         if self.activate:
             texture = self.get_buffer()
             width, height = self.texture_width_height
-            # x, y = self.xy_offset
             gl_color_constant = gl_color_dict.get(self.color_mode)
 
-
-            name = bgl.Buffer(bgl.GL_INT, 1)
-            bgl.glGenTextures(1, name)
+            name = drawing.new_buffer_texture()
+            drawing.generate_textures(name) 
             self.texture[n_id] = name[0]
             init_texture(width, height, name[0], texture, gl_color_constant)
 

--- a/nodes/viz/viewer_texture.py
+++ b/nodes/viz/viewer_texture.py
@@ -198,8 +198,7 @@ class SvTextureViewerNode(SverchCustomTreeNode, bpy.types.Node):
     def get_buffer(self):
         data = self.inputs['Float'].sv_get(deepcopy=False)
         self.total_size = self.calculate_total_size()
-
-        texture = bgl.Buffer(bgl.GL_FLOAT, self.total_size, np.resize(data, self.total_size).tolist())
+        texture = drawing.new_buffer_texture_sized(self.total_size, np.resize(data, self.total_size).tolist())
         return texture
 
     def draw_buttons(self, context, layout):

--- a/nodes/viz/viewer_texture.py
+++ b/nodes/viz/viewer_texture.py
@@ -264,7 +264,7 @@ class SvTextureViewerNode(SverchCustomTreeNode, bpy.types.Node):
     def delete_texture(self):
         n_id = node_id(self)
         if n_id in self.texture:
-            names = drawing.get_buffer(self.texture[n_id])
+            names = drawing.get_buffer([self.texture[n_id]])
             drawing.delete_texture(names)
 
     def process(self):

--- a/nodes/viz/viewer_texture_lite.py
+++ b/nodes/viz/viewer_texture_lite.py
@@ -8,7 +8,6 @@
 
 import os
 import numpy as np
-import bgl
 import gpu
 import bpy
 from bpy.props import EnumProperty, StringProperty, IntProperty, PointerProperty, FloatProperty
@@ -21,6 +20,7 @@ from sverchok.ui import bgl_callback_nodeview as nvBGL2
 from sverchok.utils.sv_texture_utils import generate_batch_shader
 from sverchok.utils.sv_texture_utils import simple_screen, init_texture, get_drawing_location
 from sverchok.utils.sv_texture_utils import gl_color_list, gl_color_dict, factor_buffer_dict
+from sverchok.utils.modules.drawing_abstractions import drawing
 
 
 out_modes = [
@@ -94,8 +94,8 @@ class SvTextureViewerNodeLite(SverchCustomTreeNode, bpy.types.Node):
     def delete_texture(self):
         n_id = node_id(self)
         if n_id in self.texture:
-            names = bgl.Buffer(bgl.GL_INT, 1, [self.texture[n_id]])
-            bgl.glDeleteTextures(1, names)
+            names = drawing.get_buffer([self.texture[n_id]])
+            drawing.delete_texture(names)
 
     def process(self):
 
@@ -120,10 +120,10 @@ class SvTextureViewerNodeLite(SverchCustomTreeNode, bpy.types.Node):
             # x, y = self.xy_offset
             width, height, colm = self.width_custom_tex, self.height_custom_tex, self.color_mode
             total_size = width * height * factor_buffer_dict.get(colm)
-            texture = bgl.Buffer(bgl.GL_FLOAT, total_size, np.resize(self.inputs[0].sv_get(), total_size).tolist())
+            texture = drawing.new_buffer_texture_sized(total_size, np.resize(self.inputs[0].sv_get(), total_size).tolist())
 
-            name = bgl.Buffer(bgl.GL_INT, 1)
-            bgl.glGenTextures(1, name)
+            name = drawing.new_buffer_texture()
+            drawing.generate_textures(name)
             self.texture[n_id] = name[0]
             init_texture(width, height, name[0], texture, gl_color_constant)
 

--- a/nodes/viz/viewer_waveform_output.py
+++ b/nodes/viz/viewer_waveform_output.py
@@ -12,8 +12,6 @@ import struct
 import inspect
 
 import bpy
-import blf
-import bgl
 import gpu
 from gpu_extras.batch import batch_for_shader
 

--- a/ui/bgl_callback_3dview.py
+++ b/ui/bgl_callback_3dview.py
@@ -17,7 +17,7 @@
 # ##### END GPL LICENSE BLOCK #####
 
 import bpy
-import bgl
+from sverchok.utils.modules.drawing_abstractions import drawing 
 
 
 SpaceView3D = bpy.types.SpaceView3D
@@ -62,9 +62,9 @@ def callback_disable_all():
 
 
 def restore_opengl_defaults():
-    bgl.glLineWidth(1)
-    bgl.glDisable(bgl.GL_BLEND)
-    bgl.glDisable(bgl.GL_DEPTH_TEST)
+    drawing.reset_line_width()
+    drawing.disable_blendmode()
+    drawing.disable_depth_test()
 
     # glIsEnabled with argument 
     # GL_POLYGON_OFFSET_FILL, 
@@ -80,7 +80,7 @@ def draw_callback_px(n_id, data):
     context = bpy.context
     drawing_func = data.get('custom_function')   # must accept 'context' first
     args = data.get('args', (None,))             # args does not need to be a tuple.
-    bgl.glEnable(bgl.GL_DEPTH_TEST)
+    drawing.enable_depth_test()
     drawing_func(context, args)
     restore_opengl_defaults()
 

--- a/ui/bgl_callback_nodeview.py
+++ b/ui/bgl_callback_nodeview.py
@@ -188,12 +188,10 @@ def draw_callback_px(n_id, data):
         '''
         x, y = get_xy_from_data(data)
 
-        # bgl.glEnable(bgl.GL_DEPTH_TEST)
         drawing_func = data.get('custom_function')
         args = data.get('args', (None,))
         drawing_func(bpy.context, args, (x, y))
         restore_opengl_defaults()
-        # bgl.glDisable(bgl.GL_DEPTH_TEST)
 
 
 def _draw_text_handler(tree_id, node_id, text: str, color=(1, 1, 1, 1), scale=1.0, align='RIGHT',

--- a/ui/bgl_callback_nodeview.py
+++ b/ui/bgl_callback_nodeview.py
@@ -232,7 +232,7 @@ def _draw_text_handler(tree_id, node_id, text: str, color=(1, 1, 1, 1), scale=1.
     font_id = 0
     dpi = 72
 
-    blf.size(font_id, text_height, dpi)
+    drawing.blf_size(font_id, text_height, dpi)
     blf.color(font_id, *color)
 
     for line in text.split('\n'):

--- a/ui/bgl_callback_nodeview.py
+++ b/ui/bgl_callback_nodeview.py
@@ -24,11 +24,11 @@ from inspect import isfunction
 
 import bpy
 import blf
-import bgl
 from bpy.types import SpaceNodeEditor
 
 from sverchok.utils.sv_stethoscope_helper import draw_text_data, draw_graphical_data
 from sverchok.utils.sv_logging import sv_logger
+from sverchok.utils.modules.drawing_abstractions import drawing 
 
 callback_dict = {}
 point_dict = {}
@@ -98,9 +98,8 @@ def callback_disable_filtered(pattern):
 
 
 def restore_opengl_defaults():
-    bgl.glLineWidth(1)
-    bgl.glDisable(bgl.GL_BLEND)
-    # bgl.glColor4f(0.0, 0.0, 0.0, 1.0)     # doesn't exist anymore ..    
+    drawing.set_line_width(1)
+    drawing.disable_blendmode()
 
 
 def get_xy_from_data(data):
@@ -245,7 +244,7 @@ def _draw_text_handler(tree_id, node_id, text: str, color=(1, 1, 1, 1), scale=1.
 
 
 def _get_text_location(node, align='RIGHT') -> tuple[int, int]:
-    """Find location for a text nearby give node"""
+    """Find location for a text nearby given node"""
     (x, y) = node.absolute_location
     gap = 10
 

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -49,19 +49,23 @@ if bpy.app.version >= (3, 5, 0):
     class Drawing:
 
         set_wireframe_line = placeholder_function
-        set_wireframe_fill = placeholder_function
+
+        def set_wireframe_fill(self):
+            gpu.state.face_culling_set("FRONT")
+            gpu.state.front_facing_set(False)
+
         set_line_width = gpu.state.line_width_set
         reset_line_width = lambda self: gpu.state.line_width_set(1)
         set_point_size = gpu.state.point_size_set
         reset_point_size = lambda self: gpu.state.point_size_set(1)
-        enable_polygon_offset_fill = placeholder_function
+        enable_polygon_offset_fill = lambda self: gpu.state.face_culling_set("FRONT")
         disable_polygon_offset_fill = placeholder_function
         set_polygon_offset_amounts = placeholder_function
 
-        enable_blendmode = placeholder_function
-        disable_blendmode = placeholder_function
-        enable_depth_test = placeholder_function
-        disable_depth_test = placeholder_function
+        enable_blendmode = lambda self: gpu.state.blend_set("ALPHA")
+        disable_blendmode = lambda self: gpu.state.blend_set("NONE")
+        enable_depth_test = lambda self: gpu.state.depth_test_set("ALWAYS")
+        disable_depth_test = lambda self: gpu.state.depth_test_set("NONE")
 
         new_buffer_texture = placeholder_function
         get_buffer = placeholder_function

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -91,9 +91,11 @@ class OldDrawing:
     delete_texture = lambda texture: bgl.glDeleteTextures(1, texture)
 
     def init_complex_texture(self, width, height, texname, texture, data, format):
-        if format == 'RGBA':
-            format = bgl.GL_RGBA
+
+        format = {'BW': bgl.GL_RED, 'RGB': bgl.GL_RGB, 'RGBA': bgl.GL_RGBA}.get(format)
+
         texture = self.new_buffer_texture_sized(bgl.GL_FLOAT, data.size, data.tolist())
+
         bgl.glPixelStorei(bgl.GL_UNPACK_ALIGNMENT, 1)
         bgl.glEnable(bgl.GL_TEXTURE_2D)
         bgl.glBindTexture(bgl.GL_TEXTURE_2D, texname)

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -69,6 +69,7 @@ if bpy.app.version >= (3, 5, 0):
 
         new_buffer_texture = placeholder_function
         get_buffer = placeholder_function
+        new_buffer_texture_sized = lambda self, size, data: gpu.types.Buffer("FLOAT", size, data)
         bind_texture_2d = placeholder_function
         init_complex_texture = placeholder_function
         generate_textures = placeholder_function

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -51,20 +51,20 @@ if bpy.app.version >= (3, 5, 0):
         set_wireframe_line = placeholder_function
 
         def set_wireframe_fill(self):
-            gpu.state.face_culling_set("FRONT")
-            # gpu.state.front_facing_set(False)
+            gpu.state.face_culling_set("BACK")
+            gpu.state.front_facing_set(False)
 
         set_line_width = gpu.state.line_width_set
         reset_line_width = lambda self: gpu.state.line_width_set(1)
         set_point_size = gpu.state.point_size_set
         reset_point_size = lambda self: gpu.state.point_size_set(1)
-        enable_polygon_offset_fill = lambda self: gpu.state.face_culling_set("FRONT")
+        enable_polygon_offset_fill = lambda self: gpu.state.face_culling_set("BACK")
         disable_polygon_offset_fill = placeholder_function
         set_polygon_offset_amounts = placeholder_function
 
         enable_blendmode = lambda self: gpu.state.blend_set("ALPHA")
         disable_blendmode = lambda self: gpu.state.blend_set("NONE")
-        enable_depth_test = lambda self: gpu.state.depth_test_set("ALWAYS")
+        enable_depth_test = lambda self: gpu.state.depth_test_set("LESS_EQUAL")
         disable_depth_test = lambda self: gpu.state.depth_test_set("NONE")
 
         new_buffer_texture = placeholder_function

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -105,7 +105,7 @@ class OldDrawing:
         bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MIN_FILTER, bgl.GL_LINEAR)
         bgl.glTexImage2D(bgl.GL_TEXTURE_2D, 0, format, width, height, 0, format, bgl.GL_FLOAT, texture)
 
-    def init_complex_texture(self, width, height, texname, texture, data, format):
+    def init_complex_texture(self, width, height, texname, data, format):
         texture = self.new_buffer_texture_sized(bgl.GL_FLOAT, data.size, data.tolist())
         self.init_image_from_texture(width, height, texname, texture, format)
         

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -12,19 +12,22 @@ else:
 
 drawing = lambda: None
 
-
 if bpy.app.version >= (3, 5, 0):
     drawing.set_wireframe_line = pass
     drawing.set_wireframe_fill = pass
-    drawing.set_line_width = pass
-    drawing.reset_line_width = pass
-    drawing.set_point_size = pass
-    drawing.reset_point_size = pass
+    drawing.set_line_width = gpu.state.line_width_set
+    drawing.reset_line_width = lambda: gpu.state.line_width_set(1)
+    drawing.set_point_size = gpu.state.point_size_set
+    drawing.reset_point_size = lambda: gpu.state.point_size_set(1)
     drawing.enable_polygon_offset_fill = pass
     drawing.disable_polygon_offset_fill = pass
     drawing.set_polygon_offset_amounts = pass
-    drawing.enable_blendmode = pass 
+
+    drawing.enable_blendmode = pass
     drawing.disable_blendmode = pass
+    drawing.enable_depth_test = pass
+    drawing.disable_depth_test = pass
+
     drawing.new_buffer_texture = pass
     drawing.get_buffer = pass
     drawing.bind_texture_2d = pass
@@ -44,8 +47,12 @@ else:
     drawing.enable_polygon_offset_fill = lambda: bgl.glEnable(bgl.GL_POLYGON_OFFSET_FILL)
     drawing.disable_polygon_offset_fill = lambda: bgl.glDisable(bgl.GL_POLYGON_OFFSET_FILL)
     drawing.set_polygon_offset_amounts = lambda: bgl.glPolygonOffset(1.0, 1.0)
+    
     drawing.enable_blendmode = lambda: bgl.glEnable(bgl.GL_BLEND)
     drawing.disable_blendmode = lambda: bgl.glDisable(bgl.GL_BLEND)
+    drawing.enable_depth_test = lambda: bgl.glEnable(bgl.GL_DEPTH_TEST)
+    drawing.disable_depth_test = lambda: bgl.glDisable(bgl.GL_DEPTH_TEST)
+
     drawing.new_buffer_texture = lambda: bgl.Buffer(bgl.GL_INT, 1)
     drawing.get_buffer = lambda indexed_buffer: bgl.Buffer(bgl.GL_INT, 1, indexed_buffer)
     drawing.new_buffer_texture_sized = lambda size, data: bgl.Buffer(bgl.GL_FLOAT, size, data)

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -52,7 +52,7 @@ if bpy.app.version >= (3, 5, 0):
 
         def set_wireframe_fill(self):
             gpu.state.face_culling_set("FRONT")
-            gpu.state.front_facing_set(False)
+            # gpu.state.front_facing_set(False)
 
         set_line_width = gpu.state.line_width_set
         reset_line_width = lambda self: gpu.state.line_width_set(1)

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -26,10 +26,11 @@ if bpy.app.version >= (3, 5, 0):
     drawing.enable_blendmode = pass 
     drawing.disable_blendmode = pass
     drawing.new_buffer_texture = pass
+    drawing.get_buffer = pass
     drawing.bind_texture_2d = pass
     drawing.init_complex_texture = pass
     drawing.generate_textures = pass
-
+    drawing.delete_texture = pass
 else:
     # from sverchok.utils.modules.drawing_abstractions import drawing 
 
@@ -46,8 +47,10 @@ else:
     drawing.enable_blendmode = lambda: bgl.glEnable(bgl.GL_BLEND)
     drawing.disable_blendmode = lambda: bgl.glDisable(bgl.GL_BLEND)
     drawing.new_buffer_texture = lambda: bgl.Buffer(bgl.GL_INT, 1)
+    drawing.get_buffer = lambda indexed_buffer: bgl.Buffer(bgl.GL_INT, 1, indexed_buffer)
     drawing.new_buffer_texture_sized = lambda size, data: bgl.Buffer(bgl.GL_FLOAT, size, data)
     drawing.bind_texture_2d = lambda texture: bgl.glBindTexture(bgl.GL_TEXTURE_2D, texture)
+    drawing.delete_texture = lambda texture: bgl.glDeleteTextures(1, texture)
 
     def initialize_complex_texture(width, height, texname, texture, data, format):
         if format == 'RGBA':

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -10,6 +10,7 @@
 
 import bpy
 import gpu
+import blf
 from typing import NamedTuple
 
 
@@ -64,9 +65,12 @@ class Drawing:
     generate_textures = pass
     delete_texture = pass
 
+    blf_size = lambda font_id, height, dpi: blf.size(font_id, height)
 
 
 class OldDrawing:
+
+    blf_size = blf.size
 
     import bgl
     set_wireframe_line = lambda: bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_LINE)

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -25,7 +25,11 @@ if bpy.app.version >= (3, 5, 0):
     drawing.disable_blendmode = pass
     drawing.new_buffer_texture = pass
     drawing.bind_texture_2d = pass
+    drawing.init_complex_texture = pass
+    drawing.generate_textures = pass
+
 else:
+
     import bgl
     drawing.set_wireframe_line = lambda: bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_LINE)
     drawing.set_wireframe_fill = lambda: bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_FILL)
@@ -57,3 +61,4 @@ else:
         bgl.glTexImage2D(bgl.GL_TEXTURE_2D, 0, format, width, height, 0, format, bgl.GL_FLOAT, texture)        
 
     drawing.init_complex_texture = initialize_complex_texture
+    drawing.generate_textures = lambda name: bgl.glGenTextures(1, name)

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -1,11 +1,13 @@
 import bpy
 
-if bpy.app.version >= (3, 5, 0):
-    UNIFORM_COLOR = "UNIFORM_COLOR"
-    SMOOTH_COLOR = "SMOOTH_COLOR"
+shading_3d = lambda: None
+
+if bpy.app.version <= (3, 4):
+    shading_3d.UNIFORM_COLOR = "3D_UNIFORM_COLOR"
+    shading_3d.SMOOTH_COLOR = "3D_SMOOTH_COLOR"
 else:
-    UNIFORM_COLOR = "3D_UNIFORM_COLOR"
-    SMOOTH_COLOR = "3D_SMOOTH_COLOR"
+    shading_3d.UNIFORM_COLOR = "UNIFORM_COLOR"
+    shading_3d.SMOOTH_COLOR = "SMOOTH_COLOR"
 
 
 drawing = lambda: None

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -109,7 +109,10 @@ else:
 
         def init_image_from_texture(self, width, height, texname, texture, format):
 
-            format = {'BW': bgl.GL_RED, 'RGB': bgl.GL_RGB, 'RGBA': bgl.GL_RGBA}.get(format)
+            if format in {bgl.GL_RGBA, bgl.GL_RGB, bgl.GL_RED}:
+                ...
+            else:
+                format = {'BW': bgl.GL_RED, 'RGB': bgl.GL_RGB, 'RGBA': bgl.GL_RGBA}.get(format)
 
             bgl.glPixelStorei(bgl.GL_UNPACK_ALIGNMENT, 1)
             bgl.glEnable(bgl.GL_TEXTURE_2D)

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -40,83 +40,89 @@ configurations will need additional attention and might even not reach parity fo
 or indeed at all. Replacement techniques will be investigated. 
 
 """
-def placeholder_function(*params):
-    return
 
-class Drawing:
+if bpy.app.version >= (3, 5, 0):
 
-    set_wireframe_line = placeholder_function
-    set_wireframe_fill = placeholder_function
-    set_line_width = gpu.state.line_width_set
-    reset_line_width = lambda: gpu.state.line_width_set(1)
-    set_point_size = gpu.state.point_size_set
-    reset_point_size = lambda: gpu.state.point_size_set(1)
-    enable_polygon_offset_fill = placeholder_function
-    disable_polygon_offset_fill = placeholder_function
-    set_polygon_offset_amounts = placeholder_function
+    def placeholder_function(*params):
+        return
 
-    enable_blendmode = placeholder_function
-    disable_blendmode = placeholder_function
-    enable_depth_test = placeholder_function
-    disable_depth_test = placeholder_function
+    class Drawing:
 
-    new_buffer_texture = placeholder_function
-    get_buffer = placeholder_function
-    bind_texture_2d = placeholder_function
-    init_complex_texture = placeholder_function
-    generate_textures = placeholder_function
-    delete_texture = placeholder_function
+        set_wireframe_line = placeholder_function
+        set_wireframe_fill = placeholder_function
+        set_line_width = gpu.state.line_width_set
+        reset_line_width = lambda self: gpu.state.line_width_set(1)
+        set_point_size = gpu.state.point_size_set
+        reset_point_size = lambda self: gpu.state.point_size_set(1)
+        enable_polygon_offset_fill = placeholder_function
+        disable_polygon_offset_fill = placeholder_function
+        set_polygon_offset_amounts = placeholder_function
 
-    blf_size = lambda font_id, height, dpi: blf.size(font_id, height)
+        enable_blendmode = placeholder_function
+        disable_blendmode = placeholder_function
+        enable_depth_test = placeholder_function
+        disable_depth_test = placeholder_function
+
+        new_buffer_texture = placeholder_function
+        get_buffer = placeholder_function
+        bind_texture_2d = placeholder_function
+        init_complex_texture = placeholder_function
+        generate_textures = placeholder_function
+        delete_texture = placeholder_function
+
+        blf_size = lambda self, font_id, height, dpi: blf.size(font_id, height)
 
 
-class OldDrawing:
-
-    blf_size = blf.size
+else:
 
     import bgl
-    set_wireframe_line = lambda: bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_LINE)
-    set_wireframe_fill = lambda: bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_FILL)
-    set_line_width = bgl.glLineWidth
-    reset_line_width = lambda: bgl.glLineWidth(1)
-    set_point_size = bgl.glPointSize
-    reset_point_size = lambda: bgl.glPointSize(1)
-    enable_polygon_offset_fill = lambda: bgl.glEnable(bgl.GL_POLYGON_OFFSET_FILL)
-    disable_polygon_offset_fill = lambda: bgl.glDisable(bgl.GL_POLYGON_OFFSET_FILL)
-    set_polygon_offset_amounts = lambda: bgl.glPolygonOffset(1.0, 1.0)
-    
-    enable_blendmode = lambda: bgl.glEnable(bgl.GL_BLEND)
-    disable_blendmode = lambda: bgl.glDisable(bgl.GL_BLEND)
-    enable_depth_test = lambda: bgl.glEnable(bgl.GL_DEPTH_TEST)
-    disable_depth_test = lambda: bgl.glDisable(bgl.GL_DEPTH_TEST)
-    disable_texture_2d = lambda: bgl.glDisable(bgl.GL_TEXTURE_2D)
 
-    new_buffer_texture = lambda: bgl.Buffer(bgl.GL_INT, 1)
-    get_buffer = lambda indexed_buffer: bgl.Buffer(bgl.GL_INT, 1, indexed_buffer)
-    new_buffer_texture_sized = lambda size, data: bgl.Buffer(bgl.GL_FLOAT, size, data)
-    bind_texture_2d = lambda texture: bgl.glBindTexture(bgl.GL_TEXTURE_2D, texture)
-    delete_texture = lambda texture: bgl.glDeleteTextures(1, texture)
+    class Drawing:
 
-    def init_image_from_texture(self, width, height, texname, texture, format):
+        blf_size = blf.size
 
-        format = {'BW': bgl.GL_RED, 'RGB': bgl.GL_RGB, 'RGBA': bgl.GL_RGBA}.get(format)
-
-        bgl.glPixelStorei(bgl.GL_UNPACK_ALIGNMENT, 1)
-        bgl.glEnable(bgl.GL_TEXTURE_2D)
-        bgl.glBindTexture(bgl.GL_TEXTURE_2D, texname)
-        bgl.glActiveTexture(bgl.GL_TEXTURE0)
-        bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_S, bgl.GL_CLAMP_TO_EDGE)
-        bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_T, bgl.GL_CLAMP_TO_EDGE)
-        bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MAG_FILTER, bgl.GL_LINEAR)
-        bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MIN_FILTER, bgl.GL_LINEAR)
-        bgl.glTexImage2D(bgl.GL_TEXTURE_2D, 0, format, width, height, 0, format, bgl.GL_FLOAT, texture)
-
-    def init_complex_texture(self, width, height, texname, data, format):
-        texture = self.new_buffer_texture_sized(bgl.GL_FLOAT, data.size, data.tolist())
-        self.init_image_from_texture(width, height, texname, texture, format)
+        set_wireframe_line = lambda self: bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_LINE)
+        set_wireframe_fill = lambda self: bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_FILL)
+        set_line_width = bgl.glLineWidth
+        reset_line_width = lambda self: bgl.glLineWidth(1)
+        set_point_size = bgl.glPointSize
+        reset_point_size = lambda self: bgl.glPointSize(1)
+        enable_polygon_offset_fill = lambda self: bgl.glEnable(bgl.GL_POLYGON_OFFSET_FILL)
+        disable_polygon_offset_fill = lambda self: bgl.glDisable(bgl.GL_POLYGON_OFFSET_FILL)
+        set_polygon_offset_amounts = lambda self: bgl.glPolygonOffset(1.0, 1.0)
         
+        enable_blendmode = lambda self: bgl.glEnable(bgl.GL_BLEND)
+        disable_blendmode = lambda self: bgl.glDisable(bgl.GL_BLEND)
+        enable_depth_test = lambda self: bgl.glEnable(bgl.GL_DEPTH_TEST)
+        disable_depth_test = lambda self: bgl.glDisable(bgl.GL_DEPTH_TEST)
+        disable_texture_2d = lambda self: bgl.glDisable(bgl.GL_TEXTURE_2D)
 
-    generate_textures = lambda name: bgl.glGenTextures(1, name)  # returns an indexable item
+        new_buffer_texture = lambda self: bgl.Buffer(bgl.GL_INT, 1)
+        get_buffer = lambda self, indexed_buffer: bgl.Buffer(bgl.GL_INT, 1, indexed_buffer)
+        new_buffer_texture_sized = lambda self, size, data: bgl.Buffer(bgl.GL_FLOAT, size, data)
+        bind_texture_2d = lambda self, texture: bgl.glBindTexture(bgl.GL_TEXTURE_2D, texture)
+        delete_texture = lambda self, texture: bgl.glDeleteTextures(1, texture)
+
+        def init_image_from_texture(self, width, height, texname, texture, format):
+
+            format = {'BW': bgl.GL_RED, 'RGB': bgl.GL_RGB, 'RGBA': bgl.GL_RGBA}.get(format)
+
+            bgl.glPixelStorei(bgl.GL_UNPACK_ALIGNMENT, 1)
+            bgl.glEnable(bgl.GL_TEXTURE_2D)
+            bgl.glBindTexture(bgl.GL_TEXTURE_2D, texname)
+            bgl.glActiveTexture(bgl.GL_TEXTURE0)
+            bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_S, bgl.GL_CLAMP_TO_EDGE)
+            bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_T, bgl.GL_CLAMP_TO_EDGE)
+            bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MAG_FILTER, bgl.GL_LINEAR)
+            bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MIN_FILTER, bgl.GL_LINEAR)
+            bgl.glTexImage2D(bgl.GL_TEXTURE_2D, 0, format, width, height, 0, format, bgl.GL_FLOAT, texture)
+
+        def init_complex_texture(self, width, height, texname, data, format):
+            texture = self.new_buffer_texture_sized(bgl.GL_FLOAT, data.size, data.tolist())
+            self.init_image_from_texture(width, height, texname, texture, format)
+            
+
+        generate_textures = lambda self, name: bgl.glGenTextures(1, name)  # returns an indexable item
 
 
-drawing = Drawing() if bpy.app.version >= (3, 5, 0) else OldDrawing()
+drawing = Drawing()

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -48,9 +48,9 @@ if bpy.app.version >= (3, 5, 0):
 
     class Drawing:
 
-        set_wireframe_line = placeholder_function
+        set_polygonmode_line = placeholder_function
 
-        def set_wireframe_fill(self):
+        def set_polygonmode_fill(self):
             gpu.state.face_culling_set("BACK")
             gpu.state.front_facing_set(False)
 
@@ -85,8 +85,8 @@ else:
 
         blf_size = blf.size
 
-        set_wireframe_line = lambda self: bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_LINE)
-        set_wireframe_fill = lambda self: bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_FILL)
+        set_polygonmode_line = lambda self: bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_LINE)
+        set_polygonmode_fill = lambda self: bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_FILL)
         set_line_width = bgl.glLineWidth
         reset_line_width = lambda self: bgl.glLineWidth(1)
         set_point_size = bgl.glPointSize

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -23,6 +23,8 @@ if bpy.app.version >= (3, 5, 0):
     drawing.set_polygon_offset_amounts = pass
     drawing.enable_blendmode = pass 
     drawing.disable_blendmode = pass
+    drawing.new_buffer_texture = pass
+    drawing.bind_texture_2d = pass
 else:
     import bgl
     drawing.set_wireframe_line = lambda: bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_LINE)
@@ -36,3 +38,22 @@ else:
     drawing.set_polygon_offset_amounts = lambda: bgl.glPolygonOffset(1.0, 1.0)
     drawing.enable_blendmode = lambda: bgl.glEnable(bgl.GL_BLEND)
     drawing.disable_blendmode = lambda: bgl.glDisable(bgl.GL_BLEND)
+    drawing.new_buffer_texture = lambda: bgl.Buffer(bgl.GL_INT, 1)
+    drawing.new_buffer_texture_sized = lambda size, data: bgl.Buffer(bgl.GL_FLOAT, size, data)
+    drawing.bind_texture_2d = lambda texture: bgl.glBindTexture(bgl.GL_TEXTURE_2D, texture)
+
+    def initialize_complex_texture(width, height, texname, texture, data, format):
+        if format == 'RGBA':
+            format = bgl.GL_RGBA
+        texture = drawing.new_buffer_texture_sized(bgl.GL_FLOAT, data.size, data.tolist())
+        bgl.glPixelStorei(bgl.GL_UNPACK_ALIGNMENT, 1)
+        bgl.glEnable(bgl.GL_TEXTURE_2D)
+        bgl.glBindTexture(bgl.GL_TEXTURE_2D, texname)
+        bgl.glActiveTexture(bgl.GL_TEXTURE0)
+        bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_S, bgl.GL_CLAMP_TO_EDGE)
+        bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_T, bgl.GL_CLAMP_TO_EDGE)
+        bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MAG_FILTER, bgl.GL_LINEAR)
+        bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MIN_FILTER, bgl.GL_LINEAR)
+        bgl.glTexImage2D(bgl.GL_TEXTURE_2D, 0, format, width, height, 0, format, bgl.GL_FLOAT, texture)        
+
+    drawing.init_complex_texture = initialize_complex_texture

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -90,11 +90,9 @@ class OldDrawing:
     bind_texture_2d = lambda texture: bgl.glBindTexture(bgl.GL_TEXTURE_2D, texture)
     delete_texture = lambda texture: bgl.glDeleteTextures(1, texture)
 
-    def init_complex_texture(self, width, height, texname, texture, data, format):
+    def init_image_from_texture(self, width, height, texname, texture, format):
 
         format = {'BW': bgl.GL_RED, 'RGB': bgl.GL_RGB, 'RGBA': bgl.GL_RGBA}.get(format)
-
-        texture = self.new_buffer_texture_sized(bgl.GL_FLOAT, data.size, data.tolist())
 
         bgl.glPixelStorei(bgl.GL_UNPACK_ALIGNMENT, 1)
         bgl.glEnable(bgl.GL_TEXTURE_2D)
@@ -104,7 +102,13 @@ class OldDrawing:
         bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_T, bgl.GL_CLAMP_TO_EDGE)
         bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MAG_FILTER, bgl.GL_LINEAR)
         bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MIN_FILTER, bgl.GL_LINEAR)
-        bgl.glTexImage2D(bgl.GL_TEXTURE_2D, 0, format, width, height, 0, format, bgl.GL_FLOAT, texture)        
+
+        bgl.glTexImage2D(bgl.GL_TEXTURE_2D, 0, format, width, height, 0, format, bgl.GL_FLOAT, texture)
+
+    def init_complex_texture(self, width, height, texname, texture, data, format):
+        texture = self.new_buffer_texture_sized(bgl.GL_FLOAT, data.size, data.tolist())
+        self.init_image_from_texture(width, height, texname, texture, format)
+        
 
     generate_textures = lambda name: bgl.glGenTextures(1, name)  # returns an indexable item
 

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -83,6 +83,7 @@ class OldDrawing:
     disable_blendmode = lambda: bgl.glDisable(bgl.GL_BLEND)
     enable_depth_test = lambda: bgl.glEnable(bgl.GL_DEPTH_TEST)
     disable_depth_test = lambda: bgl.glDisable(bgl.GL_DEPTH_TEST)
+    disable_texture_2d = lambda: bgl.glDisable(bgl.GL_TEXTURE_2D)
 
     new_buffer_texture = lambda: bgl.Buffer(bgl.GL_INT, 1)
     get_buffer = lambda indexed_buffer: bgl.Buffer(bgl.GL_INT, 1, indexed_buffer)
@@ -102,7 +103,6 @@ class OldDrawing:
         bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_T, bgl.GL_CLAMP_TO_EDGE)
         bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MAG_FILTER, bgl.GL_LINEAR)
         bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MIN_FILTER, bgl.GL_LINEAR)
-
         bgl.glTexImage2D(bgl.GL_TEXTURE_2D, 0, format, width, height, 0, format, bgl.GL_FLOAT, texture)
 
     def init_complex_texture(self, width, height, texname, texture, data, format):

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -29,6 +29,7 @@ if bpy.app.version >= (3, 5, 0):
     drawing.generate_textures = pass
 
 else:
+    # from sverchok.utils.modules.drawing_abstractions import drawing 
 
     import bgl
     drawing.set_wireframe_line = lambda: bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_LINE)
@@ -61,4 +62,5 @@ else:
         bgl.glTexImage2D(bgl.GL_TEXTURE_2D, 0, format, width, height, 0, format, bgl.GL_FLOAT, texture)        
 
     drawing.init_complex_texture = initialize_complex_texture
-    drawing.generate_textures = lambda name: bgl.glGenTextures(1, name)
+    drawing.generate_textures = lambda name: bgl.glGenTextures(1, name)  # returns an indexable item
+

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -40,30 +40,32 @@ configurations will need additional attention and might even not reach parity fo
 or indeed at all. Replacement techniques will be investigated. 
 
 """
+def placeholder_function(*params):
+    return
 
 class Drawing:
 
-    set_wireframe_line = pass
-    set_wireframe_fill = pass
+    set_wireframe_line = placeholder_function
+    set_wireframe_fill = placeholder_function
     set_line_width = gpu.state.line_width_set
     reset_line_width = lambda: gpu.state.line_width_set(1)
     set_point_size = gpu.state.point_size_set
     reset_point_size = lambda: gpu.state.point_size_set(1)
-    enable_polygon_offset_fill = pass
-    disable_polygon_offset_fill = pass
-    set_polygon_offset_amounts = pass
+    enable_polygon_offset_fill = placeholder_function
+    disable_polygon_offset_fill = placeholder_function
+    set_polygon_offset_amounts = placeholder_function
 
-    enable_blendmode = pass
-    disable_blendmode = pass
-    enable_depth_test = pass
-    disable_depth_test = pass
+    enable_blendmode = placeholder_function
+    disable_blendmode = placeholder_function
+    enable_depth_test = placeholder_function
+    disable_depth_test = placeholder_function
 
-    new_buffer_texture = pass
-    get_buffer = pass
-    bind_texture_2d = pass
-    init_complex_texture = pass
-    generate_textures = pass
-    delete_texture = pass
+    new_buffer_texture = placeholder_function
+    get_buffer = placeholder_function
+    bind_texture_2d = placeholder_function
+    init_complex_texture = placeholder_function
+    generate_textures = placeholder_function
+    delete_texture = placeholder_function
 
     blf_size = lambda font_id, height, dpi: blf.size(font_id, height)
 

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -1,0 +1,38 @@
+import bpy
+
+if bpy.app.version >= (3, 5, 0):
+    UNIFORM_COLOR = "UNIFORM_COLOR"
+    SMOOTH_COLOR = "SMOOTH_COLOR"
+else:
+    UNIFORM_COLOR = "3D_UNIFORM_COLOR"
+    SMOOTH_COLOR = "3D_SMOOTH_COLOR"
+
+
+drawing = lambda: None
+
+
+if bpy.app.version >= (3, 5, 0):
+    drawing.set_wireframe_line = pass
+    drawing.set_wireframe_fill = pass
+    drawing.set_line_width = pass
+    drawing.reset_line_width = pass
+    drawing.set_point_size = pass
+    drawing.reset_point_size = pass
+    drawing.enable_polygon_offset_fill = pass
+    drawing.disable_polygon_offset_fill = pass
+    drawing.set_polygon_offset_amounts = pass
+    drawing.enable_blendmode = pass 
+    drawing.disable_blendmode = pass
+else:
+    import bgl
+    drawing.set_wireframe_line = lambda: bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_LINE)
+    drawing.set_wireframe_fill = lambda: bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_FILL)
+    drawing.set_line_width = bgl.glLineWidth
+    drawing.reset_line_width = lambda: bgl.glLineWidth(1)
+    drawing.set_point_size = bgl.glPointSize
+    drawing.reset_point_size = lambda: bgl.glPointSize(1)
+    drawing.enable_polygon_offset_fill = lambda: bgl.glEnable(bgl.GL_POLYGON_OFFSET_FILL)
+    drawing.disable_polygon_offset_fill = lambda: bgl.glDisable(bgl.GL_POLYGON_OFFSET_FILL)
+    drawing.set_polygon_offset_amounts = lambda: bgl.glPolygonOffset(1.0, 1.0)
+    drawing.enable_blendmode = lambda: bgl.glEnable(bgl.GL_BLEND)
+    drawing.disable_blendmode = lambda: bgl.glDisable(bgl.GL_BLEND)

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -21,6 +21,25 @@ class shading_3d(NamedTuple):
         UNIFORM_COLOR = "UNIFORM_COLOR"
         SMOOTH_COLOR = "SMOOTH_COLOR"
 
+class shading_2d(NamedTuple):
+    if bpy.app.version <= (3, 4):
+        UNIFORM_COLOR = "2D_UNIFORM_COLOR"
+        SMOOTH_COLOR = "2D_SMOOTH_COLOR"
+    else:
+        UNIFORM_COLOR = "UNIFORM_COLOR"
+        SMOOTH_COLOR = "SMOOTH_COLOR"
+
+
+"""
+These classes encapsulate any and all sets of bgl instructions that Sverchok used prior to
+the deprecation of the bgl module. It's not clear yet if the gpu module will achieve parity,
+some Nodes might need considerable revision - here we attempt to make at least some viz nodes
+draw in a useful way in B3.5 and up. Certain nodes that use elaborate buffer and texture 
+configurations will need additional attention and might even not reach parity for some time, 
+or indeed at all. Replacement techniques will be investigated. 
+
+"""
+
 class Drawing:
 
     set_wireframe_line = pass

--- a/utils/modules/drawing_abstractions.py
+++ b/utils/modules/drawing_abstractions.py
@@ -1,68 +1,80 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#  
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+
+# from sverchok.utils.modules.drawing_abstractions import drawing 
+
 import bpy
-
-shading_3d = lambda: None
-
-if bpy.app.version <= (3, 4):
-    shading_3d.UNIFORM_COLOR = "3D_UNIFORM_COLOR"
-    shading_3d.SMOOTH_COLOR = "3D_SMOOTH_COLOR"
-else:
-    shading_3d.UNIFORM_COLOR = "UNIFORM_COLOR"
-    shading_3d.SMOOTH_COLOR = "SMOOTH_COLOR"
+import gpu
+from typing import NamedTuple
 
 
-drawing = lambda: None
+class shading_3d(NamedTuple):
+    if bpy.app.version <= (3, 4):
+        UNIFORM_COLOR = "3D_UNIFORM_COLOR"
+        SMOOTH_COLOR = "3D_SMOOTH_COLOR"
+    else:
+        UNIFORM_COLOR = "UNIFORM_COLOR"
+        SMOOTH_COLOR = "SMOOTH_COLOR"
 
-if bpy.app.version >= (3, 5, 0):
-    drawing.set_wireframe_line = pass
-    drawing.set_wireframe_fill = pass
-    drawing.set_line_width = gpu.state.line_width_set
-    drawing.reset_line_width = lambda: gpu.state.line_width_set(1)
-    drawing.set_point_size = gpu.state.point_size_set
-    drawing.reset_point_size = lambda: gpu.state.point_size_set(1)
-    drawing.enable_polygon_offset_fill = pass
-    drawing.disable_polygon_offset_fill = pass
-    drawing.set_polygon_offset_amounts = pass
+class Drawing:
 
-    drawing.enable_blendmode = pass
-    drawing.disable_blendmode = pass
-    drawing.enable_depth_test = pass
-    drawing.disable_depth_test = pass
+    set_wireframe_line = pass
+    set_wireframe_fill = pass
+    set_line_width = gpu.state.line_width_set
+    reset_line_width = lambda: gpu.state.line_width_set(1)
+    set_point_size = gpu.state.point_size_set
+    reset_point_size = lambda: gpu.state.point_size_set(1)
+    enable_polygon_offset_fill = pass
+    disable_polygon_offset_fill = pass
+    set_polygon_offset_amounts = pass
 
-    drawing.new_buffer_texture = pass
-    drawing.get_buffer = pass
-    drawing.bind_texture_2d = pass
-    drawing.init_complex_texture = pass
-    drawing.generate_textures = pass
-    drawing.delete_texture = pass
-else:
-    # from sverchok.utils.modules.drawing_abstractions import drawing 
+    enable_blendmode = pass
+    disable_blendmode = pass
+    enable_depth_test = pass
+    disable_depth_test = pass
+
+    new_buffer_texture = pass
+    get_buffer = pass
+    bind_texture_2d = pass
+    init_complex_texture = pass
+    generate_textures = pass
+    delete_texture = pass
+
+
+
+class OldDrawing:
 
     import bgl
-    drawing.set_wireframe_line = lambda: bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_LINE)
-    drawing.set_wireframe_fill = lambda: bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_FILL)
-    drawing.set_line_width = bgl.glLineWidth
-    drawing.reset_line_width = lambda: bgl.glLineWidth(1)
-    drawing.set_point_size = bgl.glPointSize
-    drawing.reset_point_size = lambda: bgl.glPointSize(1)
-    drawing.enable_polygon_offset_fill = lambda: bgl.glEnable(bgl.GL_POLYGON_OFFSET_FILL)
-    drawing.disable_polygon_offset_fill = lambda: bgl.glDisable(bgl.GL_POLYGON_OFFSET_FILL)
-    drawing.set_polygon_offset_amounts = lambda: bgl.glPolygonOffset(1.0, 1.0)
+    set_wireframe_line = lambda: bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_LINE)
+    set_wireframe_fill = lambda: bgl.glPolygonMode(bgl.GL_FRONT_AND_BACK, bgl.GL_FILL)
+    set_line_width = bgl.glLineWidth
+    reset_line_width = lambda: bgl.glLineWidth(1)
+    set_point_size = bgl.glPointSize
+    reset_point_size = lambda: bgl.glPointSize(1)
+    enable_polygon_offset_fill = lambda: bgl.glEnable(bgl.GL_POLYGON_OFFSET_FILL)
+    disable_polygon_offset_fill = lambda: bgl.glDisable(bgl.GL_POLYGON_OFFSET_FILL)
+    set_polygon_offset_amounts = lambda: bgl.glPolygonOffset(1.0, 1.0)
     
-    drawing.enable_blendmode = lambda: bgl.glEnable(bgl.GL_BLEND)
-    drawing.disable_blendmode = lambda: bgl.glDisable(bgl.GL_BLEND)
-    drawing.enable_depth_test = lambda: bgl.glEnable(bgl.GL_DEPTH_TEST)
-    drawing.disable_depth_test = lambda: bgl.glDisable(bgl.GL_DEPTH_TEST)
+    enable_blendmode = lambda: bgl.glEnable(bgl.GL_BLEND)
+    disable_blendmode = lambda: bgl.glDisable(bgl.GL_BLEND)
+    enable_depth_test = lambda: bgl.glEnable(bgl.GL_DEPTH_TEST)
+    disable_depth_test = lambda: bgl.glDisable(bgl.GL_DEPTH_TEST)
 
-    drawing.new_buffer_texture = lambda: bgl.Buffer(bgl.GL_INT, 1)
-    drawing.get_buffer = lambda indexed_buffer: bgl.Buffer(bgl.GL_INT, 1, indexed_buffer)
-    drawing.new_buffer_texture_sized = lambda size, data: bgl.Buffer(bgl.GL_FLOAT, size, data)
-    drawing.bind_texture_2d = lambda texture: bgl.glBindTexture(bgl.GL_TEXTURE_2D, texture)
-    drawing.delete_texture = lambda texture: bgl.glDeleteTextures(1, texture)
+    new_buffer_texture = lambda: bgl.Buffer(bgl.GL_INT, 1)
+    get_buffer = lambda indexed_buffer: bgl.Buffer(bgl.GL_INT, 1, indexed_buffer)
+    new_buffer_texture_sized = lambda size, data: bgl.Buffer(bgl.GL_FLOAT, size, data)
+    bind_texture_2d = lambda texture: bgl.glBindTexture(bgl.GL_TEXTURE_2D, texture)
+    delete_texture = lambda texture: bgl.glDeleteTextures(1, texture)
 
-    def initialize_complex_texture(width, height, texname, texture, data, format):
+    def init_complex_texture(self, width, height, texname, texture, data, format):
         if format == 'RGBA':
             format = bgl.GL_RGBA
-        texture = drawing.new_buffer_texture_sized(bgl.GL_FLOAT, data.size, data.tolist())
+        texture = self.new_buffer_texture_sized(bgl.GL_FLOAT, data.size, data.tolist())
         bgl.glPixelStorei(bgl.GL_UNPACK_ALIGNMENT, 1)
         bgl.glEnable(bgl.GL_TEXTURE_2D)
         bgl.glBindTexture(bgl.GL_TEXTURE_2D, texname)
@@ -73,6 +85,7 @@ else:
         bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MIN_FILTER, bgl.GL_LINEAR)
         bgl.glTexImage2D(bgl.GL_TEXTURE_2D, 0, format, width, height, 0, format, bgl.GL_FLOAT, texture)        
 
-    drawing.init_complex_texture = initialize_complex_texture
-    drawing.generate_textures = lambda name: bgl.glGenTextures(1, name)  # returns an indexable item
+    generate_textures = lambda name: bgl.glGenTextures(1, name)  # returns an indexable item
 
+
+drawing = Drawing() if bpy.app.version >= (3, 5, 0) else OldDrawing()

--- a/utils/nodes_mixins/console_mixin.py
+++ b/utils/nodes_mixins/console_mixin.py
@@ -125,7 +125,7 @@ class LexMixin():
 
         if not 'texture_buffer' in self.texture_dict:
             #print('initializing texture longform')
-            texture = new_buffer_texture_sized(data.size, data.tolist())
+            texture = drawing.new_buffer_texture_sized(data.size, data.tolist())
             self.texture_dict['texture_buffer'] = texture
         else:
             #print("reusing")

--- a/utils/nodes_mixins/console_mixin.py
+++ b/utils/nodes_mixins/console_mixin.py
@@ -13,7 +13,7 @@ import gpu
 from gpu_extras.batch import batch_for_shader
 
 from sverchok.utils.sv_nodeview_draw_helper import get_console_grid, get_xy_for_bgl_drawing 
-
+from sverchok.utils.modules.drawing_abstractions import drawing 
 from sverchok.nodes.viz.console_node import (
     simple_console_xy, 
     terminal_text_to_uv, 

--- a/utils/nodes_mixins/console_mixin.py
+++ b/utils/nodes_mixins/console_mixin.py
@@ -144,7 +144,7 @@ class LexMixin():
             dsize = data.size
             data = data.repeat(3).reshape(-1, 3)
             data = np.concatenate((data, np.ones(dsize)[:,None]),axis=1).flatten()
-            name = bgl.new_buffer_texture()
+            name = drawing.new_buffer_texture()
             drawing.generate_textures(name)
 
             self.texture_dict['texture'] = name[0]

--- a/utils/nodeview_time_graph_drawing.py
+++ b/utils/nodeview_time_graph_drawing.py
@@ -16,7 +16,7 @@ from gpu_extras.batch import batch_for_shader
 import sverchok
 from sverchok.ui import bgl_callback_nodeview as nvBGL2
 from sverchok.utils.modules.shader_utils import ShaderLib2D
-
+from sverchok.utils.modules.drawing_abstractions import drawing 
 
 # https://github.com/nortikin/sverchok/commit/c0ef777acef561a5e9cd308ec05c1382b9006de8
 
@@ -110,7 +110,7 @@ def draw_node_time_infos(*data):
         _x, _y = _x, _y + (text_height - 9)
         return _x * location_theta, _y * location_theta
 
-    blf.size(font_id, int(text_height), 72)
+    drawing.blf_size(font_id, int(text_height), 72)
     blf.color(font_id, r, g, b, 1.0)
     for idx, node_data in data_tree.items():
         node = node_tree.nodes.get(node_data['name'])
@@ -151,7 +151,7 @@ def draw_overlay(*data):
     text_height = 10
     line_height = 10 + 3
 
-    blf.size(font_id, int(text_height), 72)
+    drawing.blf_size(font_id, int(text_height), 72)
     blf.color(font_id, r, g, b, 1.0)
 
     if not node_tree.sv_show_time_graph:

--- a/utils/nodeview_time_graph_drawing.py
+++ b/utils/nodeview_time_graph_drawing.py
@@ -6,7 +6,7 @@
 # License-Filename: LICENSE
 
 
-import bgl
+# import bgl
 import blf
 import bpy
 from mathutils import Vector

--- a/utils/sv_batch_primitives.py
+++ b/utils/sv_batch_primitives.py
@@ -10,6 +10,8 @@ import gpu
 from gpu_extras.batch import batch_for_shader
 from mathutils import Matrix, Vector
 from sverchok.utils.sv_logging import sv_logger
+from sverchok.utils.modules.drawing_abstractions import shading_3d
+
 
 if bpy.app.background:
     print("Will not initialize shaders in the background mode")
@@ -19,10 +21,8 @@ if bpy.app.background:
             sv_logger.info("draw_matrix: do nothing in background mode")
 
 else:
-    shader_name = f'{"3D_" if bpy.app.version < (3, 4) else ""}UNIFORM_COLOR'
-    uniform_shader = gpu.shader.from_builtin(shader_name)
-    shader_name = f'{"3D_" if bpy.app.version < (3, 4) else ""}SMOOTH_COLOR'
-    smooth_shader = gpu.shader.from_builtin(shader_name)
+    uniform_shader = gpu.shader.from_builtin(shading_3d.UNIFORM_COLOR)
+    smooth_shader = gpu.shader.from_builtin(shading_3d.SMOOTH_COLOR)
 
 
     class MatrixDraw28(object):

--- a/utils/sv_idx_viewer28_draw.py
+++ b/utils/sv_idx_viewer28_draw.py
@@ -19,6 +19,8 @@ from mathutils import Vector
 from mathutils.bvhtree import BVHTree
 
 from sverchok.data_structure import Vector_generate
+from sverchok.utils.modules.drawing_abstractions import drawing 
+
 
 SpaceView3D = bpy.types.SpaceView3D
 callback_dict = {}
@@ -84,7 +86,7 @@ def draw_indices_2D(context, args):
 
     font_id = 0
     text_height = int(13.0 * scale)
-    blf.size(font_id, text_height, 72)  # should check prefs.dpi
+    drawing.blf_size(font_id, text_height, 72)  # should check prefs.dpi
 
     region_mid_width = region.width / 2.0
     region_mid_height = region.height / 2.0
@@ -248,7 +250,7 @@ def draw_indices_2D_wbg(context, args):
 
     font_id = 0
     text_height = int(13.0 * scale)
-    blf.size(font_id, text_height, 72)  # should check prefs.dpi
+    drawing.blf_size(font_id, text_height, 72)  # should check prefs.dpi
 
     region_mid_width = region.width / 2.0
     region_mid_height = region.height / 2.0

--- a/utils/sv_idx_viewer28_draw.py
+++ b/utils/sv_idx_viewer28_draw.py
@@ -11,7 +11,6 @@ import traceback
 
 import bpy
 import blf
-import bgl
 import gpu
 from gpu_extras.batch import batch_for_shader
 

--- a/utils/sv_stethoscope_helper.py
+++ b/utils/sv_stethoscope_helper.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 
 import blf
 import bpy
+from sverchok.utils.modules.drawing_abstractions import drawing
 
 def get_sane_xy(data):
     return_value = (120, 120)
@@ -37,7 +38,7 @@ def draw_text_data(data):
     text_height = 15 * scale
     line_height = 14 * scale
 
-    blf.size(font_id, int(text_height), 72)
+    drawing.blf_size(font_id, int(text_height), 72)
     blf.color(font_id, r, g, b, 1.0)
     ypos = y
 
@@ -58,7 +59,7 @@ def draw_graphical_data(data):
     if not lines:
         return
 
-    blf.size(font_id, int(text_height), 72)
+    drawing.blf_size(font_id, int(text_height), 72)
 
     def draw_text(color, xpos, ypos, line):
         r, g, b = color

--- a/utils/sv_stethoscope_helper.py
+++ b/utils/sv_stethoscope_helper.py
@@ -62,7 +62,7 @@ def draw_graphical_data(data):
 
     def draw_text(color, xpos, ypos, line):
         r, g, b = color
-        blf.color(font_id, r, g, b, 1.0) # bgl.glColor3f(*color)
+        blf.color(font_id, r, g, b, 1.0)
         blf.position(0, xpos, ypos, 0)
         blf.draw(font_id, line)
         return blf.dimensions(font_id, line)

--- a/utils/sv_texture_utils.py
+++ b/utils/sv_texture_utils.py
@@ -49,7 +49,6 @@ tx_fragment_shader = '''
 '''
 
 def init_texture(width, height, texname, texture, clr):  # good luck with this one
-    # function to init the texture
     bgl.glPixelStorei(bgl.GL_UNPACK_ALIGNMENT, 1)
 
     bgl.glEnable(bgl.GL_TEXTURE_2D)
@@ -61,11 +60,7 @@ def init_texture(width, height, texname, texture, clr):  # good luck with this o
     bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MAG_FILTER, bgl.GL_LINEAR)
     bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MIN_FILTER, bgl.GL_LINEAR)
 
-    bgl.glTexImage2D(
-        bgl.GL_TEXTURE_2D,
-        0, clr, width, height,
-        0, clr, bgl.GL_FLOAT, texture
-    )
+    bgl.glTexImage2D(bgl.GL_TEXTURE_2D, 0, clr, width, height, 0, clr, bgl.GL_FLOAT, texture)
 
 
 def simple_screen(context, args, xy):

--- a/utils/sv_texture_utils.py
+++ b/utils/sv_texture_utils.py
@@ -8,7 +8,7 @@
 import bgl
 import gpu
 from gpu_extras.batch import batch_for_shader
-
+from sverchok.utils.modules.drawing_abstractions import drawing 
 
 tx_vertex_shader = '''
     uniform mat4 viewProjectionMatrix;
@@ -48,19 +48,8 @@ tx_fragment_shader = '''
     }
 '''
 
-def init_texture(width, height, texname, texture, clr):  # good luck with this one
-    bgl.glPixelStorei(bgl.GL_UNPACK_ALIGNMENT, 1)
-
-    bgl.glEnable(bgl.GL_TEXTURE_2D)
-    bgl.glBindTexture(bgl.GL_TEXTURE_2D, texname)
-    bgl.glActiveTexture(bgl.GL_TEXTURE0)
-
-    bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_S, bgl.GL_CLAMP_TO_EDGE)
-    bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_T, bgl.GL_CLAMP_TO_EDGE)
-    bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MAG_FILTER, bgl.GL_LINEAR)
-    bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MIN_FILTER, bgl.GL_LINEAR)
-
-    bgl.glTexImage2D(bgl.GL_TEXTURE_2D, 0, clr, width, height, 0, clr, bgl.GL_FLOAT, texture)
+def init_texture(width, height, texname, texture, clr):
+    drawing.init_image_from_texture(width, height, texname, texture, clr)
 
 
 def simple_screen(context, args, xy):

--- a/utils/sv_texture_utils.py
+++ b/utils/sv_texture_utils.py
@@ -48,7 +48,7 @@ tx_fragment_shader = '''
     }
 '''
 
-def init_texture(width, height, texname, texture, clr):
+def init_texture(width, height, texname, texture, clr):  # good luck with this one
     # function to init the texture
     bgl.glPixelStorei(bgl.GL_UNPACK_ALIGNMENT, 1)
 

--- a/utils/sv_texture_utils.py
+++ b/utils/sv_texture_utils.py
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: GPL3
 # License-Filename: LICENSE
 
-import bgl
 import gpu
 from gpu_extras.batch import batch_for_shader
 from sverchok.utils.modules.drawing_abstractions import drawing 
@@ -63,10 +62,9 @@ def simple_screen(context, args, xy):
         # function to draw a texture
         matrix = gpu.matrix.get_projection_matrix()
 
-        bgl.glDisable(bgl.GL_DEPTH_TEST)
-
-        act_tex = bgl.Buffer(bgl.GL_INT, 1)
-        bgl.glBindTexture(bgl.GL_TEXTURE_2D, texname)
+        drawing.disable_depth_test()
+        act_tex = drawing.new_buffer_texture()
+        drawing.bind_texture_2d(texname)
 
         shader.bind()
         shader.uniform_int("image", act_tex)
@@ -77,8 +75,8 @@ def simple_screen(context, args, xy):
         batch.draw(shader)
 
         # restoring settings
-        bgl.glBindTexture(bgl.GL_TEXTURE_2D, act_tex[0])
-        bgl.glDisable(bgl.GL_TEXTURE_2D)
+        drawing.bind_texture_2d(act_tex[0])
+        drawing.disable_texture_2d()
 
     draw_texture(x=x, y=y, w=width, h=height, texname=texname, c=cMod)
 


### PR DESCRIPTION
alternative bgl abstraction.

continuation of https://github.com/nortikin/sverchok/pull/4936

- [x] remove bgl from current node set and modules/utils
- [x] adjust `blf.text` to handle 3 vs 2 parameters
- [ ] implement texture/image loading for texture/buffer using nodes (texture viewers and console node)
   - https://docs.blender.org/api/4.0/gpu.types.html
   - affected nodes ( TextViewer, TVLite, Stethoscope ( nice mode ), Console Node ) , These are not the most
     essential nodes but 
        - "nice mode" for `stethoscope` is pretty cool and if I get that to work then console node will also work
    automatically (they share the same code)
        - `Texture Viewer` nodes use some Gl code to place the texture in a state to receive data which i'm only tangentially 
          familiar with :)
- [x] bug fix front_facing polygon drawing thru
   - ```lines are not being obscured by polygons.```
- [x] polygon offset alternative
   -  [x] ```avoid z-fighting``` ( proof of concept: at the moment implements a normal shader in custom-shader mode )
   -  [ ] reimplement custom shader
   -  [ ] implement shader for flat/facet/smooth 


Node | works in < 4.0 | works in > 4.0 | feature parity | issue
 --- | --- | --- | --- | ---
Viewer Draw | yes | yes | no | zfighting lines
Stethoscope MK2 | yes | yes | no | advanced drawing to buffer not implemented, no colour highlighting 
Matrix View | yes | yes | maybe | plane seems to always draw
Viewer Index | yes | yes | yes | ...
Viewer 2D | yes | yes | yes | ...
Viewer Draw Curve | yes | yes | yes | ...
Viewer Draw Surface | yes | yes | yes | ...
Texture Viewer | yes | ? | ? | ?
Texture Viewer Lite | yes | ? | ? | ?
SvWaveformViewer | yes | yes | yes | ...
Console Node | yes | ? | ? | ?
Solid Viewer (did not test) | yes | ? | ? | ?
Easing 0..1 | yes | yes | yes | ...