### PR TITLE
fix 5194. Update Straight Skeleton 2D Offset

### DIFF
--- a/docs/nodes/CAD/straight_skeleton_2d_offset.rst
+++ b/docs/nodes/CAD/straight_skeleton_2d_offset.rst
@@ -1,8 +1,8 @@
 Straight Skeleton 2d Offset (Alpha)
 ===================================
 
-.. image:: https://github.com/user-attachments/assets/e127c195-2b76-44b8-a75b-976e772000f1
-  :target: https://github.com/user-attachments/assets/e127c195-2b76-44b8-a75b-976e772000f1
+.. image:: https://github.com/user-attachments/assets/c4f3f9dd-9866-4a52-b49b-fc3ea4b84ad8
+  :target: https://github.com/user-attachments/assets/c4f3f9dd-9866-4a52-b49b-fc3ea4b84ad8
 
 Functionality
 -------------
@@ -42,14 +42,19 @@ Inputs
     .. image:: https://github.com/user-attachments/assets/8249d2f4-6c22-4899-b63e-1ded807a7f82
       :target: https://github.com/user-attachments/assets/8249d2f4-6c22-4899-b63e-1ded807a7f82
 
-- **Join mode**. Preprocess source meshes. Split, Keep, Merge. **Split** - separate source meshes into independent islands and process them individually. Results boundaries can overlaps. **Keep** - If source meshes has several islands then they has influence. **Merge** - Combine all islands to influence all islands.
+- **Join mode**. Preprocess source meshes. **Split**, **Keep**, **Merge**. 
+    - **Split** - separate source meshes into independent islands and process them individually. Results boundaries can overlaps.
+    - **Keep** - If source meshes has several islands then they has influence.
+    - **Merge** - Combine all islands to influence all islands.
 
     .. image:: https://github.com/user-attachments/assets/3cc4b707-2068-4743-8c81-2b707edfc8ef 
       :target: https://github.com/user-attachments/assets/3cc4b707-2068-4743-8c81-2b707edfc8ef
 
 - **Shapes mode**. **Original**, **Exclude Holes**, **Invert Holes**.
 
-    **Original** - Process original meshes. **Exclude holes** - process only external boundaries. **Invert Holes** - process holes as islands, exclude external boundaries from process.
+    - **Original** - Process original meshes.
+    - **Exclude holes** - process only external boundaries.
+    - **Invert Holes** - process holes as islands, exclude external boundaries from process.
 
     .. image:: https://github.com/user-attachments/assets/f3b577f9-25c1-424b-ac55-0b7ceb754877
       :target: https://github.com/user-attachments/assets/f3b577f9-25c1-424b-ac55-0b7ceb754877
@@ -135,8 +140,12 @@ Parameters
       .. image:: https://github.com/user-attachments/assets/e469b38b-a0de-4e7a-a595-a027e77aae48
         :target: https://github.com/user-attachments/assets/e469b38b-a0de-4e7a-a595-a027e77aae48
 
+- **Force z=0.0** - To force use meshes as planes. Useful for ex. bezier 2D curve some time take Z not zero.
+
+      .. image:: https://github.com/user-attachments/assets/171ee664-1f24-4f00-aed7-4d69ab0f8e75
+        :target: https://github.com/user-attachments/assets/171ee664-1f24-4f00-aed7-4d69ab0f8e75
+
 - **Only Tests** - If you have a hi poly mesh like imported SVG file one can save time and do not Skeletonize all meshes before fix all. You can connect viewer draw into the "Wrong Contours Verts" with red color or any color you prefer for errors to see any wrong contrours. Red dots are wrong contours.
-- **Force z=0.0** - To force use meshes as planes. Iy is useful for ex. bezier 2D curve some time take Z not zero.
 - **Verbose** - Enabled - Show process messages in console while process meshes. Disabled - Hide any process messages.
 
       .. image:: https://github.com/user-attachments/assets/5b1ffdef-8a1a-4ed0-b580-c53b2d1fdb9d
@@ -144,10 +153,10 @@ Parameters
 
 - **Use cache** - Store Straight Skeleton 2D calculations in cache. If you pass the geometry for calculation a Straight Skeleton a second time, the result will be taken from the cache. This is a new feature so this is disabled by default. If the setting is disabled, the cache is not used.
 
-- **Bevel more split** - Work only in Bevel mode. Additional separation of the object by profile faces in **split** mode.
+- **Detailed split** - Work only in Bevel mode. Additional separation of the object by profile faces in **split** mode.
 
-      .. image:: https://github.com/user-attachments/assets/cdc0ee17-f050-41b3-889c-9b3b369667de
-        :target: https://github.com/user-attachments/assets/cdc0ee17-f050-41b3-889c-9b3b369667de
+      .. image:: https://github.com/user-attachments/assets/69670c31-d4e8-42ff-936f-699500f41359
+        :target: https://github.com/user-attachments/assets/69670c31-d4e8-42ff-936f-699500f41359
 
 Output sockets
 --------------
@@ -175,6 +184,12 @@ If you try high poly like Besier 2D with many points and hi resolution (1) then 
 .. image:: https://github.com/user-attachments/assets/429e6571-fe73-4fc7-b242-4f038f670871
   :target: https://github.com/user-attachments/assets/429e6571-fe73-4fc7-b242-4f038f670871
 
