### PR TITLE
Append buttons to show Sverchok settings and Blender console.

### DIFF
--- a/ui/sv_examples_menu.py
+++ b/ui/sv_examples_menu.py
@@ -10,6 +10,7 @@ from os.path import basename
 from pathlib import Path
 
 import bpy
+from bpy.types import Operator
 
 import sverchok
 from sverchok.utils.sv_json_import import JSONImporter
@@ -22,6 +23,23 @@ def node_examples_pulldown(self, context):
         row.scale_x = 1.3
         row.menu("SV_MT_layouts_examples", icon="RNA")
 
+def node_settings_pulldown(self, context):
+    if context.space_data.tree_type == 'SverchCustomTreeType':
+        layout = self.layout
+        row = layout.row(align=True)
+        row.scale_x = 1.3
+        row.operator(
+                "preferences.addon_show", icon="SETTINGS" #, text="Settings"
+            ).module = __package__.split('.')[0]
+        row.operator("switcher.console", icon="CONSOLE", text="")
+
+class SW_OT_Console(Operator):
+    """Show/hide console"""
+    bl_label = "Open Blender system console"
+    bl_idname = "switcher.console"
+    def execute(self, context):
+        bpy.ops.wm.console_toggle()
+        return {'FINISHED'}
 
 class SV_MT_LayoutsExamples(bpy.types.Menu):
     """Node tree examples"""
@@ -96,15 +114,17 @@ class SvNodeTreeImporterSilent(bpy.types.Operator):
         return {'FINISHED'}
 
 
-classes = [SV_MT_LayoutsExamples, SvNodeTreeImporterSilent]
+classes = [SW_OT_Console, SV_MT_LayoutsExamples, SvNodeTreeImporterSilent]
 
 
 def register():
     submenu_classes = (make_submenu_classes(path, category_name) for path, category_name in example_categories_names())
     _ = [bpy.utils.register_class(cls) for cls in chain(classes, submenu_classes)]
     bpy.types.NODE_HT_header.append(node_examples_pulldown)
+    bpy.types.NODE_HT_header.append(node_settings_pulldown)
 
 
 def unregister():
+    bpy.types.NODE_HT_header.remove(node_settings_pulldown)
     bpy.types.NODE_HT_header.remove(node_examples_pulldown)
     _ = [bpy.utils.unregister_class(cls) for cls in reversed(classes)]


### PR DESCRIPTION
proposal #5025. Open Sverchok and Blender Console with menu:

![image](https://github.com/nortikin/sverchok/assets/14288520/1d365e60-1ab7-4980-9f0f-45b3caec93e5)
