### PR TITLE
Use modern Python unittest API for testing

### DIFF
--- a/tests/cubic_spline_tests.py
+++ b/tests/cubic_spline_tests.py
@@ -41,7 +41,7 @@ class CubicSplineTests(SverchokTestCase):
     def test_control_points_1(self):
         #index = np.array([0,1,2])
         points = self.spline.get_control_points()
-        self.assertEquals(points.shape, (3, 4, 3))
+        self.assertEqual(points.shape, (3, 4, 3))
         #print(points)
         for i in range(3):
             with self.subTest(segmentNum=i):

--- a/tests/data_structure_tests.py
+++ b/tests/data_structure_tests.py
@@ -7,54 +7,54 @@ class DataStructureTests(SverchokTestCase):
         inputs = [[1,2,3,4,5], [10,11]]
         output = match_long_repeat(inputs)
         expected_output = [[1,2,3,4,5], [10,11,11,11,11]]
-        self.assertEquals(output, expected_output)
+        self.assertEqual(output, expected_output)
 
     def test_match_long_repeat_2(self):
         inputs = [[1], [2]]
         output = match_long_repeat(inputs)
         expected_output = [[1], [2]]
-        self.assertEquals(output, expected_output)
+        self.assertEqual(output, expected_output)
 
     def test_match_long_cycle(self):
         inputs = [[1,2,3,4,5] ,[10,11]]
         output = match_long_cycle(inputs)
         expected_output = [[1,2,3,4,5] ,[10,11,10,11,10]]
-        self.assertEquals(output, expected_output)
+        self.assertEqual(output, expected_output)
 
     def test_full_list_1(self):
         data = [1,2,3]
         fullList(data, 7)
-        self.assertEquals(data, [1, 2, 3, 3, 3, 3, 3])
+        self.assertEqual(data, [1, 2, 3, 3, 3, 3, 3])
 
     def test_full_list_2(self):
         data = [[1], [2], [3]]
         fullList(data, 7)
-        self.assertEquals(data, [[1], [2], [3], [3], [3], [3], [3]])
+        self.assertEqual(data, [[1], [2], [3], [3], [3], [3], [3]])
 
     def test_full_list_deep_copy(self):
         data = [[3], [2], [1]]
         fullList_deep_copy(data, 7)
-        self.assertEquals(data, [[3], [2], [1], [1], [1], [1], [1]])
+        self.assertEqual(data, [[3], [2], [1], [1], [1], [1], [1]])
 
     def test_repeat_last_for_length_1(self):
         data = None
         result = repeat_last_for_length(data, 4)
-        self.assertEquals(result, None)
+        self.assertEqual(result, None)
 
     def test_repeat_last_for_length_2(self):
         data = []
         result = repeat_last_for_length(data, 4)
-        self.assertEquals(result, [])
+        self.assertEqual(result, [])
 
     def test_repeat_last_for_length_3(self):
         data = [1,2,3,4]
         result = repeat_last_for_length(data, 4)
-        self.assertEquals(result, data)
+        self.assertEqual(result, data)
 
     def test_repeat_last_for_length_4(self):
         data = [1,2,3]
         result = repeat_last_for_length(data, 4)
-        self.assertEquals(result, [1,2,3,3])
+        self.assertEqual(result, [1,2,3,3])
 
     def test_get_data_nesting_level_1(self):
         self.subtest_assert_equals(get_data_nesting_level(1), 0)
@@ -86,13 +86,13 @@ class DataStructureTests(SverchokTestCase):
         input = [1, 2, 3]
         expected_output = [2, 3, 1]
         output = rotate_list(input)
-        self.assertEquals(output, expected_output)
+        self.assertEqual(output, expected_output)
 
     def test_rotate_list_2(self):
         input = [1, 2, 3]
         expected_output = [3, 1, 2]
         output = rotate_list(input, 2)
-        self.assertEquals(output, expected_output)
+        self.assertEqual(output, expected_output)
 
     def test_describe_data_shape_1(self):
         self.subtest_assert_equals(describe_data_shape(None), 'Level 0: NoneType')
