### PR TITLE
fix #5082 (Polyline has inverted tangents)

### DIFF
--- a/tests/linear_spline_tests.py
+++ b/tests/linear_spline_tests.py
@@ -29,12 +29,12 @@ class LinearSplineTests(SverchokTestCase):
         result = self.spline.tangent(t_in)
         #info(result)
         expected_result = np.array(
-                [[-1, -1,  0],
-                 [-1, -1,  0],
-                 [-1, -2,  0],
-                 [-1, -2,  0],
-                 [-1, -2,  0],
-                 [-1, -1,  0]])
+                [[ 1,  1,  0],
+                 [ 1,  1,  0],
+                 [ 1,  2,  0],
+                 [ 1,  2,  0],
+                 [ 1,  2,  0],
+                 [ 1,  1,  0]])
         self.assert_numpy_arrays_equal(result, expected_result)
 
     def test_control_points(self):

--- a/utils/geom.py
+++ b/utils/geom.py
@@ -662,7 +662,7 @@ class GenerateLookup():
         add_to_sumlist = self.summed_lengths.append
         current_length = 0.0
         for idx in range(len(vlist)-1):
-            v = vlist[idx][0]-vlist[idx+1][0], vlist[idx][1]-vlist[idx+1][1], vlist[idx][2]-vlist[idx+1][2]
+            v = vlist[idx+1][0]-vlist[idx][0], vlist[idx+1][1]-vlist[idx][1], vlist[idx+1][2]-vlist[idx][2]
             length = math.sqrt((v[0]*v[0]) + (v[1]*v[1]) + (v[2]*v[2]))
             add_normal(v)
             add_len(length)


### PR DESCRIPTION
fix #5082 Normals are good

![image](https://github.com/nortikin/sverchok/assets/14288520/c68cc00d-91b7-4f6c-9b7b-d28fdd064b49)

**File for tests:**
[BendAlongCurveField.inverted_normals.002.blend.zip](https://github.com/nortikin/sverchok/files/14470547/BendAlongCurveField.inverted_normals.002.blend.zip)