+Also you can use cache mode (it is experimental property for a while!!!):
+
+.. image:: https://github.com/user-attachments/assets/2e8eaadc-ac14-4789-826a-3bf992ebeb7d
+  :target: https://github.com/user-attachments/assets/2e8eaadc-ac14-4789-826a-3bf992ebeb7d
+
+
 Examples
 --------
 
@@ -188,7 +203,7 @@ Inner Offset
 .. image:: https://github.com/user-attachments/assets/78568725-254e-469c-98bd-50ffb24321b0
   :target: https://github.com/user-attachments/assets/78568725-254e-469c-98bd-50ffb24321b0
 
-Extrude by offsets:
+Extrude with profile faces:
 
 .. image:: https://github.com/user-attachments/assets/e7278c18-18aa-4e3c-8897-71369f8566b9
   :target: https://github.com/user-attachments/assets/e7278c18-18aa-4e3c-8897-71369f8566b9

--- a/docs/nodes/CAD/straight_skeleton_2d_offset.rst
+++ b/docs/nodes/CAD/straight_skeleton_2d_offset.rst
@@ -1,8 +1,8 @@
 Straight Skeleton 2d Offset (Alpha)
 ===================================
 
-.. image:: https://github.com/user-attachments/assets/68a3e88e-8e16-4c0c-8b68-58d81312a265
-  :target: https://github.com/user-attachments/assets/68a3e88e-8e16-4c0c-8b68-58d81312a265
+.. image:: https://github.com/user-attachments/assets/e127c195-2b76-44b8-a75b-976e772000f1
+  :target: https://github.com/user-attachments/assets/e127c195-2b76-44b8-a75b-976e772000f1
 
 Functionality
 -------------
@@ -21,6 +21,12 @@ More complex example:
 .. image:: https://github.com/user-attachments/assets/afa62b30-d5e4-4877-8efc-ccade1730e63
   :target: https://github.com/user-attachments/assets/afa62b30-d5e4-4877-8efc-ccade1730e63
 
+Additionally you can perform the offset connection of profiles to get a dimensional shape:
+
+.. image:: https://github.com/user-attachments/assets/72cbb4df-097c-4a2f-9b7b-413d539c642f
+  :target: https://github.com/user-attachments/assets/72cbb4df-097c-4a2f-9b7b-413d539c642f
+
+
 Install dependency
 ------------------
 
@@ -33,23 +39,28 @@ Inputs
 ------
 
 - **Vertices**, **Edges**, **Faces** - Input Mesh (2D only) or Meshes. You can use several meshes as input.
-    .. image:: https://github.com/user-attachments/assets/460ffdd6-f2d0-4277-9137-fd9e56862f42
-      :target: https://github.com/user-attachments/assets/460ffdd6-f2d0-4277-9137-fd9e56862f42
+    .. image:: https://github.com/user-attachments/assets/8249d2f4-6c22-4899-b63e-1ded807a7f82
+      :target: https://github.com/user-attachments/assets/8249d2f4-6c22-4899-b63e-1ded807a7f82
 
 - **Join mode**. Preprocess source meshes. Split, Keep, Merge. **Split** - separate source meshes into independent islands and process them individually. Results boundaries can overlaps. **Keep** - If source meshes has several islands then they has influence. **Merge** - Combine all islands to influence all islands.
 
     .. image:: https://github.com/user-attachments/assets/3cc4b707-2068-4743-8c81-2b707edfc8ef 
       :target: https://github.com/user-attachments/assets/3cc4b707-2068-4743-8c81-2b707edfc8ef
 
-- **Shapes mode**. Original, Exclude Holes, Invert Holes. Original - Process original meshes. Exclude holes - process only external boundaries. Invert Holes - process holes as islands, exclude external boundaries from process.
+- **Shapes mode**. **Original**, **Exclude Holes**, **Invert Holes**.
+
+    **Original** - Process original meshes. **Exclude holes** - process only external boundaries. **Invert Holes** - process holes as islands, exclude external boundaries from process.
 
     .. image:: https://github.com/user-attachments/assets/f3b577f9-25c1-424b-ac55-0b7ceb754877
       :target: https://github.com/user-attachments/assets/f3b577f9-25c1-424b-ac55-0b7ceb754877
 
-- **Offsets**, **Altitudes**. **Offsets** - distance from contour in plane (one can use negative value). **Altitudes** - results heights in Z axis (one can use negative value).
+- **Offsets**, **Altitudes**. 
 
-    .. image:: https://github.com/user-attachments/assets/1f5868a6-141d-4a32-bb9a-1596f2f954a9
-      :target: https://github.com/user-attachments/assets/1f5868a6-141d-4a32-bb9a-1596f2f954a9
+    **Offsets** - distance from contour in plane (one can use negative value). 
+    **Altitudes** - results heights in Z axis (one can use negative value).
+
+    .. image:: https://github.com/user-attachments/assets/ea4938cc-7c67-4543-900a-1b2edeb473f1
+      :target: https://github.com/user-attachments/assets/ea4938cc-7c67-4543-900a-1b2edeb473f1
 
 
 If you do not connect any lists of floats values then this value will be used for every objects