@@ -226,49 +226,49 @@ class CalcMaskTests(SverchokTestCase):
         set = [1, 2, 3]
         mask = calc_mask(subset, set, level=0)
         expected = [True, False, False]
-        self.assertEquals(mask, expected)
+        self.assertEqual(mask, expected)
 
     def test_calc_mask_2(self):
         subset = [1]
         set = [1, 2, 3]
         mask = calc_mask(subset, set, negate=True)
         expected = [False, True, True]
-        self.assertEquals(mask, expected)
+        self.assertEqual(mask, expected)
 
     def test_calc_mask_3(self):
         subset = [[1, 2], [3, 4]]
         set = [[1, 2], [3, 4], [5, 6]]
         mask = calc_mask(subset, set, level=0)
         expected = [True, True, False]
-        self.assertEquals(mask, expected)
+        self.assertEqual(mask, expected)
 
     def test_calc_mask_4(self):
         subset = [[1, 2], [3, 4]]
         set = [[1, 2], [3, 4], [5, 6]]
         mask = calc_mask(subset, set, level=1)
         expected = [[True, True], [True, True], [False, False]]
-        self.assertEquals(mask, expected)
+        self.assertEqual(mask, expected)
 
     def test_calc_mask_5(self):
         subset = [[1], [5,6]]
         set = [[1, 2, 3], [7, 8, 9]]
         mask = calc_mask(subset, set, level=0)
         expected = [False, False]
-        self.assertEquals(mask, expected)
+        self.assertEqual(mask, expected)
 
     def test_calc_mask_6(self):
         subset = [[1], [5,6]]
         set = [[1, 2, 3], [7, 8, 9]]
         mask = calc_mask(subset, set, level=1)
         expected = [[True, False, False], [False, False, False]]
-        self.assertEquals(mask, expected)
+        self.assertEqual(mask, expected)
 
     def test_calc_mask_7(self):
         subset = [[1, 2], [3, 4]]
         set = [[2, 1], [5, 6]]
         mask = calc_mask(subset, set, ignore_order=True)
         expected = [True, False]
-        self.assertEquals(mask, expected)
+        self.assertEqual(mask, expected)
 
 class MapRecursiveTests(SverchokTestCase):
     def test_map_1(self):

--- a/tests/dict_tests.py
+++ b/tests/dict_tests.py
@@ -9,37 +9,37 @@ class ApproxDictTests(SverchokTestCase):
     def test_repr(self):
         d = SvApproxDict([(1.0, "A"), (2.0, "B")])
         s = repr(d)
-        self.assertEquals(s, "{1.0: A, 2.0: B}")
+        self.assertEqual(s, "{1.0: A, 2.0: B}")
 
     def test_dict_1(self):
         d = SvApproxDict([(1.0, "A"), (2.0, "B")], precision=1)
         d[2.01] = "C"
 
-        self.assertEquals(repr(d), "{1.0: A, 2.0: C}")
+        self.assertEqual(repr(d), "{1.0: A, 2.0: C}")
 
-        self.assertEquals(d[1.0], "A")
-        self.assertEquals(d[1.01], "A")
-        self.assertEquals(d[0.99], "A")
+        self.assertEqual(d[1.0], "A")
+        self.assertEqual(d[1.01], "A")
+        self.assertEqual(d[0.99], "A")
 
-        self.assertEquals(d[2.0], "C")
-        self.assertEquals(d[2.01], "C")
-        self.assertEquals(d[1.99], "C")
+        self.assertEqual(d[2.0], "C")
+        self.assertEqual(d[2.01], "C")
+        self.assertEqual(d[1.99], "C")
 
         d[2.5] = "K"
 
-        self.assertEquals(repr(d), "{1.0: A, 2.0: C, 2.5: K}")
+        self.assertEqual(repr(d), "{1.0: A, 2.0: C, 2.5: K}")
 
-        self.assertEquals(d[2.5], "K")
-        self.assertEquals(d[2.51], "K")
-        self.assertEquals(d[2.49], "K")
+        self.assertEqual(d[2.5], "K")
+        self.assertEqual(d[2.51], "K")
+        self.assertEqual(d[2.49], "K")
 
         d[1.5] = "H"
 
