### PR TITLE
fix #4729 Inset special ignore list of ignored faces in Fan mode if distance is not zero

### DIFF
--- a/nodes/CAD/inset_special_mk2.py
+++ b/nodes/CAD/inset_special_mk2.py
@@ -43,8 +43,8 @@ class SvInsetSpecialMk2(
     sv_icon = 'SV_INSET'
 
     implentation_items = [
-        ('mathutils', 'Mathutils', 'Slower (Legacy. Face order may differ with new implementation)', 0),
-        ('numpy', 'Numpy', 'Faster', 1)]
+        ('mathutils', 'Mathutils (Legacy)', 'Slower (Legacy. Face order may differ with new implementation)', 0),
+        ('numpy', 'Numpy', 'Faster (Face order may differ of Mathutils mode implementation)', 1)]
     implementation: bpy.props.EnumProperty(
         name='Implementation',
         items=implentation_items,

--- a/utils/mesh/inset_faces.py
+++ b/utils/mesh/inset_faces.py
@@ -60,7 +60,7 @@ def inset_special_np(vertices, faces, inset_rates, distances, ignores, make_inne
         use_custom_normals = False
 
     if offset_mode == 'CENTER':
-        zero_inset = np_inset_rate == 0
+        zero_inset = np.logical_and( np_inset_rate == 0, np_faces_mask==True)
         if zero_mode == 'SKIP':
             np_faces_mask[zero_inset] = False
             invert_face_mask[zero_inset] = True


### PR DESCRIPTION
Blender 3.6.1, Windows 11, Sverchok 1.3.0-alpha
fix #4729 

All faces has to be Fan but 0 and 1 faces are excepted by list of exception so only 2 and 3 faces are FAN:

![image](https://github.com/nortikin/sverchok/assets/14288520/43ff1854-329c-4645-b581-ea3d5e0a734e)