@@ -58,31 +69,85 @@ connected into this node:
     .. image:: https://github.com/user-attachments/assets/21b5edc3-5304-4a40-afb8-f1a2b5781443
       :target: https://github.com/user-attachments/assets/21b5edc3-5304-4a40-afb8-f1a2b5781443
 
+- **Profile faces indexes**. Only used in **Bevel mode**. List of indexes to connect offsets. If you use some mesh objects you can use profile faces to connect these offset as in profile shape:
+
+      .. image:: https://github.com/user-attachments/assets/96398637-a68b-4439-a379-e5f718e0865c
+        :target: https://github.com/user-attachments/assets/96398637-a68b-4439-a379-e5f718e0865c
+
+
+- **Profile close mode**. Only used in **Bevel mode**. This option affects the way the profile points are connected.
+
+      - **Close** - Profile forms closed shape. The first and last points are connected. The shape is closed from all sides.
+
+          .. image:: https://github.com/user-attachments/assets/12a69746-7ecf-492d-84ce-964aa1f0af66
+            :target: https://github.com/user-attachments/assets/12a69746-7ecf-492d-84ce-964aa1f0af66
+
+      - **Open**  - Profile forms opened shape. The first and last points do not connect
+
+          .. image:: https://github.com/user-attachments/assets/826f2671-8167-4a75-b2bc-a2add3b404a1
+            :target: https://github.com/user-attachments/assets/826f2671-8167-4a75-b2bc-a2add3b404a1
+
+      - **Pair**  - List items are joined in pairs. If an index is out of offset index range, the pair is completely ignored. Ex.: [1,2,3,4,5,6,7,8,9,0] will be [1,2],[3,4],[5,6],[7,8],[9,0] and you get the bands
+
+          .. image:: https://github.com/user-attachments/assets/4f461c1e-86f4-47fe-bcf2-8cba5d23c29f
+            :target: https://github.com/user-attachments/assets/4f461c1e-86f4-47fe-bcf2-8cba5d23c29f
+
+
 - **Mask of objects** - Mask hide objects. If element of boolean mask is True then object are hidden. If length of mask is more than length of objects then exceeded values will be omitted.
+
+      .. image:: https://github.com/user-attachments/assets/0afddc03-fb45-483e-aad5-01f387a4a584
+        :target: https://github.com/user-attachments/assets/0afddc03-fb45-483e-aad5-01f387a4a584
+
+      You can get this result with boolean mask too
+
+      .. image:: https://github.com/user-attachments/assets/b96936b4-68bf-4037-8d9b-e5ec592f04ae
+        :target: https://github.com/user-attachments/assets/b96936b4-68bf-4037-8d9b-e5ec592f04ae
+
 
 Parameters
 ----------
 
-.. image:: https://github.com/user-attachments/assets/bc18752b-7ce5-43dd-b0c1-df658a057ded
-  :target: https://github.com/user-attachments/assets/bc18752b-7ce5-43dd-b0c1-df658a057ded
+.. image:: https://github.com/user-attachments/assets/40187fad-ab8f-4e01-b299-c19d3c383f5a
+  :target: https://github.com/user-attachments/assets/40187fad-ab8f-4e01-b299-c19d3c383f5a
 
-- **Result Type**. **Contours** or **Faces**. **Contours** - results are only edges. **Faces** - Results are faces with holes.
+- **Result Type**. **Contours**, **Faces**, **Bevel**, **Skeleton**. 
 
-    .. image:: https://github.com/user-attachments/assets/7c8edb34-aef2-43a0-907e-83b18e833fe2
-      :target: https://github.com/user-attachments/assets/7c8edb34-aef2-43a0-907e-83b18e833fe2
+    .. image:: https://github.com/user-attachments/assets/c9fb9213-649b-4e31-a608-22af8d84b461
+      :target: https://github.com/user-attachments/assets/c9fb9213-649b-4e31-a608-22af8d84b461
+
+    - **Contours** - results are only edges.
+    - **Faces** - Results are faces with holes.
+    - **Bevel** - Offsets are connected in shapes or figures.
+    - **Skeleton** - Show Straight Skeleton scheme.
+
+    .. image:: https://github.com/user-attachments/assets/3f04fc16-212e-457d-9dc2-3b56a0284d5f
+      :target: https://github.com/user-attachments/assets/3f04fc16-212e-457d-9dc2-3b56a0284d5f
 
 - **Results Join Mode**. **Split**, **Keep**, **Merge**.
-    - **Split** - Separate all results into independent meshes. **Keep** - If some of objects has several independent meshes then they will be as one object on output. **Merge** - This node will merge all vertices, edjes, and faces into a single object. Results in merge mode can be overlapped.
+
+      .. image:: https://github.com/user-attachments/assets/64594acc-667e-4547-bee5-49004dc9f9b6
+        :target: https://github.com/user-attachments/assets/64594acc-667e-4547-bee5-49004dc9f9b6
+
+    - **Split** - Separate all results into independent meshes.
+    - **Keep** - If some of objects has several independent meshes then they will be as one object on output.
+    - **Merge** - This node will merge all vertices, edjes, and faces into a single object. Results in merge mode can be overlapped.
 
       .. image:: https://github.com/user-attachments/assets/e469b38b-a0de-4e7a-a595-a027e77aae48
         :target: https://github.com/user-attachments/assets/e469b38b-a0de-4e7a-a595-a027e77aae48
 