-        self.assertEquals(repr(d), "{1.0: A, 1.5: H, 2.0: C, 2.5: K}")
+        self.assertEqual(repr(d), "{1.0: A, 1.5: H, 2.0: C, 2.5: K}")
 
-        self.assertEquals(d[1.5], "H")
-        self.assertEquals(d[1.51], "H")
-        self.assertEquals(d[1.49], "H")
+        self.assertEqual(d[1.5], "H")
+        self.assertEqual(d[1.51], "H")
+        self.assertEqual(d[1.49], "H")
 
 class KnotvectorDictTests(SverchokTestCase):
     def test_dict_1(self):
@@ -54,7 +54,7 @@ class KnotvectorDictTests(SverchokTestCase):
             d.update(2, k, 1)
 
         expected_items = [(0, 1), (0.499, 1), (0.5, 1), (0.501, 1), (1, 1)]
-        self.assertEquals(d.items(), expected_items)
+        self.assertEqual(d.items(), expected_items)
 
     def test_dict_2(self):
         d = KnotvectorDict(accuracy=3)
@@ -68,7 +68,7 @@ class KnotvectorDictTests(SverchokTestCase):
             d.update(2, k, m)
 
         expected_items = [(0, 4), (0.499, 3), (0.5, 3), (0.501, 3), (1, 4)]
-        self.assertEquals(d.items(), expected_items)
+        self.assertEqual(d.items(), expected_items)
 
     def test_dict_3(self):
         d = KnotvectorDict(accuracy=2)
@@ -78,12 +78,12 @@ class KnotvectorDictTests(SverchokTestCase):
             d.update(1, k, m)
 
         expected_items = [(0, 4), (0.499, 3), (0.501, 3), (1, 4)]
-        self.assertEquals(d.items(), expected_items)
+        self.assertEqual(d.items(), expected_items)
 
         curve2_kv = [(0,4), (0.5, 3), (1, 4)]
         for k, m in curve2_kv:
             d.update(2, k, m)
 
         expected_items = [(0, 4), (0.5, 3), (0.501, 3), (1, 4)]
-        self.assertEquals(d.items(), expected_items)
+        self.assertEqual(d.items(), expected_items)
 

--- a/tests/formula_interpolate_tests.py
+++ b/tests/formula_interpolate_tests.py
@@ -8,43 +8,43 @@ class DocumentationTests(SverchokTestCase):
         points = []
         result = split_points(points)
         expected_result = []
-        self.assertEquals(result, expected_result)
+        self.assertEqual(result, expected_result)
 
     def test_single(self):
         points = [ControlPoint(1, 2, False)]
         result = split_points(points)
         expected_result = [points]
-        self.assertEquals(result, expected_result)
+        self.assertEqual(result, expected_result)
 
     def test_two_smooth(self):
         points = [ControlPoint(1, 2, False), ControlPoint(2, 3, False)]
         result = split_points(points)
         expected_result = [points]
-        self.assertEquals(result, expected_result)
+        self.assertEqual(result, expected_result)
 
     def test_two_sharp(self):
         points = [ControlPoint(1, 2, True), ControlPoint(2, 3, True)]
         result = split_points(points)
         expected_result = [points]
-        self.assertEquals(result, expected_result)
+        self.assertEqual(result, expected_result)
 
     def test_two_mixed_1(self):
         points = [ControlPoint(1, 2, True), ControlPoint(2, 3, False)]
         result = split_points(points)
         expected_result = [points]
-        self.assertEquals(result, expected_result)
+        self.assertEqual(result, expected_result)
 
     def test_two_mixed_2(self):
         points = [ControlPoint(1, 2, False), ControlPoint(2, 3, True)]
         result = split_points(points)
         expected_result = [points]
-        self.assertEquals(result, expected_result)
+        self.assertEqual(result, expected_result)
 
     def test_three(self):
         points = [ControlPoint(1, 2, False), ControlPoint(2, 3, False), ControlPoint(3, 1, False)]
         result = split_points(points)
         expected_result = [points]
