### PR TITLE
fix #4862. No dependency "numexpr" in list of dependency for a node "Num expression node"

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -177,6 +177,14 @@ try:
 except ImportError:
     pyOpenSubdiv = None 
 
+numexpr_d = sv_dependencies["numexpr"] = SvDependency("numexpr","https://github.com/pydata/numexpr")
+numexpr_d.pip_installable = True
+try:
+    import numexpr
+    numexpr_d.module = numexpr
+except ImportError:
+    numexpr = None 
+
 
 settings.pip = pip
 settings.sv_dependencies = sv_dependencies

--- a/settings.py
+++ b/settings.py
@@ -619,6 +619,7 @@ dependencies, or install only some of them.""")
         draw_message(box, "cython")
         draw_message(box, "numba")
         draw_message(box, "pyOpenSubdiv")
+        draw_message(box, "numexpr")
 
         draw_freecad_ops()
 


### PR DESCRIPTION
Windows 11, Blender 3.6.x, Sverchok 1.3.0-alpha.

numexpr package is visible in dependencies list of "Extra Nodes" tabs:

![image](https://github.com/nortikin/sverchok/assets/14288520/0ead0d51-6097-4e60-b7b2-e14aeb3c996c)
