### PR TITLE
Use text wrapping when displaying node errors.

### DIFF
--- a/core/sv_custom_exceptions.py
+++ b/core/sv_custom_exceptions.py
@@ -61,7 +61,6 @@ class SvNotFullyConnected(SvProcessingError):
 
 class ImplicitConversionProhibited(Exception):
     def __init__(self, socket, msg=None):
-        super().__init__()
         self.socket = socket
         self.node = socket.node
         self.from_socket_type = socket.other.bl_idname
@@ -71,11 +70,8 @@ class ImplicitConversionProhibited(Exception):
                   f" to socket type {self.to_socket_type} is not supported for" \
                   f" socket {socket.name} of node {socket.node.name}. Please" \
                   f" use explicit conversion nodes."
+        super().__init__(msg)
         self.message = msg
-
-    def __str__(self):
-        return self.message
-
 
 class DependencyError(Exception):
     """Raise when some library is not installed"""

--- a/node_tree.py
+++ b/node_tree.py
@@ -32,6 +32,7 @@ from contextlib import contextmanager
 from itertools import chain, cycle
 from pathlib import Path
 from typing import Iterable, final, Optional
+import textwrap
 
 import bpy
 from bpy.props import StringProperty, BoolProperty, EnumProperty
@@ -461,7 +462,7 @@ class UpdateNodes:
         if error is not None:
             color = no_data_color if isinstance(error, SvNoDataError) else exception_color
             self.set_temp_color(color)
-            sv_bgl.draw_text(self, str(error), error_pref + self.node_id, color, 1.3, "UP")
+            sv_bgl.draw_text(self, textwrap.fill(str(error)), error_pref + self.node_id, color, 1.3, "UP")
         else:
             sv_bgl.callback_disable(error_pref + self.node_id)
             self.set_temp_color()

--- a/ui/bgl_callback_nodeview.py
+++ b/ui/bgl_callback_nodeview.py
@@ -194,6 +194,13 @@ def draw_callback_px(n_id, data):
         drawing_func(bpy.context, args, (x, y))
         restore_opengl_defaults()
 
+def get_line_height(scale=1.0):
+    ui_scale = bpy.context.preferences.system.ui_scale
+    return int(18 * scale * ui_scale)
+
+def get_text_height(scale=1.0):
+    ui_scale = bpy.context.preferences.system.ui_scale
+    return int(15 * scale * ui_scale)
 
 def _draw_text_handler(tree_id, node_id, text: str, color=(1, 1, 1, 1), scale=1.0, align='RIGHT',
                        text_coordinates=None):
@@ -228,8 +235,8 @@ def _draw_text_handler(tree_id, node_id, text: str, color=(1, 1, 1, 1), scale=1.
     x, y = x * ui_scale, y * ui_scale
 
     # todo add scale from the preferences
-    text_height = int(15 * scale * ui_scale)
-    line_height = int(18 * scale * ui_scale)
+    text_height = get_text_height(scale)
+    line_height = get_line_height(scale)
     font_id = 0
     dpi = 72
 
@@ -261,8 +268,7 @@ def _get_text_location(node, text, scale, align='RIGHT') -> tuple[int, int]:
             max_sock_num = max(len([s for s in node.inputs if not s.hide]),
                                len([s for s in node.outputs if not s.hide]))
             gap += (max_sock_num * 0.3) * max_sock_num
-        ui_scale = bpy.context.preferences.system.ui_scale
-        line_height = int(18 * scale * ui_scale)
+        line_height = get_line_height(scale)
         n = len(text.split('\n'))
         x, y = int(x), int(y + (n-1)*line_height + gap)
     elif align == "DOWN":

--- a/ui/bgl_callback_nodeview.py
+++ b/ui/bgl_callback_nodeview.py
@@ -21,6 +21,7 @@
 from __future__ import annotations  # this will fix backward compatibility with Python 3.8 and less
 
 from inspect import isfunction
+import textwrap
 
 import bpy
 import blf
@@ -63,7 +64,7 @@ def draw_text(node, text: str, draw_id=None, color=(1, 1, 1, 1), scale=1., align
         callback_disable(draw_id)
 
     color = color if len(color) == 4 else (*color, 1)
-    text_location = None if dynamic_location else _get_text_location(node, align)
+    text_location = None if dynamic_location else _get_text_location(node, text, scale, align)
     handle_pixel = SpaceNodeEditor.draw_handler_add(
         _draw_text_handler,
         (node.id_data.tree_id, node.node_id, text, color, scale, align, text_location),
@@ -216,7 +217,7 @@ def _draw_text_handler(tree_id, node_id, text: str, color=(1, 1, 1, 1), scale=1.
 
         # find node location
         node = next(n for n in editor.edit_tree.nodes if n.node_id == node_id)
-        (x, y), z = _get_text_location(node, align), 0
+        (x, y), z = _get_text_location(node, text, scale, align), 0
 
     # put static coordinates if there are a lot of nodes with text to draw (does not react on the node movements)
     else:
@@ -241,7 +242,7 @@ def _draw_text_handler(tree_id, node_id, text: str, color=(1, 1, 1, 1), scale=1.
         y -= line_height
 
 
-def _get_text_location(node, align='RIGHT') -> tuple[int, int]:
+def _get_text_location(node, text, scale, align='RIGHT') -> tuple[int, int]:
     """Find location for a text nearby given node"""
     (x, y) = node.absolute_location
     gap = 10
@@ -260,7 +261,10 @@ def _get_text_location(node, align='RIGHT') -> tuple[int, int]:
             max_sock_num = max(len([s for s in node.inputs if not s.hide]),
                                len([s for s in node.outputs if not s.hide]))
             gap += (max_sock_num * 0.3) * max_sock_num
-        x, y = int(x), int(y + gap)
+        ui_scale = bpy.context.preferences.system.ui_scale
+        line_height = int(18 * scale * ui_scale)
+        n = len(text.split('\n'))
+        x, y = int(x), int(y + (n-1)*line_height + gap)
     elif align == "DOWN":
         x, y = int(x), int(y - dy - gap)
     else:


### PR DESCRIPTION
Before:

![Screenshot_20250409_222844](https://github.com/user-attachments/assets/89259ce9-0c66-4e83-b50b-ae8b53c5fab5)

After:

![Screenshot_20250409_222908](https://github.com/user-attachments/assets/c8b0c10b-774e-4819-be1a-2406bed0a4ed)


## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

