### PR TITLE
fix #5086. Cannot create groupmenu icons for sverchok addons.

### DIFF
--- a/ui/nodeview_space_menu.py
+++ b/ui/nodeview_space_menu.py
@@ -396,7 +396,9 @@ class Category(MenuItem):
                         if isinstance(prop_value, list):  # some sub menu
                             continue
                         props.update(prop)
-
+                elif isinstance(value, str):
+                    extra_props.update(elem) # to use for properties of root element in addons (like {'icon_name': 'MESH_CUBE'}). Non root element work good. Without this "elif" root menu icon of sverchok addons cannot be created.
+                    continue
                 elif value is None:  # empty category
                     value = []
                 else:  # menu property


### PR DESCRIPTION
fix #5086 
This fix is backward compatible with sverchok .yaml files.

Now one can show icon on root group menu:

![image](https://github.com/nortikin/sverchok/assets/14288520/27c0cad9-7074-487f-93c5-bf77a53be387)


