### PR TITLE
fix 5098. Some nodes generate exceptions if output sockets are not connected

### DIFF
--- a/nodes/CAD/crop_mesh_2d.py
+++ b/nodes/CAD/crop_mesh_2d.py
@@ -97,8 +97,10 @@ class SvCropMesh2D(ModifierLiteNode, SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvStringsSocket', 'Face index')
 
     def process(self):
-        if not all([sock.is_linked for sock in self.inputs]) and any([sock.is_linked for sock in self.outputs]):
+        if not any(socket.is_linked for socket in self.outputs):
             return
+        if not all([sock.is_linked for sock in self.inputs]):
+            raise Exception("All input sockets has to be connected")
         if self.alg_mode == "Blender" and not crop_mesh_delaunay:
             return
 

--- a/nodes/CAD/edges_intersect_mk3.py
+++ b/nodes/CAD/edges_intersect_mk3.py
@@ -93,7 +93,8 @@ class SvIntersectEdgesNodeMK3(
             layout.prop(self, 'epsilon')
 
     def process(self):
-
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         inputs = self.inputs
         outputs = self.outputs
         try:

--- a/nodes/CAD/edges_to_faces_2d.py
+++ b/nodes/CAD/edges_to_faces_2d.py
@@ -53,8 +53,10 @@ class SvEdgesToFaces2D(ModifierLiteNode, SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvStringsSocket', "Faces")
 
     def process(self):
-        if not all([soc.is_linked for soc in self.inputs]):
+        if not any(socket.is_linked for socket in self.outputs):
             return
+        if not all([soc.is_linked for soc in self.inputs]):
+            raise Exception("All input sockets has to be connected")
         out = []
         for vs, es in zip(self.inputs['Verts'].sv_get(), self.inputs['Edges'].sv_get()):
             out.append(edges_to_faces(vs, es, self.do_intersect, self.fill_holes, self.accuracy))

--- a/nodes/CAD/embed mesh.py
+++ b/nodes/CAD/embed mesh.py
@@ -209,6 +209,8 @@ class SvEmbedMesh(SverchCustomTreeNode,bpy.types.Node):
         self.outputs.new('SvStringsSocket', "Faces")
         self.outputs.new('SvStringsSocket', "Index")
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         out = []
         for V_A,E_A,F_A,V_B,E_B,F_B,I in zip(
         self.inputs['VertsA'].sv_get(default=[[]]),

--- a/nodes/CAD/merge_mesh_2d.py
+++ b/nodes/CAD/merge_mesh_2d.py
@@ -65,8 +65,10 @@ class SvMergeMesh2D(ModifierLiteNode, SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvStringsSocket', 'Mask B')
 
     def process(self):
-        if not all([sock.is_linked for sock in self.inputs]):
+        if not any(socket.is_linked for socket in self.outputs):
             return
+        if not all([sock.is_linked for sock in self.inputs]):
+            raise Exception("All input sockets has to be connected")
         out = []
         for sv_verts_a, sv_faces_a, sv_verts_b, sv_faces_b in zip(self.inputs['Verts A'].sv_get(),
                                                                   self.inputs['Faces A'].sv_get(),

--- a/nodes/CAD/merge_mesh_2d_lite.py
+++ b/nodes/CAD/merge_mesh_2d_lite.py
@@ -87,8 +87,10 @@ class SvMergeMesh2DLite(ModifierLiteNode, SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvStringsSocket', "Faces")
 
     def process(self):
-        if not all([sock.is_linked for sock in self.inputs]):
+        if not any(socket.is_linked for socket in self.outputs):
             return
+        if not all([sock.is_linked for sock in self.inputs]):
+            raise Exception("All input sockets has to be connected")
         if self.alg_mode == "Blender" and not bl_merge_mesh:
             return
         out = []

--- a/nodes/analyzer/chess_selection.py
+++ b/nodes/analyzer/chess_selection.py
@@ -64,6 +64,8 @@ class SvChessSelection(SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvStringsSocket', "Face mask")
 
     def process(self):
+        if not any(sock.is_linked for sock in self.outputs):
+            return
         if not all([sock.is_linked for sock in self.inputs]):
             return
         out = []

--- a/nodes/analyzer/distance_pp.py
+++ b/nodes/analyzer/distance_pp.py
@@ -29,7 +29,7 @@ from sverchok.data_structure import (
 class DistancePPNode(SverchCustomTreeNode, bpy.types.Node):
     ''' Distance Point to Point '''
     bl_idname = 'DistancePPNode'
-    bl_label = 'Distance'
+    bl_label = 'Distance Point Point'
     bl_icon = 'OUTLINER_OB_EMPTY'
     sv_icon = 'SV_DISTANCE'
 

--- a/nodes/analyzer/kd_tree_path.py
+++ b/nodes/analyzer/kd_tree_path.py
@@ -100,7 +100,7 @@ class SvKDTreePathNode(SverchCustomTreeNode, bpy.types.Node):
         outputs = self.outputs
         so = self.outputs
         si = self.inputs
-        if not so[0].is_linked and si[0].is_linked:
+        if not so[0].is_linked:
             return
 
         result = []

--- a/nodes/analyzer/object_insolation.py
+++ b/nodes/analyzer/object_insolation.py
@@ -95,6 +95,8 @@ class SvOBJInsolationNode(SverchCustomTreeNode, bpy.types.Node):
         #row.prop(self,    "mode2",   text="Out Mode")
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
 
         o,r,e = self.inputs
         #dd,o,r,e = self.inputs

--- a/nodes/analyzer/origins.py
+++ b/nodes/analyzer/origins.py
@@ -132,6 +132,8 @@ class SvOrigins(SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvMatrixSocket', "Matrix")
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         if not self.inputs['Verts'].is_linked:
             return
         if self.mode == MODE.faces and not self.inputs['Faces'].is_linked:

--- a/nodes/analyzer/points_inside_mesh.py
+++ b/nodes/analyzer/points_inside_mesh.py
@@ -274,7 +274,9 @@ class SvPointInside(SverchCustomTreeNode, bpy.types.Node):
         return main_func, params
 
     def process(self):
-
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        
         if not all(socket.is_linked for socket in self.inputs[:3]):
             return
 

--- a/nodes/analyzer/project_point_to_line.py
+++ b/nodes/analyzer/project_point_to_line.py
@@ -372,6 +372,8 @@ class SvProjectPointToLine(SverchCustomTreeNode, bpy.types.Node):
         layout.row().prop(self, 'set_res', toggle=True)
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         if not (self.inputs['Vectors_lines'].is_linked and self.inputs['Project_points'].is_linked):
             return
 

--- a/nodes/analyzer/volume.py
+++ b/nodes/analyzer/volume.py
@@ -36,6 +36,8 @@ class SvVolumeNodeMK2(SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvStringsSocket', "Volume")
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         vertices = self.inputs['Vers'].sv_get(deepcopy=False, default=[])
         faces = self.inputs['Pols'].sv_get(deepcopy=False, default=[])
 

--- a/nodes/color/color_in_mk1.py
+++ b/nodes/color/color_in_mk1.py
@@ -177,7 +177,7 @@ class SvColorsInNodeMK1(SverchCustomTreeNode, bpy.types.Node):
 
     def process(self):
 
-        if not self.outputs['Colors'].is_linked:
+        if not any(socket.is_linked for socket in self.outputs):
             return
         inputs = self.inputs
 

--- a/nodes/color/color_input.py
+++ b/nodes/color/color_input.py
@@ -59,6 +59,8 @@ class SvColorInputNode(Show3DProperties, SverchCustomTreeNode, bpy.types.Node):
         row.prop(self, 'color_data', text='')
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         if self.use_alpha:
             color = self.color_data[:]
         else:

--- a/nodes/color/color_out_mk1.py
+++ b/nodes/color/color_out_mk1.py
@@ -103,8 +103,10 @@ class SvColorsOutNodeMK1(SverchCustomTreeNode, bpy.types.Node):
         layout.prop_menu_enum(self, "selected_mode", text="Function")
         # layout.prop(self, 'use_alpha')
         layout.prop(self, "output_numpy", toggle=True)
-    def process(self):
 
+    def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         color_input = self.inputs['Colors']
         if color_input.is_linked:
             abc = self.inputs['Colors'].sv_get(deepcopy=False)

--- a/nodes/curve/ellipse_curve.py
+++ b/nodes/curve/ellipse_curve.py
@@ -83,9 +83,7 @@ class SvEllipseCurveNodeMK2(SverchCustomTreeNode, bpy.types.Node):
         self.update_sockets(context)
 
     def process(self):
-        outputs = self.outputs
-        # return if no outputs are connected
-        if not any(s.is_linked for s in outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         major_radius_s = self.inputs['Major Radius'].sv_get(deepcopy=False)

--- a/nodes/curve/polyline.py
+++ b/nodes/curve/polyline.py
@@ -63,7 +63,7 @@ class SvPolylineNode(SverchCustomTreeNode, bpy.types.Node):
         return curves
 
     def process(self):
-        if not any(o.is_linked for o in self.outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         vertices_s = self.inputs['Vertices'].sv_get(default=[[]])

--- a/nodes/dictionary/dictionary_out.py
+++ b/nodes/dictionary/dictionary_out.py
@@ -108,6 +108,9 @@ class SvDictionaryOut(SverchCustomTreeNode, bpy.types.Node):
             return
 
         self.rebuild_output()
+        
+        if not any(socket.is_linked for socket in self.outputs):
+            return
 
         out = {key: [] for key in self.inputs['Dict'].sv_get()[0]}
         for d in self.inputs['Dict'].sv_get():

--- a/nodes/exchange/bezier_in.py
+++ b/nodes/exchange/bezier_in.py
@@ -156,9 +156,10 @@ class SvBezierInNode(Show3DProperties, SverchCustomTreeNode, bpy.types.Node):
             return points, segments
 
     def process(self):
-
-        if not self.object_names:
+        if not any(socket.is_linked for socket in self.outputs):
             return
+        if not self.object_names:
+            raise Exception("Empty objects list")
 
         curves_out = []
         matrices_out = []

--- a/nodes/generator/basic_3pt_arc.py
+++ b/nodes/generator/basic_3pt_arc.py
@@ -132,6 +132,8 @@ class svBasicArcNode(SverchCustomTreeNode, bpy.types.Node):
         pass
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         outputs = self.outputs
         inputs = self.inputs
 

--- a/nodes/generator/basic_spline.py
+++ b/nodes/generator/basic_spline.py
@@ -82,14 +82,9 @@ class BasicSplineNode(SverchCustomTreeNode, bpy.types.Node):
         layout.prop(self, "list_match")
 
     def process(self):
-        outputs = self.outputs
-
-        '''
-        - is hnd_edges socket created, means all sockets exist.
-        - is anything connected to the Verts socket?
-        '''
-        if not (('hnd Edges' in outputs) and (outputs['Verts'].is_linked)):
+        if not any(socket.is_linked for socket in self.outputs):
             return
+        outputs = self.outputs
 
         '''
         operational scheme: (spline = handle set (k1, ctrl1, ctrl2, k2))

--- a/nodes/generator/box_mk2.py
+++ b/nodes/generator/box_mk2.py
@@ -367,12 +367,10 @@ class SvBoxNodeMk2(SverchCustomTreeNode, bpy.types.Node):
         return list_match_func[self.list_match_global](params)
 
     def process(self):
-
-        outputs = self.outputs
-
-        if not any(s.is_linked for s in outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
-
+        
+        outputs = self.outputs
         data_in = self.get_data()
 
         verts_out, edges_out, pols_out = [], [], []

--- a/nodes/generator/bricks.py
+++ b/nodes/generator/bricks.py
@@ -391,7 +391,7 @@ class SvBricksNode(SverchCustomTreeNode, bpy.types.Node):
         return vertex_idx, list(vertices.keys())
 
     def process(self):
-        if not (self.outputs['Vertices'].is_linked or self.outputs['Centers'].is_linked):
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         # inputs

--- a/nodes/generator/circle.py
+++ b/nodes/generator/circle.py
@@ -105,7 +105,8 @@ class SvCircleNode(SverchCustomTreeNode, bpy.types.Node):
         return [_list_indexes]
 
     def process(self):
-        
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         # inputs
         
         input_socket_names = ['Radius', 'num Verts', 'Degrees']

--- a/nodes/generator/cricket.py
+++ b/nodes/generator/cricket.py
@@ -32,8 +32,7 @@ class SvCricketNode(SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvStringsSocket',  "Faces")
 
     def process(self):
-        # return if no outputs are connected
-        if not any(s.is_linked for s in self.outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         out_verts = []

--- a/nodes/generator/cylinder_mk2.py
+++ b/nodes/generator/cylinder_mk2.py
@@ -335,7 +335,7 @@ class SvCylinderNodeMK2(SverchCustomTreeNode, bpy.types.Node):
         layout.prop(self, "list_match")
 
     def process(self):
-        if not any(s.is_linked for s in self.outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         inputs = self.inputs

--- a/nodes/generator/formula_shape.py
+++ b/nodes/generator/formula_shape.py
@@ -112,6 +112,8 @@ class SvFormulaShapeNode(SverchCustomTreeNode, bpy.types.Node):
         col.prop(self, 'i_override', text='i')
     
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         # inputs
         Count = self.inputs['Count'].sv_get()[0][0]
         Scale = self.inputs['Scale'].sv_get()[0][0]

--- a/nodes/generator/image.py
+++ b/nodes/generator/image.py
@@ -81,9 +81,10 @@ class ImageNode(SverchCustomTreeNode, bpy.types.Node):
         row.prop(self, "B", text="B")
 
     def process(self):
-        
-        if not self.image_pointer:
+        if not any(socket.is_linked for socket in self.outputs):
             return
+        if not self.image_pointer:
+            raise Exception("No Image. Select image")
 
         inputs, outputs = self.inputs, self.outputs
 

--- a/nodes/generator/line_mk4.py
+++ b/nodes/generator/line_mk4.py
@@ -323,8 +323,12 @@ class SvLineNodeMK4(SverchCustomTreeNode, bpy.types.Node):
         layout.prop(self, 'as_numpy')
 
     def process(self):
-        if self.length_mode == LENGTH.step and not self.inputs['Steps'].is_linked:
+        if not any(socket.is_linked for socket in self.outputs):
             return
+        if self.length_mode == LENGTH.step and not self.inputs['Steps'].is_linked:
+            raise Exception("If length mode is 'Step' then input socket 'Steps' has to be connected")
+        if self.length_mode == LENGTH.step_size and not self.inputs['Steps'].is_linked:
+            raise Exception("If length mode is 'Step+Size' then input socket 'Steps' has to be connected")
 
         number, step, size, ors, dirs = [sock.sv_get(deepcopy=False, default=[[None]]) for sock in self.inputs]
         num_objects = max([len(item) for item in [number, step, size, ors, dirs]])

--- a/nodes/generator/ngon.py
+++ b/nodes/generator/ngon.py
@@ -145,6 +145,8 @@ class SvNGonNode(SverchCustomTreeNode, bpy.types.Node):
         layout.prop(self, "list_match")
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         # inputs
         radius = self.inputs['Radius'].sv_get()[0]
 

--- a/nodes/generator/plane_mk3.py
+++ b/nodes/generator/plane_mk3.py
@@ -453,12 +453,9 @@ class SvPlaneNodeMk3(SverchCustomTreeNode, bpy.types.Node):
         return list_match_func[self.list_match_global](params)
 
     def process(self):
-
-        outputs = self.outputs
-
-        if not any(s.is_linked for s in outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
-
+        outputs = self.outputs
         data_in = self.get_data()
 
         verts_out, edges_out, pols_out = [], [], []

--- a/nodes/generator/random_vector_mk3.py
+++ b/nodes/generator/random_vector_mk3.py
@@ -106,10 +106,8 @@ class RandomVectorNodeMK3(SverchCustomTreeNode, bpy.types.Node):
         layout.prop(self, 'correct_output')
 
     def process(self):
-
-        if not self.outputs['Random'].is_linked:
+        if not any(socket.is_linked for socket in self.outputs):
             return
-
         params = [si.sv_get(default=[[]], deepcopy=False) for si in self.inputs]
 
         matching_f = list_match_func[self.list_match]

--- a/nodes/generator/segment.py
+++ b/nodes/generator/segment.py
@@ -190,6 +190,8 @@ class SvSegmentGenerator(SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvStringsSocket', 'Edges')
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         num_objects = max([len(sock.sv_get(deepcopy=False, default=[])) for sock in self.inputs])
         out = []
         list_match_f = iter_list_match_func[self.list_match_global]

--- a/nodes/generator/sphere.py
+++ b/nodes/generator/sphere.py
@@ -177,6 +177,8 @@ class SphereNode(SverchCustomTreeNode, bpy.types.Node):
         layout.prop(self, "list_match")
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         # inputs
         if 'Polygons' not in self.outputs:
             return

--- a/nodes/generator/suzanne.py
+++ b/nodes/generator/suzanne.py
@@ -39,8 +39,7 @@ class SvSuzanneNode(SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvStringsSocket',  "Faces")
 
     def process(self):
-        # return if no outputs are connected
-        if not any(s.is_linked for s in self.outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         out_verts = []

--- a/nodes/generator/torus_mk2.py
+++ b/nodes/generator/torus_mk2.py
@@ -313,8 +313,7 @@ class SvTorusNodeMK2(SverchCustomTreeNode, bpy.types.Node, SvAngleHelper):
         layout.prop(self, "list_match")
 
     def process(self):
-        # return if no outputs are connected
-        if not any(s.is_linked for s in self.outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         # input values lists (single or multi value)

--- a/nodes/generators_extended/box_rounded.py
+++ b/nodes/generators_extended/box_rounded.py
@@ -387,6 +387,8 @@ class SvBoxRoundedNode(SverchCustomTreeNode, bpy.types.Node):
         pass
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         inputs = self.inputs
         outputs = self.outputs
         sizes = inputs['vector_size'].sv_get()[0]

--- a/nodes/generators_extended/ellipse_mk3.py
+++ b/nodes/generators_extended/ellipse_mk3.py
@@ -334,10 +334,9 @@ class SvEllipseNodeMK3(SverchCustomTreeNode, bpy.types.Node, SvAngleHelper):
         return list_verts, edges, polys, f1, f2
 
     def process(self):
-        outputs = self.outputs
-        # return if no outputs are connected
-        if not any(s.is_linked for s in outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
+        outputs = self.outputs
 
         # input values lists (single or multi value)
         inputs = self.inputs

--- a/nodes/generators_extended/hilbert.py
+++ b/nodes/generators_extended/hilbert.py
@@ -51,6 +51,8 @@ class HilbertNode(SverchCustomTreeNode, bpy.types.Node):
         pass
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         level_socket, size_socket = self.inputs
         verts_socket, edges_socket = self.outputs
 

--- a/nodes/generators_extended/hilbert3d.py
+++ b/nodes/generators_extended/hilbert3d.py
@@ -69,6 +69,8 @@ class Hilbert3dNode(SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvStringsSocket', "Edges")
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         level_socket, size_socket = self.inputs
         verts_socket, edges_socket = self.outputs
 

--- a/nodes/generators_extended/hilbert_image.py
+++ b/nodes/generators_extended/hilbert_image.py
@@ -80,6 +80,8 @@ class HilbertImageNode(SverchCustomTreeNode, bpy.types.Node):
         row.prop(self, "B", text="B")
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         level_socket, size_socket, sensitivity_socket = self.inputs
         verts_socket, edges_socket = self.outputs
 

--- a/nodes/generators_extended/pentagon_tiler.py
+++ b/nodes/generators_extended/pentagon_tiler.py
@@ -221,8 +221,7 @@ class SvPentagonTilerNode(SverchCustomTreeNode, bpy.types.Node):
         return vert_list, edge_list, poly_list
 
     def process(self):
-        # return if no outputs are connected
-        if not any(s.is_linked for s in self.outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
         # input values lists
         params = [s.sv_get() for s in self.inputs]

--- a/nodes/generators_extended/polygon_grid.py
+++ b/nodes/generators_extended/polygon_grid.py
@@ -357,8 +357,7 @@ class SvPolygonGridNode(SverchCustomTreeNode, bpy.types.Node):
         row.prop(self, 'center', toggle=True)
 
     def process(self):
-        # return if no outputs are connected
-        if not any(s.is_linked for s in self.outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         if self.gridType == 'HEXAGON':

--- a/nodes/generators_extended/regular_solid.py
+++ b/nodes/generators_extended/regular_solid.py
@@ -221,7 +221,7 @@ class SvRegularSolid(SverchCustomTreeNode, bpy.types.Node):
         return match_long_repeat(params)
 
     def process(self):
-        if not any(s.is_linked for s in self.outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         verts_out, edges_out, polys_out = [], [], []

--- a/nodes/generators_extended/ring_mk2.py
+++ b/nodes/generators_extended/ring_mk2.py
@@ -288,8 +288,7 @@ class SvRingNodeMK2(SverchCustomTreeNode, bpy.types.Node, SvAngleHelper):
         layout.prop(self, 'ring_u')
 
     def process(self):
-        # return if no outputs are connected
-        if not any(s.is_linked for s in self.outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         # list of MAJOR or EXTERIOR radii

--- a/nodes/generators_extended/smooth_lines.py
+++ b/nodes/generators_extended/smooth_lines.py
@@ -199,8 +199,7 @@ class SvSmoothLines(SverchCustomTreeNode, bpy.types.Node):
 
 
     def process(self):
-        necessary_sockets = [self.inputs["vectors"],]
-        if not all(s.is_linked for s in necessary_sockets):
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         if self.inputs["attributes"].is_linked:

--- a/nodes/generators_extended/spiral_mk2.py
+++ b/nodes/generators_extended/spiral_mk2.py
@@ -578,10 +578,9 @@ class SvSpiralNodeMK2(SverchCustomTreeNode, bpy.types.Node, SvAngleHelper):
         self.draw_angle_units_buttons(context, layout)
 
     def process(self):
-        outputs = self.outputs
-        # return if no outputs are connected
-        if not any(s.is_linked for s in outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
+        outputs = self.outputs
 
         # input values lists (single or multi value)
         inputs = self.inputs

--- a/nodes/generators_extended/super_ellipsoid.py
+++ b/nodes/generators_extended/super_ellipsoid.py
@@ -297,7 +297,7 @@ class SvSuperEllipsoidNode(SverchCustomTreeNode, bpy.types.Node):
         row.prop(self, "cap_top", text="Cap T", toggle=True)
 
     def process(self):
-        if not any(s.is_linked for s in self.outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         inputs = self.inputs

--- a/nodes/generators_extended/torus_knot_mk2.py
+++ b/nodes/generators_extended/torus_knot_mk2.py
@@ -383,10 +383,9 @@ class SvTorusKnotNodeMK2(SverchCustomTreeNode, bpy.types.Node, SvAngleHelper):
         layout.prop(self, 'mode', expand=True)
 
     def process(self):
-        outputs = self.outputs
-        # return if no outputs are connected
-        if not any(s.is_linked for s in outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
+        outputs = self.outputs
 
         # input values lists (single or multi value)
         inputs = self.inputs

--- a/nodes/generators_extended/triangle.py
+++ b/nodes/generators_extended/triangle.py
@@ -202,8 +202,7 @@ class SvTriangleNode(SverchCustomTreeNode, bpy.types.Node):
         return out_verts, out_edges, out_faces
 
     def process(self):
-        # return if no outputs are connected
-        if not any(s.is_linked for s in self.outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         out_verts = []

--- a/nodes/generators_extended/wfc_texture.py
+++ b/nodes/generators_extended/wfc_texture.py
@@ -63,8 +63,10 @@ class SvWFCTextureNode(SverchCustomTreeNode, bpy.types.Node):
         layout.prop(self, 'tries_number')
 
     def process(self):
-        if not self.image_name:
+        if not any(socket.is_linked for socket in self.outputs):
             return
+        if not self.image_name:
+            raise Exception("No image selected")
 
         image = load_image(self.image_name)
         wave = WaveFunctionCollapse(

--- a/nodes/layout/converter.py
+++ b/nodes/layout/converter.py
@@ -40,6 +40,8 @@ class ConverterNode(SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvDictionarySocket', 'dict')
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         if self.inputs[0].is_linked:
             out = self.inputs[0].sv_get(deepcopy=False)
             for s in self.outputs:

--- a/nodes/list_main/decompose.py
+++ b/nodes/list_main/decompose.py
@@ -81,6 +81,8 @@ class SvListDecomposeNode(SverchCustomTreeNode, bpy.types.Node):
                 out.replace_socket(other.bl_idname)
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         data = self.inputs['data'].sv_get()
         result = self.beat(data, self.level)
         for out, socket in zip(result, self.outputs[:30]):

--- a/nodes/list_main/delete_levels.py
+++ b/nodes/list_main/delete_levels.py
@@ -54,6 +54,8 @@ class ListLevelsNode(SverchCustomTreeNode, bpy.types.Node):
             changable_sockets(self, inputsocketname, outputsocketname)
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         if self.outputs['data'].is_linked:
             data = self.inputs['data'].sv_get()
             userlevelb = literal_eval('['+self.Sverch_LisLev+']')

--- a/nodes/list_main/func.py
+++ b/nodes/list_main/func.py
@@ -114,7 +114,11 @@ class ListFuncNode(SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvStringsSocket', "Function")
 
     def process(self):
-
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not self.inputs['Data'].is_linked:
+            raise Exception("Input socket 'Data' has to be connected")
+        
         if self.outputs['Function'].is_linked and self.inputs['Data'].is_linked:
             data = self.inputs['Data'].sv_get()
             func = func_dict[self.func_]

--- a/nodes/list_main/index.py
+++ b/nodes/list_main/index.py
@@ -49,6 +49,10 @@ class SvIndexListNode(SverchCustomTreeNode, bpy.types.Node):
         col.prop(self,'use_range')
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not any(socket.is_linked for socket in self.inputs):
+            raise Exception("All input sockets has to be connected")
         data = self.inputs['data'].sv_get(deepcopy=False, default=[])
         items = self.inputs['Item'].sv_get(deepcopy=False, default=[])
 

--- a/nodes/list_main/join.py
+++ b/nodes/list_main/join.py
@@ -186,9 +186,10 @@ class ListJoinNode(SverchCustomTreeNode, bpy.types.Node):
         self.set_output_socketype([sock.other.bl_idname for sock in self.inputs if sock.is_linked and sock.other])
 
     def process(self):
-
-        if not self.outputs['data'].is_linked:
+        if not any(socket.is_linked for socket in self.outputs):
             return
+        if not any(socket.is_linked for socket in self.inputs):
+            raise Exception("Some input sockets has to be connected")
 
         slots = []
         for socket in self.inputs:

--- a/nodes/list_main/length.py
+++ b/nodes/list_main/length.py
@@ -36,7 +36,10 @@ class ListLengthNode(SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvStringsSocket', "Length")
 
     def process(self):
-
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not all(socket.is_linked for socket in self.inputs):
+            raise Exception("All input sockets has to be connected")
         if 'Length' in self.outputs and self.outputs['Length'].is_linked:
             if 'Data' in self.inputs and self.inputs['Data'].is_linked:
                 data = self.inputs['Data'].sv_get(deepcopy=False)

--- a/nodes/list_main/match.py
+++ b/nodes/list_main/match.py
@@ -103,6 +103,10 @@ class ListMatchNode(SverchCustomTreeNode, bpy.types.Node):
                     self.outputs[socket.name].replace_socket(from_sock.bl_idname)
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not any(socket.is_linked for socket in self.inputs):
+            raise Exception("Some input sockets has to be connected")
         # check inputs and that there is at least one output
 
         count_inputs = sum(s.is_linked for s in self.inputs)

--- a/nodes/list_main/statistics.py
+++ b/nodes/list_main/statistics.py
@@ -426,6 +426,10 @@ class SvListStatisticsNode(SverchCustomTreeNode, bpy.types.Node):
         nvBGL.callback_disable(node_id(self))
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not any(socket.is_linked for socket in self.inputs):
+            raise Exception("Input socket 'Data' has to be connected")
         inputs = self.inputs
         outputs = self.outputs
 

--- a/nodes/list_main/sum_mk2.py
+++ b/nodes/list_main/sum_mk2.py
@@ -43,6 +43,10 @@ class ListSumNodeMK2(SverchCustomTreeNode, bpy.types.Node):
         layout.prop(self, "level", text="level")
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not any(socket.is_linked for socket in self.inputs):
+            raise Exception("Input socket 'Data' has to be connected")
         # достаём два слота - вершины и полики
         if self.outputs['Sum'].is_linked and self.inputs['Data'].is_linked:
             data = self.inputs['Data'].sv_get()

--- a/nodes/list_main/zip.py
+++ b/nodes/list_main/zip.py
@@ -68,6 +68,11 @@ class ZipNode(SverchCustomTreeNode, bpy.types.Node):
 
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if len([s for s in self.inputs if s.is_linked])<2:
+            raise Exception("Minimum two input sockets has to be connected")
+        
         if self.outputs['data'].is_linked:
             slots = []
             for socket in self.inputs:

--- a/nodes/list_masks/calc_mask.py
+++ b/nodes/list_masks/calc_mask.py
@@ -53,8 +53,7 @@ class SvCalcMaskNode(SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvStringsSocket', 'Mask')
 
     def process(self):
-
-        if not any(output.is_linked for output in self.outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         subset_s = self.inputs['Subset'].sv_get(default=[[]])

--- a/nodes/list_masks/index_to_mask.py
+++ b/nodes/list_masks/index_to_mask.py
@@ -84,6 +84,8 @@ class SvIndexToMaskNode(SverchCustomTreeNode, bpy.types.Node):
         if 'mask' in self.outputs:
             self.outputs['mask'].name = 'Mask'
 
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         index = self.inputs["Index"].sv_get(deepcopy=False, default=[])
         mask_size = self.inputs['Mask size'].sv_get(deepcopy=False, default=[None])
         data_to_mask = self.inputs['Data masking'].sv_get(deepcopy=False,

--- a/nodes/list_masks/mask.py
+++ b/nodes/list_masks/mask.py
@@ -121,6 +121,10 @@ class MaskListNode(SverchCustomTreeNode, bpy.types.Node):
         changable_sockets(self, inputsocketname, outputsocketname)
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not all(socket.is_linked for socket in self.inputs):
+            raise Exception("All input sockets has to be connected")
         inputs = self.inputs
         outputs = self.outputs
         if not any(s.is_linked for s in outputs) and inputs[0].is_linked:

--- a/nodes/list_masks/mask_convert.py
+++ b/nodes/list_masks/mask_convert.py
@@ -180,7 +180,6 @@ faces -> vertex and edges indexes'''
         self.update_mode(context)
 
     def process(self):
-
         if not any(output.is_linked for output in self.outputs):
             return
 

--- a/nodes/list_masks/mask_join.py
+++ b/nodes/list_masks/mask_join.py
@@ -68,6 +68,10 @@ class SvMaskJoinNodeMK2(SverchCustomTreeNode, bpy.types.Node):
         changable_sockets(self, inputsocketname, outputsocketname)
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not all(socket.is_linked for socket in self.inputs):
+            raise Exception("All input sockets has to be connected")
         Ouso = self.outputs[0]
         if Ouso.is_linked:
             mask = self.inputs['Mask'].sv_get([[1, 0]])

--- a/nodes/list_masks/mask_to_index.py
+++ b/nodes/list_masks/mask_to_index.py
@@ -43,6 +43,10 @@ class SvMaskToIndexNode(SverchCustomTreeNode, bpy.types.Node):
 
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not all(socket.is_linked for socket in self.inputs):
+            raise Exception("Input socket 'Mask' has to be connected")
         inputs = self.inputs
         outputs = self.outputs
         if not (any(s.is_linked for s in outputs) and inputs[0].is_linked):

--- a/nodes/list_mutators/combinatorics.py
+++ b/nodes/list_mutators/combinatorics.py
@@ -127,11 +127,15 @@ class SvCombinatoricsNode(SverchCustomTreeNode, bpy.types.Node):
         layout.prop(self, "operation", text="")
 
     def process(self):
-        outputs = self.outputs
-        # return if no outputs are connected
-        if not any(s.is_linked for s in outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
-
+        if len([s for s in self.inputs if s.is_linked])==0:
+            raise Exception("Minimum one input sockets [A,B,...] has to be connected")
+        if len([s for s in self.inputs if s.is_linked])==1:
+            if self.inputs["Repeat"].is_linked:
+                raise Exception("Minimum one input sockets [A,B,...] has to be connected")
+            
+        outputs = self.outputs
         inputs = self.inputs
 
         all_AZ_sockets = list(filter(lambda s: s.name in ABC, inputs))

--- a/nodes/list_mutators/filter_empty_lists.py
+++ b/nodes/list_mutators/filter_empty_lists.py
@@ -36,6 +36,10 @@ class SvFixEmptyObjectsNode(SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvStringsSocket', "numpy mask")
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not all(socket.is_linked for socket in self.inputs):
+            raise Exception("Input socket 'Data' has to be connected")
         sd, m, nm = self.outputs
         D = self.inputs[0].sv_get()
         if sd.is_linked:

--- a/nodes/list_mutators/find_closest.py
+++ b/nodes/list_mutators/find_closest.py
@@ -49,6 +49,9 @@ class SvFindClosestValue(SverchCustomTreeNode, bpy.types.Node):
         layout.prop(self, 'mode', expand=True)
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        
         vals = self.inputs['Values'].sv_get(deepcopy=False)
         data = self.inputs['Data'].sv_get(deepcopy=False, default=[])
         _range = self.inputs['Range'].sv_get(deepcopy=False)

--- a/nodes/list_mutators/modifier.py
+++ b/nodes/list_mutators/modifier.py
@@ -131,12 +131,14 @@ Symmetric Diff'''
         return self.func_
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if len([s for s in self.inputs if s.is_linked])<2:
+            raise Exception("Minimum one input socket has to be connected")
+        
         inputs = self.inputs
         outputs = self.outputs
 
-        if not outputs[0].is_linked:
-            return
-        
         unary = (num_inputs[no_space(self.func_)] == 1)
         f = self.get_f(unary)
 

--- a/nodes/list_mutators/multi_cache.py
+++ b/nodes/list_mutators/multi_cache.py
@@ -98,7 +98,7 @@ class SvMultiCacheNode(SverchCustomTreeNode, bpy.types.Node):
             changable_sockets(self, inputsocketname, outputsocketname)
 
     def process(self):
-        if not self.outputs['Data'].is_linked:
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         in_bucket_s = self.inputs['In Bucket'].sv_get()[0]

--- a/nodes/list_mutators/polygon_sort.py
+++ b/nodes/list_mutators/polygon_sort.py
@@ -243,7 +243,7 @@ class SvPolygonSortNode(SverchCustomTreeNode, bpy.types.Node):
         layout.prop(self, "descending")
 
     def process(self):
-        if not any(s.is_linked for s in self.outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         inputs = self.inputs

--- a/nodes/list_mutators/unique_items.py
+++ b/nodes/list_mutators/unique_items.py
@@ -143,9 +143,11 @@ class SvUniqueItemsNode(SverchCustomTreeNode, bpy.types.Node):
             changable_sockets(self, inputsocketname, outputsocketname)
 
     def process(self):
-
-        if not (self.inputs[0].is_linked and any([s.is_linked for s in self.outputs])):
+        if not any(socket.is_linked for socket in self.outputs):
             return
+        if not any(socket.is_linked for socket in self.inputs):
+            raise Exception("Input socket 'Data'has to be connected")
+        
         data_in = self.inputs[0].sv_get(deepcopy=False)
         linked_outputs = [s.is_linked for s in self.outputs[1:]]
         out_lists = recursive_unique_items(data_in, self.level, linked_outputs, self.output_numpy)

--- a/nodes/list_struct/flip.py
+++ b/nodes/list_struct/flip.py
@@ -81,6 +81,11 @@ class ListFlipNode(SverchCustomTreeNode, bpy.types.Node):
         changable_sockets(self, inputsocketname, outputsocketname)
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not all(socket.is_linked for socket in self.inputs):
+            raise Exception("Input socket 'Data' has to be connected")
+        
         if self.inputs['data'].is_linked and self.outputs['data'].is_linked:
             outEval = self.inputs['data'].sv_get(deepcopy=False)
             #outCorr = dataCorrect(outEval)  # this is bullshit, as max 3 in levels

--- a/nodes/list_struct/item.py
+++ b/nodes/list_struct/item.py
@@ -66,6 +66,9 @@ class SvListItemNode(SverchCustomTreeNode, bpy.types.Node):
             changable_sockets(self, inputsocketname, outputsocketname)
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+            
         data = self.inputs['Data'].sv_get(default=[], deepcopy=False)
         indexes = self.inputs['Index'].sv_get(deepcopy=False)
 

--- a/nodes/list_struct/item_insert.py
+++ b/nodes/list_struct/item_insert.py
@@ -84,10 +84,14 @@ class SvListItemInsertNode(SverchCustomTreeNode, bpy.types.Node):
             changable_sockets(self, inputsocketname, outputsocketname)
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         out_socket = self.outputs[0]
         si = self.inputs
-        if not (si['Data'].is_linked and si['Item'].is_linked and out_socket.is_linked):
-            return
+        if not (si['Data'].is_linked):
+            raise Exception("Input socket 'Data' has to be connected")
+        if not (si['Item'].is_linked):
+            raise Exception("Input socket 'Item' has to be connected")
 
         data = si['Data'].sv_get(deepcopy=False)
 

--- a/nodes/list_struct/levels.py
+++ b/nodes/list_struct/levels.py
@@ -100,6 +100,10 @@ class SvListLevelsNodeMK2(SverchCustomTreeNode, bpy.types.Node):
         changable_sockets(self, 'Data', ['Data', ])
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not any(socket.is_linked for socket in self.inputs):
+            raise Exception("Input socket 'Data' has to be connected")
         data = self.inputs['Data'].sv_get(default=[], deepcopy=False)
 
         nesting, descriptions = describe_data_shape_by_level(data, include_numpy_nesting=False)

--- a/nodes/list_struct/numpy_array.py
+++ b/nodes/list_struct/numpy_array.py
@@ -51,6 +51,8 @@ class SvNumpyArrayNode(SverchCustomTreeNode, bpy.types.Node):
             layout.prop(self, "Cust", text="")
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         out = self.outputs[0]
         if out.is_linked:
             X,Y = self.inputs

--- a/nodes/list_struct/repeater.py
+++ b/nodes/list_struct/repeater.py
@@ -52,6 +52,10 @@ class ListRepeaterNode(SverchCustomTreeNode, bpy.types.Node):
             changable_sockets(self, inputsocketname, outputsocketname)
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not (self.inputs["Data"].is_linked):
+            raise Exception("Input socket 'Data' has to be connected")
         data = self.inputs['Data'].sv_get(deepcopy=False, default=[])
         number = self.inputs['Number'].sv_get(deepcopy=False)[0]
 

--- a/nodes/list_struct/reverse.py
+++ b/nodes/list_struct/reverse.py
@@ -51,6 +51,11 @@ class ListReverseNode(SverchCustomTreeNode, bpy.types.Node):
             changable_sockets(self, inputsocketname, outputsocketname)
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not (self.inputs["data"].is_linked):
+            raise Exception("Input socket 'data' has to be connected")
+
         if self.outputs[0].is_linked:
             data = self.inputs['data'].sv_get(deepcopy=False)
             output = self.revers(data, self.level)

--- a/nodes/list_struct/shift_mk2.py
+++ b/nodes/list_struct/shift_mk2.py
@@ -62,7 +62,7 @@ class ShiftNodeMK2(SverchCustomTreeNode, bpy.types.Node):
             changable_sockets(self, inputsocketname, outputsocketname)
 
     def process(self):
-        if not self.outputs["data"].is_linked:
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         data = self.inputs['data'].sv_get(deepcopy=False)

--- a/nodes/list_struct/shuffle.py
+++ b/nodes/list_struct/shuffle.py
@@ -58,6 +58,11 @@ class ListShuffleNode(SverchCustomTreeNode, bpy.types.Node):
             changable_sockets(self, inputsocketname, outputsocketname)
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not (self.inputs["data"].is_linked):
+            raise Exception("Input socket 'data' has to be connected")
+        
         if self.outputs[0].is_linked and self.inputs[0].is_linked:
 
             seed = self.inputs['seed'].sv_get(deepcopy=False)[0][0]

--- a/nodes/list_struct/slice.py
+++ b/nodes/list_struct/slice.py
@@ -63,6 +63,11 @@ class ListSliceNode(SverchCustomTreeNode, bpy.types.Node):
             changable_sockets(self, inputsocketname, outputsocketname)
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not (self.inputs["Data"].is_linked):
+            raise Exception("Input socket 'Data' has to be connected")
+        
         data = self.inputs['Data'].sv_get(deepcopy=False)
         start = self.inputs['Start'].sv_get(deepcopy=False)[0]
         stop = self.inputs['Stop'].sv_get(deepcopy=False)[0]

--- a/nodes/list_struct/sort.py
+++ b/nodes/list_struct/sort.py
@@ -73,6 +73,8 @@ class SvListSortNode(SverchCustomTreeNode, bpy.types.Node):
         self.level = 4-old_node.level
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         if not self.outputs['data'].is_linked and not self.newsock:
             return
         self.newsock = False

--- a/nodes/list_struct/split.py
+++ b/nodes/list_struct/split.py
@@ -72,6 +72,11 @@ class SvListSplitNode(SverchCustomTreeNode, bpy.types.Node):
         changable_sockets(self, inputsocketname, outputsocketname)
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not (self.inputs["Data"].is_linked):
+            raise Exception("Input socket 'Data' has to be connected")
+        
         if self.outputs['Split'].is_linked:
             data = self.inputs['Data'].sv_get(deepcopy=False)
             sizes = self.inputs['Split'].sv_get(deepcopy=False)[0]

--- a/nodes/list_struct/start_end.py
+++ b/nodes/list_struct/start_end.py
@@ -54,6 +54,11 @@ class ListFLNode(SverchCustomTreeNode, bpy.types.Node):
             changable_sockets(self, inputsocketname, outputsocketname)
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not (self.inputs["Data"].is_linked):
+            raise Exception("Input socket 'Data' has to be connected")
+        
         if self.inputs['Data'].is_linked:
             data = self.inputs['Data'].sv_get(deepcopy=False)
 

--- a/nodes/logic/custom_switcher.py
+++ b/nodes/logic/custom_switcher.py
@@ -92,6 +92,10 @@ class SvCustomSwitcher(Show3DProperties, SverchCustomTreeNode, bpy.types.Node):
                 col.prop(self, "user_list", toggle=True, index=i, text=val.name)
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not (self.inputs["Data"].is_linked):
+            raise Exception("Input socket 'Data' has to be connected")
         # Storing names of items
         if self.inputs['Data'].is_linked:
             data = self.inputs['Data'].sv_get()

--- a/nodes/matrix/apply_and_join.py
+++ b/nodes/matrix/apply_and_join.py
@@ -172,6 +172,8 @@ class SvMatrixApplyJoinNode(SverchCustomTreeNode, bpy.types.Node):
         layout.prop_menu_enum(self, "implementation", text="Implementation")
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         vertices = self.inputs['Vertices'].sv_get(default=[], deepcopy=False)
         edges = self.inputs['Edges'].sv_get(default=[], deepcopy=False)
         faces = self.inputs['Faces'].sv_get(default=[], deepcopy=False)

--- a/nodes/matrix/euler.py
+++ b/nodes/matrix/euler.py
@@ -90,7 +90,7 @@ class SvMatrixEulerNode(SverchCustomTreeNode, bpy.types.Node):
         layout.prop(self, "flat_output", text="Flat Output", expand=False)
 
     def process(self):
-        if not self.outputs['Matrix'].is_linked:
+        if not any(socket.is_linked for socket in self.outputs):
             return
         inputs = self.inputs
         params = [s.sv_get() for s in inputs]

--- a/nodes/matrix/interpolation.py
+++ b/nodes/matrix/interpolation.py
@@ -50,8 +50,7 @@ class MatrixInterpolationNode(SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvMatrixSocket', "C")
 
     def process(self):
-        # inputs
-        if not self.outputs['C'].is_linked:
+        if not any(socket.is_linked for socket in self.outputs):
             return
         id_mat = [Matrix.Identity(4)]
         A = self.inputs['A'].sv_get(default=id_mat)

--- a/nodes/matrix/iterate.py
+++ b/nodes/matrix/iterate.py
@@ -125,6 +125,13 @@ class SvIterateNode(SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvMatrixSocket', 'Matrices')
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not (self.inputs["Matrix"].is_linked):
+            raise Exception("Input socket 'Matrix' has to be connected")
+        if not (self.inputs["Vertices"].is_linked):
+            raise Exception("Input socket 'Vertices' has to be connected")
+
         # inputs
         if not self.inputs['Matrix'].is_linked:
             return

--- a/nodes/matrix/matrix_deform.py
+++ b/nodes/matrix/matrix_deform.py
@@ -37,6 +37,8 @@ class MatrixDeformNode(SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvMatrixSocket', "Matrix")
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         O,L,S,R,A = self.inputs
         Om = self.outputs[0]
         if Om.is_linked:

--- a/nodes/matrix/matrix_in_mk4.py
+++ b/nodes/matrix/matrix_in_mk4.py
@@ -219,7 +219,7 @@ class SvMatrixInNodeMK4(SverchCustomTreeNode, bpy.types.Node, SvAngleHelper):
         layout.prop(self, "flat_output", text="Flat Output", expand=False)
 
     def process(self):
-        if not self.outputs['Matrices'].is_linked:
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         inputs = self.inputs

--- a/nodes/matrix/matrix_math.py
+++ b/nodes/matrix/matrix_math.py
@@ -240,9 +240,9 @@ class SvMatrixMathNode(SverchCustomTreeNode, bpy.types.Node):
                 inputs.remove(inputs[-1])
 
     def process(self):
-        outputs = self.outputs
-        if not any(s.is_linked for s in outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
+        outputs = self.outputs
 
         data_in = []  # collect the inputs from the connected sockets
         for s in filter(lambda s: s.is_linked, self.inputs):

--- a/nodes/matrix/matrix_normal.py
+++ b/nodes/matrix/matrix_normal.py
@@ -93,9 +93,9 @@ class SvMatrixNormalNode(SverchCustomTreeNode, bpy.types.Node):
         layout.prop(self, "flat_output", text="Flat Output", expand=False)
 
     def process(self):
-        Ma = self.outputs[0]
-        if not Ma.is_linked:
+        if not any(socket.is_linked for socket in self.outputs):
             return
+
         L, N = self.inputs
         T, U = self.track, self.up
         loc = L.sv_get()

--- a/nodes/matrix/matrix_track_to.py
+++ b/nodes/matrix/matrix_track_to.py
@@ -191,11 +191,9 @@ class SvMatrixTrackToNode(SverchCustomTreeNode, bpy.types.Node):
         return matrix_list, x_list, y_list, z_list
 
     def process(self):
-        outputs = self.outputs
-
-        # return if no outputs are connected
-        if not any(s.is_linked for s in outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
+        outputs = self.outputs
 
         # input values lists
         inputs = self.inputs

--- a/nodes/matrix/shear.py
+++ b/nodes/matrix/shear.py
@@ -57,7 +57,7 @@ class MatrixShearNode(SverchCustomTreeNode, bpy.types.Node):
         layout.prop(self, "plane_", text="Shear plane:", expand=True)
 
     def process(self):
-        if not self.outputs['Matrix'].is_linked:
+        if not any(socket.is_linked for socket in self.outputs):
             return
         # inputs
 

--- a/nodes/network/file_path.py
+++ b/nodes/network/file_path.py
@@ -91,8 +91,7 @@ class SvFilePathNode(SverchCustomTreeNode, bpy.types.Node):
             self.files_num = len(files)
 
     def process(self):
-        # return if no outputs are connected
-        if not any(s.is_linked for s in self.outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
         directory = self.directory
         if self.files:

--- a/nodes/number/curve_mapper.py
+++ b/nodes/number/curve_mapper.py
@@ -100,6 +100,8 @@ class SvCurveMapperNode(SverchCustomTreeNode, bpy.types.Node):
         return 'RGB Curves'+n_id
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         inputs = self.inputs
         outputs = self.outputs
         curve_node_name = self._get_curve_node_name()

--- a/nodes/number/easing.py
+++ b/nodes/number/easing.py
@@ -254,6 +254,9 @@ class SvEasingNode(SverchCustomTreeNode, bpy.types.Node):
         return geom
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        
         p = self.inputs['Float'].sv_get()
         n_id = node_id(self)
 

--- a/nodes/number/exponential.py
+++ b/nodes/number/exponential.py
@@ -114,6 +114,8 @@ class SvGenExponential(SverchCustomTreeNode, bpy.types.Node):
         layout.prop(self, "mode", expand=True)
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         # inputs
         x0 = self.inputs['X0'].sv_get()[0]
         alpha = self.inputs['Alpha'].sv_get()[0]

--- a/nodes/number/fibonacci.py
+++ b/nodes/number/fibonacci.py
@@ -77,6 +77,8 @@ class SvGenFibonacci(SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvStringsSocket', "Sequence")
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         # inputs
         x1 = self.inputs['X1'].sv_get()[0]
         x2 = self.inputs['X2'].sv_get()[0]

--- a/nodes/number/float_to_int.py
+++ b/nodes/number/float_to_int.py
@@ -37,6 +37,11 @@ class Float2IntNode(SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvStringsSocket', "int")
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not (self.inputs["float"].is_linked):
+            raise Exception("Input socket 'float' has to be connected")
+        
         Number = self.inputs['float'].sv_get()
         if self.outputs['int'].is_linked:
             result = self.inte(Number)

--- a/nodes/number/list_input.py
+++ b/nodes/number/list_input.py
@@ -140,6 +140,9 @@ class SvListInputNode(Show3DProperties, SverchCustomTreeNode, bpy.types.Node):
                     row.scale_x = 0.8
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        
         if self.outputs[0].is_linked:
             if self.mode == 'int_list':
                 data = listinput_getI_needed(self)

--- a/nodes/number/mix_inputs.py
+++ b/nodes/number/mix_inputs.py
@@ -343,8 +343,7 @@ class SvMixInputsNode(SverchCustomTreeNode, bpy.types.Node):
         self.outputs[0].replace_socket(new_socket_type, self.mode.title())
 
     def process(self):
-        # return if no outputs are connected
-        if not any(s.is_linked for s in self.outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         # input values lists (single or multi value)

--- a/nodes/number/mix_numbers.py
+++ b/nodes/number/mix_numbers.py
@@ -229,8 +229,7 @@ class SvMixNumbersNode(SverchCustomTreeNode, bpy.types.Node):
 
 
     def process(self):
-        # return if no outputs are connected
-        if not any(s.is_linked for s in self.outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         # input values lists (single or multi value)

--- a/nodes/number/number_range.py
+++ b/nodes/number/number_range.py
@@ -209,10 +209,11 @@ class SvGenNumberRange(SverchCustomTreeNode, bpy.types.Node):
             self.range_mode = "RANGE_STEP"
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         inputs = self.inputs
         outputs = self.outputs
-        if not outputs[0].is_linked:
-            return
+
         matching_f = list_match_func[self.list_match]
         params = [s.sv_get() for s in inputs]
         if self.number_mode == 'int':

--- a/nodes/number/numbers.py
+++ b/nodes/number/numbers.py
@@ -168,7 +168,9 @@ class SvNumberNode(Show3DProperties, DraftMode, SverchCustomTreeNode, bpy.types.
 
 
     def process(self):
-
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        
         if not self.inputs[0].is_linked:
             prop_name = self.get_prop_name()
             self.outputs[0].sv_set([[getattr(self, prop_name)]])

--- a/nodes/number/oscillator.py
+++ b/nodes/number/oscillator.py
@@ -175,7 +175,9 @@ class SvOscillatorNode(SverchCustomTreeNode, bpy.types.Node):
 
 
     def process(self):
-
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        
         if self.outputs[0].is_linked:
             if self.current_op == 'Custom' and not self.inputs["Wave"].is_linked:
                 return

--- a/nodes/number/random.py
+++ b/nodes/number/random.py
@@ -44,7 +44,7 @@ class RandomNode(SverchCustomTreeNode, bpy.types.Node):
         self.outputs.new('SvStringsSocket', "Random")
 
     def process(self):
-        if not self.outputs[0].is_linked:
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         Coun = self.inputs['Count'].sv_get()[0]

--- a/nodes/number/random_num_gen.py
+++ b/nodes/number/random_num_gen.py
@@ -298,21 +298,22 @@ class SvRndNumGen(SverchCustomTreeNode, bpy.types.Node):
         return result
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
         inputs = self.inputs
         outputs = self.outputs
         mode = self.type_selected_mode
-        if outputs['Value'].is_linked:
 
-            if mode == 'Int':
-                params = [inputs[i].sv_get()[0] for i in range(4)]
-                if self.weighted and inputs[4].is_linked:
-                    params.append(inputs[4].sv_get())
+        if mode == 'Int':
+            params = [inputs[i].sv_get()[0] for i in range(4)]
+            if self.weighted and inputs[4].is_linked:
+                params.append(inputs[4].sv_get())
 
-            elif mode == 'Float':
-                params = [inputs[i].sv_get()[0] for i in range(len(inputs)) if not inputs[i].hide]
+        elif mode == 'Float':
+            params = [inputs[i].sv_get()[0] for i in range(len(inputs)) if not inputs[i].hide]
 
-            out = [self.produce_range(*args) for args in zip(*match_long_repeat(params))]
-            outputs['Value'].sv_set(out)
+        out = [self.produce_range(*args) for args in zip(*match_long_repeat(params))]
+        outputs['Value'].sv_set(out)
 
 
 def register():

--- a/nodes/number/range_map.py
+++ b/nodes/number/range_map.py
@@ -141,12 +141,9 @@ class SvMapRangeNode(SverchCustomTreeNode, bpy.types.Node):
         layout.prop(self, "output_numpy", expand=False)
 
     def process(self):
-        inputs = self.inputs
-        outputs = self.outputs
-
-        # no outputs, end early.
-        if not outputs['Value'].is_linked:
+        if not any(socket.is_linked for socket in self.outputs):
             return
+        inputs = self.inputs
 
         params = [si.sv_get(default=[[]], deepcopy=False) for si in inputs]
         matching_f = list_match_func[self.list_match]

--- a/nodes/number/smooth_numbers.py
+++ b/nodes/number/smooth_numbers.py
@@ -99,17 +99,19 @@ class SvSmoothNumbersNode(SverchCustomTreeNode, bpy.types.Node):
 
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+        if not (self.inputs["Value"].is_linked):
+            raise Exception("Input socket 'Value' has to be connected")
 
-        if self.outputs[0].is_linked:
+        params = [si.sv_get(default=[[]], deepcopy=False) for si in self.inputs]
+        matching_f = list_match_func[self.list_match]
 
-            params = [si.sv_get(default=[[]], deepcopy=False) for si in self.inputs]
-            matching_f = list_match_func[self.list_match]
+        desired_levels = [2, 2, 2]
+        ops = [self.cyclic, self.output_numpy]
+        result = recurse_f_level_control(params, ops, smooth_numbers, matching_f, desired_levels)
 
-            desired_levels = [2, 2, 2]
-            ops = [self.cyclic, self.output_numpy]
-            result = recurse_f_level_control(params, ops, smooth_numbers, matching_f, desired_levels)
-
-            self.outputs[0].sv_set(result)
+        self.outputs[0].sv_set(result)
 
 
 classes = [SvSmoothNumbersNode]


### PR DESCRIPTION
fix #5098
- Add check if output sockets are connected before execute nodes.
- For some nodes did exception if some input sockets are not connected. This show source of problems more precisely.

Examples if some input sockets are not connected.

![image](https://github.com/nortikin/sverchok/assets/14288520/ac6f0815-abe0-4253-af2a-be70d46bf345)
