### PR TITLE
Fix 2D shaders usage for Blender 5.x

### DIFF
--- a/nodes/viz/data_tree_viz.py
+++ b/nodes/viz/data_tree_viz.py
@@ -26,6 +26,59 @@ from sverchok.utils.curve.bakery import curve_to_meshdata
 from sverchok.utils.visualize_data_tree import nesting_circles, data_tree_lines, Line, Item
 from sverchok.settings import get_params
 
+def get_batch_for_shader(shader, mode, attrs, indices=None):
+    """Универсальная функция для создания батча"""
+    
+    if bpy.app.version >= (5, 0, 0):
+        # Blender 5.x
+        vert_format = gpu.types.GPUVertFormat()
+        
+        # Добавляем атрибуты на основе переданных данных
+        for attr_name, attr_data in attrs.items():
+            if not attr_data:
+                continue
+            # Определяем размерность и тип
+            elem_len = len(attr_data[0])
+            
+            if elem_len == 2:
+                attr_type = 'VEC2F'
+            elif elem_len == 3:
+                attr_type = 'VEC3F'
+            elif elem_len == 4:
+                attr_type = 'VEC4F'
+            elif elem_len == 1:
+                attr_type = 'FLOAT'
+            else:
+                attr_type = 'VEC4F'  # по умолчанию
+            
+            # Добавляем атрибут со всеми параметрами
+            vert_format.attr_add(
+                id=attr_name,
+                comp_type='F32',
+                len=elem_len,
+                fetch_mode='FLOAT'
+            )
+        
+        vert_buf = gpu.types.GPUVertBuf(vert_format, len=len(attr_data))
+        for attr_name, attr_data in attrs.items():
+            vert_buf.attr_fill(id=attr_name, data=attr_data)
+        
+        if indices is not None:
+            idx_len = len(indices[0])
+            if idx_len == 2:
+                elem_type = 'LINES'
+            else:
+                elem_type = 'TRIS'
+            print(f"Elem {idx_len}, {elem_type}")
+            index_buf = gpu.types.GPUIndexBuf(type=elem_type, seq=indices)
+            return gpu.types.GPUBatch(type=mode, buf=vert_buf, elem=index_buf)
+        else:
+            return gpu.types.GPUBatch(type='POINTS', buf=vert_buf)
+    else:
+        # Blender 4.x
+        from gpu_extras.batch import batch_for_shader
+        return batch_for_shader(shader, mode, attrs, indices=indices)
+
 def mesh_join(vertices, edges, polygons):
     is_py_input = isinstance(vertices[0], (list, tuple))
     meshes = (meshes_py if is_py_input else meshes_np)(vertices, edges, polygons)

--- a/utils/modules/shader_utils.py
+++ b/utils/modules/shader_utils.py
@@ -7,6 +7,7 @@
 
 import numpy as np
 
+import bpy
 import gpu
 from mathutils.geometry import interpolate_bezier as bezlerp
 from mathutils import Vector
@@ -260,56 +261,140 @@ class ShaderLib2D():
         return geom
 
 def get_2d_uniform_color_shader():
-    uniform_2d_vertex_shader = '''
-    in vec2 pos;
-    uniform mat4 viewProjectionMatrix;
-    uniform float x_offset;
-    uniform float y_offset;
+    if bpy.app.version >= (4,2):
+        uniform_2d_vertex_shader = '''
+        //in vec2 pos;
+        //uniform mat4 viewProjectionMatrix;
+        //uniform float x_offset;
+        //uniform float y_offset;
 
-    void main()
-    {
-       gl_Position = viewProjectionMatrix * vec4(pos.x + x_offset, pos.y + y_offset, 0.0f, 1.0f);
-    }
-    '''
+        void main()
+        {
+        gl_Position = viewProjectionMatrix * vec4(pos.x + x_offset, pos.y + y_offset, 0.0f, 1.0f);
+        }
+        '''
 
-    uniform_2d_fragment_shader = '''
-    uniform vec4 color;
-    out vec4 FragColor;
+        uniform_2d_fragment_shader = '''
+        //uniform vec4 color;
+        out vec4 FragColor;
 
