### PR TITLE
fix #5361 make Group node searchable

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-28T07:38:03.880Z for PR creation at branch issue-5361-867ccbb28034 for issue https://github.com/nortikin/sverchok/issues/5361

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-28T07:38:03.880Z for PR creation at branch issue-5361-867ccbb28034 for issue https://github.com/nortikin/sverchok/issues/5361

--- a/core/node_group.py
+++ b/core/node_group.py
@@ -309,7 +309,10 @@ class BaseNode:
 
 
 class SvGroupTreeNode(SverchCustomTreeNode, bpy.types.NodeCustomGroup):
-    """Node for keeping sub trees"""
+    """
+    Triggers: group node sub tree subtree monad
+    Tooltip: Node for keeping sub trees (group node)
+    """
     bl_idname = 'SvGroupTreeNode'
     bl_label = 'Group node (Alpha)'
 

--- a/experiments/test_group_in_index.py
+++ b/experiments/test_group_in_index.py
@@ -1,0 +1,55 @@
+"""
+Verify that the modified index.yaml is parsed such that:
+  - SvGroupTreeNode appears as a direct AddNode entry under the Group category.
+  - The original SverchokGroupMenu is preserved as a nested CustomMenu (Group tools).
+
+Run with:
+    python experiments/test_group_in_index.py
+"""
+import os
+import sys
+
+repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, repo_root)
+
+from utils import yaml_parser  # type: ignore
+
+
+def find_group_entry(data):
+    for entry in data:
+        if isinstance(entry, dict) and 'Group' in entry:
+            return entry['Group']
+    return None
+
+
+def collect_strings_recursively(items):
+    out = []
+    if isinstance(items, list):
+        for it in items:
+            out.extend(collect_strings_recursively(it))
+    elif isinstance(items, dict):
+        for v in items.values():
+            out.extend(collect_strings_recursively(v))
+    elif isinstance(items, str):
+        out.append(items)
+    return out
+
+
+def run(path):
+    print(f"Checking {path}")
+    data = yaml_parser.load(path)
+    group = find_group_entry(data)
+    assert group is not None, f"'Group' entry not found in {path}"
+    flat = collect_strings_recursively(group)
+    assert 'SvGroupTreeNode' in flat, (
+        f"SvGroupTreeNode not found inside Group entry of {path}: {flat}")
+    assert 'NODE_MT_SverchokGroupMenu' in flat, (
+        f"NODE_MT_SverchokGroupMenu not preserved inside Group entry of {path}: {flat}")
+    print(f"  OK: SvGroupTreeNode + NODE_MT_SverchokGroupMenu present")
+
+
+if __name__ == '__main__':
+    run(os.path.join(repo_root, 'index.yaml'))
+    run(os.path.join(repo_root, 'menus', 'full_by_data_type.yaml'))
+    run(os.path.join(repo_root, 'menus', 'full_by_operations.yaml'))
+    print("All checks passed.")

--- a/experiments/test_group_search_match.py
+++ b/experiments/test_group_search_match.py
@@ -1,0 +1,52 @@
+"""
+Verify that the docstring on SvGroupTreeNode produces the right Triggers/Tooltip
+metadata used by the search system.
+"""
+import os
+import sys
+
+repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, repo_root)
+
+# The SvDocstring class used by AddNode.search_match
+from utils.docstring import SvDocstring  # type: ignore
+
+
+# Same docstring text as on SvGroupTreeNode after the fix
+docstring_text = """
+    Triggers: group node sub tree subtree monad
+    Tooltip: Node for keeping sub trees (group node)
+    """
+
+doc = SvDocstring(docstring_text)
+shorthand = doc.get_shorthand()
+tooltip = doc.get_tooltip()
+
+print(f"shorthand: {shorthand!r}")
+print(f"tooltip:   {tooltip!r}")
+
+
+def search_match(label_upper, doc, request):
+    """Re-implementation of AddNode.search_match for testing."""
+    request = request.upper()
+    words = [w for w in request.split(' ') if w]
+    if all(w in label_upper for w in words):
+        return True
+    sh = doc.get_shorthand().upper()
+    if all(w in sh for w in words):
+        return True
+    tt = doc.get_tooltip().upper()
+    if all(w in tt for w in words):
+        return True
+    return False
+
+
+label = "Group node (Alpha)".upper()
+queries = ["group", "GROUP", "monad", "sub tree", "subtree", "group node"]
+print()
+for q in queries:
+    matches = search_match(label, doc, q)
+    print(f"  query={q!r}  matches={matches}")
+    assert matches, f"Search for {q!r} did not match!"
+
+print("\nAll search-match checks passed.")