-        self.assertEquals(result, expected_result)
+        self.assertEqual(result, expected_result)
 
     def test_one_sharp(self):
         points = [ControlPoint(1, 2, False), ControlPoint(2, 3, True), ControlPoint(3, 1, False)]
@@ -53,7 +53,7 @@ class DocumentationTests(SverchokTestCase):
                 [ControlPoint(1, 2, False), ControlPoint(2, 3, True)],
                 [ControlPoint(2, 3, True), ControlPoint(3, 1, False)]
             ]
-        self.assertEquals(result, expected_result)
+        self.assertEqual(result, expected_result)
 
     def test_two_sharp_1(self):
         points = [ControlPoint(1, 2, False), ControlPoint(2, 3, True), ControlPoint(3, 1, True), ControlPoint(4, 2, False)]
@@ -63,7 +63,7 @@ class DocumentationTests(SverchokTestCase):
                 [ControlPoint(2, 3, True), ControlPoint(3, 1, True)],
                 [ControlPoint(3, 1, True), ControlPoint(4, 2, False)]
             ]
-        self.assertEquals(result, expected_result)
+        self.assertEqual(result, expected_result)
 
     def test_two_sharp_2(self):
         points = [ControlPoint(1, 2, False), ControlPoint(2, 3, True), ControlPoint(3, 1, False), ControlPoint(4, 2, True), ControlPoint(5, 1, False)]
@@ -73,4 +73,4 @@ class DocumentationTests(SverchokTestCase):
                 [ControlPoint(2, 3, True), ControlPoint(3, 1, False), ControlPoint(4, 2, True)],
                 [ControlPoint(4, 2, True), ControlPoint(5, 1, False)]
             ]
-        self.assertEquals(result, expected_result)
+        self.assertEqual(result, expected_result)

--- a/tests/general_fuse_tests.py
+++ b/tests/general_fuse_tests.py
@@ -43,9 +43,9 @@ class GeneralFuseTests(NodeProcessTestCase):
 
         out = self.get_output_data("Solid")
         out_level = get_data_nesting_level(out, data_types=(Part.Shape,))
-        self.assertEquals(out_level, 1)
+        self.assertEqual(out_level, 1)
         out_len = len(out)
-        self.assertEquals(out_len, 1)
+        self.assertEqual(out_len, 1)
 
         map = self.get_output_data("SolidSources")
         self.assert_sverchok_data_equal(map, [[0, 1]])
@@ -86,9 +86,9 @@ class GeneralFuseTests(NodeProcessTestCase):
 
         out = self.get_output_data("Solid")
         out_level = get_data_nesting_level(out, data_types=(Part.Shape,))
-        self.assertEquals(out_level, 1)
+        self.assertEqual(out_level, 1)
         out_len = len(out)
-        self.assertEquals(out_len, 3)
+        self.assertEqual(out_len, 3)
 
         map = self.get_output_data("SolidSources")
         self.assert_sverchok_data_equal(map, [[0], [0,1], [1]])
@@ -126,9 +126,9 @@ class GeneralFuseTests(NodeProcessTestCase):
 
         out = self.get_output_data("Solid")
         out_level = get_data_nesting_level(out, data_types=(Part.Shape,))
-        self.assertEquals(out_level, 1)
+        self.assertEqual(out_level, 1)
         out_len = len(out)
-        self.assertEquals(out_len, 1)
+        self.assertEqual(out_len, 1)
 
         map = self.get_output_data("SolidSources")
         self.assert_sverchok_data_equal(map, [[0,1]])
@@ -166,9 +166,9 @@ class GeneralFuseTests(NodeProcessTestCase):
 
         out = self.get_output_data("Solid")
         out_level = get_data_nesting_level(out, data_types=(Part.Shape,))
-        self.assertEquals(out_level, 2)
+        self.assertEqual(out_level, 2)
         #out_len = len(out)
-        #self.assertEquals(out_len, 1)
+        #self.assertEqual(out_len, 1)
 
         map = self.get_output_data("SolidSources")
         self.assert_sverchok_data_equal(map, [[[0], [0,1], [1]]])

