### PR TITLE
fix 5115 Extend functionality of Mesh Clustering Node

### DIFF
--- a/docs/nodes/spatial/mesh_clustering.rst
+++ b/docs/nodes/spatial/mesh_clustering.rst
@@ -17,11 +17,15 @@ Functionality
 
 This node takes a surface mesh and returns a uniformly meshed surface using voronoi clustering.
 
+.. image:: https://github.com/nortikin/sverchok/assets/14288520/fb0d011c-8550-4262-bf77-29d2012511c2
+  :target: https://github.com/nortikin/sverchok/assets/14288520/fb0d011c-8550-4262-bf77-29d2012511c2
+
 .. image:: https://github.com/nortikin/sverchok/assets/14288520/f50b985a-45b6-482c-8b7c-1f7551a50b8f
   :target: https://github.com/nortikin/sverchok/assets/14288520/f50b985a-45b6-482c-8b7c-1f7551a50b8f
 
 .. image:: https://github.com/nortikin/sverchok/assets/14288520/e761653b-a88f-42e1-b222-fa243b1642a5
   :target: https://github.com/nortikin/sverchok/assets/14288520/e761653b-a88f-42e1-b222-fa243b1642a5
+
 
 Inputs
 ------
@@ -121,5 +125,8 @@ High poly clusterizing with dual mesh
 .. image:: https://github.com/nortikin/sverchok/assets/14288520/1f786c06-cde4-4227-b539-59926e1e737b
   :target: https://github.com/nortikin/sverchok/assets/14288520/1f786c06-cde4-4227-b539-59926e1e737b
 
+example_001_
+
 .. _pyacvd: https://github.com/pyvista/pyacvd
 .. _triangulate: https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.polydatafilters.triangulate
+.. _example_001: https://github.com/nortikin/sverchok/files/15172028/RoundedCube.Juwelry.0003.blend.zip

--- a/docs/nodes/spatial/mesh_clustering.rst
+++ b/docs/nodes/spatial/mesh_clustering.rst
@@ -1,8 +1,8 @@
 Mesh clustering
 ===============
 
-.. image:: https://github.com/nortikin/sverchok/assets/14288520/050bd959-f825-48c8-8036-790030ea5729
-  :target: https://github.com/nortikin/sverchok/assets/14288520/050bd959-f825-48c8-8036-790030ea5729
+.. image:: https://github.com/nortikin/sverchok/assets/14288520/0ff2d512-2da9-492d-93af-00d85c2b38de
+  :target: https://github.com/nortikin/sverchok/assets/14288520/0ff2d512-2da9-492d-93af-00d85c2b38de
 
 Dependencies
 ------------
@@ -41,15 +41,64 @@ This node has the following inputs:
     .. image:: https://github.com/nortikin/sverchok/assets/14288520/6d49a5cf-704d-4566-b56e-861a88b9d34f
       :target: https://github.com/nortikin/sverchok/assets/14288520/6d49a5cf-704d-4566-b56e-861a88b9d34f
 
-- **Triangulate mesh polygons**. If your mesh has faces with different count of vertices then this mash has to be triangulated.
+- **Matrixes**. Spread you source meshes by matrixes. You can use vertices of another meshes as matrixes:
+
+    .. image:: https://github.com/nortikin/sverchok/assets/14288520/1b110e99-ebec-4805-9e45-ba7cb49b640f
+      :target: https://github.com/nortikin/sverchok/assets/14288520/1b110e99-ebec-4805-9e45-ba7cb49b640f
+
+Parameters
+----------
+
+Triangulation.
+
+Before clusterisation your source meshes has to be triangulated. Here are parameters for process of triangulation.
+
+If source mesh has ngons woth different count of vertices then source mesh has to be triangulated with the next methods [**Quads mode** and **Polygons mode**].
+If ngons of source mesh are equals (they can has 3,4,5 verts but for all faces) the mesh will be triangulated with pyvista method triangulate_ authomatically.
+
+.. image:: https://github.com/nortikin/sverchok/assets/14288520/66bedca2-c62f-4603-b42a-5b86a6a8eef6
+  :target: https://github.com/nortikin/sverchok/assets/14288520/66bedca2-c62f-4603-b42a-5b86a6a8eef6
+
+- **Quads mode**:
+    - **Beauty**. Split the quads in nice triangles, slower method
+    - **Fixed**. Split the quads on the 1st and 3rd vertices
+    - **Fixed Alternate**. Split the quads on the 2nd and 4th vertices
+    - **Shortest Diagonal**. Split the quads based on the distance between the vertices
+
+- **Polygons mode**:
+    - **Beauty**. Arrange the new triangles nicely, slower method
+    - **Clip**. Split the ngons using a scanfill algorithm
+
+If your mesh is low poly and you want to smooth it then you can use subdivide mode:
+
+- **Subdiv mode**:
+    - **Butterfly**.
+    - **Loop**. Butterfly and loop subdivision perform smoothing when dividing, and may introduce artifacts into the mesh when dividing
+    - **Linear**. Linear subdivision results in the fastest mesh subdivision, but it does not smooth mesh edges, but rather splits each triangle into 4 smaller triangles
+
+    .. image:: https://github.com/nortikin/sverchok/assets/14288520/672dc04d-4f3d-4dff-b359-1b40b98de57a
+      :target: https://github.com/nortikin/sverchok/assets/14288520/672dc04d-4f3d-4dff-b359-1b40b98de57a
 
 Outputs
 -------
 
