### PR TITLE
fix #5051. node Mesh Viewer show exception face new already exists.

### DIFF
--- a/utils/sv_bmesh_utils.py
+++ b/utils/sv_bmesh_utils.py
@@ -162,7 +162,12 @@ def add_mesh_to_bmesh(bm, verts, edges=None, faces=None, sv_index_name=None, upd
         new_edges = []
     #[new_face([bm_verts[i] for i in face]) for face in faces or []] # не надо так делать
     if faces is not None:
-        for face in faces:
+        # remove double faces. Some times get faces with same verts but with another order: [62,103,102] and [102,103,62].
+        # this is not compatible with mesh and only one of that faces can be used. So convert this faces indices into dictionary.
+        # this remove faces with the same vertices but same or different orders. This may happens on some of Voronoi if
+        # it slice self intersected mesh.
+        dict_faces = { tuple(sorted(f)): f for f in list(faces) }
+        for face in dict_faces.values():
             new_face([bm_verts[i] for i in face])
     else:
         new_face = []


### PR DESCRIPTION
fix #5051 . node Mesh Viewer show exception face new is exists. Fixed

Source of problem. Some faces try same vertices but another sequence:
![image](https://github.com/nortikin/sverchok/assets/14288520/e632e586-1353-4e48-a18d-5ab6168d2a19)


![image](https://github.com/nortikin/sverchok/assets/14288520/d28c48af-06ea-4b53-ae71-48503fc1fc84)

file for tests:
[fix_5051_node_Mesh_Viewer_show_exception_face_new_is_exists.001.blend.zip](https://github.com/nortikin/sverchok/files/13271656/fix_5051_node_Mesh_Viewer_show_exception_face_new_is_exists.001.blend.zip)
