### PR TITLE
fix #5055. Append quick method to display_type and hide_render of selected objects in the node "Get Objects Data"

### DIFF
--- a/docs/nodes/scene/get_objects_data.rst
+++ b/docs/nodes/scene/get_objects_data.rst
@@ -1,8 +1,8 @@
 Get Objects Data
 ================
 
-.. image:: https://github.com/nortikin/sverchok/assets/14288520/b24e7fbc-3383-49ca-bc96-ae5ff823fee3
-  :target: https://github.com/nortikin/sverchok/assets/14288520/b24e7fbc-3383-49ca-bc96-ae5ff823fee3
+.. image:: https://github.com/nortikin/sverchok/assets/14288520/3794a700-0b9e-4b05-8d54-d3b330ddf112
+  :target: https://github.com/nortikin/sverchok/assets/14288520/3794a700-0b9e-4b05-8d54-d3b330ddf112
 
 Functionality
 -------------
@@ -21,6 +21,18 @@ A few points worth stating explicitly.
 limitations:
 
 - When you use the ``Post`` mode Sverchok/Blender expect Objects to be visible. If you want to "hide" the original Objects in the scene to avoid visual clutter, you can place them into a Collection and hide the collection. This is a current Blender API limitation.
+- Another method to work with objects - select wireframe mode and hide objects in Render by buttons:
+
+  .. image:: https://github.com/nortikin/sverchok/assets/14288520/0ef92cf2-d512-49f8-b803-da9af748e829
+    :target: https://github.com/nortikin/sverchok/assets/14288520/0ef92cf2-d512-49f8-b803-da9af748e829
+
+.. raw:: html
+
+   <video width="700" controls>
+     <source src="https://github.com/nortikin/sverchok/assets/14288520/7a158c33-814a-43be-9a9c-929096495354" type="video/mp4">
+    Your browser does not support the video tag.
+   </video>
+
 - We have Bezier-in and NURBS-in nodes if you want to get Curve data from Scene objects, instead of Mesh. 
 
 Inputs
@@ -32,17 +44,22 @@ Objects Socket
 Parameters
 ----------
 
-+-----------------+---------------+--------------------------------------------------------------------------+
-| Param           | Type          | Description                                                              |
-+=================+===============+==========================================================================+
-| **G E T**       | Button        | Button to get selected objects from scene.                               |
-+-----------------+---------------+--------------------------------------------------------------------------+
-| **sorting**     | Bool, toggle  | Sorting inserted objects by name                                         |
-+-----------------+---------------+--------------------------------------------------------------------------+
-| **post**        | Bool, toggle  | Postprocessing, if activated, modifiers applied to mesh before importing |
-+-----------------+---------------+--------------------------------------------------------------------------+
-| **vert groups** | Bool, toggle  | Import all vertex groups that in object's data. just import indexes      |
-+-----------------+---------------+--------------------------------------------------------------------------+
++----------------------+---------------+--------------------------------------------------------------------------+
+| Param                | Type          | Description                                                              |
++======================+===============+==========================================================================+
+| **G E T**            | Button        | Button to get selected objects from scene.                               |
++----------------------+---------------+--------------------------------------------------------------------------+
+| **Apply_Matrix**     | Bool,toggle   | Apply object Matrix to output sockets (Vertices, Vertex Normals,         |
+|                      |               | Poligon Centers, Polygon Normals). Has no infuence for Matrix and Object |
++----------------------+---------------+--------------------------------------------------------------------------+
+| **Merge**            | Bool,toggle   | Merge Meshes into one mesh                                               |
++----------------------+---------------+--------------------------------------------------------------------------+
+| **sorting**          | Bool,toggle   | Sorting inserted objects by name                                         |
++----------------------+---------------+--------------------------------------------------------------------------+
+| **post**             | Bool,toggle   | Postprocessing, if activated, modifiers applied to mesh before importing |
++----------------------+---------------+--------------------------------------------------------------------------+
+| **vert groups**      | Bool,toggle   | Import all vertex groups that in object's data. just import indexes      |
++----------------------+---------------+--------------------------------------------------------------------------+
 
 3D panel
 --------

--- a/docs/nodes/scene/get_objects_data.rst
+++ b/docs/nodes/scene/get_objects_data.rst
@@ -1,8 +1,8 @@
 Get Objects Data
 ================
 
-.. image:: https://github.com/nortikin/sverchok/assets/14288520/3794a700-0b9e-4b05-8d54-d3b330ddf112
-  :target: https://github.com/nortikin/sverchok/assets/14288520/3794a700-0b9e-4b05-8d54-d3b330ddf112
+.. image:: https://github.com/nortikin/sverchok/assets/14288520/d7662f9f-d398-4b73-8337-d0d228f104bc
+  :target: https://github.com/nortikin/sverchok/assets/14288520/d7662f9f-d398-4b73-8337-d0d228f104bc
 
 Functionality
 -------------
@@ -23,8 +23,8 @@ limitations:
 - When you use the ``Post`` mode Sverchok/Blender expect Objects to be visible. If you want to "hide" the original Objects in the scene to avoid visual clutter, you can place them into a Collection and hide the collection. This is a current Blender API limitation.
 - Another method to work with objects - select wireframe mode and hide objects in Render by buttons:
 
-  .. image:: https://github.com/nortikin/sverchok/assets/14288520/0ef92cf2-d512-49f8-b803-da9af748e829
-    :target: https://github.com/nortikin/sverchok/assets/14288520/0ef92cf2-d512-49f8-b803-da9af748e829
+  .. image:: https://github.com/nortikin/sverchok/assets/14288520/30158800-3cd8-483d-a162-2d13ddfdc289
+    :target: https://github.com/nortikin/sverchok/assets/14288520/30158800-3cd8-483d-a162-2d13ddfdc289
 
 .. raw:: html
 

--- a/nodes/scene/get_objects_data.py
+++ b/nodes/scene/get_objects_data.py
@@ -158,7 +158,7 @@ class SvGetObjectsDataMK2(Show3DProperties, SverchCustomTreeNode, bpy.types.Node
     display_types = [
             ('BOUNDS', "", "BOUNDS: Display the bounds of the object", "MATPLANE", 0),
             ('WIRE', "", "WIRE: Display the object as a wireframe", "MESH_CUBE", 1),
-            ('SOLID', "", "SOLID: Display the object as a solid (if solid drawing is enabled in the viewport)", custom_icon("SV_MAKE_SOLID"), 2),
+            ('SOLID', "", "SOLID: Display the object as a solid (if solid drawing is enabled in the viewport)", "SNAP_VOLUME", 2),  #custom_icon("SV_MAKE_SOLID")
             ('TEXTURED', "", "TEXTURED: Display the object with textures (if textures are enabled in the viewport)", "TEXTURE",  3),
         ]
     


### PR DESCRIPTION
fix #5055. 

![image](https://github.com/nortikin/sverchok/assets/14288520/51e00ae8-1e5b-4b2a-b99a-91c40fec01cf)

**Update**:
![image](https://github.com/nortikin/sverchok/assets/14288520/181a76d8-8cd5-4bbb-8a0a-96e3c0550bd4)


https://github.com/nortikin/sverchok/assets/14288520/7a158c33-814a-43be-9a9c-929096495354

