### PR TITLE
Fix 4352. SvOB3BDataCollection should be registered only once

### DIFF
--- a/nodes/scene/get_objects_data.py
+++ b/nodes/scene/get_objects_data.py
@@ -19,7 +19,7 @@ from sverchok.utils.blender_mesh import (
     read_face_normal, read_face_center, read_face_area, read_materials_idx)
 
 
-class SvOB3BDataCollection(bpy.types.PropertyGroup):
+class SvOB3BDataCollectionMK2(bpy.types.PropertyGroup):
     name: bpy.props.StringProperty()
     icon: bpy.props.StringProperty(default="BLANK1")
 
@@ -28,7 +28,7 @@ class ReadingObjectDataError(Exception):
     pass
 
 
-class SVOB3B_UL_NamesList(bpy.types.UIList):
+class SVOB3B_UL_NamesListMK2(bpy.types.UIList):
 
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
 
@@ -40,14 +40,14 @@ class SVOB3B_UL_NamesList(bpy.types.UIList):
                 item_icon = ""
 
         layout.label(text=item.name, icon=item_icon)
-        action = data.wrapper_tracked_ui_draw_op(layout, "node.sv_ob3b_collection_operator", icon='X', text='')
+        action = data.wrapper_tracked_ui_draw_op(layout, "node.sv_ob3b_collection_operator_mk2", icon='X', text='')
         action.fn_name = 'REMOVE'
         action.idx = index
 
 
-class SvOB3BItemOperator(bpy.types.Operator, SvGenericNodeLocator):
+class SvOB3BItemOperatorMK2(bpy.types.Operator, SvGenericNodeLocator):
 
-    bl_idname = "node.sv_ob3b_collection_operator"
+    bl_idname = "node.sv_ob3b_collection_operator_mk2"
     bl_label = "generic bladibla"
 
     fn_name: StringProperty(default='')
@@ -59,9 +59,9 @@ class SvOB3BItemOperator(bpy.types.Operator, SvGenericNodeLocator):
         node.process_node(None)
 
 
-class SvOB3Callback(bpy.types.Operator, SvGenericNodeLocator):
+class SvOB3CallbackMK2(bpy.types.Operator, SvGenericNodeLocator):
 
-    bl_idname = "node.ob3_callback"
+    bl_idname = "node.ob3_callback_mk2"
     bl_label = "Object In mk3 callback"
     bl_options = {'INTERNAL'}
 
@@ -126,7 +126,7 @@ class SvGetObjectsData(Show3DProperties, SverchCustomTreeNode, bpy.types.Node):
         description='sorting inserted objects by names',
         default=True, update=updateNode)
 
-    object_names: bpy.props.CollectionProperty(type=SvOB3BDataCollection)
+    object_names: bpy.props.CollectionProperty(type=SvOB3BDataCollectionMK2)
 
     active_obj_index: bpy.props.IntProperty()
 
@@ -189,7 +189,7 @@ class SvGetObjectsData(Show3DProperties, SverchCustomTreeNode, bpy.types.Node):
 
     def draw_obj_names(self, layout):
         if self.object_names:
-            layout.template_list("SVOB3B_UL_NamesList", "", self, "object_names", self, "active_obj_index")
+            layout.template_list("SVOB3B_UL_NamesListMK2", "", self, "object_names", self, "active_obj_index")
         else:
             layout.label(text='--None--')
 
@@ -204,7 +204,7 @@ class SvGetObjectsData(Show3DProperties, SverchCustomTreeNode, bpy.types.Node):
             row = col.row()
 
             op_text = "Get selection"  # fallback
-            callback = 'node.ob3_callback'
+            callback = 'node.ob3_callback_mk2'
 
             if self.prefs_over_sized_buttons:
                 row.scale_y = 4.0
@@ -242,7 +242,7 @@ class SvGetObjectsData(Show3DProperties, SverchCustomTreeNode, bpy.types.Node):
 
     def draw_buttons_3dpanel(self, layout):
         if not self.by_input:
-            callback = 'node.ob3_callback'
+            callback = 'node.ob3_callback_mk2'
             row = layout.row(align=True)
             row.label(text=self.label if self.label else self.name)
             colo = row.row(align=True)
@@ -379,5 +379,5 @@ class SvGetObjectsData(Show3DProperties, SverchCustomTreeNode, bpy.types.Node):
                 outputs['Object'].sv_set([data_objects.get(o.name) for o in self.object_names])
 
 
-classes = [SvOB3BItemOperator, SvOB3BDataCollection, SVOB3B_UL_NamesList, SvOB3Callback, SvGetObjectsData]
+classes = [SvOB3BItemOperatorMK2, SvOB3BDataCollectionMK2, SVOB3B_UL_NamesListMK2, SvOB3CallbackMK2, SvGetObjectsData]
 register, unregister = bpy.utils.register_classes_factory(classes)

