### PR TITLE
Enhance error handling

### DIFF
--- a/core/sv_custom_exceptions.py
+++ b/core/sv_custom_exceptions.py
@@ -7,6 +7,7 @@
 
 
 class SvNoDataError(LookupError):
+    __description__ = "No data passed to socket"
     def __init__(self, socket=None, node=None, msg=None):
 
         self.extra_message = msg if msg else ""
@@ -40,14 +41,17 @@ class SvNoDataError(LookupError):
 
 
 class CancelError(Exception):
+    __description__ = "Aborted by user"
     """Aborting tree evaluation by user"""
 
 
 class SvProcessingError(Exception):
+    __description__ = "General processing error"
     pass
 
 
 class SvNotFullyConnected(SvProcessingError):
+    __description__ = "Not all required inputs are connected"
 
     def __init__(self, node, sockets):
         self.node = node
@@ -60,6 +64,7 @@ class SvNotFullyConnected(SvProcessingError):
 
 
 class ImplicitConversionProhibited(Exception):
+    __description__ = "Implicit sockets conversion is not supported"
     def __init__(self, socket, msg=None):
         self.socket = socket
         self.node = socket.node

--- a/core/update_system.py
+++ b/core/update_system.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Optional, Generator, Iterable
 from bpy.types import Node, NodeSocket, NodeTree, NodeLink
 import sverchok.core.events as ev
 import sverchok.core.tasks as ts
-from sverchok.core.sv_custom_exceptions import CancelError, SvNoDataError
+from sverchok.core.sv_custom_exceptions import CancelError, SvNoDataError, ImplicitConversionProhibited
 from sverchok.core.socket_conversions import conversions
 from sverchok.utils.profile import profile
 from sverchok.utils.sv_logging import node_error_logger
@@ -676,6 +676,16 @@ class UpdateTree(SearchTree):
             _set_color(node, use_color)
             yield node, *args
 
