### PR TITLE
Fix error creating group node in Blender 4.0+

### DIFF
--- a/core/node_group.py
+++ b/core/node_group.py
@@ -582,7 +582,13 @@ class AddGroupTree(bpy.types.Operator):
         context.node.group_tree = sub_tree  # link sub tree to group node
         sub_tree.nodes.new('NodeGroupInput').location = (-250, 0)  # create node for putting data into sub tree
         sub_tree.nodes.new('NodeGroupOutput').location = (250, 0)  # create node for getting data from sub tree
-        return bpy.ops.node.edit_group_tree({'node': context.node})
+
+        temp_context = {"node": context.node}
+        if bpy.app.version >= (3, 2):
+            with context.temp_override(**temp_context):
+                return bpy.ops.node.edit_group_tree()
+        else:
+            return bpy.ops.node.edit_group_tree(temp_context)
 
 
 class AddGroupTreeFromSelected(bpy.types.Operator):


### PR DESCRIPTION
Resolves the same error described in https://github.com/nortikin/sverchok/issues/5228, but for creating group node.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [x] Unit-tests implemented.
- [x] Ready for merge.

@satabol
