### PR TITLE
fix #5057. Append new dependency ezdxf (Python DXF)

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -185,6 +185,13 @@ try:
 except ImportError:
     numexpr = None 
 
+ezdxf_d = sv_dependencies["ezdxf"] = SvDependency("ezdxf","https://github.com/mozman/ezdxf")
+ezdxf_d.pip_installable = True
+try:
+    import ezdxf
+    ezdxf_d.module = ezdxf
+except ImportError:
+    ezdxf = None 
 
 settings.pip = pip
 settings.sv_dependencies = sv_dependencies

--- a/settings.py
+++ b/settings.py
@@ -620,6 +620,7 @@ dependencies, or install only some of them.""")
         draw_message(box, "numba")
         draw_message(box, "pyOpenSubdiv")
         draw_message(box, "numexpr")
+        draw_message(box, "ezdxf")
 
         draw_freecad_ops()
 


### PR DESCRIPTION
Sverchok 1.3.0-Alpha, Blender 3.6.x.

fix #5057 . Append new dependency ezdxf (Python DXF)

![image](https://github.com/nortikin/sverchok/assets/14288520/ebe9cb28-c869-48f7-874a-2429212f978e)

