### PR TITLE
fixed 5443 SvProfileNodeMK3 - SyntaxWarning: invalid escape sequence

### DIFF
--- a/old_nodes/profile_mk2.py
+++ b/old_nodes/profile_mk2.py
@@ -418,7 +418,7 @@ class PathParser(object):
         # extract parens, but allow internal parens if needed.. internal parens
         # are not supported in literal_eval.
         side = component[1:-1]
-        pat = '([\(\)\-+*\/])'
+        pat = r'([\(\)\-+*\/])'
         chopped = re.split(pat, side)
 
         # - replace known variable chars with intended variable

--- a/utils/sv_viewer_utils.py
+++ b/utils/sv_viewer_utils.py
@@ -37,7 +37,7 @@ def natural_plus_one(object_names):
 
     def extended_sort(a):
         ''' finds the digit trailing, or 0 if no digits '''
-        k = re.split('(\d*)', a)
+        k = re.split(r'(\d*)', a)
         return 0 if len(k) == 1 else int(k[1])
 
     natural_sort = sorted(object_names, key=extended_sort)


### PR DESCRIPTION
fixed #5443

No warning SyntaxError.

Python in version 3.13 has become more demanding of regular expressions.