--- a/tests/geom_tests.py
+++ b/tests/geom_tests.py
@@ -12,19 +12,19 @@ class GeometryTests(SverchokTestCase):
         input = [(0, 0, 0)]
         output = center(input)
         expected_output = input[0]
-        self.assertEquals(output, expected_output)
+        self.assertEqual(output, expected_output)
 
     def test_center_quad(self):
         inputs = [(-1, 0, 0), (0, -1, 0), (0, 1, 0), (1, 0, 0)]
         output = center(inputs)
         expected_output = (0, 0, 0)
-        self.assertEquals(output, expected_output)
+        self.assertEqual(output, expected_output)
 
     def test_normal_quad(self):
         inputs = [(-1, 0, 0), (0, -1, 0), (1, 0, 0), (0, 1, 0)]
         output = calc_normal(inputs)
         expected_output = Vector((0, 0, 1))
-        self.assertEquals(output, expected_output)
+        self.assertEqual(output, expected_output)
 
     def test_circle_equal_1(self):
         circle1 = SvCircle(Matrix(), 1.0)
@@ -116,7 +116,7 @@ class GeometryTests(SverchokTestCase):
         plane = PlaneEquation.from_coordinate_plane('XY')
         point = (1,1,1)
         uv = tuple(plane.point_uv_projection(point))
-        self.assertEquals(uv, (1,1))
+        self.assertEqual(uv, (1,1))
 
     def test_intersect_planes_1(self):
         plane1 = PlaneEquation.from_coordinate_plane('XY')

--- a/tests/issue_4757_tests.py
+++ b/tests/issue_4757_tests.py
@@ -32,7 +32,7 @@ class ConcatenateTests(SverchokTestCase):
                 else:
                     curve = concatenate_curves([curve1, curve2, curve3, curve4])
 
-                self.assertEquals(len(curve.get_control_points()), 13)
+                self.assertEqual(len(curve.get_control_points()), 13)
 
         run_test(SvNurbsMaths.NATIVE, True)
         run_test(SvNurbsMaths.NATIVE, False)

--- a/tests/linear_approximation_tests.py
+++ b/tests/linear_approximation_tests.py
@@ -9,10 +9,10 @@ class PlaneTests(SverchokTestCase):
         p2 = (0, 1, 0)
         p3 = (0, 0, 1)
         plane = PlaneEquation.from_three_points(p1, p2, p3)
-        self.assertEquals(plane.a, 1)
-        self.assertEquals(plane.b, 1)
-        self.assertEquals(plane.c, 1)
-        self.assertEquals(plane.d, -1)
+        self.assertEqual(plane.a, 1)
+        self.assertEqual(plane.b, 1)
+        self.assertEqual(plane.c, 1)
+        self.assertEqual(plane.d, -1)
 
     def test_nearest_to_origin(self):
         p1 = (1, 0, 0)
@@ -49,7 +49,7 @@ class PlaneTests(SverchokTestCase):
         plane = PlaneEquation.from_coordinate_plane('XY')
         point = (1, 2, 3)
         distance = plane.distance_to_point(point)
-        self.assertEquals(distance, 3)
+        self.assertEqual(distance, 3)
 
     def test_distance_to_points(self):
         plane = PlaneEquation.from_coordinate_plane('XY')
@@ -95,7 +95,7 @@ class LineTests(SverchokTestCase):
     def test_distance_to_point(self):
         line = LineEquation.from_coordinate_axis('Z')
         point = (0, 2, 0)
-        self.assertEquals(line.distance_to_point(point), 2)
+        self.assertEqual(line.distance_to_point(point), 2)
 
 class LinearApproximationTests(SverchokTestCase):
     def test_approximate_line_1(self):

--- a/tests/linear_spline_tests.py
+++ b/tests/linear_spline_tests.py
@@ -39,7 +39,7 @@ class LinearSplineTests(SverchokTestCase):
 
     def test_control_points(self):
         points = self.spline.get_control_points()
-        self.assertEquals(points.shape, (3,2,3))
+        self.assertEqual(points.shape, (3,2,3))
         expected = np.array(list(zip(self.control_points, self.control_points[1:])))
         self.assert_numpy_arrays_equal(points, expected)
 

