### PR TITLE
fix 5024: 'NoneType' object has no attribute 'is_animation_playing

### DIFF
--- a/core/handlers.py
+++ b/core/handlers.py
@@ -101,7 +101,8 @@ def sv_scene_change_handler(scene):
     # should be suppressed because it repeats animation trigger. When Play
     # animation is on and user changes something in the scene this trigger is
     # only called if frame rate is equal to maximum.
-    if bpy.context.screen.is_animation_playing:
+    screen = bpy.context.screen
+    if screen and screen.is_animation_playing:
         return
 
     # scene handler can be triggered even when new node or its property


### PR DESCRIPTION
## Addressed problem description

fix 5024: 'NoneType' object has no attribute 'is_animation_playing
[5024](https://github.com/nortikin/sverchok/issues/5024)

## Solution description

Added checking for context screen:
```    
screen = bpy.context.screen
    if screen and screen.is_animation_playing:
        return
```

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [ ] Code documentation complete.
- [ ] Documentation for users complete (or not required, if user never sees these changes).
- [ ] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

