### PR TITLE
fix 5254 Sverchok do not start with Blender 3.[0,1,2,3]

### DIFF
--- a/nodes/CAD/straight_skeleton_2d_extrude.py
+++ b/nodes/CAD/straight_skeleton_2d_extrude.py
@@ -196,7 +196,7 @@ class SvStraightSkeleton2DExtrude(ModifierLiteNode, SverchCustomTreeNode, bpy.ty
     """
     bl_idname = 'SvStraightSkeleton2DExtrude'
     bl_label = 'Straight Skeleton 2D Extrude (Alpha)'
-    bl_icon = 'MOD_OUTLINE'
+    bl_icon = 'MOD_OUTLINE' if bpy.app.version >= (3, 4, 0) else 'MOD_SKIN'
 
     sv_dependencies = ['pySVCGAL', 'more_itertools']
 

--- a/nodes/CAD/straight_skeleton_2d_offset.py
+++ b/nodes/CAD/straight_skeleton_2d_offset.py
@@ -271,7 +271,7 @@ class SvStraightSkeleton2DOffset(ModifierLiteNode, SverchCustomTreeNode, bpy.typ
     """
     bl_idname = 'SvStraightSkeleton2DOffset'
     bl_label = 'Straight Skeleton 2D Offset (Alpha)'
-    bl_icon = 'MOD_OUTLINE'
+    bl_icon = 'MOD_OUTLINE' if bpy.app.version >= (3, 4, 0) else 'MOD_SKIN'
 
     sv_dependencies = ['pySVCGAL', 'more_itertools']
 

--- a/utils/nodes_mixins/console_mixin.py
+++ b/utils/nodes_mixins/console_mixin.py
@@ -131,7 +131,7 @@ class LexMixin():
             #print("reusing")
             texture = self.texture_dict['texture_buffer'] 
 
-        drawing.init_image_from_texture(self, width, height, texname, texture, 'RGBA')
+        drawing.init_image_from_texture(width, height, texname, texture, 'RGBA')
 
 
     def get_font_texture(self):


### PR DESCRIPTION
fix #5254 

Sverchok CAN start with Blender 3.0.0 and use old BGL module until Blender <3.5.0

<img width="2655" height="3028" alt="image" src="https://github.com/user-attachments/assets/4efaaae0-a122-474b-ac66-d747d62f6125" />