-    - **Only Tests** - If you have a hi poly mesh like imported SVG file one can save time and do not Skeletonize all meshes before fix all. You can connect viewer draw into the "Wrong Contours Verts" with red color or any color you prefer for errors to see any wrong contrours. Red dots are wrong contours.
-    - **Force z=0.0** - To force use meshes as planes
-    - **Verbose** - Enabled - Show process messages in console while process meshes. Disabled - Hide any process messages.
+- **Only Tests** - If you have a hi poly mesh like imported SVG file one can save time and do not Skeletonize all meshes before fix all. You can connect viewer draw into the "Wrong Contours Verts" with red color or any color you prefer for errors to see any wrong contrours. Red dots are wrong contours.
+- **Force z=0.0** - To force use meshes as planes. Iy is useful for ex. bezier 2D curve some time take Z not zero.
+- **Verbose** - Enabled - Show process messages in console while process meshes. Disabled - Hide any process messages.
 
       .. image:: https://github.com/user-attachments/assets/5b1ffdef-8a1a-4ed0-b580-c53b2d1fdb9d
         :target: https://github.com/user-attachments/assets/5b1ffdef-8a1a-4ed0-b580-c53b2d1fdb9d
+
+- **Use cache** - Store Straight Skeleton 2D calculations in cache. If you pass the geometry for calculation a Straight Skeleton a second time, the result will be taken from the cache. This is a new feature so this is disabled by default. If the setting is disabled, the cache is not used.
+
+- **Bevel more split** - Work only in Bevel mode. Additional separation of the object by profile faces in **split** mode.
+
+      .. image:: https://github.com/user-attachments/assets/cdc0ee17-f050-41b3-889c-9b3b369667de
+        :target: https://github.com/user-attachments/assets/cdc0ee17-f050-41b3-889c-9b3b369667de
 
 Output sockets
 --------------
@@ -96,7 +161,7 @@ Output sockets
 Performance
 -----------
 
-If you have a low poly model then no problem - you can work with that model in real time:
+If you have a low poly model then no problem - you can work with it in real time:
 
 .. raw:: html
 
@@ -122,6 +187,11 @@ Inner Offset
 
 .. image:: https://github.com/user-attachments/assets/78568725-254e-469c-98bd-50ffb24321b0
   :target: https://github.com/user-attachments/assets/78568725-254e-469c-98bd-50ffb24321b0
+
+Extrude by offsets:
+
+.. image:: https://github.com/user-attachments/assets/e7278c18-18aa-4e3c-8897-71369f8566b9
+  :target: https://github.com/user-attachments/assets/e7278c18-18aa-4e3c-8897-71369f8566b9
 
 
 DEVELOPMENT

--- a/nodes/CAD/straight_skeleton_2d_offset.py
+++ b/nodes/CAD/straight_skeleton_2d_offset.py
@@ -386,7 +386,7 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
     verbose_messages_while_process: BoolProperty(
         name='Verbose',
         description='Show additional debug info in console',
-        default=True, update=updateNode) # type: ignore
+        default=False, update=updateNode) # type: ignore
 
     use_cache_of_straight_skeleton: BoolProperty(
         name='Use cache',
@@ -394,7 +394,7 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
         default=False, update=updateNode) # type: ignore
 
     bevel_more_split: BoolProperty(
-        name='Bevel more split',
+        name='Detailed split',
         description='If use negative offsets then this will split result beveled Offset with more parts (used only in Bevel mode). For fun. )',
         default=False, update=updateNode) # type: ignore
 
@@ -521,6 +521,9 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
         grid = layout.grid_flow(row_major=False, columns=3, align=True)
         col = grid.row(align=True)
         socket_label = socket.objects_number if hasattr(socket, "objects_number")==True else '-'
+        col.enabled = False
+        if(self.res_type=='BEVEL'):
+            col.enabled = True
         col.label(text=f"Profile faces indexes {socket_label}")
         pass
         
@@ -536,14 +539,14 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
         if socket.is_linked==True:
             col.enabled = False
         else:
-            col.enabled = True
+            col.enabled = False
+            if(self.res_type=='BEVEL'):
+                col.enabled = True
         grid.prop(self, 'profile_faces__close_mode__mode', expand=True, icon_only=True) 
         pass
 
     def draw_objects_mask_in_socket(self, socket, context, layout):
         grid = layout.grid_flow(row_major=True, columns=2)
-        if not socket.is_linked:
-            grid.enabled = False
         col2 = grid.column()
         col2_row1 = col2.row()
         col2_row1.alignment='LEFT'
@@ -557,13 +560,18 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
         col3 = grid.column()
         col3.prop(self, "objects_mask_mode", expand=True)
 
+        col2_row2.enabled = True
+        col3.enabled = True
+        if not socket.is_linked:
+            #grid.enabled = False
+            col2_row2.enabled = False
+            col3.enabled = False
+
     def draw_buttons(self, context, layout):
         col = layout.column()
         col.grid_flow(columns=2,align=True, row_major=True).prop(self, 'res_type', expand=True)
         #col.row(align=True).prop(self, 'res_type', expand=True)
