### PR TITLE
fix #5045. Append "Angle Units" to properties of node "Revolution Surface" and fix documents.

### DIFF
--- a/docs/nodes/surface/revolution_surface.rst
+++ b/docs/nodes/surface/revolution_surface.rst
@@ -1,8 +1,8 @@
 Revolution Surface
 ==================
 
-.. image:: https://github.com/nortikin/sverchok/assets/14288520/49bc8bfc-cfbc-4ee9-8edc-1bc6511a1ed0
-  :target: https://github.com/nortikin/sverchok/assets/14288520/49bc8bfc-cfbc-4ee9-8edc-1bc6511a1ed0
+.. image:: https://github.com/nortikin/sverchok/assets/14288520/3a410340-d935-4569-8ca5-c6ab77cf4fa9
+  :target: https://github.com/nortikin/sverchok/assets/14288520/3a410340-d935-4569-8ca5-c6ab77cf4fa9
 
 Functionality
 -------------
@@ -63,8 +63,20 @@ This node has the following parameter:
 
   The default value is **Revolution axis**.
 
-.. image:: https://github.com/nortikin/sverchok/assets/14288520/b582fd3f-65ed-4d39-b2a6-87d9d2ba4de6
-  :target: https://github.com/nortikin/sverchok/assets/14288520/b582fd3f-65ed-4d39-b2a6-87d9d2ba4de6
+  .. image:: https://github.com/nortikin/sverchok/assets/14288520/b582fd3f-65ed-4d39-b2a6-87d9d2ba4de6
+    :target: https://github.com/nortikin/sverchok/assets/14288520/b582fd3f-65ed-4d39-b2a6-87d9d2ba4de6
+
+* **Angle Units**. The units in which values of **T Min**, **T Max** inputs are
+  measured. The available options are:
+
+  * **Rad**. Radians (2*pi is full circle).
+  * **Deg**. Degrees (360 is full circle).
+  * **Uni**. Unit circles (1.0 is full circle).
+
+  The default value is **Rad**.
+
+    .. image:: https://github.com/nortikin/sverchok/assets/14288520/008a1043-33c4-4635-8757-a6efb4a4134f
+      :target: https://github.com/nortikin/sverchok/assets/14288520/008a1043-33c4-4635-8757-a6efb4a4134f
 
 Outputs
 -------

--- a/index.yaml
+++ b/index.yaml
@@ -177,7 +177,7 @@
         - SvSurfaceElevateDegreeNode
         - SvSurfaceReduceDegreeNode
     - ---
-    - SvExRevolutionSurfaceNode
+    - SvRevolutionSurfaceNodeMK2
     - SvExTaperSweepSurfaceNode
     - SvBendCurveSurfaceNode
     - SvExExtrudeCurveVectorNode

--- a/menus/full_by_data_type.yaml
+++ b/menus/full_by_data_type.yaml
@@ -337,7 +337,7 @@
         - SvExMinimalSurfaceNode
         - SvExMinSurfaceFromCurveNode
         - ---
-        - SvExRevolutionSurfaceNode
+        - SvRevolutionSurfaceNodeMK2
         - SvExTaperSweepSurfaceNode
         - SvBendCurveSurfaceNode
         - SvExExtrudeCurveVectorNode

--- a/menus/full_nortikin.yaml
+++ b/menus/full_nortikin.yaml
@@ -313,7 +313,7 @@
             - ---
             - SvSurfaceElevateDegreeNode
             - SvSurfaceReduceDegreeNode
-        - SvExRevolutionSurfaceNode
+        - SvRevolutionSurfaceNodeMK2
         - SvExTaperSweepSurfaceNode
         - SvBendCurveSurfaceNode
         - SvExExtrudeCurveVectorNode


### PR DESCRIPTION
fix #5045. Append "Angle Units" to the node "Revolution Surface":

![image](https://github.com/nortikin/sverchok/assets/14288520/9726b843-58b5-4359-8db8-46d5ccbcdf37)

**File for tests**:

[fix_5045_Append_Angle_Units_to_node_Revolution_Surface.test.blend.zip](https://github.com/nortikin/sverchok/files/13257226/fix_5045_Append_Angle_Units_to_node_Revolution_Surface.test.blend.zip)
