### PR TITLE
`node.sv_quicklink_new_node_input` - fix missing undo step

### DIFF
--- a/core/sockets.py
+++ b/core/sockets.py
@@ -1307,6 +1307,7 @@ class SvLinkNewNodeInput(bpy.types.Operator):
     ''' Spawn and link new node to the left of the caller node'''
     bl_idname = "node.sv_quicklink_new_node_input"
     bl_label = "Add a new node to the left"
+    bl_options = {"UNDO"}
 
     @classmethod
     def poll(cls, context):


### PR DESCRIPTION
Fixing a little caveat with `node.sv_quicklink_new_node_input` operator not creating undo step, so when doing Undo you would by accident undo one more thing. 
And it's also considered unsafe in Blender to make operators that modify blend data without creating undo steps, which can in theory lead to crashes/corrupted data - see https://docs.blender.org/api/current/bpy.types.Operator.html#modifying-blender-data-undo


Before:

https://github.com/user-attachments/assets/1cf3dfbc-ae8b-43df-9611-b8f4768c4954

After

https://github.com/user-attachments/assets/15649b4a-7750-435d-bc5e-844a32d0c675

@nortikin hi! can you please take a look?