-        col.prop(self, 'only_tests_for_valid')
         col.prop(self, 'force_z_zero')
-        col.prop(self, 'verbose_messages_while_process')
         col.prop(self, 'use_cache_of_straight_skeleton')
         col1 = layout.column()
         col1.enabled = False
@@ -578,6 +586,8 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
 
     def draw_buttons_ext(self, context, layout):
         col = layout.column(align=True)
+        col.prop(self, 'only_tests_for_valid')
+        col.prop(self, 'verbose_messages_while_process')
         pass
 
     def sv_init(self, context):

--- a/nodes/CAD/straight_skeleton_2d_offset.py
+++ b/nodes/CAD/straight_skeleton_2d_offset.py
@@ -324,8 +324,7 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
         items = altitude_modes,
         update = updateNode
         ) # type: ignore
-
-
+    
     ss_altitude1: FloatProperty(
         name="Altitudes",
         default=1, 
@@ -347,6 +346,32 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
         ) # type: ignore
 
 
+    profile_faces__close_mode__modes = [
+            ('OBJECT_ALL_OPEN_MODE', "All", "Every profile faces per object get all input modes", 'THREE_DOTS', 0),
+            ('OBJECT_ONE_OPEN_MODE', "One", "Every object get one open mode in every its profile faces", 'DECORATE', 1),
+        ]
+    profile_faces__close_mode__mode : EnumProperty(
+        name = "Open mode",
+        default = 'OBJECT_ALL_OPEN_MODE',
+        description = "How many open mode per object (One or All)",
+        items = profile_faces__close_mode__modes,
+        update = updateNode
+        ) # type: ignore
+    
+    profile_faces__close_modes = [
+            ( 'CLOSED' , "Closed", "Close contour", 'PROP_CON', 1),
+            ( 'OPENED' , "Opened", "Open contour", 'PROP_PROJECTED', 0),
+            ( 'INPAIRS', "Pairs" , "Pair list. ex.: your list is 1,2,2,3,3,4,6,7,7,8 => as program interpret it: [1,2],[2,3],[3,4],[6,7],[7,8]. Be careful. If there is no offset with this index then pair will be skipped", 'CON_TRACKTO', 2),
+        ]
+    profile_faces__close_mode1 : EnumProperty(
+        name = "Open mode",
+        description = "Open mode",
+        items = profile_faces__close_modes,
+        default = 'CLOSED',
+        update = updateNode
+        ) # type: ignore
+
+
 
     only_tests_for_valid: BoolProperty(
         name="Only tests",
@@ -362,6 +387,16 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
         name='Verbose',
         description='Show additional debug info in console',
         default=True, update=updateNode) # type: ignore