--- a/tests/math_tests.py
+++ b/tests/math_tests.py
@@ -8,21 +8,21 @@ class MathTests(SverchokTestCase):
         sizes = [5.0, 5.0]
         counts = distribute_int(n, sizes)
         expected_counts = [5, 5]
-        self.assertEquals(counts, expected_counts)
+        self.assertEqual(counts, expected_counts)
 
     def test_distribute_int_2(self):
         n = 10
         sizes = [3.0, 1.0, 2.0]
         counts = distribute_int(n, sizes)
         expected_counts = [6, 1, 3]
-        self.assertEquals(counts, expected_counts)
+        self.assertEqual(counts, expected_counts)
 
     def test_distribute_int_3(self):
         n = 10
         sizes = [3.0, 1.0, 0.0]
         counts = distribute_int(n, sizes)
         expected_counts = [8, 2, 0]
-        self.assertEquals(counts, expected_counts)
+        self.assertEqual(counts, expected_counts)
 
     @unittest.skip
     def test_distribute_int_3(self):
@@ -30,12 +30,12 @@ class MathTests(SverchokTestCase):
         sizes = [5.0, 5.0]
         counts = distribute_int(n, sizes)
         expected_counts = [0, 1]
-        self.assertEquals(counts, expected_counts)
+        self.assertEqual(counts, expected_counts)
 
     def test_binom_1(self):
-        self.assertEquals(binomial(2,1), 2)
-        self.assertEquals(binomial(2,0), 1)
-        self.assertEquals(binomial(2,2), 1)
+        self.assertEqual(binomial(2,1), 2)
+        self.assertEqual(binomial(2,0), 1)
+        self.assertEqual(binomial(2,2), 1)
 
     def test_binom_array(self):
         binom = binomial_array(4)

--- a/tests/nurbs_tests.py
+++ b/tests/nurbs_tests.py
@@ -489,7 +489,7 @@ class OtherNurbsTests(SverchokTestCase):
             raise Exception(kv_err)
         knot = 0.5
         inserted = curve.insert_knot(knot, 2)
-        self.assertEquals(len(inserted.get_control_points()), len(points)+2)
+        self.assertEqual(len(inserted.get_control_points()), len(points)+2)
         self.assert_numpy_arrays_equal(inserted.evaluate_array(ts), orig_pts, precision=8)
 
         expected_inserted_kv = np.array([0, 0, 0, 0, 0.5, 0.5, 1, 1, 1, 1])
@@ -518,7 +518,7 @@ class OtherNurbsTests(SverchokTestCase):
         knot = 0.1
         inserted = curve.insert_knot(knot, 1)
 
-        self.assertEquals(len(inserted.get_control_points()), len(points)+1)
+        self.assertEqual(len(inserted.get_control_points()), len(points)+1)
 
         expected_inserted_kv = np.array([0, 0, 0, 0,  0.1, 0.25, 0.75, 1, 1, 1, 1])
         self.assert_numpy_arrays_equal(inserted.get_knotvector(), expected_inserted_kv, precision=8)
@@ -731,8 +731,8 @@ class OtherNurbsTests(SverchokTestCase):
         arc.u_bounds = (0.0, eq.arc_angle)
         nurbs = arc.to_nurbs()
         u_min, u_max = nurbs.get_u_bounds()
-        self.assertEquals(u_min, 0, "U_min")
-        self.assertEquals(u_max, eq.arc_angle, "U_max")
+        self.assertEqual(u_min, 0, "U_min")
+        self.assertEqual(u_max, eq.arc_angle, "U_max")
         startpoint = nurbs.evaluate(u_min)
         self.assert_sverchok_data_equal(startpoint.tolist(), pt1, precision=8)
         endpoint = nurbs.evaluate(u_max)
@@ -748,8 +748,8 @@ class OtherNurbsTests(SverchokTestCase):
         arc.u_bounds = (0.0, eq.arc_angle)
         nurbs = arc.to_nurbs()
         u_min, u_max = nurbs.get_u_bounds()
