### PR TITLE
fix #5043. Add property "apply modifiers" and "select UVMap by" for Node "Find UV Coord on Surface"

### DIFF
--- a/docs/nodes/object_nodes/points_from_uv_to_mesh.rst
+++ b/docs/nodes/object_nodes/points_from_uv_to_mesh.rst
@@ -1,0 +1,33 @@
+Find UV Coord on Surface
+========================
+
+.. image:: https://github.com/nortikin/sverchok/assets/14288520/bc7f7630-6e01-4356-a214-af4546a8b04b
+  :target: https://github.com/nortikin/sverchok/assets/14288520/bc7f7630-6e01-4356-a214-af4546a8b04b
+
+Description
+-----------
+
+.. image:: https://github.com/nortikin/sverchok/assets/14288520/63b0de53-4ba2-4097-9389-9ecf9c09a665
+  :target: https://github.com/nortikin/sverchok/assets/14288520/63b0de53-4ba2-4097-9389-9ecf9c09a665
+
+.. image:: https://github.com/nortikin/sverchok/assets/14288520/248f59bf-d468-415b-a7ec-0ef04d4f014e
+  :target: https://github.com/nortikin/sverchok/assets/14288520/248f59bf-d468-415b-a7ec-0ef04d4f014e
+
+.. image:: https://github.com/nortikin/sverchok/assets/14288520/445fde34-d6a1-4365-80dd-0b0e6fb32501
+  :target: https://github.com/nortikin/sverchok/assets/14288520/445fde34-d6a1-4365-80dd-0b0e6fb32501
+
+If you see this exception then check UV Map property. Here must at least one element:
+
+.. image:: https://github.com/nortikin/sverchok/assets/14288520/630537e2-65b5-4501-aba9-ff27c6d16e88
+  :target: https://github.com/nortikin/sverchok/assets/14288520/630537e2-65b5-4501-aba9-ff27c6d16e88
+
+Property
+--------
+
+Examples
+--------
+
+Nodes of description:
+
+.. image:: https://github.com/nortikin/sverchok/assets/14288520/9cbd1034-111c-40f0-8680-b5cbe53b9347
+  :target: https://github.com/nortikin/sverchok/assets/14288520/9cbd1034-111c-40f0-8680-b5cbe53b9347

--- a/index.yaml
+++ b/index.yaml
@@ -767,7 +767,7 @@
     - SvSetCustomUVMap
     - SvUVtextureNode
     - SvMeshUVColorNode
-    - SvUVPointonMeshNode
+    - SvUVPointonMeshNodeMK2
     - SvSampleUVColorNode
     - SvArmaturePropsNode
     - SvLatticePropsNode

--- a/menus/full_by_data_type.yaml
+++ b/menus/full_by_data_type.yaml
@@ -796,7 +796,7 @@
     - SvSetCustomUVMap
     - SvUVtextureNode
     - SvMeshUVColorNode
-    - SvUVPointonMeshNode
+    - SvUVPointonMeshNodeMK2
     - SvSampleUVColorNode
     - SvArmaturePropsNode
     - SvLatticePropsNode

--- a/menus/full_nortikin.yaml
+++ b/menus/full_nortikin.yaml
@@ -913,7 +913,7 @@
     - SvSetCustomUVMap
     - SvUVtextureNode
     - SvMeshUVColorNode
-    - SvUVPointonMeshNode
+    - SvUVPointonMeshNodeMK2
     - SvSampleUVColorNode
     - SvArmaturePropsNode
     - SvLatticePropsNode

--- a/nodes/object_nodes/points_from_uv_to_mesh.py
+++ b/nodes/object_nodes/points_from_uv_to_mesh.py
@@ -94,14 +94,13 @@ class SvUVPointonMeshNodeMK2(SverchCustomTreeNode, bpy.types.Node):
         default=False, update=updateNode)
 
     uv_select_modes = [
-            #('None', "No Apply", "Modifiers are not applied", 0),
-            ('active_item', "Active Selected", "Node select UV Map actived in the list of UV Maps of object", 0),
-            ('active_render', "Active Render", "UV Map selected for render (actived photo icon)", 1)
+            ('active_item', "Active Selected", "UV Map selected by an active elem in the list of UV Maps of object data", 0),
+            ('active_render', "Active Render", "UV Map selected by property active_render in the list of UV Maps of object data (actived photo icon)", 1)
         ]
 
     uv_select_mode : EnumProperty(
-            name = "U Knots",
-            description = "What UV Map select",
+            name = "Select UV Map by",
+            description = "UV Map select from object data property by",
             items = uv_select_modes,
             default = 'active_item',
             update = updateNode)

