### PR TITLE
fix 5357 Viewer Draw show nothing if no edges data

### DIFF
--- a/nodes/viz/viewer_draw_mk4.py
+++ b/nodes/viz/viewer_draw_mk4.py
@@ -1099,8 +1099,9 @@ class SvViewerDrawMk4(SverchCustomTreeNode, bpy.types.Node):
             config.polygons = polygons
             config.matrix = matrix
             config.face_culling_set = self.face_culling_set
-            if not inputs['Edges'].is_linked and self.display_edges:
-                config.edges = polygons_to_edges_np(polygons, unique_edges=True)
+            if not inputs['Edges'].is_linked and self.display_edges or (not edges or len(edges)==1 and len(edges[0])==0):
+                if polygons and (not edges or len(edges)==1 and len(edges[0])==0):
+                    config.edges = polygons_to_edges_np(polygons, unique_edges=True)
 
             geom = generate_mesh_geom(config, vecs)
 


### PR DESCRIPTION
fix #5357 

fixed:

<img width="665" height="766" alt="image" src="https://github.com/user-attachments/assets/5f0aea75-24f4-4ddc-b309-4d04469d75bd" />
