### PR TITLE
Fix warnings registering sverchok menus after reenabling addon

### DIFF
--- a/ui/sv_examples_menu.py
+++ b/ui/sv_examples_menu.py
@@ -118,10 +118,12 @@ class SvNodeTreeImporterSilent(bpy.types.Operator):
 
 
 classes = [SW_OT_Console, SV_MT_LayoutsExamples, SvNodeTreeImporterSilent]
+submenu_classes = []
 
 
 def register():
-    submenu_classes = (make_submenu_classes(path, category_name) for path, category_name in example_categories_names())
+    global submenu_classes
+    submenu_classes = [make_submenu_classes(path, category_name) for path, category_name in example_categories_names()]
     _ = [bpy.utils.register_class(cls) for cls in chain(classes, submenu_classes)]
     bpy.types.NODE_HT_header.append(node_examples_pulldown)
     bpy.types.NODE_HT_header.append(node_settings_pulldown)
@@ -130,4 +132,4 @@ def register():
 def unregister():
     bpy.types.NODE_HT_header.remove(node_settings_pulldown)
     bpy.types.NODE_HT_header.remove(node_examples_pulldown)
-    _ = [bpy.utils.unregister_class(cls) for cls in reversed(classes)]
+    _ = [bpy.utils.unregister_class(cls) for cls in reversed(list(chain(classes, submenu_classes)))]


### PR DESCRIPTION
@zeffii @portnov 

E.g. if you disable and enable addon it would give the warnings below since menu classes were not unregistered.

Example warnings:
```
register_class(...):
Info: Registering menu class: 'SV_MT_PyMenu_Advanced', bl_idname 'SV_MT_PyMenu_Advanced' has been registered before, unregistering previous
register_class(...):
Info: Registering menu class: 'SV_MT_PyMenu_Architecture', bl_idname 'SV_MT_PyMenu_Architecture' has been registered before, unregistering previous
register_class(...):
Info: Registering menu class: 'SV_MT_PyMenu_CNC', bl_idname 'SV_MT_PyMenu_CNC' has been registered before, unregistering previous
register_class(...):
Info: Registering menu class: 'SV_MT_PyMenu_Design', bl_idname 'SV_MT_PyMenu_Design' has been registered before, unregistering previous
register_class(...):
Info: Registering menu class: 'SV_MT_PyMenu_Fields', bl_idname 'SV_MT_PyMenu_Fields' has been registered before, unregistering previous
register_class(...):
Info: Registering menu class: 'SV_MT_PyMenu_Introduction', bl_idname 'SV_MT_PyMenu_Introduction' has been registered before, unregistering previous
register_class(...):
Info: Registering menu class: 'SV_MT_PyMenu_Shapes', bl_idname 'SV_MT_PyMenu_Shapes' has been registered before, unregistering previous
register_class(...):
Info: Registering menu class: 'SV_MT_PyMenu_Surfaces', bl_idname 'SV_MT_PyMenu_Surfaces' has been registered before, unregistering previous
```