### PR TITLE
Significinatly speed up foreach_get/foreach_set in some cases

### DIFF
--- a/nodes/object_nodes/material_index.py
+++ b/nodes/object_nodes/material_index.py
@@ -92,12 +92,12 @@ class SvMaterialIndexNode(SverchCustomTreeNode, bpy.types.Node):
         if prev_material_index_layer is None:
             self.debug("Creating a layer")
             prev_material_index_layer = obj.data.polygon_layers_int.new(name="prev_material_index")
-            prev_material_indices = np.full(len(obj.data.polygons), 0, dtype=int)
+            prev_material_indices = np.empty(len(obj.data.polygons), dtype="I")
             obj.data.polygons.foreach_get("material_index", prev_material_indices)
             for face_index in range(len(obj.data.polygons)):
                 prev_material_index_layer.data[face_index].value = prev_material_indices[face_index]
 
-        material_indices = np.full(len(obj.data.polygons), 0, dtype=int)
+        material_indices = np.empty(len(obj.data.polygons), dtype="I")
         material_by_face = dict(zip(faces, materials))
         for face_index in range(len(obj.data.polygons)):
             material_index = material_by_face.get(face_index, None)

--- a/nodes/object_nodes/vertex_colors_mk3.py
+++ b/nodes/object_nodes/vertex_colors_mk3.py
@@ -34,7 +34,7 @@ vcol_options = [(k, k, '', i) for i, k in enumerate(["RGB", "RGBA"])]
 
 
 def set_vertices(loop_count, obj, index_socket, indices, input_colors, colors):
-    vertex_index = np.zeros(loop_count, dtype=int)
+    vertex_index = np.empty(loop_count, dtype="I")
     loops = obj.data.loops
     loops.foreach_get("vertex_index", vertex_index)
     if index_socket.is_linked:
@@ -53,8 +53,8 @@ def set_vertices(loop_count, obj, index_socket, indices, input_colors, colors):
                 colors[:] = np.array(input_colors)[vertex_index]
 
 def set_polygons(polygon_count, obj, index_socket, indices, input_colors, colors):
-    p_start = np.empty(polygon_count, dtype=int)
-    p_total = np.empty(polygon_count, dtype=int)
+    p_start = np.empty(polygon_count, dtype="I")
+    p_total = np.empty(polygon_count, dtype="I")
     obj.data.polygons.foreach_get("loop_start", p_start)
     obj.data.polygons.foreach_get("loop_total", p_total)
     if index_socket.is_linked:

--- a/nodes/script/mesh_eval.py
+++ b/nodes/script/mesh_eval.py
@@ -212,7 +212,7 @@ class SvJsonFromMesh(bpy.types.Operator):
             layer_names = mesh.vertex_colors.keys()
             for color_layer in mesh.vertex_colors:
                 color_data = np.empty(loop_count * num_components, dtype=np.float32)
-                vertex_index = np.zeros(loop_count, dtype=int)
+                vertex_index = np.empty(loop_count, dtype="I")
                 mesh.loops.foreach_get("vertex_index", vertex_index)
                 color_layer.data.foreach_get("color", color_data)
                 color_data.shape = (loop_count, num_components)

--- a/old_nodes/viewer_bmesh.py
+++ b/old_nodes/viewer_bmesh.py
@@ -69,7 +69,7 @@ def set_vertices(obj, islands):
         for vert_idx in isle_set:
             islands_lookup[vert_idx] = isle_num
 
-    vertex_index = np.zeros(loop_count, dtype=int)
+    vertex_index = np.empty(loop_count, dtype="I")
     loops.foreach_get("vertex_index", vertex_index)
 
     num_components = 4  # ( r g b , not a )
@@ -399,7 +399,7 @@ class SvBmeshViewerNodeV28(SverchCustomTreeNode, bpy.types.Node, SvObjHelper):
         
         for obj in objs:
             mesh = obj.data
-            smooth_states = [True] * len(mesh.polygons)
+            smooth_states = np.ones(len(mesh.polygons), dtype=bool)
             mesh.polygons.foreach_set('use_smooth', smooth_states)
             mesh.update()
 

--- a/utils/blender_mesh.py
+++ b/utils/blender_mesh.py
@@ -19,49 +19,49 @@
 import numpy as np
 # taken from here https://blenderartists.org/t/efficient-copying-of-vertex-coords-to-and-from-numpy-arrays/661467/3
 def read_verts(blender_mesh, output_numpy=False):