-        self.assertEquals(u_min, 0, "U_min")
-        self.assertEquals(u_max, eq.arc_angle, "U_max")
+        self.assertEqual(u_min, 0, "U_min")
+        self.assertEqual(u_max, eq.arc_angle, "U_max")
         startpoint = nurbs.evaluate(u_min)
         self.assert_sverchok_data_equal(startpoint.tolist(), pt1, precision=6)
         endpoint = nurbs.evaluate(u_max)
@@ -951,7 +951,7 @@ class TaylorTests(SverchokTestCase):
 
         result = curve.is_strongly_outside_sphere(np.array([0, 0, 0]), 2)
         expected_result = False
-        self.assertEquals(result, expected_result)
+        self.assertEqual(result, expected_result)
 
     def test_outside_sphere_2(self):
         cpts = np.array([[-2, 1, 0], [2, 1, 0]])
@@ -961,7 +961,7 @@ class TaylorTests(SverchokTestCase):
 
         result = curve.is_strongly_outside_sphere(np.array([0, 0, 0]), 1)
         expected_result = False
-        self.assertEquals(result, expected_result)
+        self.assertEqual(result, expected_result)
 
     def test_outside_sphere_3(self):
         cpts = np.array([[-2, 5, 0], [2, 5, 0]])
@@ -971,7 +971,7 @@ class TaylorTests(SverchokTestCase):
 
         result = curve.is_strongly_outside_sphere(np.array([0, 0, 0]), 1)
         expected_result = True
-        self.assertEquals(result, expected_result)
+        self.assertEqual(result, expected_result)
 
 class CurveDegreeTests(SverchokTestCase):
     def test_elevate_degree(self):

--- a/tests/profile_mk3_tests.py
+++ b/tests/profile_mk3_tests.py
@@ -7,92 +7,92 @@ from sverchok.nodes.script.profile_mk3 import profile_template_path
 class SimpleTests(SverchokTestCase):
     def test_identifier(self):
         result = parse(parse_identifier, "z")
-        self.assertEquals(result, "z")
+        self.assertEqual(result, "z")
 
     def test_expr(self):
         string = "{r+1}"
         result = parse(parse_value, string)
         expected = Expression.from_string(string)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_negated_var(self):
         string = "-x"
         result = parse(parse_value, string)
         expected = NegatedVariable("x")
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
 class StatementParseTests(SverchokTestCase):
     def test_parse_default(self):
         string = "default v1 = 5"
         result = parse(parse_statement, string)
         expected = Default("v1", Const(5))
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_parse_assign(self):
         string = "let v2 = v1"
         result = parse(parse_statement, string)
         expected = Assign("v2", Variable("v1"))
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_parse_moveto(self):
         string = "M x,y"
         result = parse(parse_statement, string)
         expected = MoveTo(True, Variable("x"), Variable("y"))
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_parse_lineto(self):
         string = "L 1,2 3,4"
         result = parse(parse_statement, string)
         expected = LineTo(True, [(Const(1), Const(2)), (Const(3), Const(4))], None, False)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_parse_lineto_n(self):
         string = "L 1,2 3,4 n=10"
         result = parse(parse_statement, string)
         expected = LineTo(True, [(Const(1), Const(2)), (Const(3), Const(4))], Const(10), False)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_parse_hor_lineto(self):
         string = "H 1 2;"
         result = parse(parse_statement, string)
         expected = HorizontalLineTo(True, [Const(1), Const(2)], None)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_parse_hor_lineto_n(self):
         string = "H 1 2 n=10;"
         result = parse(parse_statement, string)
         expected = HorizontalLineTo(True, [Const(1), Const(2)], Const(10))
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_parse_vert_lineto(self):
         string = "V 1 2;"
         result = parse(parse_statement, string)
         expected = VerticalLineTo(True, [Const(1), Const(2)], None)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_parse_vert_lineto_n(self):
         string = "V 1 2 n=10;"
         result = parse(parse_statement, string)
         expected = VerticalLineTo(True, [Const(1), Const(2)], Const(10))
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_parse_curveto(self):
         string = "C 1,2 3,4 5,6"
         result = parse(parse_statement, string)
         expected = CurveTo(True, [CurveTo.Segment((Const(1), Const(2)), (Const(3), Const(4)), (Const(5), Const(6)))], None, False)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_close_path(self):
         string = "x"
         result = parse(parse_statement, string)
         expected = ClosePath()
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_close_All(self):
         string = "X"
         result = parse(parse_statement, string)
         expected = CloseAll()
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     # Other statement types: to be implemented
 