--- a/nodes/object_nodes/points_from_uv_to_mesh.py
+++ b/nodes/object_nodes/points_from_uv_to_mesh.py
@@ -29,37 +29,6 @@ from sverchok.data_structure import (updateNode)
 
 def UV(self, bm, uv_layer):
     # makes UV from layout texture area to sverchok vertices and polygons.
-    # uv_layer_active = obj.data.uv_layers.active #.name
-    # uv_layer_active_render_name = obj.data.uv_layers[0].name
-    # for uv in obj.data.uv_layers:
-    #     if uv.active_render==True:
-    #         uv_layer_active_render_name = uv.name
-    #         break
-
-    # bm = bmesh.new()
-    # if self.apply_modifiers:
-    #     sv_depsgraph = bpy.context.evaluated_depsgraph_get()
-    #     scene_object = sv_depsgraph.objects[ obj.name ]
-    #     object_to_mesh = scene_object.to_mesh(preserve_all_data_layers=True, depsgraph=sv_depsgraph)
-    #     bm.from_mesh(object_to_mesh)
-    #     scene_object.to_mesh_clear()
-    # else:
-    #     bm.from_mesh(obj.data)
-
-    # uv_layer_active = bm.loops.layers.uv.active #.name
-    # uv_layer_active_render = obj.data.uv_layers[0] #.name
-    # for uv in bm.loops.layers.uv:
-    #     if uv.name==uv_layer_active_render_name:
-    #         uv_layer_active_render = uv
-    #         break
-
-    # if self.uv_select_mode=='active_item':
-    #     uv_layer = uv_layer_active
-    # elif self.uv_select_mode=='active_render':
-    #     uv_layer = uv_layer_active_render
-
-    # bm.verts.ensure_lookup_table()
-    # bm.faces.ensure_lookup_table()
     vertices_dict = {}
     polygons_new = []
     polygons_new_append = polygons_new.append
@@ -75,7 +44,6 @@ def UV(self, bm, uv_layer):
         polygons_new_append(polygons_new_pol)
 
     vertices_new = list( vertices_dict.values() )
-    #bm.clear()
     return [vertices_new, polygons_new]
 
 
@@ -171,7 +139,7 @@ class SvUVPointonMeshNodeMK2(SverchCustomTreeNode, bpy.types.Node):
             # resore UV to 3D
             pointuv = PointsUV.sv_get()[0]
             bvh = BVHTree.FromPolygons(UVMAPV, UVMAPP, all_triangles=False, epsilon=0.0)
-            out = [] # res in 3D
+            out = [] # result in 3D
             for Puv in pointuv:
                 loc, norm, ind, dist = bvh.find_nearest(Puv)
                 _found_poly = bm.faces[ind]

--- a/nodes/object_nodes/points_from_uv_to_mesh.py
+++ b/nodes/object_nodes/points_from_uv_to_mesh.py
@@ -27,39 +27,39 @@ from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import (updateNode)
 
 
-def UV(self, object, uv_select_mode, apply_modifiers):
+def UV(self, bm, uv_layer):
     # makes UV from layout texture area to sverchok vertices and polygons.
-    uv_layer_active = object.data.uv_layers.active #.name
-    uv_layer_active_render_name = object.data.uv_layers[0].name
-    for uv in object.data.uv_layers:
-        if uv.active_render==True:
-            uv_layer_active_render_name = uv.name
-            break
+    # uv_layer_active = obj.data.uv_layers.active #.name
+    # uv_layer_active_render_name = obj.data.uv_layers[0].name
+    # for uv in obj.data.uv_layers:
+    #     if uv.active_render==True:
+    #         uv_layer_active_render_name = uv.name
+    #         break
 
-    bm = bmesh.new()
-    if apply_modifiers:
-        sv_depsgraph = bpy.context.evaluated_depsgraph_get()
-        scene_object = sv_depsgraph.objects[ object.name ]
-        object_to_mesh = scene_object.to_mesh(preserve_all_data_layers=True, depsgraph=sv_depsgraph)
-        bm.from_mesh(object_to_mesh)
-        scene_object.to_mesh_clear()
-    else:
-        bm.from_mesh(object.data)
+    # bm = bmesh.new()
+    # if self.apply_modifiers:
+    #     sv_depsgraph = bpy.context.evaluated_depsgraph_get()
+    #     scene_object = sv_depsgraph.objects[ obj.name ]
+    #     object_to_mesh = scene_object.to_mesh(preserve_all_data_layers=True, depsgraph=sv_depsgraph)
+    #     bm.from_mesh(object_to_mesh)
+    #     scene_object.to_mesh_clear()
+    # else:
+    #     bm.from_mesh(obj.data)
 