-Triangulated mesh:
+Clusterized mesh:
 
-- **Vertices**, **Edges**, **Faces**
+.. image:: https://github.com/nortikin/sverchok/assets/14288520/6a203a16-e23a-4214-a674-bbe507d1c5a1
+  :target: https://github.com/nortikin/sverchok/assets/14288520/6a203a16-e23a-4214-a674-bbe507d1c5a1
 
+- **Vertices**
+- **Edges**
+- **Polygons**
+
+    .. image:: https://github.com/nortikin/sverchok/assets/14288520/6258394e-b5c6-4688-baff-dd964f599e4f
+      :target: https://github.com/nortikin/sverchok/assets/14288520/6258394e-b5c6-4688-baff-dd964f599e4f
+
+- **Centers of Polygons**
+- **Normals of Polygons**
+
+    .. image:: https://github.com/nortikin/sverchok/assets/14288520/f62224e2-0f7e-4ecc-9478-0be93ebd56d9
+      :target: https://github.com/nortikin/sverchok/assets/14288520/f62224e2-0f7e-4ecc-9478-0be93ebd56d9
 
 Example of Usage
 ----------------
@@ -67,3 +116,4 @@ Subdivide is zero.
 
 
 .. _pyacvd: https://github.com/pyvista/pyacvd
+.. _triangulate: https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.polydatafilters.triangulate

--- a/docs/nodes/spatial/mesh_clustering.rst
+++ b/docs/nodes/spatial/mesh_clustering.rst
@@ -115,5 +115,11 @@ Subdivide is zero.
   :target: https://github.com/nortikin/sverchok/assets/14288520/a25eb0d2-cccc-4086-b663-0036d60314a5
 
 
+High poly clusterizing with dual mesh
+-------------------------------------
+
+.. image:: https://github.com/nortikin/sverchok/assets/14288520/1f786c06-cde4-4227-b539-59926e1e737b
+  :target: https://github.com/nortikin/sverchok/assets/14288520/1f786c06-cde4-4227-b539-59926e1e737b
+
 .. _pyacvd: https://github.com/pyvista/pyacvd
 .. _triangulate: https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.polydatafilters.triangulate

--- a/nodes/spatial/mesh_clustering.py
+++ b/nodes/spatial/mesh_clustering.py
@@ -115,11 +115,6 @@ class SvMeshClusteringNode(SverchCustomTreeNode, bpy.types.Node, SvRecursiveNode
 
         col = layout.column()
         col.row().label(text="Triangulate mesh polygons:")
-        
-        row = col.row()
-        split = row.split(factor=0.4)
-        split.column().label(text="Subdiv mode:")
-        split.column().row(align=True).prop(self, "subdiv_mode", text='')
 
         row = col.row()
         split = row.split(factor=0.4)
@@ -130,6 +125,11 @@ class SvMeshClusteringNode(SverchCustomTreeNode, bpy.types.Node, SvRecursiveNode
         split = row.split(factor=0.5)
         split.column().label(text="Polygons mode:")
         split.column().row(align=True).prop(self, "ngon_mode", text='')
+
+        row = col.row()
+        split = row.split(factor=0.4)
+        split.column().label(text="Subdiv mode:")
+        split.column().row(align=True).prop(self, "subdiv_mode", text='')
 
         pass
 

--- a/utils/sv_bmesh_utils.py
+++ b/utils/sv_bmesh_utils.py
@@ -217,11 +217,11 @@ def numpy_data_from_bmesh(bm, out_np, face_data=None):
     else:
         return verts, edges, faces, []
 
-def pydata_from_bmesh(bm, face_data=None):
+def pydata_from_bmesh(bm, face_data=None, ret_verts=True, ret_edges=True, ret_faces=True):
 
-    verts = [v.co[:] for v in bm.verts]
-    edges = [[e.verts[0].index, e.verts[1].index] for e in bm.edges]
-    faces = [[i.index for i in p.verts] for p in bm.faces]
+    verts = [v.co[:] for v in bm.verts] if ret_verts==True and face_data is None else None
+    edges = [[e.verts[0].index, e.verts[1].index] for e in bm.edges] if ret_edges==True and face_data is None else None
+    faces = [[i.index for i in p.verts] for p in bm.faces] if ret_faces==True and face_data is None else None
 
     if face_data is None:
         return verts, edges, faces


### PR DESCRIPTION
fix #5115 

- append new parameter 'subdiv_mode' [butterfly, loop, linear]
- append new outputsockets Centers of Polygons' and 'Normals of Polygons'
- optimize pydata_from_bmesh (exclude calculations of some values)

![image](https://github.com/nortikin/sverchok/assets/14288520/d27636c4-397d-4f96-a2c6-3768b0004f60)

**Subdiv mode**:
![image](https://github.com/nortikin/sverchok/assets/14288520/81e79807-6182-4a97-8b22-9c2c81cf5958)

**New output sockets**:
![image](https://github.com/nortikin/sverchok/assets/14288520/b0917bc5-1744-43fb-b8c5-a6d1b8b94ba6)

File for tests:
[RoundedCube.Juwelry.0003.blend.zip](https://github.com/nortikin/sverchok/files/15171172/RoundedCube.Juwelry.0003.blend.zip)