--- a/tests/simple_viewer_text_tests.py
+++ b/tests/simple_viewer_text_tests.py
@@ -25,4 +25,4 @@ class TextViewerTest(EmptyTreeTestCase):
         # in the file from the first test run.
         with open(self.get_reference_file_path("text_viewer_out.txt"), "r") as f:
             expected_text = f.read()
-            self.assertEquals(text, expected_text)
+            self.assertEqual(text, expected_text)

--- a/utils/testing.py
+++ b/utils/testing.py
@@ -370,7 +370,7 @@ class SverchokTestCase(unittest.TestCase):
         """
         actual_data = self.serialize_json(actual_json)
         expected_data = self.serialize_json(expected_json)
-        self.assertEquals(actual_data, expected_data)
+        self.assertEqual(actual_data, expected_data)
 
     def assert_json_equals_file(self, actual_json, expected_json_file_name):
         """
@@ -411,7 +411,7 @@ class SverchokTestCase(unittest.TestCase):
         if not node2.inputs[node2_input_name].is_linked:
             raise AssertionError("Input `{}' of node `{}' is not linked to anything", node2_input_name, node2_name)
 
-        self.assertEquals(node1.outputs[node1_output_name].other, node2.inputs[node2_input_name])
+        self.assertEqual(node1.outputs[node1_output_name].other, node2.inputs[node2_input_name])
 
     def assert_nodes_are_equal(self, actual, reference):
         """
@@ -527,7 +527,7 @@ class SverchokTestCase(unittest.TestCase):
             else:
                 l1 = len(item1)
                 l2 = len(item2)
-                self.assertEquals(l1, l2, format_message(f"Size of data 1 at level {step} != size of data 2"))
+                self.assertEqual(l1, l2, format_message(f"Size of data 1 at level {step} != size of data 2"))
                 for next_idx in range(len(item1[index])):
                     new_indicies = prev_indicies[:]
                     new_indicies.append(next_idx)
@@ -541,7 +541,7 @@ class SverchokTestCase(unittest.TestCase):
         # sv_logger.info("Data: %s", data)
         # sv_logger.info("Expected data: %s", expected_data)
         self.assert_sverchok_data_equal(data, expected_data, precision=precision)
-        #self.assertEquals(data, expected_data)
+        #self.assertEqual(data, expected_data)
     
     def assert_dicts_equal(self, first, second, precision=None):
         keys1 = set(first.keys())
@@ -614,14 +614,14 @@ class SverchokTestCase(unittest.TestCase):
 
     def subtest_assert_equals(self, value1, value2, message=None):
         """
-        The same as assertEquals(), but within subtest.
+        The same as assertEqual(), but within subtest.
         Use this to do several assertions per test method,
         for case test execution not to be stopped at
         the first failure.
         """
 
         with self.subTest():
-            self.assertEquals(value1, value2, message)
+            self.assertEqual(value1, value2, message)
 
 
 class EmptyTreeTestCase(SverchokTestCase):
@@ -723,7 +723,7 @@ class NodeProcessTestCase(EmptyTreeTestCase):
         output socket output_name.
         """
         data = self.get_output_data(output_name)
-        self.assertEquals(data, expected_data, message)
+        self.assertEqual(data, expected_data, message)
 
     def assert_output_data_equals_file(self, output_name, expected_data_file_name, message=None):
         """


### PR DESCRIPTION
## Addressed problem description
This PR migrates from `unittest.assertEquals` to `unittest.assertEqual` which is deprecated from Python2.7:
```python
DeprecationWarning: Please use assertEqual instead.
```

## Solution description
Repalces `unittest.assertEquals` with `unittest.assertEqual`.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [ ] Code documentation complete.
- [ ] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

