### PR TITLE
fix #5036. node "Apply Vector Field" has a Gap if use circled curves

### DIFF
--- a/utils/surface/algorithms.py
+++ b/utils/surface/algorithms.py
@@ -160,7 +160,7 @@ class SvInterpolatingSurface(SvSurface):
 #         return np.array(normals)
 
     def normal_vertices_array(self, us, vs):
-        h = 0.001
+        h = 1e-4 # (np.array([1], dtype=np.float64)/100000000)[0] # 0.0001 One can use float64 of numpy. Blender float relax now. ))) 1e-8 is a diameter of hydrogen atom.
         _points         = np.empty( (0, 3), dtype=np.float64)
         _points_u_h     = np.empty( (0, 3), dtype=np.float64)
         _points_v_h     = np.empty( (0, 3), dtype=np.float64)
@@ -214,7 +214,7 @@ class SvInterpolatingSurface(SvSurface):
                 u_spline_h = self.get_u_spline(v-h, spline_vertices_h)
 
             us_v = us_by_v
-            not_reversed_us = us_by_v + h < u_max
+            not_reversed_us = us_by_v + h <= u_max
             us_h_gb = np.where( not_reversed_us, us_by_v+h, us_by_v-h )
 
             points, points_u_h = u_spline.evaluate_array( np.concatenate( (us_v, us_h_gb) ) ).reshape(2,-1,3) # to increase performance for one call
@@ -222,7 +222,7 @@ class SvInterpolatingSurface(SvSurface):
             points_v_h = u_spline_h.evaluate_array(us_by_v)
             _points     = np.concatenate( (_points, points) )
             _points_u_h = np.concatenate( (_points_u_h, points_u_h) )
-            if v+h < v_max:
+            if v+h <= v_max:
                 _points_v_h = np.concatenate( (_points_v_h, points_v_h) )
             else:
                 # reverse points if curve is reversed
@@ -249,7 +249,7 @@ class SvDeformedByFieldSurface(SvSurface):
         self.field = field
         self.coefficient = coefficient
         self.by_normal = by_normal
-        self.normal_delta = 0.001
+        self.normal_delta = 0.0001
         self.__description__ = "{}({})".format(field, surface)
 
     def get_coord_mode(self):
@@ -320,20 +320,20 @@ class SvDeformedByFieldSurface(SvSurface):
         normal = normal / n
         return normal
 
-    def normal_vertices_array(self, us, vs):
-        surf_vertices = self.evaluate_array(us, vs)
-        u_plus = self.evaluate_array(us + self.normal_delta, vs)
-        v_plus = self.evaluate_array(us, vs + self.normal_delta)
-        du = u_plus - surf_vertices
-        dv = v_plus - surf_vertices
-        #self.info("Du: %s", du)
-        #self.info("Dv: %s", dv)
-        normal = np.cross(du, dv)
-        norm = np.linalg.norm(normal, axis=1)[np.newaxis].T
-        #if norm != 0:
-        normal = normal / norm
-        #self.info("Normals: %s", normal)
-        return normal, surf_vertices
+    # def normal_vertices_array(self, us, vs):
+    #     surf_vertices = self.evaluate_array(us, vs)
+    #     u_plus = self.evaluate_array(us + self.normal_delta, vs)
+    #     v_plus = self.evaluate_array(us, vs + self.normal_delta)
+    #     du = u_plus - surf_vertices
+    #     dv = v_plus - surf_vertices
+    #     #self.info("Du: %s", du)
+    #     #self.info("Dv: %s", dv)
+    #     normal = np.cross(du, dv)
+    #     norm = np.linalg.norm(normal, axis=1)[np.newaxis].T
+    #     #if norm != 0:
+    #     normal = normal / norm
+    #     #self.info("Normals: %s", normal)
+    #     return normal, surf_vertices
 
 class SvRevolutionSurface(SvSurface):
     __description__ = "Revolution"
@@ -343,7 +343,7 @@ class SvRevolutionSurface(SvSurface):
         self.point = point
         self.direction = direction
         self.global_origin = global_origin
-        self.normal_delta = 0.001
+        self.normal_delta = 0.0001
         self.v_bounds = (0.0, 2*pi)
 
     @classmethod
@@ -389,7 +389,7 @@ class SvExtrudeCurveVectorSurface(SvSurface):
     def __init__(self, curve, vector):
         self.curve = curve
         self.vector = np.array(vector)
-        self.normal_delta = 0.001
+        self.normal_delta = 0.0001
         self.__description__ = "Extrusion of {}".format(curve)
 
     @classmethod
@@ -434,7 +434,7 @@ class SvExtrudeCurvePointSurface(SvSurface):
     def __init__(self, curve, point):
         self.curve = curve
         self.point = point
-        self.normal_delta = 0.001
+        self.normal_delta = 0.0001
         self.__description__ = "Extrusion of {}".format(curve)
 
     @staticmethod
@@ -484,7 +484,7 @@ class SvExtrudeCurveCurveSurface(SvSurface):
         self.u_curve = u_curve
         self.v_curve = v_curve
         self.origin = origin
-        self.normal_delta = 0.001
+        self.normal_delta = 0.0001
         self.__description__ = "Extrusion of {}".format(u_curve)
 
     def evaluate(self, u, v):
@@ -538,7 +538,7 @@ class SvExtrudeCurveFrenetSurface(SvSurface):
         self.profile = profile
         self.extrusion = extrusion
         self.origin = origin
-        self.normal_delta = 0.001
+        self.normal_delta = 0.0001
         self.__description__ = "Extrusion of {}".format(profile)
 
     def evaluate(self, u, v):
