### PR TITLE
Fix #5010 Refactor Spatial>Delaunay_3d_mk2 to automatically select topology for triangulation volume, planes or lines

### DIFF
--- a/nodes/spatial/delaunay_3d_mk2.py
+++ b/nodes/spatial/delaunay_3d_mk2.py
@@ -6,6 +6,7 @@
 # License-Filename: LICENSE
 
 import numpy as np
+from collections import defaultdict
 from itertools import combinations
 
 import bpy
@@ -13,11 +14,145 @@ from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode, zip_long_repeat, ensure_nesting_level, get_data_nesting_level
+from sverchok.utils.geom import PlaneEquation
 from sverchok.dependencies import scipy
+from mathutils import Vector
+import random
 
 if scipy is not None:
     from scipy.spatial import Delaunay
+    from scipy.spatial.transform import Rotation as R
 
+def is_volume_0(verts, idxs, threshold):
+    if threshold == 0:
+        return False
+    a, b, c, d = [verts[i] for i in idxs]
+    a, b, c, d = np.array(a), np.array(b), np.array(c), np.array(d)
+    v1 = b - a
+    v2 = c - a
+    v3 = d - a
+    v1 = v1 / np.linalg.norm(v1)
+    v2 = v2 / np.linalg.norm(v2)
+    v3 = v3 / np.linalg.norm(v3)
+    volume = np.cross(v1, v2).dot(v3) / 6
+    return abs(volume) < threshold
+
+
+def is_area_0(verts, idxs, threshold):
+    if threshold == 0:
+        return False
+    a, b, c = [verts[i] for i in idxs]
+    a, b, c = np.array(a), np.array(b), np.array(c)
+    v1 = b - a
+    v2 = c - a
+    v1 = v1 / np.linalg.norm(v1)
+    v2 = v2 / np.linalg.norm(v2)
+    area = np.linalg.norm(np.cross(v1, v2)) / 2
+    return abs(area) < threshold
+
+def is_length_0(verts, idxs, threshold):
+    if threshold == 0:
+        return False
+    a, b = [verts[i] for i in idxs]
+    a, b = np.array(a), np.array(b)
+    v1 = b - a
+    len = np.linalg.norm(v1)
+    return abs(len) < threshold
+
+def get_sites_delaunay_params(np_sites, n_orig_sites, threshold=0):
+        
+        delaunay = Delaunay(np_sites)
+        dimension_size_1 = -1 # simplex size on start 
+        dimension_size_2 = -1 # simplex size of finish
+        result = defaultdict(list)
+        ridges = []
+        simplices = []
+        dict_source_dsimplex = dict()
+        sites_pair = dict()
+        for i, simplex in enumerate(delaunay.simplices):
+            dsimplex = tuple(simplex[simplex<n_orig_sites])
+            sort_dsimplex = tuple(sorted(dsimplex))
+            dict_source_dsimplex[sort_dsimplex] = dsimplex
+            simplices.append( sort_dsimplex )
+            #simplices.append( np.sort(dsimplex) )
+
+        #simplices = np.asarray(simplices, dtype=np.int32)
+        simplices = np.unique(simplices)
+        simplices = np.array(sorted(simplices, key=len, reverse=True)) # https://stackoverflow.com/questions/47271229/sort-a-numpy-array-of-numpy-arrays-by-lengths-of-the-internal-arrays
+        dimension_size_1 = len(simplices[0])
+
+        # # if simplex in lower dimension has all indices in another simplex (as rule in higher dimension),
+        # # then remove that lower simplex.
+        # list_removed_inner_simplices = simplices
+        # for i in range(len(list_removed_inner_simplices)-1, -1, -1):
+        #     simplex_i = list_removed_inner_simplices[i]
+        #     for j in range(i-1, -1, -1):
+        #         simplex_j = list_removed_inner_simplices[j]
+        #         if np.all(np.isin(simplex_i, simplex_j)):
+        #             list_removed_inner_simplices = np.delete(list_removed_inner_simplices, i)
+        #             break
+
+        if threshold>0:
+            # test simplex size for threshold. Remove simplexes that do not allowed in their dimensions. (plane is disallowed in a volume, line in disallowed in a plane).
+            arr = []
+            vertices = np.array([delaunay.points[i,:3] for i,e in enumerate(delaunay.points)]) # point come with 4d vector coordinates
+            for sim in simplices:
+                simplex_size = len(sim)
+                # simplex is line. If line has size(length)==0 then do not use this simplex
+                if simplex_size==2 and is_length_0(vertices, sim, threshold):
+                    continue
+                # simplex is plane. If plane has size(area)==0 then do not use this simplex
+                if simplex_size==3 and is_area_0(vertices, sim, threshold):
+                    continue
+                # simplex is volumetric. If volume has size(volume)==0 then do not use this simplex
+                if simplex_size==4 and is_volume_0(vertices, sim, threshold):
+                    continue
+                if simplex_size>4:
+                    print(f"Very strange situation. size of simplex({simplex})=={simplex_size}. Skipped. Need attension")
+                    continue
+                arr.append(sim)
+            pass
+        else:
+            arr = simplices
+
+        # get length of first elem and select only elems with that len.
+        # this is a filter of allowed dimension of simplices. Top elem is a first elem of allowed dimensions.
+        arr_len = []
+        len_0 = len(arr[0])
+        dimension_size_2 = len_0
+        for sim in arr:
+            if len(sim)==len_0:
+                arr_len.append(sim)
+            else:
+                break
+        list_removed_inner_simplices = arr_len
+
+        #res = {"simplices": res}
+        list_restored_orders = []
+        for key in list_removed_inner_simplices:
+            list_restored_orders.append( dict_source_dsimplex[tuple(key)] )
+        #res = np.array(res.tolist(), dtype=np.int32)
+        res = np.array(list_restored_orders, dtype=np.int32)
+        return res, dimension_size_1, dimension_size_2
+
+        for ridge_idx in range(len(ridges)):
+            site1_idx, site2_idx = tuple(ridges[ridge_idx])
+            # Remove 4D simplex ridges:
+            if n_orig_sites<=site1_idx or n_orig_sites<=site2_idx:
+                continue
+            # Convert source sites to the 3D
+            site1 = delaunay.points[site1_idx]
+            site1 = Vector([site1[0], site1[1], site1[2], ])
+            site2 = delaunay.points[site2_idx]
+            site2 = Vector([site2[0], site2[1], site2[2], ])
+            middle = (site1 + site2) * 0.5
+            normal =  Vector(site1 - site2).normalized() # normal to site1
+            plane1 = PlaneEquation.from_normal_and_point( normal, middle)
+            plane2 = PlaneEquation.from_normal_and_point(-normal, middle)
+            result[site1_idx].append( (site2_idx, site1, site2, middle,  normal, plane1) )
+            result[site2_idx].append( (site1_idx, site2, site1, middle, -normal, plane2) )
+
+        return result
 
 class SvDelaunay3dMk2Node(SverchCustomTreeNode, bpy.types.Node):
     """
@@ -72,20 +207,6 @@ class SvDelaunay3dMk2Node(SverchCustomTreeNode, bpy.types.Node):
     def get_verts(self, verts, idxs):
         return [verts[i] for i in idxs]
 
-    def is_planar(self, verts, idxs, threshold):
-        if threshold == 0:
-            return False
-        a, b, c, d = [verts[i] for i in idxs]
-        a, b, c, d = np.array(a), np.array(b), np.array(c), np.array(d)
-        v1 = b - a
-        v2 = c - a
-        v3 = d - a
-        v1 = v1 / np.linalg.norm(v1)
-        v2 = v2 / np.linalg.norm(v2)
-        v3 = v3 / np.linalg.norm(v3)
-        volume = np.cross(v1, v2).dot(v3) / 6
-        return abs(volume) < threshold
-    
     def is_too_long(self, verts, idxs, threshold):
         if threshold == 0:
             return False
@@ -121,16 +242,110 @@ class SvDelaunay3dMk2Node(SverchCustomTreeNode, bpy.types.Node):
             faces_item = []
             for vertices, volume_threshold, edge_threshold in zip_long_repeat(*params):
 
-                tri = Delaunay(np.array(vertices))
+                # https://github.com/nortikin/sverchok/pull/4952
+                # http://www.qhull.org/html/qdelaun.htm
+                # http://www.qhull.org/html/qh-optc.htm
+                # https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.Delaunay.html
+                # Convert sites to 4D
+                #np_sites = np.array(vertices, dtype=np.float32)
+
+                # Think about oriented BBox:
+                # oX_size = np.max(np.array(vertices, dtype=np.float16)[:,0]) - np.min(np.array(vertices, dtype=np.float16)[:,0])
+                # oY_size = np.max(np.array(vertices, dtype=np.float16)[:,1]) - np.min(np.array(vertices, dtype=np.float16)[:,1])
+                # oZ_size = np.max(np.array(vertices, dtype=np.float16)[:,2]) - np.min(np.array(vertices, dtype=np.float16)[:,2])
+                # axis = np.argsort([oX_size, oY_size, oZ_size])
+                # plane_axis_X = axis[0]
+                # plane_axis_Y = axis[1]
+                # plane_axis_Z = axis[2]
+                # np_sites = np.array([(v[plane_axis_X], v[plane_axis_Y], v[plane_axis_Z], 0) for v in vertices], dtype=np.float32)
+
+                np_sites = np.array([(*v, 0.0 ) for v in vertices], dtype=np.float32)
+                #np_sites = np.array( vertices, dtype=np.float32)
+                #np_sites = np.pad( np_sites, (0,1), 'constant')
+                #np_sites4 = np.zeros((len(np_sites), 4))
+                #np_sites4[:,:3] = np_sites
+                for i in range(10): # 2 is max, but for insurance
+                    # Add 3D tetraedre to the 4D with W=1
+                    np_sites = np.append(np_sites, [[0.0, 0.0, 0.0, 1.0],
+                                                    [1.0, 0.0, 0.0, 1.0],
+                                                    [0.0, 1.0, 0.0, 1.0],
+                                                    [0.0, 0.0, 1.0, 1.0],
+                                                    ], axis=0)
+
+                    #delaunay = Delaunay(np.array(np_sites, dtype=np.float32))
+                    simplices, dim1, dim2 = get_sites_delaunay_params( np_sites, len(vertices), threshold=self.volume_threshold )
+                    if dim1==dim2: # 4 - volume, 3 - planes, 2 - edges, 1 - dots
+                        print(f"Found solution for dim={dim2-1} with {i} attempt")
+                        break
+                    else:
+                        oX_size = np.max(np.array(vertices, dtype=np.float16)[:,0]) - np.min(np.array(vertices, dtype=np.float16)[:,0])
+                        oY_size = np.max(np.array(vertices, dtype=np.float16)[:,1]) - np.min(np.array(vertices, dtype=np.float16)[:,1])
+                        oZ_size = np.max(np.array(vertices, dtype=np.float16)[:,2]) - np.min(np.array(vertices, dtype=np.float16)[:,2])
+                        axis = list(np.argsort([oX_size, oY_size, oZ_size]))
+                        axis.reverse()
+                        plane_axis_X = axis[0]
+                        plane_axis_Y = axis[1]
+                        plane_axis_Z = axis[2]
+                        if dim2==3: # plane. faces and edges
+                            # Find max plane axises of Bounding Box get it to XY plane
+                            # convert vertices to plane oXY. get two first elems. Is is plane max area
+                            np_sites = np.array([(v[plane_axis_X], v[plane_axis_Y], 0, 0) for v in vertices], dtype=np.float32)
+                            continue
+                        elif dim2==2: # line, only edges
+                            # Find max side axis of Bounding Box get it to oX plane
+                            np_sites = np.array([(v[plane_axis_X], 0, 0, 0) for v in vertices], dtype=np.float32)
+                            continue
+                        elif dim2==2: # dot. no edges
+                            break
+                        else:
+                            # unknown dim2. insurence
+                            break
+                else:
+                    #print("delaunay_3d_mk2. Solution not found")  # incredibly 
+                    pass
+
+                #tri = Delaunay(np.array(vertices))
+                #simplices = tri.simplices
                 if self.join:
                     verts_new = vertices
                     edges_new = set()
                     faces_new = set()
-                    for simplex_idx, simplex in enumerate(tri.simplices):
-                        if self.is_too_long(vertices, simplex, edge_threshold) or self.is_planar(vertices, simplex, volume_threshold):
+                    for simplex_idx, simplex in enumerate(simplices):
+                        # unknown simplex. skip. Incredible. get_sites_delaunay_params work with size==5 so need test.
+                        if simplex.size>4:
                             continue
-                        edges_new.update(set(self.make_edges(simplex)))
-                        faces_new.update(set(self.make_faces(simplex)))
+
+                        if self.is_too_long(vertices, simplex, edge_threshold):
+                             continue
+
+                        # simplex is line. If line has size(length)==0 then do not use this simplex
+                        if simplex.size==2 and is_length_0(vertices, simplex, volume_threshold):
+                             continue
+                        # simplex is plane. If plane has size(area)==0 then do not use this simplex
+                        if simplex.size==3 and is_area_0(vertices, simplex, volume_threshold):
+                             continue
+                        # simplex is volumetric. If volume has size(volume)==0 then do not use this simplex
+                        if simplex.size==4 and is_volume_0(vertices, simplex, volume_threshold):
+                             continue
+                        
+                        # with simplex.size>=2 (2,3,4) then create edges
+                        if simplex.size>=2:
+                            #edges_simplex = self.make_edges(list(range(simplex.size)))
+                            edges_simplex = self.make_edges(simplex)
+                            edges_new.update(edges_simplex)
+                            pass
+
+                        # with simplex.size>=3 (3,4) then create faces
+                        if simplex.size>=3:
+                            #faces_simplex = self.make_faces(list(range(simplex.size)))
+                            faces_simplex = self.make_faces(simplex)
+                            faces_new.update(faces_simplex)
+                            pass
+
+                        # if some geometry get visible then geometery need verts:
+                        #verts_simplex = self.get_verts(vertices, simplex)
+                        #verts_new.extend(verts_simplex)
+
                     verts_item.append(verts_new)
                     edges_item.append(list(edges_new))
                     faces_item.append(list(faces_new))
@@ -138,15 +353,48 @@ class SvDelaunay3dMk2Node(SverchCustomTreeNode, bpy.types.Node):
                     verts_new = []
                     edges_new = []
                     faces_new = []
-                    for simplex in tri.simplices:
-                        if self.is_too_long(vertices, simplex, edge_threshold) or self.is_planar(vertices, simplex, volume_threshold):
+                    for simplex in simplices:
+                        # unknown simplex. skip. Incredible. get_sites_delaunay_params work with size==5 so need test.
+                        if simplex.size>4:
                             continue
+
+                        if self.is_too_long(vertices, simplex, edge_threshold):
+                             continue
+
+                        # simplex is line. If line has size(length)==0 then do not use this simplex
+                        if simplex.size==2 and is_length_0(vertices, simplex, volume_threshold):
+                             continue
+                        # simplex is plane. If plane has size(area)==0 then do not use this simplex
+                        if simplex.size==3 and is_area_0(vertices, simplex, volume_threshold):
+                             continue
+                        # simplex is volumetric. If volume has size(volume)==0 then do not use this simplex
+                        if simplex.size==4 and is_volume_0(vertices, simplex, volume_threshold):
+                             continue
+
+                        # with simplex.size>=2 (2,3,4) then create edges
+                        if simplex.size>=2:
+                            edges_simplex = self.make_edges(list(range(simplex.size)))
+                            edges_new.append(edges_simplex)
+                        else:
+                            edges_new.append([])
+                            pass
+
+                        # with simplex.size>=3 (3,4) then create faces
+                        if simplex.size>=3:
+                            faces_simplex = self.make_faces(list(range(simplex.size)))
+                            faces_new.append(faces_simplex)
+                        else:
+                            faces_new.append([])
+                            pass
+
+                        #edges_simplex = self.make_edges([0, 1, 2, 3])
+                        #faces_simplex = self.make_faces([0, 1, 2, 3])
+
+                        # if some geometry get visible then geometery need verts:
                         verts_simplex = self.get_verts(vertices, simplex)
-                        edges_simplex = self.make_edges([0, 1, 2, 3])
-                        faces_simplex = self.make_faces([0, 1, 2, 3])
                         verts_new.append(verts_simplex)
-                        edges_new.append(edges_simplex)
-                        faces_new.append(faces_simplex)
+                        
+
                     verts_item.extend(verts_new)
                     edges_item.extend(edges_new)
                     faces_item.extend(faces_new)
@@ -158,6 +406,7 @@ class SvDelaunay3dMk2Node(SverchCustomTreeNode, bpy.types.Node):
                 else:
                     verts_out.extend(verts_item)
                     edges_out.extend(edges_item)
+                    #if faces_item:
                     faces_out.extend(faces_item)
 
         self.outputs['Vertices'].sv_set(verts_out)

--- a/nodes/spatial/delaunay_3d_mk2.py
+++ b/nodes/spatial/delaunay_3d_mk2.py
@@ -27,23 +27,6 @@ def is_volume_0(verts, idxs, threshold):
     '''Is volume size of 4 verts less threshold (True/False) '''
     if threshold == 0:
         return False
-    # a, b, c, d = [verts[i] for i in idxs]
-    # a, b, c, d = np.array(a), np.array(b), np.array(c), np.array(d)
-    # v1 = b - a
-    # v2 = c - a
-    # v3 = d - a
-    # v1 = v1 / np.linalg.norm(v1)
-    # v2 = v2 / np.linalg.norm(v2)
-    # v3 = v3 / np.linalg.norm(v3)
-    # volume = np.cross(v1, v2).dot(v3) / 6
-
-    # vects = verts[ list(idxs) ] # convert set to list #np.array([verts[i] for i in idxs], dtype=np.float64)
-    # vects = vects-vects[0]
-    # vects_norm = vects[1:4]/np.linalg.norm(vects[1:4], axis=1, keepdims=True)
-    # v1_ = vects_norm[0]
-    # v2_ = vects_norm[1]
-    # v3_ = vects_norm[2]
-    # volume_ = np.cross(v1_, v2_).dot(v3_) / 6
 
     a, b, c, d = [Vector(verts[i]) for i in idxs]
 
@@ -60,21 +43,6 @@ def is_area_0(verts, idxs, threshold):
     '''Is area size of 3 verts less threshold (True/False) '''
     if threshold == 0:
         return False
-    # a, b, c = [verts[i] for i in idxs]
-    # a, b, c = np.array(a), np.array(b), np.array(c)
-    # v1 = b - a
-    # v2 = c - a
-    # v1 = v1 / np.linalg.norm(v1)
-    # v2 = v2 / np.linalg.norm(v2)
-    # area = np.linalg.norm(np.cross(v1, v2)) / 2
-
-    # vects = verts[ list(idxs) ] # convert set to list #np.array([verts[i] for i in idxs], dtype=np.float64)
-    # vects = vects-vects[0]
-    # vects_norm = vects[1:3]/np.linalg.norm(vects[1:3], axis=1, keepdims=True)
-    # v1_ = vects_norm[0]
-    # v2_ = vects_norm[1]
-    # area_ = np.linalg.norm(np.cross(v1_, v2_)) / 2
-
 
     a, b, c = [Vector(verts[i]) for i in idxs]
 
@@ -89,10 +57,6 @@ def is_length_0(verts, idxs, threshold):
     '''Is length size of 2 verts less threshold (True/False) '''
     if threshold == 0:
         return False
-    # a, b = [verts[i] for i in idxs]
-    # #a, b = np.array(a), np.array(b) # verts is numpy
-    # v1 = b - a
-    # len = np.linalg.norm(v1)
 
     a, b = [Vector(verts[i]) for i in idxs]
     v1 = b-a
@@ -184,52 +148,6 @@ def get_delaunay_simplices(vertices, threshold):
     that simplixes will be removed. If no volume will exists then planes mode will be selected and recalc rise.
     So this will be for planes to lines.
     '''
-    np_sites = np.array([(*v, 0.0 ) for v in vertices], dtype=np.float32)
-    for i in range(10): # 2 is max, but for insurance
-        # Add 3D tetraedre to the 4D with W=1 (proxy shape). This trick for do not mixing vertices of a source shape and a proxy shape:
-        np_sites = np.append(np_sites, [[0.0, 0.0, 0.0, 1.0],
-                                        [1.0, 0.0, 0.0, 1.0],
-                                        [0.0, 1.0, 0.0, 1.0],
-                                        [0.0, 0.0, 1.0, 1.0],
-                                        ], axis=0)
-
-        simplices, dim1, dim2 = get_sites_delaunay_params( np_sites, len(vertices), threshold )
-        #bbox = bounding_box_aligned(vertices)
-        if dim1==dim2: # 4 - volume, 3 - planes, 2 - edges, 1 - dots
-            #print(f"Found solution for dim={dim2-1} with {i} attempt")
-            break
-        else:
-            # Get bbox size. TODO: think about oriented BBOX
-            oX_size = np.max(np.array(vertices, dtype=np.float16)[:,0]) - np.min(np.array(vertices, dtype=np.float16)[:,0])
-            oY_size = np.max(np.array(vertices, dtype=np.float16)[:,1]) - np.min(np.array(vertices, dtype=np.float16)[:,1])
-            oZ_size = np.max(np.array(vertices, dtype=np.float16)[:,2]) - np.min(np.array(vertices, dtype=np.float16)[:,2])
-            axis = list(np.argsort([oX_size, oY_size, oZ_size]))
-            axis.reverse()
-            plane_axis_X = axis[0]
-            plane_axis_Y = axis[1]
-            plane_axis_Z = axis[2]
-            if dim2==3: # plane. (faces and edges)
-                # Select max plane axises of Bounding Box get it to XY plane
-                # convert vertices to plane oXY. get two first elems. Is is plane max area
-                np_sites = np.array([(v[plane_axis_X], v[plane_axis_Y], 0, 0) for v in vertices], dtype=np.float32)
-                continue
-            elif dim2==2: # line (only edges)
-                # Select max side axis of Bounding Box get it to oX plane
-                np_sites = np.array([(v[plane_axis_X], 0, 0, 0) for v in vertices], dtype=np.float32)
-                continue
-            elif dim2==1: # dot. no edges
-                break
-            else:
-                # unknown dim2. insurence
-                break
-    else:
-        #print("delaunay_3d_mk2. Solution not found")  # incredibly 
-        pass
-
-    #simplices = get_delaunay_simplices_02(vertices, threshold)
-    return simplices
-
-def get_delaunay_simplices_02(vertices, threshold):
 
     # get shape dimension (dim):
     abbox = bounding_box_aligned(vertices)
@@ -410,8 +328,7 @@ class SvDelaunay3dMk2Node(SverchCustomTreeNode, bpy.types.Node):
             faces_item = []
             for vertices, volume_threshold, edge_threshold in zip_long_repeat(*params):
                 vertices = np.array(vertices, dtype=np.float64)
-                #simplices = get_delaunay_simplices(vertices, self.volume_threshold)
-                simplices = get_delaunay_simplices_02(vertices, self.volume_threshold)
+                simplices = get_delaunay_simplices(vertices, self.volume_threshold)
                 if self.join:
 
                     verts_new = vertices
@@ -427,9 +344,6 @@ class SvDelaunay3dMk2Node(SverchCustomTreeNode, bpy.types.Node):
 
                         if self.is_too_long(vertices, simplex, edge_threshold):
                              continue
-
-                        # for get_delaunay_simplices_02 no test for threshold dimension.
-                        # for get_delaunay_simplices: no need test for threshold now. All elements now is more than threshold.
 
                         if simplex_length==1:
                             continue

--- a/nodes/spatial/delaunay_3d_mk2.py
+++ b/nodes/spatial/delaunay_3d_mk2.py
@@ -15,8 +15,9 @@ from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode, zip_long_repeat, ensure_nesting_level, get_data_nesting_level
 from sverchok.utils.geom import PlaneEquation, bounding_box_aligned
+from sverchok.utils.modules.matrix_utils import matrix_apply_np
 from sverchok.dependencies import scipy
-from mathutils import Vector
+from mathutils import Vector, Matrix
 
 if scipy is not None:
     from scipy.spatial import Delaunay
@@ -36,13 +37,22 @@ def is_volume_0(verts, idxs, threshold):
     # v3 = v3 / np.linalg.norm(v3)
     # volume = np.cross(v1, v2).dot(v3) / 6
 
-    vects = verts[ list(idxs) ] # convert set to list #np.array([verts[i] for i in idxs], dtype=np.float64)
-    vects = vects-vects[0]
-    vects_norm = vects[1:4]/np.linalg.norm(vects[1:4], axis=1, keepdims=True)
-    v1_ = vects_norm[0]
-    v2_ = vects_norm[1]
-    v3_ = vects_norm[2]
-    volume_ = np.cross(v1_, v2_).dot(v3_) / 6
+    # vects = verts[ list(idxs) ] # convert set to list #np.array([verts[i] for i in idxs], dtype=np.float64)
+    # vects = vects-vects[0]
+    # vects_norm = vects[1:4]/np.linalg.norm(vects[1:4], axis=1, keepdims=True)
+    # v1_ = vects_norm[0]
+    # v2_ = vects_norm[1]
+    # v3_ = vects_norm[2]
+    # volume_ = np.cross(v1_, v2_).dot(v3_) / 6
+
+    a, b, c, d = [Vector(verts[i]) for i in idxs]
+
+    v1 = b-a
+    v2 = c-a
+    v3 = d-a
+
+    volume_ = abs(v1.cross(v2).dot(v3))/6
+
     return abs(volume_) < threshold
 
 
@@ -58,12 +68,20 @@ def is_area_0(verts, idxs, threshold):
     # v2 = v2 / np.linalg.norm(v2)
     # area = np.linalg.norm(np.cross(v1, v2)) / 2
 
-    vects = verts[ list(idxs) ] # convert set to list #np.array([verts[i] for i in idxs], dtype=np.float64)
-    vects = vects-vects[0]
-    vects_norm = vects[1:3]/np.linalg.norm(vects[1:3], axis=1, keepdims=True)
-    v1_ = vects_norm[0]
-    v2_ = vects_norm[1]
-    area_ = np.linalg.norm(np.cross(v1_, v2_)) / 2
+    # vects = verts[ list(idxs) ] # convert set to list #np.array([verts[i] for i in idxs], dtype=np.float64)
+    # vects = vects-vects[0]
+    # vects_norm = vects[1:3]/np.linalg.norm(vects[1:3], axis=1, keepdims=True)
+    # v1_ = vects_norm[0]
+    # v2_ = vects_norm[1]
+    # area_ = np.linalg.norm(np.cross(v1_, v2_)) / 2
+
+
+    a, b, c = [Vector(verts[i]) for i in idxs]
+
+    v1 = b-a
+    v2 = c-a
+
+    area_ = v1.cross(v2).length/2
 
     return abs(area_) < threshold
 
@@ -71,11 +89,16 @@ def is_length_0(verts, idxs, threshold):
     '''Is length size of 2 verts less threshold (True/False) '''
     if threshold == 0:
         return False
-    a, b = [verts[i] for i in idxs]
-    #a, b = np.array(a), np.array(b) # verts is numpy
-    v1 = b - a
-    len = np.linalg.norm(v1)
-    return abs(len) < threshold
+    # a, b = [verts[i] for i in idxs]
+    # #a, b = np.array(a), np.array(b) # verts is numpy
+    # v1 = b - a
+    # len = np.linalg.norm(v1)
+
+    a, b = [Vector(verts[i]) for i in idxs]
+    v1 = b-a
+    len_ = v1.length
+
+    return abs(len_) < threshold
 
 def get_sites_delaunay_params(np_sites, n_orig_sites, threshold=0):
     '''Calculate Delaunay with sites. '''
@@ -209,14 +232,20 @@ def get_delaunay_simplices(vertices, threshold):
 def get_delaunay_simplices_02(vertices, threshold):
 
     # get shape dimension (dim):
-    bbox = bounding_box_aligned(vertices)
-    oX = bbox[1]-bbox[0]
-    oX_size = abs(np.linalg.norm(oX))
-    oY = bbox[3]-bbox[0]
-    oY_size = abs(np.linalg.norm(oY))
-    oZ = bbox[4]-bbox[0]
-    oZ_size = abs(np.linalg.norm(oZ))
-    axis_sizes = list(reversed(sorted([oX_size, oY_size, oZ_size]))) # axis's sizes aligned from big to low.
+    abbox = bounding_box_aligned(vertices)
+    oX_abb_vec = abbox[1]-abbox[0]
+    oX_abb_size = abs(np.linalg.norm(oX_abb_vec))
+    oY_abb_vec = abbox[3]-abbox[0]
+    oY_abb_size = abs(np.linalg.norm(oY_abb_vec))
+    oZ_abb_vec = abbox[4]-abbox[0]
+    oZ_abb_size = abs(np.linalg.norm(oZ_abb_vec))
+    axis_sizes = list(reversed(sorted([oX_abb_size, oY_abb_size, oZ_abb_size]))) # axis's sizes aligned from big to low.
+    axis_abb_order = list(np.argsort([oX_abb_size, oY_abb_size, oZ_abb_size]))
+    axis_abb_order.reverse()
+    plane_axis_X = axis_abb_order[0].tolist()
+    plane_axis_Y = axis_abb_order[1].tolist()
+    plane_axis_Z = axis_abb_order[2].tolist()
+
     dim = 3 # default dimension as volume
     if axis_sizes[0]<threshold:
         # if first size<threshold then shape is dot:
@@ -229,30 +258,45 @@ def get_delaunay_simplices_02(vertices, threshold):
         dim=2
     
     # get real bbox and calc real max projection for shape:
-    oX_size = np.max(np.array(vertices, dtype=np.float16)[:,0]) - np.min(np.array(vertices, dtype=np.float16)[:,0])
-    oY_size = np.max(np.array(vertices, dtype=np.float16)[:,1]) - np.min(np.array(vertices, dtype=np.float16)[:,1])
-    oZ_size = np.max(np.array(vertices, dtype=np.float16)[:,2]) - np.min(np.array(vertices, dtype=np.float16)[:,2])
-    axis = list(np.argsort([oX_size, oY_size, oZ_size]))
-    axis.reverse()
-    plane_axis_X = axis[0]
-    plane_axis_Y = axis[1]
-    plane_axis_Z = axis[2]
+    oX_bb_size = np.max(np.array(vertices, dtype=np.float16)[:,0]) - np.min(np.array(vertices, dtype=np.float16)[:,0])
+    oY_bb_size = np.max(np.array(vertices, dtype=np.float16)[:,1]) - np.min(np.array(vertices, dtype=np.float16)[:,1])
+    oZ_bb_size = np.max(np.array(vertices, dtype=np.float16)[:,2]) - np.min(np.array(vertices, dtype=np.float16)[:,2])
+    axis_bb_order = list(np.argsort([oX_bb_size, oY_bb_size, oZ_bb_size]))
+    axis_bb_order.reverse()
+    plane_axis_bb_X = axis_bb_order[0].tolist()
+    plane_axis_bb_Y = axis_bb_order[1].tolist()
+    plane_axis_bb_Z = axis_bb_order[2].tolist()
 
     # to minimise approximation error orient max size of bbox to predifined dimensions
     if dim==3: # volume. (faces and edges)
         np_sites = vertices # no projection
     elif dim==2: # plane. (faces and edges)
-        # Select max plane axises of real Bounding Box get it to XY plane
-        # convert vertices to plane oXY. get two first elems. Is is plane max area
-        np_sites = np.array([(v[plane_axis_X], v[plane_axis_Y],) for v in vertices], dtype=np.float32)
+        np_sites = vertices
+        # calc matrix to rotate oXY:
+        align_bbox_axis = [oX_abb_vec, oY_abb_vec, oZ_abb_vec]
+        X = np.array(align_bbox_axis[plane_axis_X], dtype=np.float64)
+        Y = np.array(align_bbox_axis[plane_axis_Y], dtype=np.float64)
+        Z = np.cross(X,Y)
+        Y = np.cross(Z,X)
+        X = X/np.linalg.norm(X)
+        Y = Y/np.linalg.norm(Y)
+        Z = Z/np.linalg.norm(Z)
+
+        m = np.matrix(
+            [[X[0], Y[0], Z[0], 0.0],
+             [X[1], Y[1], Z[1], 0.0],
+             [X[2], Y[2], Z[2], 0.0],
+             [0, 0, 0, 1]] )
+        np_sites = matrix_apply_np(np_sites, np.linalg.inv(m) )
+        np_sites = np.delete(np_sites, 2, 1) #remove virtual Z axis
     elif dim==1: # line (only edges)
         # Select max side axis of real Bounding Box get it to oX plane
-        np_sites = np.array([(v[plane_axis_X], 0) for v in vertices], dtype=np.float32)
-        np_sites = np.append(np_sites, [[0, 1]], axis=0) # to calc delaunay in 2D. Remove this later
+        np_sites = np.array([(v[plane_axis_bb_X], 0.0) for v in vertices], dtype=np.float32)
+        np_sites = np.append(np_sites, [[0.0, 1.0]], axis=0) # to calc delaunay in virtual 2D.
     elif dim==0: # dot. no edges
         np_sites = vertices # no projection
 
-    simplices = [] #np.array([], dtype=np.float64) # no simpleces for dot dimension
+    simplices = [] # no simplices for dot dimension
     if dim>0:
         delaunay = Delaunay(np_sites)
         simplices = delaunay.simplices
@@ -267,6 +311,8 @@ def get_delaunay_simplices_02(vertices, threshold):
 
         simplices = np.unique(simplices, axis=0)
         simplices = simplices.tolist()
+    else:
+        simplices = list([[i] for i in range(len(vertices))])
 
     return simplices
 
@@ -350,11 +396,11 @@ class SvDelaunay3dMk2Node(SverchCustomTreeNode, bpy.types.Node):
         nested_output = input_level > 3
 
         edges_new_2 = [ (0, 1) ]
-        edges_new_3 = [ (0, 1), (1, 2), (2, 0), ]
-        edges_new_4 = [ (0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3) ]
+        edges_new_3 = self.make_edges([0, 1, 2])     # [ (0, 1), (1, 2), (2, 0), ]
+        edges_new_4 = self.make_edges([0, 1, 2, 3])  # [ (0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3) ]
         faces_new_2 = []
-        faces_new_3 = [ (0, 1, 2) ]
-        faces_new_4 = [ (0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3) ]
+        faces_new_3 = self.make_faces([0, 1, 2])     # [ (0, 1, 2) ]
+        faces_new_4 = self.make_faces([0, 1, 2, 3])  # [ (0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3) ]
         verts_out = []
         edges_out = []
         faces_out = []
@@ -384,20 +430,29 @@ class SvDelaunay3dMk2Node(SverchCustomTreeNode, bpy.types.Node):
 
                         # for get_delaunay_simplices_02 no test for threshold dimension.
                         # for get_delaunay_simplices: no need test for threshold now. All elements now is more than threshold.
-                        
+
+                        if simplex_length==1:
+                            continue
+
                         # if simplex.size>=2 (2,3,4) then create edges
                         if simplex_length==2:
+                            if is_length_0(vertices, simplex, self.volume_threshold):
+                                continue
                             edges_new.update( [ ( simplex[0], simplex[1] ) ] )
                             continue
 
                         # if simplex.size>=3 (3,4) then create faces
                         if simplex_length>=3:
                             if simplex_length==3:
+                                if is_area_0(vertices, simplex, self.volume_threshold):
+                                    continue
                                 edges_simplex = [ (simplex[0], simplex[1]),
                                                   (simplex[1], simplex[2]),
                                                   (simplex[2], simplex[0]), ]
                                 faces_simplex = [ (simplex[0], simplex[1], simplex[2]) ]
                             else:
+                                if is_volume_0(vertices, simplex, self.volume_threshold):
+                                    continue
                                 edges_simplex = [ (simplex[0], simplex[1]),
                                                   (simplex[0], simplex[2]),
                                                   (simplex[0], simplex[3]),
@@ -408,8 +463,6 @@ class SvDelaunay3dMk2Node(SverchCustomTreeNode, bpy.types.Node):
                                                   (simplex[0], simplex[1], simplex[3]),
                                                   (simplex[0], simplex[2], simplex[3]),
                                                   (simplex[1], simplex[2], simplex[3]) ]
-                            #edges_simplex = self.make_edges(list( range(simplex_length) ))
-                            #faces_simplex = self.make_faces(list( range(simplex_length) ))
                             edges_new.update( edges_simplex )
                             faces_new.update( faces_simplex )
 
@@ -430,28 +483,56 @@ class SvDelaunay3dMk2Node(SverchCustomTreeNode, bpy.types.Node):
                         if self.is_too_long(vertices, simplex, edge_threshold):
                              continue
 
-                        # if some geometry is visible then geometry need verts:
-                        verts_simplex = self.get_verts(vertices, simplex)
-                        verts_new.append(verts_simplex)                        
+                        if simplex_length==1:
+                            edges_new.append( [] )
+                            faces_new.append( [] )
+
+                            # if some geometry is visible then geometry need verts:
+                            verts_simplex = self.get_verts(vertices, simplex)
+                            verts_new.append(verts_simplex)                        
+                            continue
+
+                        if simplex_length==2:
+                            if is_length_0(vertices, simplex, self.volume_threshold):
+                                continue
+                            edges_new.append( edges_new_2 )
+                            faces_new.append( faces_new_2 )
+
+                            # if some geometry is visible then geometry need verts:
+                            verts_simplex = self.get_verts(vertices, simplex)
+                            verts_new.append(verts_simplex)                        
+                            continue
 
                         # if simplex.size>=2 (2,3,4) then create edges
                         if simplex_length==2:
+                            if is_length_0(vertices, simplex, self.volume_threshold):
+                                continue
                             edges_new.append( edges_new_2 )
                             faces_new.append( faces_new_2 )
+
+                            # if some geometry is visible then geometry need verts:
+                            verts_simplex = self.get_verts(vertices, simplex)
+                            verts_new.append(verts_simplex)                        
                             continue
 
                         # if simplex.size>=3 (3,4) then create faces
                         if simplex_length>=3:
                             if simplex_length==3:
+                                if is_area_0(vertices, simplex, self.volume_threshold):
+                                    continue
                                 edges_simplex = edges_new_3
                                 faces_simplex = faces_new_3
                             else:
+                                if is_volume_0(vertices, simplex, self.volume_threshold):
+                                    continue
                                 edges_simplex = edges_new_4
                                 faces_simplex = faces_new_4
-                            #edges_simplex = self.make_edges(list( range(simplex_length) ))
-                            #faces_simplex = self.make_faces(list( range(simplex_length) ))
                             edges_new.append( edges_simplex )
                             faces_new.append( faces_simplex )
+
+                            # if some geometry is visible then geometry need verts:
+                            verts_simplex = self.get_verts(vertices, simplex)
+                            verts_new.append(verts_simplex)                        
 
                     verts_item.extend(verts_new)
                     edges_item.extend(edges_new)
@@ -464,7 +545,6 @@ class SvDelaunay3dMk2Node(SverchCustomTreeNode, bpy.types.Node):
                 else:
                     verts_out.extend(verts_item)
                     edges_out.extend(edges_item)
-                    #if faces_item:
                     faces_out.extend(faces_item)
 
         self.outputs['Vertices'].sv_set(verts_out)

--- a/nodes/spatial/delaunay_3d_mk2.py
+++ b/nodes/spatial/delaunay_3d_mk2.py
@@ -203,6 +203,71 @@ def get_delaunay_simplices(vertices, threshold):
         #print("delaunay_3d_mk2. Solution not found")  # incredibly 
         pass
 
+    #simplices = get_delaunay_simplices_02(vertices, threshold)
+    return simplices
+
+def get_delaunay_simplices_02(vertices, threshold):
+
+    # get shape dimension (dim):
+    bbox = bounding_box_aligned(vertices)
+    oX = bbox[1]-bbox[0]
+    oX_size = abs(np.linalg.norm(oX))
+    oY = bbox[3]-bbox[0]
+    oY_size = abs(np.linalg.norm(oY))
+    oZ = bbox[4]-bbox[0]
+    oZ_size = abs(np.linalg.norm(oZ))
+    axis_sizes = list(reversed(sorted([oX_size, oY_size, oZ_size]))) # axis's sizes aligned from big to low.
+    dim = 3 # default dimension as volume
+    if axis_sizes[0]<threshold:
+        # if first size<threshold then shape is dot:
+        dim=0
+    elif axis_sizes[1]<threshold:
+        # if second size<threshold then shape is line:
+        dim=1
+    elif axis_sizes[2]<threshold:
+        # if third size<threshold then shape is plane:
+        dim=2
+    
+    # get real bbox and calc real max projection for shape:
+    oX_size = np.max(np.array(vertices, dtype=np.float16)[:,0]) - np.min(np.array(vertices, dtype=np.float16)[:,0])
+    oY_size = np.max(np.array(vertices, dtype=np.float16)[:,1]) - np.min(np.array(vertices, dtype=np.float16)[:,1])
+    oZ_size = np.max(np.array(vertices, dtype=np.float16)[:,2]) - np.min(np.array(vertices, dtype=np.float16)[:,2])
+    axis = list(np.argsort([oX_size, oY_size, oZ_size]))
+    axis.reverse()
+    plane_axis_X = axis[0]
+    plane_axis_Y = axis[1]
+    plane_axis_Z = axis[2]
+
+    # to minimise approximation error orient max size of bbox to predifined dimensions
+    if dim==3: # volume. (faces and edges)
+        np_sites = vertices # no projection
+    elif dim==2: # plane. (faces and edges)
+        # Select max plane axises of real Bounding Box get it to XY plane
+        # convert vertices to plane oXY. get two first elems. Is is plane max area
+        np_sites = np.array([(v[plane_axis_X], v[plane_axis_Y],) for v in vertices], dtype=np.float32)
+    elif dim==1: # line (only edges)
+        # Select max side axis of real Bounding Box get it to oX plane
+        np_sites = np.array([(v[plane_axis_X], 0) for v in vertices], dtype=np.float32)
+        np_sites = np.append(np_sites, [[0, 1]], axis=0) # to calc delaunay in 2D. Remove this later
+    elif dim==0: # dot. no edges
+        np_sites = vertices # no projection
+
+    simplices = [] #np.array([], dtype=np.float64) # no simpleces for dot dimension
+    if dim>0:
+        delaunay = Delaunay(np_sites)
+        simplices = delaunay.simplices
+        if dim==1:
+            # for lines need remove last vertice
+            arr = []
+            n_orig_sites = len(vertices)
+            for i, simplex in enumerate(delaunay.simplices):
+                dsimplex = tuple(simplex[simplex<n_orig_sites])
+                arr.append(dsimplex)
+            simplices = np.array(arr, dtype=np.int32)
+
+        simplices = np.unique(simplices, axis=0)
+        simplices = simplices.tolist()
+
     return simplices
 
 class SvDelaunay3dMk2Node(SverchCustomTreeNode, bpy.types.Node):
@@ -284,6 +349,12 @@ class SvDelaunay3dMk2Node(SverchCustomTreeNode, bpy.types.Node):
 
         nested_output = input_level > 3
 
+        edges_new_2 = [ (0, 1) ]
+        edges_new_3 = [ (0, 1), (1, 2), (2, 0), ]
+        edges_new_4 = [ (0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3) ]
+        faces_new_2 = []
+        faces_new_3 = [ (0, 1, 2) ]
+        faces_new_4 = [ (0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3) ]
         verts_out = []
         edges_out = []
         faces_out = []
@@ -293,14 +364,15 @@ class SvDelaunay3dMk2Node(SverchCustomTreeNode, bpy.types.Node):
             faces_item = []
             for vertices, volume_threshold, edge_threshold in zip_long_repeat(*params):
                 vertices = np.array(vertices, dtype=np.float64)
-                simplices = get_delaunay_simplices(vertices, self.volume_threshold)
+                #simplices = get_delaunay_simplices(vertices, self.volume_threshold)
+                simplices = get_delaunay_simplices_02(vertices, self.volume_threshold)
                 if self.join:
 
                     verts_new = vertices
                     edges_new = set()
                     faces_new = set()
 
-                    for simplex_idx, simplex in enumerate(simplices):
+                    for simplex in simplices:
                         simplex_length = len(simplex)
                         
                         # unknown simplex. skip. Incredible. get_sites_delaunay_params work with size==5 so need test.
@@ -310,19 +382,36 @@ class SvDelaunay3dMk2Node(SverchCustomTreeNode, bpy.types.Node):
                         if self.is_too_long(vertices, simplex, edge_threshold):
                              continue
 
-                        # no need test for threshold now. All elements now is more than threshold.
+                        # for get_delaunay_simplices_02 no test for threshold dimension.
+                        # for get_delaunay_simplices: no need test for threshold now. All elements now is more than threshold.
                         
-                        # if simplex_length>=2 (2,3,4) then create edges
-                        if simplex_length>=2:
-                            edges_simplex = self.make_edges(simplex)
-                            edges_new.update(edges_simplex)
-                            pass
+                        # if simplex.size>=2 (2,3,4) then create edges
+                        if simplex_length==2:
+                            edges_new.update( [ ( simplex[0], simplex[1] ) ] )
+                            continue
 
-                        # if simplex_length>=3 (3,4) then create faces
+                        # if simplex.size>=3 (3,4) then create faces
                         if simplex_length>=3:
-                            faces_simplex = self.make_faces(simplex)
-                            faces_new.update(faces_simplex)
-                            pass
+                            if simplex_length==3:
+                                edges_simplex = [ (simplex[0], simplex[1]),
+                                                  (simplex[1], simplex[2]),
+                                                  (simplex[2], simplex[0]), ]
+                                faces_simplex = [ (simplex[0], simplex[1], simplex[2]) ]
+                            else:
+                                edges_simplex = [ (simplex[0], simplex[1]),
+                                                  (simplex[0], simplex[2]),
+                                                  (simplex[0], simplex[3]),
+                                                  (simplex[1], simplex[2]),
+                                                  (simplex[1], simplex[3]),
+                                                  (simplex[2], simplex[3]) ]
+                                faces_simplex = [ (simplex[0], simplex[1], simplex[2]),
+                                                  (simplex[0], simplex[1], simplex[3]),
+                                                  (simplex[0], simplex[2], simplex[3]),
+                                                  (simplex[1], simplex[2], simplex[3]) ]
+                            #edges_simplex = self.make_edges(list( range(simplex_length) ))
+                            #faces_simplex = self.make_faces(list( range(simplex_length) ))
+                            edges_new.update( edges_simplex )
+                            faces_new.update( faces_simplex )
 
                     verts_item.append(verts_new)
                     edges_item.append(list(edges_new))
@@ -340,28 +429,29 @@ class SvDelaunay3dMk2Node(SverchCustomTreeNode, bpy.types.Node):
 
                         if self.is_too_long(vertices, simplex, edge_threshold):
                              continue
-                        
-                        # no need test for threshold here. All elements now is more than threshold.
-
-                        # if simplex.size>=2 (2,3,4) then create edges
-                        if simplex_length>=2:
-                            edges_simplex = self.make_edges(list(range(simplex_length)))
-                            edges_new.append(edges_simplex)
-                        else:
-                            edges_new.append([])
-                            pass
-
-                        # if simplex.size>=3 (3,4) then create faces
-                        if simplex_length>=3:
-                            faces_simplex = self.make_faces(list(range(simplex_length)))
-                            faces_new.append(faces_simplex)
-                        else:
-                            faces_new.append([])
-                            pass
 
                         # if some geometry is visible then geometry need verts:
                         verts_simplex = self.get_verts(vertices, simplex)
                         verts_new.append(verts_simplex)                        
+
+                        # if simplex.size>=2 (2,3,4) then create edges
+                        if simplex_length==2:
+                            edges_new.append( edges_new_2 )
+                            faces_new.append( faces_new_2 )
+                            continue
+
+                        # if simplex.size>=3 (3,4) then create faces
+                        if simplex_length>=3:
+                            if simplex_length==3:
+                                edges_simplex = edges_new_3
+                                faces_simplex = faces_new_3
+                            else:
+                                edges_simplex = edges_new_4
+                                faces_simplex = faces_new_4
+                            #edges_simplex = self.make_edges(list( range(simplex_length) ))
+                            #faces_simplex = self.make_faces(list( range(simplex_length) ))
+                            edges_new.append( edges_simplex )
+                            faces_new.append( faces_simplex )
 
                     verts_item.extend(verts_new)
                     edges_item.extend(edges_new)

--- a/utils/geom.py
+++ b/utils/geom.py
@@ -46,6 +46,7 @@ from sverchok.dependencies import numba  # not strictly needed i think...
 from sverchok.utils.decorators_compilation import njit
 
 def bounding_box_aligned(verts):
+    '''res=[[0,0,0], [0,1,0], [1,1,0], [1,0,0], [0,0,1], [0,1,1], [1,1,1], [1,0,1],]; 1-used axis'''
     # based on "3D Oriented bounding boxes": https://logicatcore.github.io/scratchpad/lidar/sensor-fusion/jupyter/2021/04/20/3D-Oriented-Bounding-Box.html
     data = np.vstack(np.array(verts).transpose())
     means = np.mean(data, axis=1)
@@ -67,7 +68,7 @@ def bounding_box_aligned(verts):
     rrc = np.matmul(evec, rectCoords(xmin, ymin, zmin, xmax, ymax, zmax))
     rrc += means[:, np.newaxis]
     rrc = rrc.transpose()
-    return tuple([rrc])
+    return tuple(rrc)
 
 identity_matrix = Matrix()
 


### PR DESCRIPTION
Sverchok 1.3.0-alpha, Blender 3.6.x, Windows 11.

- [ ] need code review or approve. Ready to merge.

for proposal #5010. With backward compatibility.

This refactor automatically get topology of source vertices and generate Volumes, Planes or Edges triangulation automatically:

![image](https://github.com/nortikin/sverchok/assets/14288520/4f8c7862-1612-420e-a679-b7ac0d735ad5)

**File for tests**: [issue_5010.test_Delaunay3D.blend.zip](https://github.com/nortikin/sverchok/files/12801276/issue_5010.test_Delaunay3D.blend.zip)