--- a/experiments/test_group_search_simulation.py
+++ b/experiments/test_group_search_simulation.py
@@ -1,0 +1,132 @@
+"""
+Simulate (without bpy) the parsing logic of `Category.from_config` from
+sverchok/ui/nodeview_space_menu.py for the Group entry, to confirm that:
+
+  - The Group entry parses to a Category whose draw_data contains an
+    `AddNode('SvGroupTreeNode')` item.
+  - The Group entry also contains a CustomMenu wrapping
+    NODE_MT_SverchokGroupMenu (preserving existing UX).
+
+The simulation is sufficient to demonstrate that the search infrastructure
+(which iterates AddNode items returned by `walk_categories`) will now find
+SvGroupTreeNode via search terms like "group", "monad", "sub tree".
+"""
+import os
+import sys
+
+repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, repo_root)
+
+from utils import yaml_parser  # type: ignore
+
+
+# --- Tiny re-implementation of detection helpers from nodeview_space_menu --- #
+
+def is_operator_config(elem):
+    if not isinstance(elem, dict):
+        return False
+    inner = list(elem.values())[0]
+    if not isinstance(inner, list):
+        return False
+    for prop in inner:
+        if isinstance(prop, dict):
+            prop_name = list(prop.keys())[0]
+            if prop_name.lower() == 'operator':
+                return True
+    return False
+
+
+def is_custom_menu_config(elem):
+    if not isinstance(elem, dict):
+        return False
+    inner = list(elem.values())[0]
+    if not isinstance(inner, list):
+        return False
+    for prop in inner:
+        if isinstance(prop, dict):
+            prop_name = list(prop.keys())[0]
+            if prop_name.lower() == 'custom_menu':
+                return True
+    return False
+
+
+def parse_category(name, conf):
+    """Returns a list of (kind, value) describing parsed children."""
+    parsed = []
+    for elem in conf:
+        if isinstance(elem, dict):
+            if is_operator_config(elem):
+                parsed.append(('Operator', list(elem.keys())[0]))
+                continue
+            if is_custom_menu_config(elem):
+                # find the custom_menu name
+                inner = list(elem.values())[0]
+                menu_name = None
+                for prop in inner:
+                    if isinstance(prop, dict) and 'custom_menu' in prop:
+                        menu_name = prop['custom_menu']
+                        break
+                parsed.append(('CustomMenu', menu_name))
+                continue
+            # nested sub-category
+            sub_name = list(elem.keys())[0]
+            sub_value = list(elem.values())[0]
+            if isinstance(sub_value, list):
+                parsed.append(('Category', (sub_name, parse_category(sub_name, sub_value))))
+            elif isinstance(sub_value, str):
+                # category property like icon_name, extra_menu — ignored here
+                continue
+        elif isinstance(elem, str):
+            if all(c == '-' for c in elem):
+                parsed.append(('Separator', None))
+            else:
+                parsed.append(('AddNode', elem))
+    return parsed
+
+
+def find_group_section(data):
+    for entry in data:
+        if isinstance(entry, dict) and 'Group' in entry:
+            return entry['Group']
+    return None
+
+
+def walk_addnodes(parsed):
+    for kind, value in parsed:
+        if kind == 'AddNode':
+            yield value
+        elif kind == 'Category':
+            _, sub_parsed = value
+            yield from walk_addnodes(sub_parsed)
+
+
+def run(path):
+    print(f"Checking {path}")
+    data = yaml_parser.load(path)
+    section = find_group_section(data)
+    assert section is not None, f"Group section missing in {path}"
+    parsed = parse_category('Group', section)
+
+    add_nodes = list(walk_addnodes(parsed))
+    custom_menus = [v for k, v in parsed if k == 'CustomMenu']
+    nested_custom_menus = [
+        cm for k, v in parsed if k == 'Category'
+        for ck, cm in v[1] if ck == 'CustomMenu'
+    ]
+    all_custom_menus = custom_menus + nested_custom_menus
+
+    print(f"  AddNodes:     {add_nodes}")
+    print(f"  CustomMenus:  {all_custom_menus}")
+
+    assert 'SvGroupTreeNode' in add_nodes, (
+        f"SvGroupTreeNode not registered as AddNode under Group: {parsed}")
+    assert 'NODE_MT_SverchokGroupMenu' in all_custom_menus, (
+        f"SverchokGroupMenu not preserved under Group: {parsed}")
+    print("  OK")
+
+
+if __name__ == '__main__':
+    run(os.path.join(repo_root, 'index.yaml'))
+    run(os.path.join(repo_root, 'menus', 'full_by_data_type.yaml'))
+    run(os.path.join(repo_root, 'menus', 'full_by_operations.yaml'))
+    print("All simulation checks passed.")

