### PR TITLE
fix #5132 Error when trying to change fonts in Typography Viewer

### DIFF
--- a/nodes/viz/viewer_typography.py
+++ b/nodes/viz/viewer_typography.py
@@ -115,7 +115,7 @@ class SvFontFileImporterOpV28(bpy.types.Operator):
         return {'FINISHED'}
 
     def invoke(self, context, event):
-        self.node = context.node
+        self.node = context.active_node
         wm = context.window_manager
         wm.fileselect_add(self)
         return {'RUNNING_MODAL'}


### PR DESCRIPTION
fix #5132 Error when trying to change fonts in Typography Viewer (In additional panel operator)

![image](https://github.com/user-attachments/assets/523fd5f0-33c8-4d41-b46c-eb7541435a14)

Reason: if you call an operator from function draw_buttons_ext then **context** argument has no an attribute "context.**node**":

![image](https://github.com/user-attachments/assets/6df80e49-dba5-4dc5-a058-023149afeb94)

replaced with an attribute "context.active_node":

![image](https://github.com/user-attachments/assets/2781f625-c2e3-421d-86a2-6c94d5012dd6)

