### PR TITLE
fix #5064. Matrix In Recreate operator exception. Fixed

### DIFF
--- a/nodes/matrix/matrix_in_mk4.py
+++ b/nodes/matrix/matrix_in_mk4.py
@@ -184,7 +184,7 @@ class SvMatrixInNodeMK4(SverchCustomTreeNode, bpy.types.Node, SvAngleHelper):
             self.angle_units = AngleUnits.DEGREES
             self.last_angle_units = AngleUnits.DEGREES
 
-        elif old_node.bl_idname == "SvMatrixInNodeMK4":
+        elif old_node.bl_idname == "SvMatrixInNodeMK3":
             self.rotation_mode = old_node.mode
 
     def sv_init(self, context):

--- a/old_nodes/matrix_in_mk3.py
+++ b/old_nodes/matrix_in_mk3.py
@@ -165,10 +165,11 @@ class SvMatrixInNodeMK3(SverchCustomTreeNode, bpy.types.Node):
 
     def migrate_from(self, old_node):
         ''' Migration from MK2 (attributes mapping) '''
-        self.location_ = old_node.l_
-        self.scale = old_node.s_
-        self.axis = old_node.r_
-        self.angle = old_node.a_
+        if old_node.bl_idname == "SvMatrixGenNodeMK2":
+            self.location_ = old_node.l_
+            self.scale = old_node.s_
+            self.axis = old_node.r_
+            self.angle = old_node.a_
 
     def sv_init(self, context):
 


### PR DESCRIPTION
fix #5064. Matrix In Recreate operator exception

Sverchok 1.3.0-Alpha, Blender 3.6.x.

**Update from the previous version of node**:
![image](https://github.com/nortikin/sverchok/assets/14288520/46ec532d-b478-4e7e-9eca-2dbe1dbc258d)

**Update from the lates version of node**:
![image](https://github.com/nortikin/sverchok/assets/14288520/dc875c02-fdb1-4e10-b12b-8801018f49f1)