+
+    use_cache_of_straight_skeleton: BoolProperty(
+        name='Use cache',
+        description='Use internal cache of Straight Skeleton to improve performance if the original coordinates have not changed',
+        default=False, update=updateNode) # type: ignore
+
+    bevel_more_split: BoolProperty(
+        name='Bevel more split',
+        description='If use negative offsets then this will split result beveled Offset with more parts (used only in Bevel mode). For fun. )',
+        default=False, update=updateNode) # type: ignore
 
     source_objects_join_modes = [
             ('SPLIT', "Split", "Separate the result meshes into individual meshes", 'SNAP_VERTEX', 0),
@@ -390,6 +425,8 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
     res_types = [
             ('CONTOURS', "Contours", "Edges of contours", 'SNAP_VERTEX', 0),
             ('FACES' , "Faces", "Fill faces", 'SYNTAX_ON', 1),
+            ('BEVEL' , "Bevel", "Beveled extrude throught offsets", 'MOD_BEVEL', 2),
+            ('STRAIGHT_SKELETON' , "Skeleton", "Straight Skeletons geometry. Ignore Altitude input socket", 'MOD_SKIN', 3),
         ]
 
     res_type : EnumProperty(
@@ -459,23 +496,6 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
             col.prop(self, 'ss_shapes_mode1', text='Shapes mode')
         pass
 
-    def draw_objects_mask_in_socket(self, socket, context, layout):
-        grid = layout.grid_flow(row_major=True, columns=2)
-        if not socket.is_linked:
-            grid.enabled = False
-        col2 = grid.column()
-        col2_row1 = col2.row()
-        col2_row1.alignment='LEFT'
-        if socket.is_linked:
-            col2_row1.label(text=f"Mask of Objects. {socket.objects_number or ''}:")
-        else:
-            col2_row1.label(text=f"Mask of Objects:")
-        col2_row2 = col2.row()
-        col2_row2.alignment='LEFT'
-        col2_row2.column(align=True).prop(self, "objects_mask_inversion")
-        col3 = grid.column()
-        col3.prop(self, "objects_mask_mode", expand=True)
-
     def draw_offset_mode_in_socket(self, socket, context, layout):
         grid = layout.grid_flow(row_major=False, columns=3, align=True)
         col = grid.column() # align=True
@@ -496,12 +516,60 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
             col.enabled = True
         grid.prop(self, 'altitude_mode', expand=True, icon_only=True) 
 
+
+    def draw_profile_faces_indexes_in_socket(self, socket, context, layout):
+        grid = layout.grid_flow(row_major=False, columns=3, align=True)
+        col = grid.row(align=True)
+        socket_label = socket.objects_number if hasattr(socket, "objects_number")==True else '-'
+        col.label(text=f"Profile faces indexes {socket_label}")
+        pass
+        
+        pass
+
+        #layout.prop(self, 'source_objects_join_mode', text='')
+        pass
+
+    def draw_profile_faces_close_mode_in_socket(self, socket, context, layout):
+        grid = layout.grid_flow(row_major=False, columns=3, align=True)
+        col = grid.row()
+        col.prop(self, 'profile_faces__close_mode1', expand=False, text='Profile close mode')
+        if socket.is_linked==True:
+            col.enabled = False
+        else:
+            col.enabled = True
+        grid.prop(self, 'profile_faces__close_mode__mode', expand=True, icon_only=True) 
+        pass
+
+    def draw_objects_mask_in_socket(self, socket, context, layout):
+        grid = layout.grid_flow(row_major=True, columns=2)
+        if not socket.is_linked:
+            grid.enabled = False
+        col2 = grid.column()
+        col2_row1 = col2.row()
+        col2_row1.alignment='LEFT'
+        if socket.is_linked:
+            col2_row1.label(text=f"Mask of Objects. {socket.objects_number or ''}:")
+        else:
+            col2_row1.label(text=f"Mask of Objects:")
+        col2_row2 = col2.row()
+        col2_row2.alignment='LEFT'
+        col2_row2.column(align=True).prop(self, "objects_mask_inversion")
+        col3 = grid.column()
+        col3.prop(self, "objects_mask_mode", expand=True)
+
     def draw_buttons(self, context, layout):
         col = layout.column()
-        col.row(align=True).prop(self, 'res_type', expand=True)
+        col.grid_flow(columns=2,align=True, row_major=True).prop(self, 'res_type', expand=True)
+        #col.row(align=True).prop(self, 'res_type', expand=True)
         col.prop(self, 'only_tests_for_valid')
         col.prop(self, 'force_z_zero')
-        col.prop(self, 'verbose_messages_while_process') 
+        col.prop(self, 'verbose_messages_while_process')
+        col.prop(self, 'use_cache_of_straight_skeleton')
+        col1 = layout.column()
+        col1.enabled = False
+        if self.res_type=='BEVEL' and  self.results_join_mode=='SPLIT':
+            col1.enabled = True
+        col1.prop(self, 'bevel_more_split') 
         #col.row().prop(self, 'join_mode', expand=True)
         #ui_file_save_dat = col.row()
         #self.wrapper_tracked_ui_draw_op(ui_file_save_dat, SvSaveCGALDatFile.bl_idname, text='', icon='DISK_DRIVE')
@@ -522,6 +590,8 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
         self.inputs.new('SvStringsSocket' , 'ss_shapes_modes')
         self.inputs.new('SvStringsSocket' , 'ss_offsets').prop_name = 'ss_offset1'
         self.inputs.new('SvStringsSocket' , 'ss_altitudes').prop_name = 'ss_altitude1'
+        self.inputs.new('SvStringsSocket' , 'ss_profile_faces_indexes')
+        self.inputs.new('SvStringsSocket' , 'ss_profile_faces_close_mode')
         self.inputs.new('SvStringsSocket' , 'objects_mask').label = "Mask of Objects"
         self.inputs.new('SvTextSocket'    , 'file_name')
 
@@ -534,6 +604,10 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
         self.inputs['ss_offsets'].custom_draw = 'draw_offset_mode_in_socket'
         self.inputs['ss_altitudes'].label = 'Offsets'
         self.inputs['ss_altitudes'].custom_draw = 'draw_altitude_mode_in_socket'
+        self.inputs['ss_profile_faces_indexes'].label = 'Profile faces indexes'
+        self.inputs['ss_profile_faces_indexes'].custom_draw = 'draw_profile_faces_indexes_in_socket'
+        self.inputs['ss_profile_faces_close_mode'].label = 'Profile Close mode'
+        self.inputs['ss_profile_faces_close_mode'].custom_draw = 'draw_profile_faces_close_mode_in_socket'
         self.inputs['objects_mask'].custom_draw = 'draw_objects_mask_in_socket'
         self.inputs['file_name'].label = 'File Name'
         self.inputs['file_name'].hide = True
@@ -571,6 +645,10 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
         ss_offsets2     = ensure_nesting_level(_ss_offsets, 2)
         _ss_altitudes   = inputs['ss_altitudes'].sv_get(default=[[self.ss_altitude1]], deepcopy=False)
         ss_altitudes2   = ensure_nesting_level(_ss_altitudes, 2)
+        _profile_faces_indexes   = inputs['ss_profile_faces_indexes'].sv_get(default=[[]], deepcopy=False)
+        profile_faces3_indexes   = ensure_nesting_level(_profile_faces_indexes, 3)
+        _profile_faces_close_mode   = inputs['ss_profile_faces_close_mode'].sv_get(default=[[self.profile_faces__close_mode1]], deepcopy=False)
+        profile_faces2_close_mode   = ensure_nesting_level(_profile_faces_close_mode, 2)
 
         # selecte shape mode in property
         ss_shapes_mode1 = [I for I, shapes_modes in enumerate(self.ss_shapes_modes) if shapes_modes[0] == self.ss_shapes_mode1]
@@ -602,7 +680,7 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
         #objects_area_boundaries = []
 
         contours_failed_at_all = []
-        params = zip_long_repeat(Vertices3, Edges3, Faces3)
+        params = zip_long_repeat(Vertices3, Edges3, Faces3, profile_faces3_indexes)
 
         len_vertices3 = len(Vertices3)
         np_mask = np.zeros(len_vertices3, dtype=bool)
@@ -630,12 +708,12 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
         _shapes_modes = create_list2_in_range(len_vertices3, ss_shapes_mode2, [shapes_modes[-1] for I, shapes_modes in enumerate(self.ss_shapes_modes)])
         allowed_shapes_modes = [shapes_modes[-1] for I, shapes_modes in enumerate(self.ss_shapes_modes)] # for ensurence for developers. Will not work in production mode.
 
-        for I, (verts_i, edges_i, faces_i) in enumerate( params ):
+        for I, (verts_i, edges_i, faces_i, profile_faces__indexes_I) in enumerate( params ):
             mask = objects_mask[I]
             if mask==True:
                 continue
 
-            if self.offset_mode=='OBJECT_ALL_OFFSETS':
+            if self.offset_mode=='OBJECT_ALL_OFFSETS' or self.res_type=='BEVEL':
                 if I<=len(ss_offsets2)-1:
                     ss_offsets = ss_offsets2[I]
                 else:
@@ -648,7 +726,7 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
                     ss_offsets = [ss_offsets2[0][-1]]
                 pass
             
-            if self.altitude_mode=='OBJECT_ALL_ALTITUDES':
+            if self.altitude_mode=='OBJECT_ALL_ALTITUDES' or self.res_type=='BEVEL':
                 if I<=len(ss_altitudes2)-1:
                     ss_altitudes = ss_altitudes2[I]
                 else:
@@ -659,6 +737,61 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
                     ss_altitudes = [ss_altitudes2[0][I]]
                 else:
                     ss_altitudes = [ss_altitudes2[0][-1]]
+                pass
+
+            if self.profile_faces__close_mode__mode=='OBJECT_ALL_OPEN_MODE':
+                if I<=len(profile_faces2_close_mode)-1:
+                    input_close_mode = profile_faces2_close_mode[I]
+                else:
+                    input_close_mode = profile_faces2_close_mode[-1]
+                ss_profile_faces__close_modes_I = []
+                for IJ in range(len(profile_faces__indexes_I)):
+                    # if IJ<len(input_close_mode):
+                    #     ss_profile_faces__close_modes_I.append(1 if input_close_mode[IJ] in ['CLOSED', True, 1] else 0)
+                    # else:
+                    #     ss_profile_faces__close_modes_I.append(1 if input_close_mode[-1] in ['CLOSED', True, 1] else 0)
+                    close_mode_IJ = 'OPENED'
+                    if IJ<len(input_close_mode):
+                        close_mode_IJ = input_close_mode[IJ]
+                    else:
+                        close_mode_IJ = input_close_mode[-1]
+
+                    close_mode = 0
+                    if close_mode_IJ in ['CLOSED', True, 1]:
+                        close_mode = 1
+                    elif close_mode_IJ in ['INPAIRS', 2]:
+                        close_mode = 2
+
+                    ss_profile_faces__close_modes_I.append(close_mode)
+
+                pass
+            elif self.profile_faces__close_mode__mode=='OBJECT_ONE_OPEN_MODE':
+                if I<=len(profile_faces2_close_mode[0])-1:
+                    input_close_mode = [profile_faces2_close_mode[0][I]]
+                else:
+                    input_close_mode = [profile_faces2_close_mode[0][-1]]
+
+                ss_profile_faces__close_modes_I = []
+                for IJ in range(len(profile_faces__indexes_I)):
+                    # if IJ<len(input_close_mode):
+                    #     ss_profile_faces__close_modes_I.append(0 if input_close_mode[IJ] in ['CLOSED', True, 1] else 1)
+                    # else:
+                    #     ss_profile_faces__close_modes_I.append(0 if input_close_mode[-1] in ['CLOSED', True, 1] else 1)
+                    close_mode_IJ = 'OPENED'
+                    if IJ<len(input_close_mode):
+                        close_mode_IJ = input_close_mode[IJ]
+                    else:
+                        close_mode_IJ = input_close_mode[-1]
+
+                    close_mode = 0
+                    if close_mode_IJ in ['CLOSED', True, 1]:
+                        close_mode = 1
+                    elif close_mode_IJ in ['INPAIRS', 2]:
+                        close_mode = 2
+
+                    ss_profile_faces__close_modes_I.append(close_mode)
+
+
                 pass
             
             if _shapes_modes[I]<0 or len(self.ss_shapes_modes) < _shapes_modes[I]:
@@ -708,7 +841,7 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
                     continue
                 if self.verbose_messages_while_process==True:
                     time_2_1 = time()-time_2_1
-                    print(f'object {I}, part {IJ} calc baunadries: {time_2_1}')
+                    print(f'\nobject {I}, part {IJ} calc baunadries: {time_2_1}')
 
                 if not object_I_plane_IJ_contours_edges:
                     raise Exception(f"Error: Object {I} has no boundaries. Extrusion is not possible. Objects should be flat.")
@@ -743,7 +876,15 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
                 if shapes_mode_1 in [ 'ORIGINAL_BOUNDARIES', 'EXCLUDE_HOLES', 'INVERT_HOLES', ]: # and len(object_boundaries_sorted_by_area)>1:
                     shapes_mode_1_id = [info for info in self.ss_shapes_modes if info[0]==shapes_mode_1][0][4]
                     if I not in objects_data:
-                        objects_data[I] = {"idx": I, 'offsets': ss_offsets, 'altitudes': ss_altitudes, 'planes':[], 'shape_mode':shapes_mode_1_id}
+                        objects_data[I] = {
+                            "idx": I,
+                            'offsets': ss_offsets,
+                            'altitudes': ss_altitudes,
+                            'profile_faces__indexes': profile_faces__indexes_I,
+                            'profile_faces__close_modes': ss_profile_faces__close_modes_I,
+                            'planes':[],
+                            'shape_mode':shapes_mode_1_id,
+                        }
                     objects_data[I]['planes'].append(object_I_plane_IJ_contours_sorted_by_area)
                     pass
                 else:
@@ -765,26 +906,34 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
                 res_type=0
             elif(self.res_type=='FACES'):
                 res_type=1
+            elif(self.res_type=='BEVEL'):
+                res_type=2
+            elif(self.res_type=='STRAIGHT_SKELETON'):
+                res_type=3
             else:
-                raise Exception(f"Unknown res_type={self.res_type}. Allowed only 'CONTOURS' or 'FACES'.")
+                raise Exception(f"Unknown res_type={self.res_type}. Allowed only 'CONTOURS' or 'FACES', 'BEVEL' and 'STRAIGHT_SKELETON'.")
 
             source_objects_join_mode_id = [info for info in self.source_objects_join_modes if info[0]==self.source_objects_join_mode][0][4]
             results_join_mode_id = [info for info in self.results_join_modes if info[0]==self.results_join_mode][0][4]
             data = {
                 'objects' : [],
-                'force_z_zero'          : self.force_z_zero, 
-                'res_type': res_type, 
-                'source_objects_join_mode'             : source_objects_join_mode_id,
-                'results_join_mode'             : results_join_mode_id,
-                'only_tests_for_valid'  : self.only_tests_for_valid, 
-                'verbose'               : self.verbose_messages_while_process,
+                'force_z_zero'              : self.force_z_zero, 
+                'res_type'                  : res_type, 
+                'source_objects_join_mode'  : source_objects_join_mode_id,
+                'results_join_mode'         : results_join_mode_id,
+                'only_tests_for_valid'      : self.only_tests_for_valid, 
+                'verbose'                   : self.verbose_messages_while_process,
+                'use_cache_of_straight_skeleton' : self.use_cache_of_straight_skeleton,
+                'bevel_more_split'          : self.bevel_more_split,
             }
             
             for I in range(len(objects_data)):
-                objects_data_I       = objects_data[I]
-                shape_mode_I         = objects_data_I["shape_mode"]
-                offsets_I            = objects_data_I["offsets"]
-                altitudes_I          = objects_data_I["altitudes"]
+                objects_data_I                  = objects_data[I]
+                shape_mode_I                    = objects_data_I["shape_mode"]
+                offsets_I                       = objects_data_I["offsets"]
+                altitudes_I                     = objects_data_I["altitudes"]
+                profile_faces__indexes_I        = objects_data_I["profile_faces__indexes"]
+                profile_faces__close_modes_I    = objects_data_I["profile_faces__close_modes"]
                 offsets = []
                 altitudes = []
                 for offset_index, offset1 in enumerate(offsets_I):
@@ -802,6 +951,8 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
                         #'polygon_id':I, 
                         'offsets': offsets,
                         'altitudes': altitudes,
+                        'profile_faces__indexes': profile_faces__indexes_I,
+                        'profile_faces__close_modes': profile_faces__close_modes_I,
                         'planes' : objects_data_I["planes"], # I is not wrong, boundary1 (array of contours) - plane
                     } )
 

--- a/utils/modules/vertex_utils.py
+++ b/utils/modules/vertex_utils.py
@@ -138,7 +138,7 @@ def np_vertex_normals(vertices, faces, algorithm='MWE', output_numpy=False):
     if isinstance(faces, np.ndarray):
         np_faces = faces
     else:
-        np_faces = np.array(faces)
+        np_faces = np.array(faces, dtype=object)
 
     v_normals = np.zeros(np_verts.shape, dtype=np_verts.dtype)
 


### PR DESCRIPTION
fix #5194.

- add Bevel into the node "Straight Skeleton 2D Offset"
- add Skeleton mesh output into the node "Straight Skeleton 2D Offset"
- add cache to SS calculations
- add Profile faces indexes socket and Profile close mode socket to control Profile edges in Bevel mode

![image](https://github.com/user-attachments/assets/8bf28c03-b45e-459d-8cc1-f9605d1f334c)

File for tests:
[fix_5194_Update_Straight_Skeleton_2D_Offset.examples.tests.blend.zip](https://github.com/user-attachments/files/18815911/fix_5194_Update_Straight_Skeleton_2D_Offset.examples.tests.blend.zip)
