### PR TITLE
fix #5142 Unify show 3D panel buttons

### DIFF
--- a/nodes/color/color_input.py
+++ b/nodes/color/color_input.py
@@ -50,8 +50,8 @@ class SvColorInputNode(Show3DProperties, SverchCustomTreeNode, bpy.types.Node):
         layout.prop(self, "use_alpha")
 
     def draw_buttons_ext(self, context, layout):
+        layout.prop(self, "draw_3dpanel", icon="PLUGIN")
         self.draw_buttons(context, layout)
-        layout.prop(self, "draw_3dpanel")
 
     def draw_buttons_3dpanel(self, layout):
         row = layout.row(align=True)

--- a/nodes/exchange/nurbs_in.py
+++ b/nodes/exchange/nurbs_in.py
@@ -133,6 +133,10 @@ class SvExNurbsInNode(Show3DProperties, SverchCustomTreeNode, bpy.types.Node):
 
         self.draw_obj_names(layout)
 
+    def draw_buttons_ext(self, context, layout):
+        layout.prop(self, "draw_3dpanel", icon="PLUGIN")
+        self.draw_buttons(context, layout)
+
     def draw_buttons_3dpanel(self, layout):
         row = layout.row(align=True)
         row.label(text=self.label if self.label else self.name)

--- a/nodes/logic/custom_switcher.py
+++ b/nodes/logic/custom_switcher.py
@@ -67,10 +67,10 @@ class SvCustomSwitcher(Show3DProperties, SverchCustomTreeNode, bpy.types.Node):
             col.prop(self, "user_list", toggle=True, index=i, text=val.name)
 
     def draw_buttons_ext(self, context, layout):
+        layout.prop(self, "draw_3dpanel", icon="PLUGIN")
         row = layout.row()
         row.scale_y = 2
         row.prop(self, 'multiple_selection', toggle=True)
-        layout.prop(self, 'draw_3dpanel', toggle=True)
         layout.prop(self, 'ui_scale', text='Size of buttons')
 
     def draw_buttons_3dpanel(self, layout, in_menu=None):

--- a/nodes/number/list_input.py
+++ b/nodes/number/list_input.py
@@ -2645,12 +2645,19 @@ class SvListInputNodeMK2(Show3DProperties, SverchCustomTreeNode, bpy.types.Node)
                 pass
         else:
             raise Exception(f"[func: draw_buttons] unknown mode {self.list_items_type}.")
+    
+    def draw_buttons_ext(self, context, layout):
+        layout.prop(self, "draw_3dpanel", icon="PLUGIN")
 
     def draw_buttons_3dpanel(self, layout, in_menu=None):
         if not in_menu:
-            menu = layout.row(align=True).operator('node.popup_3d_menu', text=f'Show: "{self.label or self.name}"')
-            menu.tree_name = self.id_data.name
-            menu.node_name = self.name
+            menu_row = layout.row(align=True)
+            menu_row.column().label(text=f'Show: {self.label or self.name}')
+            self.wrapper_tracked_ui_draw_op(menu_row.column(), "node.sv_nodeview_zoom_border", text="", icon="TRACKER_DATA")
+            # If disable next lines then 3D Panel will show context menu with menu items
+            # menu = menu_row.column().operator('node.popup_3d_menu', text=f'"{self.label or self.name}"')
+            # menu.tree_name = self.id_data.name
+            # menu.node_name = self.name
         else:
             label = self.label
             if not label:

--- a/nodes/number/numbers.py
+++ b/nodes/number/numbers.py
@@ -132,6 +132,9 @@ class SvNumberNode(Show3DProperties, DraftMode, SverchCustomTreeNode, bpy.types.
             else:
                 prop_name = 'int_'
         return prop_name
+    
+    def draw_buttons_ext(self, context, layout):
+        layout.prop(self, "draw_3dpanel", icon="PLUGIN")
 
     def draw_buttons_3dpanel(self, layout):
         row = layout.row(align=True)

--- a/nodes/scene/get_objects_data.py
+++ b/nodes/scene/get_objects_data.py
@@ -472,8 +472,6 @@ class SvGetObjectsDataMK3(Show3DProperties, SverchCustomTreeNode, bpy.types.Node
             for i in range(7):
                 r.prop(self, "out_np", index=i, text=numpy_socket_names[i], toggle=True)
 
-        layout.prop(self, 'draw_3dpanel', text="To Control panel")
-
     def rclick_menu(self, context, layout):
         '''right click sv_menu items'''
         layout.label(text="Output Numpy:")
@@ -481,6 +479,10 @@ class SvGetObjectsDataMK3(Show3DProperties, SverchCustomTreeNode, bpy.types.Node
         if not self.output_np_all:
             for i in range(7):
                 layout.prop(self, "out_np", index=i, text=numpy_socket_names[i], toggle=True)
+
+    def draw_buttons_ext(self, context, layout):
+        layout.prop(self, "draw_3dpanel", icon="PLUGIN")
+        self.sv_draw_buttons_ext(context, layout)
 
     def draw_buttons_3dpanel(self, layout):
         if not self.by_input:

--- a/ui/sv_3d_panel.py
+++ b/ui/sv_3d_panel.py
@@ -14,7 +14,7 @@ class SV_PT_3DPanel(bpy.types.Panel):
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'
     bl_category = 'Tool'
-    bl_label = "Sverchok"
+    bl_label = "3D Panel (Sverchok)"
     bl_options = {'DEFAULT_CLOSED'}
 
     def draw(self, context):

--- a/utils/nodes_mixins/show_3d_properties.py
+++ b/utils/nodes_mixins/show_3d_properties.py
@@ -16,7 +16,7 @@ class Show3DProperties:
     """
     draw_3dpanel: bpy.props.BoolProperty(
         name="To 3D Panel",
-        description="Show this node in 3D panel", 
+        description="Show this node in 3D panel. (See area 3D Viewport, N-menu->Tool->3D Panel )", 
         default=False,
         update=lambda n, c: bpy.context.scene.sv_ui_node_props.update_properties()  # automatically add/remove item
     )


### PR DESCRIPTION
fix #5142 Unify show 3D panel buttons

Next nodes use draw_3dpanel property aligned:

![image](https://github.com/user-attachments/assets/6a09d580-aed4-4856-867d-79530fa10211)

![image](https://github.com/user-attachments/assets/d7d8ff6f-febe-483f-9906-942309493e79)
