### PR TITLE
update boolean internal solver

### DIFF
--- a/docs/nodes/modifier_make/boolean_internal.rst
+++ b/docs/nodes/modifier_make/boolean_internal.rst
@@ -8,7 +8,11 @@ Functionality
 -------------
 
 This node implements Blender's internal boolean modifier with 3 functions: Intersect, Union, and Difference.
-Solver options include Fast and Exact solvers. Fast Solver is simpler and faster but does not support overlapping geometries, which Exact Solver does support overlapping geometries but is slower than the Fast Solver.
+Solver options include Float, Exact, and Manifold solvers.
+
+Float: Uses a simple solver which offers good performance but lacks support for overlapping geometry.
+Exact: Uses a complex solver which offers the best results and has full support for overlapping geometry, but is much slower.
+Manifold: Uses a solver that is usually fastest but only works on Manifold meshes (plus the special case of Difference with a plane).
 
 More information on Blender's internal boolean modifier can be found here:
 https://docs.blender.org/manual/en/latest/modeling/modifiers/generate/booleans.html

--- a/nodes/modifier_make/boolean_internal.py
+++ b/nodes/modifier_make/boolean_internal.py
@@ -91,8 +91,9 @@ class SvInternalBooleanNode(ModifierLiteNode, SverchCustomTreeNode, bpy.types.No
 
     solver_options: EnumProperty(
         items=[
-            ("FAST", "Fast", "Fast, but does not support overlapping geometry"),
-            ("EXACT", "Exact", "Best result")
+            ("FLOAT", "Float", "Uses a simple solver which offers good performance but lacks support for overlapping geometry."),
+            ("EXACT", "Exact", "Uses a complex solver which offers the best results and has full support for overlapping geometry, but is much slower."),
+            ("MANIFOLD", "Manifold", "Uses a solver that is usually fastest but only works on Manifold meshes (plus the special case of Difference with a plane).")
         ],
         description="Select solver type for the Boolean modifier",
         default="EXACT",


### PR DESCRIPTION
This PR add "Manifold" solver for boolean that was introduce in Blender version alpha 4.5.

Put an x letter in each brackets when you're done this item:

- [x] Code changes complete.
- [x] Code documentation complete.
- [x] Documentation for users complete (or not required, if user never sees these changes).
- [x] Manual testing done. 
- [ ] Unit-tests implemented.
- [x] Ready for merge.

