### PR TITLE
fix #5062. Recreated node is active now

### DIFF
--- a/ui/nodes_replacement.py
+++ b/ui/nodes_replacement.py
@@ -130,6 +130,7 @@ class SvReplaceNode(bpy.types.Operator):
                 new_node.parent = old_node.parent.parent
             tree.nodes.remove(old_node.parent)
         tree.nodes.remove(old_node)
+        context.area.spaces.active.node_tree.nodes.active = new_node
 
         return {'FINISHED'}
 


### PR DESCRIPTION
fix #5062. Recreated node is active now.

![image](https://github.com/nortikin/sverchok/assets/14288520/938657b8-c811-40b8-a0cd-236e37cce068)

new node is active now