### PR TITLE
fix 4288 Cyclic mode of Kinked curve node

### DIFF
--- a/nodes/curve/kinky_curve.py
+++ b/nodes/curve/kinky_curve.py
@@ -116,7 +116,15 @@ class SvKinkyCurveNode(SverchCustomTreeNode, bpy.types.Node):
                         else:
                             segments = [first_segment]
 
-                new_curves = [SvSplineCurve.from_points(segment, metric=self.metric) for segment in segments]
+                if len(segments)==1:
+                    # if len(segments)==1 then result curve is monosegment and smooth and is_cyclic has to be as is params 
+                    new_curves = [SvSplineCurve.from_points(segment, metric=self.metric, is_cyclic=self.is_cyclic ) for segment in segments]
+                elif len(segments)>1:
+                    # if len(segments)>1 then result curve is multisegment and not smooth and is_cyclic has to be False
+                    new_curves = [SvSplineCurve.from_points(segment, metric=self.metric, is_cyclic=False)           for segment in segments]
+                else:
+                    raise Exception("Count of segments has to be not 0")
+
                 if self.make_nurbs:
                     if self.concat:
                         new_curves = [curve.to_nurbs().elevate_degree(target=3) for curve in new_curves]


### PR DESCRIPTION
Sverchok 1.3.0-alpha, Blender 3.6.1, Windows 11.

fix #4288 (Cyclic mode of Kinked curve node)

![issue_4288_fix anim](https://github.com/nortikin/sverchok/assets/14288520/36f6b5be-1ae7-4720-a6c3-770369b5629b)

for tests:
[issue.4288.Cyclic mode of Kinked curve node.blend.zip](https://github.com/nortikin/sverchok/files/12681975/issue.4288.Cyclic.mode.of.Kinked.curve.node.blend.zip)

Additionally:
![issue_4288_fix anim 002](https://github.com/nortikin/sverchok/assets/14288520/3dec6513-5c55-42a1-a5bd-c0df05fdbffc)
