### PR TITLE
fix 5250 Get_Objects_Data node work in Blender 4.x

### DIFF
--- a/nodes/scene/get_objects_data.py
+++ b/nodes/scene/get_objects_data.py
@@ -601,7 +601,7 @@ class SvGetObjectsDataMK3(Show3DProperties, SverchCustomTreeNode, bpy.types.Node
                     # verts, edgs, pols = pydata_from_bmesh(bm)
 
                     if o_vertices:
-                        verts = [ v.co[:] for v in bm.verts]  # v.co is a Vector()
+                        verts = [ (mtrx @ Vector(v.co[:])) for v in bm.verts]  # v.co is a Vector()
                     if o_edges:
                         edgs = [[e.verts[0].index, e.verts[1].index] for e in bm.edges]
                     if o_polygons:


### PR DESCRIPTION
fix #5250.

<img width="1778" height="1184" alt="image" src="https://github.com/user-attachments/assets/c46ba14a-b5eb-4633-9a61-7bd38fa57f38" />

for tests: 
[GetObjectsDataPreoblemCrease.001.blend.zip](https://github.com/user-attachments/files/22732036/GetObjectsDataPreoblemCrease.001.blend.zip)

Also tested in 4.5