-    uv_layer_active = bm.loops.layers.uv.active #.name
-    uv_layer_active_render = object.data.uv_layers[0] #.name
-    for uv in bm.loops.layers.uv:
-        if uv.name==uv_layer_active_render_name:
-            uv_layer_active_render = uv
-            break
+    # uv_layer_active = bm.loops.layers.uv.active #.name
+    # uv_layer_active_render = obj.data.uv_layers[0] #.name
+    # for uv in bm.loops.layers.uv:
+    #     if uv.name==uv_layer_active_render_name:
+    #         uv_layer_active_render = uv
+    #         break
 
-    if uv_select_mode=='active_item':
-        uv_layer = uv_layer_active
-    elif uv_select_mode=='active_render':
-        uv_layer = uv_layer_active_render
+    # if self.uv_select_mode=='active_item':
+    #     uv_layer = uv_layer_active
+    # elif self.uv_select_mode=='active_render':
+    #     uv_layer = uv_layer_active_render
 
-    bm.verts.ensure_lookup_table()
-    bm.faces.ensure_lookup_table()
+    # bm.verts.ensure_lookup_table()
+    # bm.faces.ensure_lookup_table()
     vertices_dict = {}
     polygons_new = []
     polygons_new_append = polygons_new.append
@@ -75,7 +75,7 @@ def UV(self, object, uv_select_mode, apply_modifiers):
         polygons_new_append(polygons_new_pol)
 
     vertices_new = list( vertices_dict.values() )
-    bm.clear()
+    #bm.clear()
     return [vertices_new, polygons_new]
 
 
@@ -89,7 +89,7 @@ class SvUVPointonMeshNodeMK2(SverchCustomTreeNode, bpy.types.Node):
 
     object_ref: StringProperty(default='', update=updateNode)
 