-    mverts_co = np.zeros((len(blender_mesh.vertices)*3), dtype=np.float64)
+    mverts_co = np.empty((len(blender_mesh.vertices)*3), dtype=np.float32)
     blender_mesh.vertices.foreach_get("co", mverts_co)
     if output_numpy:
         return np.reshape(mverts_co, (len(blender_mesh.vertices), 3))
     return np.reshape(mverts_co, (len(blender_mesh.vertices), 3)).tolist()
 
 def read_verts_normal(blender_mesh, output_numpy=False):
-    mverts_normals = np.zeros((len(blender_mesh.vertices)*3), dtype=np.float64)
+    mverts_normals = np.empty((len(blender_mesh.vertices)*3), dtype=np.float32)
     blender_mesh.vertices.foreach_get("normal", mverts_normals)
     if output_numpy:
         return np.reshape(mverts_normals, (len(blender_mesh.vertices), 3))
     return np.reshape(mverts_normals, (len(blender_mesh.vertices), 3)).tolist()
 
 def read_face_normal(blender_mesh, output_numpy=False):
-    mface_normals = np.zeros((len(blender_mesh.polygons)*3), dtype=np.float64)
+    mface_normals = np.empty((len(blender_mesh.polygons)*3), dtype=np.float32)
     blender_mesh.polygons.foreach_get("normal", mface_normals)
     if output_numpy:
         return np.reshape(mface_normals, (len(blender_mesh.polygons), 3))
     return np.reshape(mface_normals, (len(blender_mesh.polygons), 3)).tolist()
 
 def read_face_center(blender_mesh, output_numpy=False):
-    centers = np.zeros((len(blender_mesh.polygons)*3), dtype=np.float64)
+    centers = np.empty((len(blender_mesh.polygons)*3), dtype=np.float32)
     blender_mesh.polygons.foreach_get("center", centers)
     if output_numpy:
         return np.reshape(centers, (len(blender_mesh.polygons), 3))
     return np.reshape(centers, (len(blender_mesh.polygons), 3)).tolist()
 
 def read_face_area(blender_mesh, output_numpy=False):
-    areas = np.zeros((len(blender_mesh.polygons)), dtype=np.float64)
+    areas = np.empty((len(blender_mesh.polygons)), dtype=np.float32)
     blender_mesh.polygons.foreach_get("area", areas)
     if output_numpy:
         return areas
     return areas.tolist()
 
 def read_edges(blender_mesh, output_numpy=False):
-    fastedges = np.zeros((len(blender_mesh.edges)*2), dtype=np.int32)
+    fastedges = np.empty((len(blender_mesh.edges)*2), dtype="I")
     blender_mesh.edges.foreach_get("vertices", fastedges)
     if output_numpy:
         return np.reshape(fastedges, (len(blender_mesh.edges), 2))
     return np.reshape(fastedges, (len(blender_mesh.edges), 2)).tolist()
 
 def read_materials_idx(blender_mesh, output_numpy=False):
-    material_index = np.zeros((len(blender_mesh.polygons)), dtype=np.float64)
+    material_index = np.empty((len(blender_mesh.polygons)), dtype="I")
     blender_mesh.polygons.foreach_get("material_index", material_index)
     if output_numpy:
         return material_index

--- a/utils/nodes_mixins/generating_objects.py
+++ b/utils/nodes_mixins/generating_objects.py
@@ -281,7 +281,7 @@ class SvMeshData(bpy.types.PropertyGroup):
         Just update position of mesh vertices, order and number of given vertices should be the same as mesh
         numpy array with float32 type will be 10 times faster than any other input data
         """
-        verts = np.array(verts, dtype=np.float32)  # todo will be this fast if it is already array float 32?
+        verts = np.array(verts, dtype=np.float32)
         self.mesh.vertices.foreach_set('co', np.ravel(verts))
 
     def copy(self) -> bpy.types.Mesh:


### PR DESCRIPTION

## Addressed problem description

Significinatly speed up foreach_get/foreach_set in some cases by using correct data types.

see https://b3d.interplanety.org/en/optimizing-the-speed-of-data-access-using-foreach_/ for general example why it's faster - basically it's just copying the entire chunk of data instead of spending time converting them to matching data type.

On "I" instead of `np.uint32` - apparently in numpy it's a different thing, see tests in https://blenderartists.org/t/foreach-get-foreach-set-attribute-types/1579029


## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [X] Code changes complete.
- [X] Code documentation complete.
- [X] Documentation for users complete (or not required, if user never sees these changes).
- [ ] Manual testing done. Will be testing for a few days.
- [X] Unit-tests implemented.
- [ ] Ready for merge.

