### PR TITLE
Fix 5388 many exceptions in console in blender 5x

### DIFF
--- a/core/event_system.py
+++ b/core/event_system.py
@@ -38,3 +38,5 @@ def handle_event(event):
         raise RuntimeError(f"{event=} was executed more than one time, {duplicates=}")
     elif results == 0:
         raise RuntimeError(f"{event} was not handled")
+    else:
+        pass

--- a/core/update_system.py
+++ b/core/update_system.py
@@ -72,7 +72,7 @@ def control_center(event):
     # also this can be called (by Blender) during undo event in this case all
     # nodes will have another hash id and the comparison method will decide that
     # all nodes are new, and won't be able to detect changes, and will update all
-    elif type(event) is ev.TreeEvent:
+    elif type(event) is ev.TreeEvent and hasattr(event.tree, 'tree_id')==True:
         UpdateTree.get(event.tree).is_updated = False
         if event.tree.sv_process:
             ts.tasks.add(ts.Task(event.tree,


### PR DESCRIPTION
fix #5388

No errors with "tree.tree_id":

<img width="1551" height="753" alt="image" src="https://github.com/user-attachments/assets/7de61f13-4be5-4fa4-9511-97186d0da3ba" />

(this is another errors)