### PR TITLE
fix #5047 node "Revolution Surface" not good result

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -177,7 +177,7 @@
         - SvSurfaceElevateDegreeNode
         - SvSurfaceReduceDegreeNode
     - ---
-    - SvExRevolutionSurfaceNode
+    - SvRevolutionSurfaceNodeMK2
     - SvExTaperSweepSurfaceNode
     - SvBendCurveSurfaceNode
     - SvExExtrudeCurveVectorNode

--- a/menus/full_by_data_type.yaml
+++ b/menus/full_by_data_type.yaml
@@ -337,7 +337,7 @@
         - SvExMinimalSurfaceNode
         - SvExMinSurfaceFromCurveNode
         - ---
-        - SvExRevolutionSurfaceNode
+        - SvRevolutionSurfaceNodeMK2
         - SvExTaperSweepSurfaceNode
         - SvBendCurveSurfaceNode
         - SvExExtrudeCurveVectorNode

--- a/menus/full_nortikin.yaml
+++ b/menus/full_nortikin.yaml
@@ -313,7 +313,7 @@
             - ---
             - SvSurfaceElevateDegreeNode
             - SvSurfaceReduceDegreeNode
-        - SvExRevolutionSurfaceNode
+        - SvRevolutionSurfaceNodeMK2
         - SvExTaperSweepSurfaceNode
         - SvBendCurveSurfaceNode
         - SvExExtrudeCurveVectorNode

--- a/old_nodes/revolution_surface.py
+++ b/old_nodes/revolution_surface.py
@@ -11,7 +11,7 @@ from sverchok.utils.curve import SvCurve
 from sverchok.utils.surface.algorithms import SvRevolutionSurface
 
 
-class SvRevolutionSurfaceNode(SverchCustomTreeNode, bpy.types.Node):
+class SvExRevolutionSurfaceNode(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Revolution Surface
     Tooltip: Generate a surface of revolution (similar to Spin / Lathe modifier)
@@ -90,8 +90,8 @@ class SvRevolutionSurfaceNode(SverchCustomTreeNode, bpy.types.Node):
         self.outputs['Surface'].sv_set(surface_out)
 
 def register():
-    bpy.utils.register_class(SvRevolutionSurfaceNode)
+    bpy.utils.register_class(SvExRevolutionSurfaceNode)
 
 def unregister():
-    bpy.utils.unregister_class(SvRevolutionSurfaceNode)
+    bpy.utils.unregister_class(SvExRevolutionSurfaceNode)
 

--- a/old_nodes/revolution_surface.py
+++ b/old_nodes/revolution_surface.py
@@ -11,20 +11,14 @@ from sverchok.utils.curve import SvCurve
 from sverchok.utils.surface.algorithms import SvRevolutionSurface
 
 
-class SvRevolutionSurfaceNodeMK2(SverchCustomTreeNode, bpy.types.Node):
+class SvRevolutionSurfaceNode(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Revolution Surface
     Tooltip: Generate a surface of revolution (similar to Spin / Lathe modifier)
     """
-    bl_idname = 'SvRevolutionSurfaceNodeMK2'
+    bl_idname = 'SvExRevolutionSurfaceNode'
     bl_label = 'Revolution Surface'
     bl_icon = 'MOD_SCREW'
-
-    use_nurbs : BoolProperty(
-        name = "NURBS",
-        description = "Process NURBS curves and output a NURBS surface",
-        default = False,
-        update = updateNode)
 
     v_min : FloatProperty(
         name = "Angle From",
@@ -64,7 +58,6 @@ class SvRevolutionSurfaceNodeMK2(SverchCustomTreeNode, bpy.types.Node):
         self.origin = 'POINT'
 
     def draw_buttons(self, context, layout):
-        layout.prop(self, 'use_nurbs')
         layout.prop(self, "origin")
 
     def process(self):
@@ -88,21 +81,17 @@ class SvRevolutionSurfaceNodeMK2(SverchCustomTreeNode, bpy.types.Node):
         for curves, points, directions, v_mins, v_maxs in zip_long_repeat(curve_s, point_s, direction_s, v_min_s, v_max_s):
             for curve, point, direction, v_min, v_max in zip_long_repeat(curves, points, directions, v_mins, v_maxs):
                 origin = self.origin == 'GLOBAL'
-                if self.use_nurbs:
-                    surface = SvRevolutionSurface.build(curve,
-                                    np.array(point), np.array(direction),
-                                    v_min, v_max,
-                                    global_origin=origin)
-                else:
-                    surface = SvRevolutionSurface(curve, np.array(point), np.array(direction), global_origin=origin)
-                    surface.v_bounds = (v_min, v_max)
+                surface = SvRevolutionSurface.build(curve,
+                                np.array(point), np.array(direction),
+                                v_min, v_max,
+                                global_origin=origin)
                 surface_out.append(surface)
 
         self.outputs['Surface'].sv_set(surface_out)
 
 def register():
-    bpy.utils.register_class(SvRevolutionSurfaceNodeMK2)
+    bpy.utils.register_class(SvRevolutionSurfaceNode)
 
 def unregister():
-    bpy.utils.unregister_class(SvRevolutionSurfaceNodeMK2)
+    bpy.utils.unregister_class(SvRevolutionSurfaceNode)
 


### PR DESCRIPTION
fix #5047. 
this is not fix of problem but take a user opportunity to select another way to build Revolution Surface.

Append Property "NURBS"

![image](https://github.com/nortikin/sverchok/assets/14288520/bc07a7c0-cbfa-4440-8d1e-9f791da84e3d)


https://github.com/nortikin/sverchok/assets/14288520/60467d45-727d-4b65-944c-f7f5521c8a8e

file for tests:
[fix_5047_node_Revolution_Surface_not_good_result.test.new_node.002.blend.zip](https://github.com/nortikin/sverchok/files/13260286/fix_5047_node_Revolution_Surface_not_good_result.test.new_node.002.blend.zip)
