### PR TITLE
fix 5364 insert example into current subgroup instead of root tree

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-28T07:45:34.992Z for PR creation at branch issue-5364-2ece662b6bc0 for issue https://github.com/nortikin/sverchok/issues/5364

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-28T07:45:34.992Z for PR creation at branch issue-5364-2ece662b6bc0 for issue https://github.com/nortikin/sverchok/issues/5364

--- a/ui/sv_examples_menu.py
+++ b/ui/sv_examples_menu.py
@@ -285,6 +285,11 @@ class SvNodeTreeImporterSilent(bpy.types.Operator):
             tree = bpy.data.node_groups.new(basename(self.filepath), 'SverchCustomTreeType')
             context.space_data.node_tree = tree  # pass this tree to the active node view
 
+        # if user is editing a subgroup, target the currently edited tree
+        # so the example is inserted into the subgroup, not the root tree
+        if len(context.space_data.path) > 1:
+            tree = context.space_data.path[-1].node_tree
+
         # Deselect everything, so as a result only imported nodes will be selected
         bpy.ops.node.select_all(action='DESELECT')
         JSONImporter.init_from_path(self.filepath).import_into_tree(tree)


### PR DESCRIPTION
## Summary

Fixes #5364.

When editing a node group (subgroup), importing a template/example through the Examples menu placed nodes into the **root** tree instead of the **currently edited** subgroup.

`SvNodeTreeImporterSilent.execute` (in `ui/sv_examples_menu.py`) read the target tree from `context.space_data.node_tree`, which always returns the root Sverchok tree. The fix uses `context.space_data.path[-1].node_tree` when the user is inside a subgroup (`len(context.space_data.path) > 1`), so the example is inserted where the user expects.

This mirrors the pattern already used in `SverchPresetReplaceOperator` (`ui/presets.py:382`):

```python
ntree = context.space_data.path[-1].node_tree  # in case if the node in a node group
```

## Reproduction

1. Open Sverchok node editor.
2. Create a node group and enter (edit) it.
3. Open the Examples menu and pick any template.

**Before:** the example is inserted into the root tree (visible after exiting the group).
**After:** the example is inserted into the subgroup currently being edited.

## Changes

- `ui/sv_examples_menu.py` — target the currently edited tree when inside a subgroup.