### PR TITLE
fix 5329 Get Objects Data no data in materials sockets in Edit mode for Mesh

### DIFF
--- a/nodes/scene/get_objects_data.py
+++ b/nodes/scene/get_objects_data.py
@@ -706,9 +706,7 @@ class SvGetObjectsDataMK4(Show3DProperties, SvNodeInDataMK4, bpy.types.Node):
                                 if obj.material_slots:
                                     material_indexes = read_materials_idx(obj_data, out_np[3])
                                     material_socket_ids = set(material_indexes)
-                                    # Требуется запомнить все материалы объекта, даже если они не используются. Возможна ситуация, что задано несколько материалов, но используется только один последний.
-                                    # Если не запомнить все, то будет указан только один используемый материал и он пойдёт первым в списке материалов, хотя в списке id материалов будет написано не нулевое число
-                                    # и будет выглядеть странно, что материал указан в 0-й позиции, а индексы начинаются не с 0, поэтому надо запомнить, были ли использованы эти материалы. 
+                                    # save all sockets materials in materials sockets of object (materials name if it is not null and info about faces)
                                     materials_info = dict([(id, dict(material_name=(None if obj.material_slots[id].material is None else obj.material_slots[id].material.name), is_faces=id in material_socket_ids )) for id in range(len(obj.material_slots))])
                                 else:
                                     if obj_data.polygons:


### PR DESCRIPTION
fix #5329

Now materials info shown for Edit mode on Mesh Object if no materials:

<img width="840" height="786" alt="image" src="https://github.com/user-attachments/assets/973eedb4-6201-4f00-8329-9917ab8d1f75" />