-    apply_midifiers: BoolProperty(
+    apply_modifiers: BoolProperty(
         name="Apply Modifiers", description="Off: use original object from scene\nOn: Apply modifiers before select UV Map",
         default=False, update=updateNode)
 
@@ -112,7 +112,7 @@ class SvUVPointonMeshNodeMK2(SverchCustomTreeNode, bpy.types.Node):
         col.label(text='Apply midifiers:')
         col = row.column()
         col.alignment = 'LEFT'
-        col.prop(self, 'apply_midifiers', expand=True, text='')
+        col.prop(self, 'apply_modifiers', expand=True, text='')
         row = layout.row()
         row.column().label(text="Select UV Map by:")
         row.column().prop(self, 'uv_select_mode', expand=True ) #, text='')
@@ -133,23 +133,57 @@ class SvUVPointonMeshNodeMK2(SverchCustomTreeNode, bpy.types.Node):
         obj = Object.sv_get()[0]  # triangulate faces
         if not obj.data.uv_layers:
             raise Exception(f"Object '{obj.data.name}' has no UV Maps. Open Properties->Data->UV Maps and check list of UV Maps.")
-        UVMAPV, UVMAPP = UV(self, obj, self.uv_select_mode, self.apply_midifiers)
+        
+        # get all UV Maps name in object UV Maps list
+        uv_layer_active_render_name = obj.data.uv_layers[0].name
+        for uv in obj.data.uv_layers:
+            if uv.active_render==True:
+                uv_layer_active_render_name = uv.name  # get UV Map name active render (photo mark)
+                break
+
+        bm = bmesh.new()
+        if self.apply_modifiers:
+            # apply modifiers and build mesh after it
+            sv_depsgraph = bpy.context.evaluated_depsgraph_get()
+            scene_object = sv_depsgraph.objects[ obj.name ]
+            object_to_mesh = scene_object.to_mesh(preserve_all_data_layers=True, depsgraph=sv_depsgraph)
+            bm.from_mesh(object_to_mesh)
+            scene_object.to_mesh_clear()
+        else:
+            # get mesh of original object from scene
+            bm.from_mesh(obj.data)
+
+        uv_layer_active = bm.loops.layers.uv.active
+        uv_layer_active_render = obj.data.uv_layers[0]
+        for uv in bm.loops.layers.uv:
+            if uv.name==uv_layer_active_render_name:
+                uv_layer_active_render = uv
+                break
+
+        if self.uv_select_mode=='active_item':
+            uv_layer = uv_layer_active
+        else: #if self.uv_select_mode=='active_render':
+            uv_layer = uv_layer_active_render
+
+        bm.verts.ensure_lookup_table()
+        bm.faces.ensure_lookup_table()
+        UVMAPV, UVMAPP = UV(self, bm, uv_layer)
         if Pom.is_linked:
+            # resore UV to 3D
             pointuv = PointsUV.sv_get()[0]
             bvh = BVHTree.FromPolygons(UVMAPV, UVMAPP, all_triangles=False, epsilon=0.0)
-            ran = range(3)
-            out = []
-            uvMap = obj.data.uv_layers[0].data
+            out = [] # res in 3D
             for Puv in pointuv:
                 loc, norm, ind, dist = bvh.find_nearest(Puv)
-                found_poly = obj.data.polygons[ind]
-                verticesIndices = found_poly.vertices
-                p1, p2, p3 = [obj.data.vertices[verticesIndices[i]].co for i in ran]
-                uvMapIndices = found_poly.loop_indices
-                uv1, uv2, uv3 = [uvMap[uvMapIndices[i]].uv.to_3d() for i in ran]
-                V = barycentric_transform(Puv, uv1, uv2, uv3, p1, p2, p3)
-                out.append(V[:])
+                _found_poly = bm.faces[ind]
+                _p1, _p2, _p3 = [v.co for v in bm.faces[ind].verts[0:3] ]
+                _uv1, _uv2, _uv3 = [l[uv_layer].uv.to_3d() for l in _found_poly.loops[0:3] ]
+                _V = barycentric_transform(Puv, _uv1, _uv2, _uv3, _p1, _p2, _p3)
+                out.append(_V[:])
+            
             Pom.sv_set([out])
+        bm.clear()
+
         if uvV.is_linked:
             uvV.sv_set([UVMAPV])
             uvP.sv_set([UVMAPP])

--- a/tests/docs_tests.py
+++ b/tests/docs_tests.py
@@ -37,7 +37,7 @@ class DocumentationTests(SverchokTestCase):
                 continue
             with self.subTest(node_module=f"{file_name}.py"):
                 if file_name in modules:
-                    self.fail(f'There are tow modules with the same name "{file_name}" \n'
+                    self.fail(f'There are two modules with the same name "{file_name}" \n'
                               f'File 1: {Path(modules[file_name]).relative_to(sv_root)} \n'
                               f'file 2: {Path(path).relative_to(sv_root)}')
                 else:
@@ -59,7 +59,6 @@ closest_point_on_mesh2.py
 scene_raycast2.py
 sculpt_mask.py
 set_blenddata2.py
-points_from_uv_to_mesh.py
 custom_mesh_normals.py
 color_uv_texture.py
 filter_blenddata.py


### PR DESCRIPTION
fix #5043 .

Sverchok 1.3.0-alpha, Blender 3.6.x

**File for tests**:
[fix_5043_Add_property_apply_modifiers_and_select_UVMap_of_Node_Find_UV_Coord_on_Surface.test.blend.zip](https://github.com/nortikin/sverchok/files/13254327/fix_5043_Add_property_apply_modifiers_and_select_UVMap_of_Node_Find_UV_Coord_on_Surface.test.blend.zip)

**file for tests with apply modifiers**:
[fix_5043_Add_property_apply_modifiers_and_select_UVMap_of_Node_Find_UV_Coord_on_Surface.test.v004.blend.zip](https://github.com/nortikin/sverchok/files/13255391/fix_5043_Add_property_apply_modifiers_and_select_UVMap_of_Node_Find_UV_Coord_on_Surface.test.v004.blend.zip)

--------

**Select UV Map by Item of list:**
![image](https://github.com/nortikin/sverchok/assets/14288520/5942d100-e82d-4965-8a6a-a163a41bbb5e)

--------

**Select UV Map by Item with property "Active Render"**
![image](https://github.com/nortikin/sverchok/assets/14288520/250fcc3b-88ce-4a4c-8b27-b1c04052d4ba)

--------

**Apply modifiers before select UV Map:**
![image](https://github.com/nortikin/sverchok/assets/14288520/445fde34-d6a1-4365-80dd-0b0e6fb32501)