### PR TITLE
fix 4783 Ellipse center point unexpected result for F1 or F2

### DIFF
--- a/utils/curve/primitives.py
+++ b/utils/curve/primitives.py
@@ -789,10 +789,10 @@ class SvEllipse(SvCurve):
             return self.center
         elif self.center_type == SvEllipse.F1:
             df = self.matrix @ np.array([self.c, 0, 0])
-            return self.center + df
+            return self.center - df
         else: # F2
             df = self.matrix @ np.array([self.c, 0, 0])
-            return self.center - df
+            return self.center + df
 
     def get_degree(self):
         return 2


### PR DESCRIPTION
Sverchok 1.3.0-alpha-master, Blender 3.6.1, Windows 11

fix focus center for F1/F2

see #4783 