--- a/experiments/test_menu_presets_consistency.py
+++ b/experiments/test_menu_presets_consistency.py
@@ -1,0 +1,64 @@
+"""
+Reproduce the logic of `tests/ui_tests.py::UiTests::test_full_menu_presets`
+without Blender to confirm the node sets are consistent across:
+  - index.yaml
+  - menus/full_by_data_type.yaml
+  - menus/full_by_operations.yaml
+"""
+import os
+import sys
+
+repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, repo_root)
+
+from utils import yaml_parser  # type: ignore
+
+
+def _load_node_names_from_menu(menu_path):
+    def search_in_list(data):
+        for item in data:
+            if isinstance(item, str) and item != '---':
+                yield item
+            elif isinstance(item, dict):
+                yield from search_in_dict(item)
+
+    def search_in_dict(data):
+        for key, value in data.items():
+            if key in {'icon_name', 'extra_menu', 'operator', 'custom_menu'}:
+                continue
+            if isinstance(value, list):
+                yield from search_in_list(value)
+
+    def search_node_names(menu):
+        for item in menu:
+            if isinstance(item, dict):
+                yield from search_in_dict(item)
+            elif isinstance(item, list):
+                yield from search_in_list(item)
+
+    menu = yaml_parser.load(menu_path)
+    return set(search_node_names(menu))
+
+
+index_nodes = _load_node_names_from_menu(os.path.join(repo_root, 'index.yaml'))
+data_type_nodes = _load_node_names_from_menu(os.path.join(repo_root, 'menus', 'full_by_data_type.yaml'))
+operations_nodes = _load_node_names_from_menu(os.path.join(repo_root, 'menus', 'full_by_operations.yaml'))
+
+print(f"index.yaml node count: {len(index_nodes)}")
+print(f"full_by_data_type.yaml node count: {len(data_type_nodes)}")
+print(f"full_by_operations.yaml node count: {len(operations_nodes)}")
+
+print(f"\nSvGroupTreeNode in index.yaml: {'SvGroupTreeNode' in index_nodes}")
+print(f"SvGroupTreeNode in full_by_data_type.yaml: {'SvGroupTreeNode' in data_type_nodes}")
+print(f"SvGroupTreeNode in full_by_operations.yaml: {'SvGroupTreeNode' in operations_nodes}")
+
+assert index_nodes == data_type_nodes, (
+    f"index.yaml != full_by_data_type.yaml\n"
+    f"only-in-index: {index_nodes - data_type_nodes}\n"
+    f"only-in-data-type: {data_type_nodes - index_nodes}")
+assert index_nodes == operations_nodes, (
+    f"index.yaml != full_by_operations.yaml\n"
+    f"only-in-index: {index_nodes - operations_nodes}\n"
+    f"only-in-operations: {operations_nodes - index_nodes}")
+assert 'SvGroupTreeNode' in index_nodes, "SvGroupTreeNode not registered in index.yaml"
+print("\nAll preset-consistency checks passed.")

--- a/index.yaml
+++ b/index.yaml
@@ -881,10 +881,13 @@
 
 - ---
 
-- Group:  # label of custom menu to show
-    - custom_menu: NODE_MT_SverchokGroupMenu  # bl_idname of the custom menu
+- Group:  # Group sub-tree (monad) node category
     - icon_name: NODETREE
     - extra_menu: UiToolsPartialMenu
+    - SvGroupTreeNode  # listed directly so the node is discoverable via search
+    - Group tools:  # extra operators (input/output/from-selected)
+        - custom_menu: NODE_MT_SverchokGroupMenu
+        - icon_name: NODETREE
 
 - Presets:
     - custom_menu: NODEVIEW_MT_AddPresetMenu

--- a/menus/full_by_data_type.yaml
+++ b/menus/full_by_data_type.yaml
@@ -920,10 +920,13 @@
 
 - ---
 
-- Group:  # label of custom menu to show
-    - custom_menu: NODE_MT_SverchokGroupMenu  # bl_idname of the custom menu
+- Group:  # Group sub-tree (monad) node category
     - icon_name: NODETREE
     - extra_menu: UiToolsPartialMenu
+    - SvGroupTreeNode  # listed directly so the node is discoverable via search
+    - Group tools:  # extra operators (input/output/from-selected)
+        - custom_menu: NODE_MT_SverchokGroupMenu
+        - icon_name: NODETREE
 
 - Presets:
     - custom_menu: NODEVIEW_MT_AddPresetMenu

--- a/menus/full_by_operations.yaml
+++ b/menus/full_by_operations.yaml
@@ -1070,10 +1070,13 @@
 #################################### GRUP ######################################
 ################################################################################
 
-- Group:  # label of custom menu to show
-    - custom_menu: NODE_MT_SverchokGroupMenu  # bl_idname of the custom menu
+- Group:  # Group sub-tree (monad) node category
     - icon_name: NODETREE
     - extra_menu: UiToolsPartialMenu