--- a/nodes/scene/node_remote_mk2.py
+++ b/nodes/scene/node_remote_mk2.py
@@ -29,7 +29,7 @@ from bpy.props import (
 
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import dataCorrect, updateNode
-from sverchok.old_nodes.getsetprop import assign_data
+from sverchok.old_nodes.getprop import assign_data
 
 
 # can't use a PointerProperty for type=bpy.data.node_group

--- a/old_nodes/__init__.py
+++ b/old_nodes/__init__.py
@@ -128,7 +128,7 @@ def register_all():
             # when a code of an old node is copied to old folder
             # it can be copied with other classes (property groups)
             # which does not change it version to MK2, so we have the error
-            sv_logger.error( (bl_id, e) )
+            sv_logger.error(e)
 
 
 def register():
@@ -141,8 +141,8 @@ def register():
 
 
 def unregister():
-    for i, mod in enumerate(imported_mods.values()):
+    for mod in imported_mods.values():
         try:
             mod.unregister()
         except Exception as e:
-            sv_logger.error( (mod, e) )
+            sv_logger.error(e)

--- a/old_nodes/__init__.py
+++ b/old_nodes/__init__.py
@@ -128,7 +128,7 @@ def register_all():
             # when a code of an old node is copied to old folder
             # it can be copied with other classes (property groups)
             # which does not change it version to MK2, so we have the error
-            sv_logger.error(e)
+            sv_logger.error( (bl_id, e) )
 
 
 def register():
@@ -141,8 +141,8 @@ def register():
 
 
 def unregister():
-    for mod in imported_mods.values():
+    for i, mod in enumerate(imported_mods.values()):
         try:
             mod.unregister()
         except Exception as e:
-            sv_logger.error(e)
+            sv_logger.error( (mod, e) )

--- a/old_nodes/getprop.py
+++ b/old_nodes/getprop.py
@@ -207,99 +207,11 @@ class SvGetPropNode(SverchCustomTreeNode, bpy.types.Node):
         # print(">> Get process is called")
         self.outputs[0].sv_set(wrap_output_data(self.obj))
 
-
-class SvSetPropNode(SverchCustomTreeNode, bpy.types.Node):
-    ''' Set Property '''
-    bl_idname = 'SvSetPropNode'
-    bl_label = 'Set Property'
-    bl_icon = 'FORCE_VORTEX'
-    sv_icon = 'SV_PROP_SET'
-
-    ok_prop: BoolProperty(default=False)
-    bad_prop: BoolProperty(default=False)
-
-
-    @property
-    def obj(self):
-        eval_str = apply_alias(self.prop_name)
-        ast_path = ast.parse(eval_str)
-        path = parse_to_path(ast_path.body[0].value)
-        return get_object(path)
-        
-    def verify_prop(self, context):
-
-        # test first 
-        try:
-            obj = self.obj
-        except:
-            traceback.print_exc()
-            self.bad_prop = True
-            return
-
-        # execute second
-        self.bad_prop = False
-
-        s_type = types.get(type(self.obj))
-        if not s_type:
-            s_type = secondary_type_assesment(self.obj)
-
-        p_name = {
-            float: "float_prop", 
-            int: "int_prop",
-            bpy_prop_array: "color_prop"
-        }.get(type(self.obj),"")
-        
-        inputs = self.inputs
-
-        if inputs and s_type: 
-            socket = inputs[0].replace_socket(s_type)
-            socket.prop_name = p_name
-        elif s_type:
-            inputs.new(s_type, "Data").prop_name = p_name
-        if s_type == "SvVerticesSocket":
-            inputs[0].use_prop = True
-
-        updateNode(self, context)
-
-    def local_updateNode(self, context):
-        # no further interaction with the nodetree is required.
-        self.process()
-        
-    prop_name: StringProperty(name='', update=verify_prop)
-    float_prop: FloatProperty(update=updateNode, name="x")
-    int_prop: IntProperty(update=updateNode, name="x")
-    color_prop: FloatVectorProperty(
-        name="Color", description="Color", size=4,
-        min=0.0, max=1.0, subtype='COLOR', update=local_updateNode)
-
-    def draw_buttons(self, context, layout):
-        layout.alert = self.bad_prop
-        layout.prop(self, "prop_name", text="")
-
-    def process(self):
-        # print("<< Set process is called")
-        data = self.inputs[0].sv_get()
-        eval_str = apply_alias(self.prop_name)
-        ast_path = ast.parse(eval_str)
-        path = parse_to_path(ast_path.body[0].value)
-        obj = get_object(path)
-
-        if isinstance(obj, (int, float, bpy_prop_array)):
-            obj = get_object(path[:-1])
-            p_type, value = path[-1]
-            if p_type == "attr":
-                setattr(obj, value, data[0][0])
-            else: 
-                obj[value] = data[0][0]
-        else:
-            assign_data(obj, data)
-
-
 def register():
-    bpy.utils.register_class(SvSetPropNode)
+#    bpy.utils.register_class(SvSetPropNode)
     bpy.utils.register_class(SvGetPropNode)
 
 
 def unregister():
-    bpy.utils.unregister_class(SvSetPropNode)
+#    bpy.utils.unregister_class(SvSetPropNode)
     bpy.utils.unregister_class(SvGetPropNode)

--- a/old_nodes/getprop.py
+++ b/old_nodes/getprop.py
@@ -208,10 +208,8 @@ class SvGetPropNode(SverchCustomTreeNode, bpy.types.Node):
         self.outputs[0].sv_set(wrap_output_data(self.obj))
 
 def register():
-#    bpy.utils.register_class(SvSetPropNode)
     bpy.utils.register_class(SvGetPropNode)
 
 
 def unregister():
-#    bpy.utils.unregister_class(SvSetPropNode)
     bpy.utils.unregister_class(SvGetPropNode)

--- a/old_nodes/node_remote.py
+++ b/old_nodes/node_remote.py
@@ -29,7 +29,7 @@ from bpy.props import (
 
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import dataCorrect, updateNode
-from sverchok.old_nodes.getsetprop import assign_data
+from sverchok.old_nodes.getprop import assign_data
 
 
 class SvNodePickup(bpy.types.Operator):

--- a/old_nodes/objects_mk3.py
+++ b/old_nodes/objects_mk3.py
@@ -42,7 +42,6 @@ class SvOB3BItemOperator(bpy.types.Operator, SvGenericNodeLocator):
 
     bl_idname = "node.sv_ob3b_collection_operator"
     bl_label = "generic bladibla"
-    #bl_options = {'INTERNAL'}
 
     fn_name: StringProperty(default='')
     idx: IntProperty()
@@ -311,12 +310,4 @@ class SvObjectsNodeMK3(Show3DProperties, SverchCustomTreeNode, bpy.types.Node):
 
 
 classes = [SvOB3BItemOperator, SvOB3BDataCollection, SVOB3B_UL_NamesList, SvOB3Callback, SvObjectsNodeMK3]
-#register, unregister = bpy.utils.register_classes_factory(classes)
-def register():
-    for cls in classes:
-        bpy.utils.register_class(cls)
-
-def unregister():
-    for cls in reversed(classes):
-        bpy.utils.unregister_class(cls)
-
+register, unregister = bpy.utils.register_classes_factory(classes)

--- a/old_nodes/objects_mk3.py
+++ b/old_nodes/objects_mk3.py
@@ -16,6 +16,7 @@ from sverchok.utils.sv_bmesh_utils import pydata_from_bmesh
 from sverchok.utils.nodes_mixins.show_3d_properties import Show3DProperties
 
 class SvOB3BDataCollection(bpy.types.PropertyGroup):
+    bl_idname = "SvOB3BDataCollection"
     name: bpy.props.StringProperty()
     icon: bpy.props.StringProperty(default="BLANK1")
 
@@ -41,6 +42,7 @@ class SvOB3BItemOperator(bpy.types.Operator, SvGenericNodeLocator):
 
     bl_idname = "node.sv_ob3b_collection_operator"
     bl_label = "generic bladibla"
+    #bl_options = {'INTERNAL'}
 
     fn_name: StringProperty(default='')
     idx: IntProperty()
@@ -309,4 +311,12 @@ class SvObjectsNodeMK3(Show3DProperties, SverchCustomTreeNode, bpy.types.Node):
 
 
 classes = [SvOB3BItemOperator, SvOB3BDataCollection, SVOB3B_UL_NamesList, SvOB3Callback, SvObjectsNodeMK3]
-register, unregister = bpy.utils.register_classes_factory(classes)
+#register, unregister = bpy.utils.register_classes_factory(classes)
+def register():
+    for cls in classes:
+        bpy.utils.register_class(cls)
+
+def unregister():
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)
+

--- a/old_nodes/setprop.py
+++ b/old_nodes/setprop.py
@@ -26,10 +26,8 @@ import mathutils
 from mathutils import Matrix, Vector, Euler, Quaternion, Color
 
 from sverchok.node_tree import SverchCustomTreeNode
-
 from sverchok.data_structure import Matrix_generate, updateNode, node_id
-
-from sverchok.old_nodes.getprop import assign_data
+from sverchok.old_nodes.getprop import assign_data, get_object, apply_alias, parse_to_path, secondary_type_assesment, types
 
 class SvSetPropNode(SverchCustomTreeNode, bpy.types.Node):
     ''' Set Property '''

--- a/old_nodes/setprop.py
+++ b/old_nodes/setprop.py
@@ -1,0 +1,125 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import ast
+import traceback
+
+import bpy
+from bpy.props import StringProperty, BoolProperty, IntProperty, FloatProperty, FloatVectorProperty
+from bpy.types import bpy_prop_array
+import mathutils
+from mathutils import Matrix, Vector, Euler, Quaternion, Color
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+from sverchok.data_structure import Matrix_generate, updateNode, node_id
+
+from sverchok.old_nodes.getprop import assign_data
+
+class SvSetPropNode(SverchCustomTreeNode, bpy.types.Node):
+    ''' Set Property '''
+    bl_idname = 'SvSetPropNode'
+    bl_label = 'Set Property'
+    bl_icon = 'FORCE_VORTEX'
+    sv_icon = 'SV_PROP_SET'
+
+    ok_prop: BoolProperty(default=False)
+    bad_prop: BoolProperty(default=False)
+
+
+    @property
+    def obj(self):
+        eval_str = apply_alias(self.prop_name)
+        ast_path = ast.parse(eval_str)
+        path = parse_to_path(ast_path.body[0].value)
+        return get_object(path)
+        
+    def verify_prop(self, context):
+
+        # test first 
+        try:
+            obj = self.obj
+        except:
+            traceback.print_exc()
+            self.bad_prop = True
+            return
+
+        # execute second
+        self.bad_prop = False
+
+        s_type = types.get(type(self.obj))
+        if not s_type:
+            s_type = secondary_type_assesment(self.obj)
+
+        p_name = {
+            float: "float_prop", 
+            int: "int_prop",
+            bpy_prop_array: "color_prop"
+        }.get(type(self.obj),"")
+        
+        inputs = self.inputs
+
+        if inputs and s_type: 
+            socket = inputs[0].replace_socket(s_type)
+            socket.prop_name = p_name
+        elif s_type:
+            inputs.new(s_type, "Data").prop_name = p_name
+        if s_type == "SvVerticesSocket":
+            inputs[0].use_prop = True
+
+        updateNode(self, context)
+
+    def local_updateNode(self, context):
+        # no further interaction with the nodetree is required.
+        self.process()
+        
+    prop_name: StringProperty(name='', update=verify_prop)
+    float_prop: FloatProperty(update=updateNode, name="x")
+    int_prop: IntProperty(update=updateNode, name="x")
+    color_prop: FloatVectorProperty(
+        name="Color", description="Color", size=4,
+        min=0.0, max=1.0, subtype='COLOR', update=local_updateNode)
+
+    def draw_buttons(self, context, layout):
+        layout.alert = self.bad_prop
+        layout.prop(self, "prop_name", text="")
+
+    def process(self):
+        # print("<< Set process is called")
+        data = self.inputs[0].sv_get()
+        eval_str = apply_alias(self.prop_name)
+        ast_path = ast.parse(eval_str)
+        path = parse_to_path(ast_path.body[0].value)
+        obj = get_object(path)
+
+        if isinstance(obj, (int, float, bpy_prop_array)):
+            obj = get_object(path[:-1])
+            p_type, value = path[-1]
+            if p_type == "attr":
+                setattr(obj, value, data[0][0])
+            else: 
+                obj[value] = data[0][0]
+        else:
+            assign_data(obj, data)
+
+
+def register():
+    bpy.utils.register_class(SvSetPropNode)
+
+def unregister():
+    bpy.utils.unregister_class(SvSetPropNode)


### PR DESCRIPTION
Sverchok 1.3.0-alpha, Blender 3.6.1, Windows 11.
#4352

Fixed several console error messages relied to [SvOB3BItemOperator, SvOB3BDataCollection, SVOB3B_UL_NamesList, SvOB3Callback].

![image](https://github.com/nortikin/sverchok/assets/14288520/0bc7a65e-512e-4229-92b0-5228b5cc602b)

Before fix:
![image](https://github.com/nortikin/sverchok/assets/14288520/f7ac3e00-cd8b-4807-9867-2c502aedec0b)

Additionally was error message. No errors after split into two files:
![image](https://github.com/nortikin/sverchok/assets/14288520/ab43c3a1-d6fb-472d-9e8d-bb4d236a1663)

After fix this error for [SvOB3BItemOperator, SvOB3BDataCollection, SVOB3B_UL_NamesList, SvOB3Callback] got visible and now no error messages.