+def get_exception_text(ex):
+    if hasattr(ex, '__description__'):
+        descr = ex.__description__
+    elif hasattr(ex, '__doc__'):
+        descr = ex.__doc__.split('\n')[0].strip()
+    else:
+        descr = type(ex).__name__
+    if not descr.endswith('.'):
+        descr = descr + ":"
+    return descr + " " + str(ex)
 
 class AddStatistic:
     """It caches errors during execution of process method of a node and saves
@@ -701,7 +711,7 @@ class AddStatistic:
         else:
             node_error_logger.error(exc_val, exc_info=True)
             self._node[UPDATE_KEY] = False
-            self._node[ERROR_KEY] = repr(exc_val)
+            self._node[ERROR_KEY] = get_exception_text(exc_val)
 
         if self._supress and exc_type is not None:
             if issubclass(exc_type, CancelError):
@@ -726,7 +736,11 @@ def prepare_input_data(prev_socks: list[Optional[NodeSocket]],
             # cast data
             if ps.bl_idname != ns.bl_idname:
                 implicit_conversion = conversions[ns.default_conversion_name]
-                data = implicit_conversion.convert(ns, ps, data)
+                try:
+                    data = implicit_conversion.convert(ns, ps, data)
+                except ImplicitConversionProhibited as e:
+                    e.socket.links[0].is_valid = False
+                    raise
 
             ns.sv_set(data)
 

--- a/core/update_system.py
+++ b/core/update_system.py
@@ -5,6 +5,7 @@ from graphlib import TopologicalSorter
 from itertools import chain
 from time import perf_counter
 from typing import TYPE_CHECKING, Optional, Generator, Iterable
+import traceback
 
 from bpy.types import Node, NodeSocket, NodeTree, NodeLink
 import sverchok.core.events as ev
@@ -21,6 +22,7 @@ if TYPE_CHECKING:
 
 UPDATE_KEY = "US_is_updated"
 ERROR_KEY = "US_error"
+ERROR_STACK_KEY = "US_error_stack"
 TIME_KEY = "US_time"
 
 
@@ -707,11 +709,13 @@ class AddStatistic:
         if exc_type is None:
             self._node[UPDATE_KEY] = True
             self._node[ERROR_KEY] = None
+            self._node[ERROR_STACK_KEY] = None
             self._node[TIME_KEY] = perf_counter() - self._start
         else:
             node_error_logger.error(exc_val, exc_info=True)
             self._node[UPDATE_KEY] = False
             self._node[ERROR_KEY] = get_exception_text(exc_val)
+            self._node[ERROR_STACK_KEY] = "".join(traceback.format_exception(exc_val))
 
         if self._supress and exc_type is not None:
             if issubclass(exc_type, CancelError):

--- a/docs/user_interface/preferences.rst
+++ b/docs/user_interface/preferences.rst
@@ -120,6 +120,11 @@ errors in your node trees or in Sverchok itself.
   * **Warnings**. Write only warnings and errors.
   * **Errors**. Write error messages only.
 
+* **Log exception stacks**. If checked, then for each logged error Sverchok
+  will also write it's Python traceback flag into log. Such tracebacks can help
+  Sverchok developers to understand the cause of error. Unchecked by default.
+  This flag is not visible when **Logging level** is set to Debug, because with
+  Debug level exception stacks are always logged.
 * **Log to text buffer**. If checked, Sverchok will write log into text buffer
   within current Blender file. The name of that buffer is specified in the
   **Buffer name** parameter (the default is ``sverchok.log``).

--- a/settings.py
+++ b/settings.py
@@ -412,6 +412,9 @@ class SverchokPreferences(AddonPreferences):
     log_buffer_name: StringProperty(name = "Buffer name", default = "sverchok.log")
     log_file_name: StringProperty(name = "File path", default = join(datafiles, "sverchok.log"))
 
+    log_tracebacks: BoolProperty(name = "Log exception stacks",
+                                 description = "Write Python exception tracebacks to logs",
+                                 default = False)
 
     # updating sverchok
     dload_archive_name: StringProperty(name="archive name", default="master") # default = "master"
@@ -501,6 +504,8 @@ class SverchokPreferences(AddonPreferences):
         log_box = col2.box()
         log_box.label(text="Logging:")
         log_box.prop(self, "log_level")
+        if self.log_level != 'DEBUG':
+            log_box.prop(self, "log_tracebacks")
 
         buff_row = log_box.row()
         buff_row.prop(self, "log_to_buffer")

--- a/ui/nodeview_rclick_menu.py
+++ b/ui/nodeview_rclick_menu.py
@@ -240,7 +240,6 @@ class SvGenericDeligationOperator(bpy.types.Operator):
         elif self.fn == 'copy_error':
             message = tree.nodes.active.get(ERROR_KEY, None)
             stack = tree.nodes.active.get(ERROR_STACK_KEY, "")
-            print("STACK:", tree.nodes.active, stack)
             if message:
                 message = message + "\n" + stack
                 context.window_manager.clipboard = message

--- a/ui/nodeview_rclick_menu.py
+++ b/ui/nodeview_rclick_menu.py
@@ -7,7 +7,7 @@
 
 
 import bpy
-from sverchok.core.update_system import ERROR_KEY
+from sverchok.core.update_system import ERROR_KEY, ERROR_STACK_KEY
 import sverchok.ui.nodeview_space_menu as sm
 from sverchok.utils.sv_node_utils import frame_adjust
 from sverchok.ui.presets import node_supports_presets, apply_default_preset
@@ -239,7 +239,10 @@ class SvGenericDeligationOperator(bpy.types.Operator):
             add_connection(tree, bl_idname_new_node="SvStethoscopeNodeMK2", offset=[60, 0])
         elif self.fn == 'copy_error':
             message = tree.nodes.active.get(ERROR_KEY, None)
+            stack = tree.nodes.active.get(ERROR_STACK_KEY, "")
+            print("STACK:", tree.nodes.active, stack)
             if message:
+                message = message + "\n" + stack
                 context.window_manager.clipboard = message
         return {'FINISHED'}
 

--- a/utils/sv_logging.py
+++ b/utils/sv_logging.py
@@ -75,7 +75,7 @@ def add_node_error_location(record: logging.LogRecord):
     frame_info = inspect.getinnerframes(record.exc_info[-1])[-1]
     record.relative_path = Path(frame_info.filename).name
     record.lineno = frame_info.lineno
-    if not is_enabled_for('DEBUG'):  # show traceback only in DEBUG mode
+    if not is_log_traceback_enabled():
         record.exc_info = None
     return True
 
@@ -224,3 +224,8 @@ def is_enabled_for(log_level="DEBUG") -> bool:
     current_level = getattr(logging, addon.preferences.log_level)
     given_level = getattr(logging, log_level)
     return given_level >= current_level
+
+def is_log_traceback_enabled() -> bool:
+    addon = bpy.context.preferences.addons.get(sverchok.__name__)
+    return addon.preferences.log_tracebacks or is_enabled_for("DEBUG")
+


### PR DESCRIPTION
* By "Copy error message" command in node right-click menu, copy both error message and exception stack.
* Use separate flag ("Log exception stacks") in Sverchok preferences to indicate if it is required to write stacks to log.
* When displaying the exception in node view, use exception description instead of programmatic name, and use more human-readable format: `Inappropriate argument type: blablabla` instead of `TypeError("blablabla")`.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

