### PR TITLE
fix #5027. Fix Evaluate Surface Explicit mode glitch.

### DIFF
--- a/nodes/surface/evaluate_surface.py
+++ b/nodes/surface/evaluate_surface.py
@@ -268,9 +268,15 @@ class SvEvalSurfaceNode(SverchCustomTreeNode, bpy.types.Node):
                     new_edges, new_faces = self.make_edges_and_faces(samples_u, samples_v, self.outputs['Edges'].is_linked, self.outputs['Faces'].is_linked)
                 else:
                     if self.input_mode == 'VERTICES':
-                        target_us, target_vs = self.parse_input(target_verts)
+                        target_us, target_vs = self.parse_input(target_verts) # this mode take aligned target_us, target_vs
                     else:
                         target_us, target_vs = np.array(target_us), np.array(target_vs)
+                        # Align target_us, target_vs
+                        if target_us.size<target_vs.size:
+                            target_us = np.append( target_us, np.repeat(target_us[-1], target_vs.size-target_us.size ))
+                        elif  target_vs.size<target_us.size:
+                            target_vs = np.append( target_vs, np.repeat(target_vs[-1], target_us.size-target_vs.size ))
+
                     if self.clamp_mode == 'CLAMP':
                         target_us, target_vs = self._clamp(surface, target_us, target_vs)
                     elif self.clamp_mode == 'WRAP':

--- a/utils/surface/algorithms.py
+++ b/utils/surface/algorithms.py
@@ -106,7 +106,7 @@ class SvInterpolatingSurface(SvSurface):
 #         return np.array(normals)
 
     def evaluate_array(self, us, vs):
-        result = np.empty(( min( len(us), len(vs) ), 3))
+        result = np.empty((len(us), 3))
         v_to_u = defaultdict(list)
         v_to_i = defaultdict(list)
         for i, (u, v) in enumerate(zip(us, vs)):

--- a/utils/surface/algorithms.py
+++ b/utils/surface/algorithms.py
@@ -106,7 +106,7 @@ class SvInterpolatingSurface(SvSurface):
 #         return np.array(normals)
 
     def evaluate_array(self, us, vs):
-        result = np.empty((len(us), 3))
+        result = np.empty(( min( len(us), len(vs) ), 3))
         v_to_u = defaultdict(list)
         v_to_i = defaultdict(list)
         for i, (u, v) in enumerate(zip(us, vs)):


### PR DESCRIPTION
Sverchok 1.3.0-Alpha, Blender 3.6.x, Windows 11. fix #5027.

![image](https://github.com/nortikin/sverchok/assets/14288520/f5139d24-085b-4ef1-80de-ac707723e137)

File for tests: 
[issue_5027.EvaluateSurface.glitch.Example.001.blend.zip](https://github.com/nortikin/sverchok/files/13058660/issue_5027.EvaluateSurface.glitch.Example.001.blend.zip)
