### PR TITLE
Fix missing sockets tooltip #5206

### DIFF
--- a/core/sockets.py
+++ b/core/sockets.py
@@ -350,7 +350,6 @@ class SvSocketCommon(SvSocketProcessing):
     # utility field for showing number of objects in sockets data
     objects_number: IntProperty(min=0, options={'SKIP_SAVE'})
 
-    description : StringProperty()
     is_mandatory: BoolProperty(default=False)
     nesting_level: IntProperty(default=2)
     default_mode: EnumProperty(items=enum_item_4(['NONE', 'EMPTY_LIST', 'MATRIX', 'MASK']), default='EMPTY_LIST')


### PR DESCRIPTION
## Addressed problem description

Fix #5206

## Solution description

It seems the root cause for the missing description tooltip is that `description` property that's already present on [NodeSocket](https://docs.blender.org/api/current/bpy.types.NodeSocket.html) is overridden by custom property with the same name.
Removing override resolves the issue.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [x] Unit-tests implemented.
- [x] Ready for merge.