+    - SvGroupTreeNode  # listed directly so the node is discoverable via search
+    - Group tools:  # extra operators (input/output/from-selected)
+        - custom_menu: NODE_MT_SverchokGroupMenu
+        - icon_name: NODETREE
 
 ################################################################################
 #################################### PSET ######################################


### PR DESCRIPTION
## Summary

Fixes nortikin/sverchok#5361.

In Blender 5.0, searching for `group` in the Shift+A node-add menu does not find Sverchok's "Group node (Alpha)". The same issue affects Sverchok's own search paths (the side-panel search and the `node.sv_extra_search` popup). The owner reaffirmed in the issue thread that the group node is "still not used" — i.e. it is effectively undiscoverable.

### Root cause

The Sverchok `Group` entry in `index.yaml` is registered as a `CustomMenu` wrapping `NODE_MT_SverchokGroupMenu`. The search systems iterate `Category.walk_categories()` and only index `AddNode` items (or items whose `bl_idname` resolves to a `bpy.types.Node` subclass). Because the group node is exposed only through an operator inside a custom menu, none of the search systems ever see `SvGroupTreeNode`.

Relevant code:
- `ui/nodeview_space_menu.py:238` — `AddNode.search_match` only runs on `AddNode` items.
- `ui/add_nodes_panel.py:48` — side-panel search filters by `isinstance(add_node, sm.AddNode)`.
- `ui/sv_extra_search.py:104-114` — `gather_items` skips items whose `bl_idname` does not resolve to a `bpy.types.Node` (so a `CustomMenu` is skipped).

### Fix

- Register `SvGroupTreeNode` as a direct `AddNode` entry under the `Group` category in `index.yaml` and the two full menu presets (`menus/full_by_data_type.yaml`, `menus/full_by_operations.yaml`).
- Keep the existing rich UX (`Add group node`, `Group input`, `Group output`, `Group from selected`) by demoting the existing `NODE_MT_SverchokGroupMenu` to a nested `Group tools` submenu inside the `Group` category — nothing is removed, the operators are still one click away.
- Add `Triggers`/`Tooltip` metadata to `SvGroupTreeNode`'s docstring so search matches on synonyms like `monad`, `sub tree`, and `subtree` (parsed by `utils/docstring.py`, used by `AddNode.search_match`).

### Why this works

After the change, `Category.walk_categories()` yields a `Group` `Category` containing an `AddNode('SvGroupTreeNode')`. All three search systems iterate this collection and now find the group node. `AddNode.search_match` matches on `bl_label` (`Group node (Alpha)`), `Triggers`, and `Tooltip` text.

The CI test `tests/ui_tests.py::UiTests::test_full_menu_presets` (which asserts the set of node names in `index.yaml` and the full presets is identical) keeps passing — `SvGroupTreeNode` is added to all three files together.

## How to reproduce the original problem

1. In Blender 5.0+, open a Sverchok node tree.
2. Press Shift+A → type `group`.
3. Before the fix: nothing relevant appears.
4. After the fix: `Group node (Alpha)` appears in the search results.

## Test plan

- [x] `experiments/test_group_in_index.py` — verifies YAML structure: SvGroupTreeNode + NODE_MT_SverchokGroupMenu present in all three files.
- [x] `experiments/test_group_search_simulation.py` — simulates `Category.from_config` and confirms the parsed `Group` category contains an `AddNode('SvGroupTreeNode')` and a `CustomMenu('NODE_MT_SverchokGroupMenu')`.
- [x] `experiments/test_group_search_match.py` — confirms `AddNode.search_match` would match queries `group`, `GROUP`, `monad`, `sub tree`, `subtree`, `group node`.
- [x] `experiments/test_menu_presets_consistency.py` — replicates `tests/ui_tests.py::UiTests::test_full_menu_presets` without Blender, confirming all three menu files share the same node set.
- [ ] Existing CI (Blender 3.6.16 + Sverchok unit tests) — runs on push.
- [ ] Manual verification in Blender 5.0+: search "group" in Shift+A and confirm `Group node (Alpha)` appears.

## Files changed

- `core/node_group.py` — Added `Triggers`/`Tooltip` docstring on `SvGroupTreeNode`.
- `index.yaml` — Restructured `Group` from a top-level `CustomMenu` to a `Category` containing `SvGroupTreeNode` plus a nested `Group tools` submenu wrapping the original `NODE_MT_SverchokGroupMenu`.
- `menus/full_by_data_type.yaml`, `menus/full_by_operations.yaml` — Same restructuring for the two preset menus, keeping presets in sync with `index.yaml` (required by `test_full_menu_presets`).
- `experiments/` — Standalone verification scripts (don't require Blender).