### PR TITLE
Add Alt + Right Click for Sv right click menu

### DIFF
--- a/docs/user_interface/shortcuts.rst
+++ b/docs/user_interface/shortcuts.rst
@@ -67,6 +67,8 @@ This is a collection of shortcuts useful in the Sverchok node tree, some are Ble
 
 **Right Click** - Access to Sverchok Right Click Menu
 
+**Alt + Right Click** - Access to Sverchok Right Click Menu
+
 **Shift + P** - on a node in Node Editor - open Load / Save Preset menu for this node
 
 **Ctrl+Z** - Zoom to selected node and vice versa

--- a/ui/nodeview_keymaps.py
+++ b/ui/nodeview_keymaps.py
@@ -202,6 +202,11 @@ def add_keymap():
         kmi.properties.name = "NODEVIEW_MT_sv_rclick_menu"
         nodeview_keymaps.append((km, kmi))
 
+        # Alt + Right Click   | show custom menu (to avoid conflict with the Blender right click menu)
+        kmi = km.keymap_items.new('wm.call_menu', 'RIGHTMOUSE', 'RELEASE', alt=True)
+        kmi.properties.name = "NODEVIEW_MT_sv_rclick_menu"
+        nodeview_keymaps.append((km, kmi))
+
         kmi = km.keymap_items.new('wm.call_menu', 'P', 'PRESS', shift=True)
         kmi.properties.name = "SV_MT_LoadPresetMenu"
         nodeview_keymaps.append((km, kmi))


### PR DESCRIPTION
When you are using left click to select then the right click pops up a blender menu.
Alt + Right Click will always give the Sv menu