@@ -587,7 +587,7 @@ class SvExtrudeCurveZeroTwistSurface(SvSurface):
         self.profile = profile
         self.extrusion = extrusion
         self.origin = origin
-        self.normal_delta = 0.001
+        self.normal_delta = 0.0001
         self.extrusion.pre_calc_torsion_integral(resolution)
         self.__description__ = "Extrusion of {}".format(profile)
 
@@ -638,7 +638,7 @@ class SvExtrudeCurveTrackNormalSurface(SvSurface):
         self.profile = profile
         self.extrusion = extrusion
         self.origin = origin
-        self.normal_delta = 0.001
+        self.normal_delta = 0.0001
         self.tracker = SvNormalTrack(extrusion, resolution)
         self.__description__ = "Extrusion of {}".format(profile)
 
@@ -681,7 +681,7 @@ class SvExtrudeCurveMathutilsSurface(SvSurface):
         self.orient_axis = orient_axis
         self.up_axis = up_axis
         self.origin = origin
-        self.normal_delta = 0.001
+        self.normal_delta = 0.0001
         self.__description__ = "Extrusion of {}".format(profile)
 
     def evaluate(self, u, v):
@@ -754,7 +754,7 @@ class SvExtrudeCurveNormalDirSurface(SvSurface):
         self.extrusion = extrusion
         self.origin = origin
         self.plane_normal = np.array(plane_normal)
-        self.normal_delta = 0.001
+        self.normal_delta = 0.0001
         self.__description__ = "Extrusion of {}".format(profile)
 
     def evaluate(self, u, v):
@@ -806,7 +806,7 @@ class SvConstPipeSurface(SvSurface):
         self.radius = radius
         self.circle = SvCircle(Matrix(), radius)
         self.algorithm = algorithm
-        self.normal_delta = 0.001
+        self.normal_delta = 0.00001
         self.u_bounds = self.circle.get_u_bounds()
         if algorithm in {FRENET, ZERO, TRACK_NORMAL}:
             self.calculator = DifferentialRotationCalculator(curve, algorithm, resolution)
@@ -864,7 +864,7 @@ class SvCurveLerpSurface(SvSurface):
     def __init__(self, curve1, curve2):
         self.curve1 = curve1
         self.curve2 = curve2
-        self.normal_delta = 0.001
+        self.normal_delta = 0.0001
         self.v_bounds = (0.0, 1.0)
         self.u_bounds = (0.0, 1.0)
         self.c1_min, self.c1_max = curve1.get_u_bounds()
@@ -926,7 +926,7 @@ class SvSurfaceLerpSurface(SvSurface):
         self.surface1 = surface1
         self.surface2 = surface2
         self.coefficient = coefficient
-        self.normal_delta = 0.001
+        self.normal_delta = 0.0001
         self.v_bounds = (0.0, 1.0)
         self.u_bounds = (0.0, 1.0)
         self.s1_u_min, self.s1_u_max = surface1.get_u_min(), surface1.get_u_max()
@@ -982,7 +982,7 @@ class SvTaperSweepSurface(SvSurface):
         self.point = point
         self.line = LineEquation.from_direction_and_point(direction, point)
         self.scale_base = scale_base
-        self.normal_delta = 0.001
+        self.normal_delta = 0.0001
 
     def get_u_min(self):
         return self.profile.get_u_bounds()[0]

--- a/utils/surface/core.py
+++ b/utils/surface/core.py
@@ -218,7 +218,7 @@ class SvFlipSurface(SvSurface):
         if hasattr(surface, "normal_delta"):
             self.normal_delta = surface.normal_delta
         else:
-            self.normal_delta = 0.001
+            self.normal_delta = 0.0001
         self.__description__ = "Flipped {}".format(surface)
 
     def get_u_min(self):
@@ -265,7 +265,7 @@ class SvSwapSurface(SvSurface):
         if hasattr(surface, "normal_delta"):
             self.normal_delta = surface.normal_delta
         else:
-            self.normal_delta = 0.001
+            self.normal_delta = 0.0001
         self.__description__ = "Swapped {}".format(surface)
 
     @staticmethod
@@ -308,7 +308,7 @@ class SvReparametrizedSurface(SvSurface):
         if hasattr(surface, "normal_delta"):
             self.normal_delta = surface.normal_delta
         else:
-            self.normal_delta = 0.001
+            self.normal_delta = 0.0001
 
     @classmethod
     def build(cls, surface, new_u_min, new_u_max, new_v_min, new_v_max):
@@ -383,7 +383,7 @@ class SvLambdaSurface(SvSurface):
         self.function_numpy = function_numpy
         self.u_bounds = (0.0, 1.0)
         self.v_bounds = (0.0, 1.0)
-        self.normal_delta = 0.001
+        self.normal_delta = 0.0001
 
     def get_u_min(self):
         return self.u_bounds[0]


### PR DESCRIPTION
fix #5036. Calc normals without out of surface with reverse directions of used vectors

Issue:
![image](https://github.com/nortikin/sverchok/assets/14288520/815dc45d-598f-4f7b-9ec5-b32cacb47305)

Fix:
![image](https://github.com/nortikin/sverchok/assets/14288520/59ad2845-9a1d-4bb9-b772-dcfa02b47b69)

File for tests:
[fix_5036_node_Apply_Vector_Field_has_a_Gap_if_use_circled_curves.v001.blend.zip](https://github.com/nortikin/sverchok/files/13199200/fix_5036_node_Apply_Vector_Field_has_a_Gap_if_use_circled_curves.v001.blend.zip)

Description of problem (short):
In the source algorithm calc points next to border of surface not on the border but step inside of surface. So this step of algorithm do a little gap on a finished mesh. So I put points in these places but reverse direction of vector that help calc normals then that vectors are reversed and got normals in border.