-    void main()
-    {
-       FragColor = color;
-    }
-    '''
-    return gpu.types.GPUShader(uniform_2d_vertex_shader, uniform_2d_fragment_shader)
+        void main()
+        {
+        FragColor = color;
+        }
+        '''
+        shader_info = gpu.types.GPUShaderCreateInfo()
+        shader_info.vertex_source(uniform_2d_vertex_shader)
+        shader_info.fragment_source(uniform_2d_fragment_shader)
+        
+        # Объявляем uniform переменные как push constants
+        shader_info.push_constant('MAT4', 'viewProjectionMatrix')
+        shader_info.push_constant('FLOAT', 'x_offset')
+        shader_info.push_constant('FLOAT', 'y_offset')
+        shader_info.push_constant('VEC4', 'color')
+        shader_info.vertex_in(0, 'VEC2', 'pos')
+        
+        return gpu.shader.create_from_info(shader_info)
+    else:
+        uniform_2d_vertex_shader = '''
+        in vec2 pos;
+        uniform mat4 viewProjectionMatrix;
+        uniform float x_offset;
+        uniform float y_offset;
+
+        void main()
+        {
+        gl_Position = viewProjectionMatrix * vec4(pos.x + x_offset, pos.y + y_offset, 0.0f, 1.0f);
+        }
+        '''
+
+        uniform_2d_fragment_shader = '''
+        uniform vec4 color;
+        out vec4 FragColor;
+
+        void main()
+        {
+        FragColor = color;
+        }
+        '''
+        return gpu.types.GPUShader(uniform_2d_vertex_shader, uniform_2d_fragment_shader)
 
 def get_2d_smooth_color_shader():
+    if bpy.app.version >= (4,2):
+# Вершинный шейдер (без указания layout – они будут заданы через create_info)
+        vertex_src = '''
+        //in vec2 pos;
+        //in vec4 color;
 
-    smooth_2d_vertex_shader = '''
-    in vec2 pos;
-    layout(location=1) in vec4 color;
+        //out vec4 a_color;
 
-    uniform mat4 viewProjectionMatrix;
-    uniform float x_offset;
-    uniform float y_offset;
+        void main()
+        {
+            gl_Position = viewProjectionMatrix * vec4(pos.x + x_offset, pos.y + y_offset, 0.0, 1.0);
+            a_color = color;
+        }
+        '''
 
-    out vec4 a_color;
+        # Фрагментный шейдер
+        fragment_src = '''
+        //in vec4 a_color;
+        out vec4 FragColor;
 
-    void main()
-    {
-        gl_Position = viewProjectionMatrix * vec4(pos.x + x_offset, pos.y + y_offset, 0.0f, 1.0f);
-        a_color = color;
-    }
-    '''
+        void main()
+        {
+            FragColor = a_color;
+        }
+        '''
 
-    smooth_2d_fragment_shader = '''
-    in vec4 a_color;
+        # Создаём объект описания шейдера
+        create_info = gpu.types.GPUShaderCreateInfo()
 
-    out vec4 FragColor;
-    void main()
-    {
-        FragColor = a_color;
-    }
-    '''
-    return gpu.types.GPUShader(smooth_2d_vertex_shader, smooth_2d_fragment_shader)
+        # Передаём исходники
+        create_info.vertex_source(vertex_src)
+        create_info.fragment_source(fragment_src)
+
+        # Явно описываем входные атрибуты (layout)
+        create_info.vertex_in(0, 'VEC2', 'pos')
+        create_info.vertex_in(1, 'VEC4', 'color')
+
+        # Определяем интерфейс передачи данных из вершинного во фрагментный шейдер
+        interface = gpu.types.GPUStageInterfaceInfo("sv_smooth_color_shader")
+        interface.smooth('VEC4', 'a_color')   # интерполируемая переменная
+        create_info.vertex_out(interface)
+
+        # Uniform-переменные теперь описываются как push-константы
+        create_info.push_constant('MAT4', 'viewProjectionMatrix')
+        create_info.push_constant('FLOAT', 'x_offset')
+        create_info.push_constant('FLOAT', 'y_offset')
+
+        # Создаём и возвращаем готовый шейдер
+        return gpu.shader.create_from_info(create_info)
+    else:
+        smooth_2d_vertex_shader = '''
+        in vec2 pos;
+        layout(location=1) in vec4 color;
+
+        uniform mat4 viewProjectionMatrix;
+        uniform float x_offset;
+        uniform float y_offset;
+
+        out vec4 a_color;
+
+        void main()
+        {
+            gl_Position = viewProjectionMatrix * vec4(pos.x + x_offset, pos.y + y_offset, 0.0f, 1.0f);
+            a_color = color;
+        }
+        '''
+
+        smooth_2d_fragment_shader = '''
+        in vec4 a_color;
+
+        out vec4 FragColor;
+        void main()
+        {
+            FragColor = a_color;
+        }
+        '''
+        return gpu.types.GPUShader(smooth_2d_vertex_shader, smooth_2d_fragment_shader)
 


### PR DESCRIPTION
At least, "View Data Tree" and "Viewer 2D" nodes now work in Blender 5.x.

## Preflight checklist

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [ ] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

